### PR TITLE
story(contrib): add story issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/story.yaml
+++ b/.github/ISSUE_TEMPLATE/story.yaml
@@ -1,0 +1,28 @@
+name: Story
+description: Represents stories
+title: "story(subject): short description"
+labels: ["story"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Please provide an informal, general explanation of the work needed to be done, written from the perspective of the end user.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: List the criteria for accepting this story as done
+    validations:
+      required: true
+
+  - type: textarea
+    id: related-issues
+    attributes:
+      label: Related Issues
+      description: Please reference any other related issue, for example, if this story was created to address a bug report, reference the bug report issue here
+    validations:
+      required: false


### PR DESCRIPTION
Adds `.github/ISSUE_TEMPLATE/story.yaml`, copied from [z5labs/devex](https://github.com/z5labs/devex/blob/main/.github/ISSUE_TEMPLATE/story.yaml).

The form captures:
- **Description** (required) — informal explanation from the end user's perspective
- **Acceptance Criteria** (required)
- **Related Issues** (optional)

Content is identical to the upstream file (plus a trailing newline). YAML validated.

### Note
The template declares `labels: ["story"]`, but this repo has no `story` label yet — GitHub silently drops unknown labels, so issues filed from this template will come out unlabeled until the label is created.

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)