### PR TITLE
story(issue-15): establish SPEC.md conventions and the docs layout

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,3 +114,62 @@ v2 syntax once the standard pipeline runs v2 — tracked upstream as
 
 If you run `golangci-lint` directly rather than through `dagger call lint`, use
 v1.64.8 or it will reject the config for the mirror-image reason.
+
+## Specs
+
+Four of this project's interfaces are built against from outside it — the file
+layout format, the resolved IR, the plugin CLI contract and the container
+base-image contract — and each is far harder to change than the code behind it.
+Each has a `SPEC.md` under [`docs/`](docs/), linked from
+[README.md](README.md), which is the only list of them.
+
+[`docs/CONVENTIONS.md`](docs/CONVENTIONS.md) is what those four agree on: the
+conformance language, the section set every spec carries, how sources are cited
+and how requirements are traced back to stories. It is defined there once and
+referenced, never restated — the same argument this file already makes about the
+pipeline and the lint configuration, applied to the word **MUST**.
+
+### Why `docs/` and not beside the code
+
+[`cobol-go`](https://github.com/Zaba505/cobol-go) puts `codec/SPEC.md` next to
+package `codec`, and it is the model these specs follow in every other respect.
+It is not followed here because three of the four specify things that are not Go
+packages: a YAML format, a CLI contract for executables that may be shell
+scripts, and an OCI image. Package-adjacency would have conjured an empty
+`container/` package into existence to hold one markdown file, and would have
+scattered four documents that are peers — a reader comparing what the plugin
+contract promises against what the image provides should not have to know the
+package tree to find both.
+
+Each spec gets a directory rather than a bare file because they grow supporting
+material: the layout format's published JSON Schema belongs beside the layout
+spec, not in a second place that has to be kept in step with it.
+
+### Changing a spec
+
+Read `docs/CONVENTIONS.md` first; it is short, and it is what a reviewer will
+check against. Then:
+
+- Keep the section set. A spec missing `Out of Scope` is a spec that will have
+  the same exclusion proposed to it every six months.
+- Fill a stub heading and its `<!-- -->` brief goes in the same change, along
+  with the *Mapping to Stories* row. A section with prose and its scaffolding
+  comment still above it is a change somebody stopped halfway through.
+- Cite, do not restate. Anything true of COBOL source or of byte-level field
+  layout is `cobol-go`'s to say, and a second copy here is a second thing to be
+  wrong.
+- A new spec is a new row in `README.md`. There is one index; keep it complete.
+
+`dagger call ci` does not read `docs/` — it is fmt, vet, lint and
+`go test -race`, and it will pass on a documentation change without having
+looked at it. Run it anyway, because a change that claims to be docs-only and is
+not should fail in the same place as everything else, but do not mistake it for
+review. What checks a spec is a reader asking whether every link resolves from
+the file it is written in, whether every **MUST** names who it binds, and
+whether anything is restated that could have been cited.
+
+Mechanising the first of those — link resolution and the 80-column wrap — would
+be welcome. It arrives as another function on the root Dagger module, called by
+another `dagger call`, for the reason
+[`.github/workflows/ci.yaml`](.github/workflows/ci.yaml) already gives: raw
+steps beside it would be a second definition of what this repository checks.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,7 @@ pipeline and the lint configuration, applied to the word **MUST**.
 [`cobol-go`](https://github.com/Zaba505/cobol-go) puts `codec/SPEC.md` next to
 package `codec`, and it is the model these specs follow in every other respect.
 It is not followed here because three of the four specify things that are not Go
-packages: a YAML format, a CLI contract for executables that may be shell
+packages: a text file format, a CLI contract for executables that may be shell
 scripts, and an OCI image. Package-adjacency would have conjured an empty
 `container/` package into existence to hold one markdown file, and would have
 scattered four documents that are peers — a reader comparing what the plugin
@@ -142,8 +142,8 @@ contract promises against what the image provides should not have to know the
 package tree to find both.
 
 Each spec gets a directory rather than a bare file because they grow supporting
-material: the layout format's published JSON Schema belongs beside the layout
-spec, not in a second place that has to be kept in step with it.
+material: the layout format's published schema belongs beside the layout spec,
+not in a second place that has to be kept in step with it.
 
 ### Changing a spec
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A modular code generator for files composed COBOL copybook records
 Four interfaces are built against from outside this repository, so each is
 specified rather than merely implemented:
 
-- [The file layout format](docs/layout/SPEC.md) — the YAML an adopter writes to
+- [The file layout format](docs/layout/SPEC.md) — what an adopter writes to
   describe a data file that a copybook alone cannot.
 - [The resolved IR](docs/ir/SPEC.md) — what every generator plugin consumes, in
   any language.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 # cpybkc
 A modular code generator for files composed COBOL copybook records
 
+## Specs
+
+Four interfaces are built against from outside this repository, so each is
+specified rather than merely implemented:
+
+- [The file layout format](docs/layout/SPEC.md) — the YAML an adopter writes to
+  describe a data file that a copybook alone cannot.
+- [The resolved IR](docs/ir/SPEC.md) — what every generator plugin consumes, in
+  any language.
+- [The generator plugin CLI contract](docs/plugin/SPEC.md) — what
+  `cpybkc-gen-<name>` has to implement.
+- [The container base-image contract](docs/container/SPEC.md) — what a
+  Dockerfile building `FROM` the published image may rely on.
+
+[docs/CONVENTIONS.md](docs/CONVENTIONS.md) defines the conformance language all
+four use, and what else they have in common.
+
 ## Contributing
 
 `dagger call ci` runs fmt, vet, lint and `go test -race` — the same call CI

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -1,0 +1,177 @@
+# Spec conventions
+
+Four of cpybkc's interfaces are things other people build against rather than
+things it is free to change: the file layout format, the resolved IR, the
+generator plugin CLI contract, and the container base-image contract. Each is
+harder to change than the code behind it, so each gets a `SPEC.md` under this
+directory. They are linked from the [README](../README.md), which is the only
+list of them — a second list here would be a second answer to what the specs
+are, and two answers drift.
+
+This document is what those specs agree on. It exists because the alternative is
+four documents that each invent a shape and each define **MUST** in their own
+wording, so that having read one teaches you nothing about how to read the next.
+
+The model throughout is [`cobol-go`'s `codec/SPEC.md`][codec-spec] — the spec
+this project exists to be able to generate code against. Where a convention
+below has no stated reason, the reason is that cobol-go does it that way, and
+agreement between the two repositories is worth more than a local improvement.
+
+[codec-spec]: https://github.com/Zaba505/cobol-go/blob/main/codec/SPEC.md
+
+## What belongs here
+
+A document under `docs/` specifies an interface a third party builds against.
+That is the whole test, and it excludes more than it admits:
+
+- **Implementation gets no spec.** The `resolve` stage turns a copybook and a
+  layout into IR, and its correctness criterion is that its output satisfies
+  `ir/SPEC.md`. A second document describing how it computes that would drift
+  from the code the first time an optimisation landed, and nobody outside this
+  repository builds against it.
+- **Test infrastructure documents itself where it lives.** The conformance
+  corpus is a `testdata/` format, run by a harness here and by third-party
+  generators against their own output. It is documented with the corpus.
+- **Conveniences over a contract are not contracts.** The Dagger module that
+  runs cpybkc for a caller wraps the container contract; what it needs to say is
+  said by its module comment and `dagger call --help`.
+
+Something that fails the test and still needs writing down goes in a package
+comment, in `CONTRIBUTING.md`, or in a comment in the file it is about. All
+three are places this repository already keeps its reasoning.
+
+## Conformance language
+
+**MUST**, **MUST NOT**, **SHOULD** and **MAY** are normative requirements on the
+interface a document specifies and on the code implementing it. Everything else
+is descriptive. A requirement written in a spec is not a suggestion a downstream
+story may weigh against ergonomics.
+
+Those four, and no others. There is no **SHOULD NOT**, no **SHALL**, no
+**REQUIRED**/**RECOMMENDED**/**OPTIONAL**, and no citation of RFC 2119 or RFC
+8174. Citing 2119 would import eight keywords and 8174's rule about lowercase
+uses in order to define the four that have been needed and four that have not,
+and a keyword nobody has used is a keyword nobody has agreed the meaning of.
+
+Keywords are **always bolded**, never bare. A document that separates a
+normative `MUST` from an ordinary "must" by capitalisation alone depends on the
+reader noticing capitalisation, and stops working the moment a sentence is
+quoted into an issue or a review comment.
+
+A spec restates this by reference and never by rewording, in a
+`### Conformance language` subsection of its overview. What that sentence
+repeats is *which words are normative*, so a reader never has to leave the
+document to learn what to watch for. What is defined once, here, and never
+repeated is what they mean, that there is no fifth, and that they are bolded:
+
+```markdown
+### Conformance language
+
+**MUST**, **MUST NOT**, **SHOULD** and **MAY** are normative requirements on
+⟨what the document specifies⟩, interpreted as described in
+[CONVENTIONS.md](../CONVENTIONS.md). Everything else is descriptive.
+```
+
+## The shape of a spec
+
+In this order:
+
+1. `# Title`.
+2. `## Overview`, opening by disclaiming the neighbouring specs' territory and
+   closing with the formula cobol-go uses for it — *X questions belong there; Y
+   questions belong here.* A spec that never says what it is not about leaves
+   the gap between two documents to be discovered by whoever falls into it.
+3. `### Scope`, a short paragraph of what is in, ending with a pointer to `Out
+   of Scope` rather than a list of exclusions. The exclusions are long and carry
+   reasons; they do not belong in front matter.
+4. `### Governing sources`, below.
+5. `### Conformance language`, the reference sentence above.
+6. The normative body, one `##` per topic.
+7. `## Out of Scope`, near the back and before any appendix. One `###` per
+   non-trivial exclusion, each with an explicit `Reason:` paragraph, then a
+   catch-all `### Also out of scope` list for the cheap ones. An exclusion
+   without a reason gets re-proposed every six months.
+8. `## Appendix: Mapping to Stories`, below. Other appendices — test vectors, a
+   cross-reference table — go before it as the document needs them.
+
+Subsection titles that carry an argument are welcome throughout. cobol-go's
+*ASCII is a target, not a footnote* and *Byte order — an explicit fork* are
+load-bearing headings rather than decoration: a heading that states its
+conclusion is a heading somebody can find again.
+
+### Governing sources
+
+A bulleted list. Each entry names the source in bold and its title in italics,
+then says in prose what it is normative *for* and why it is needed, with a bare
+autolink where the source has a URL:
+
+> - **ISO/IEC 1989:2014**, *Programming language COBOL* — the normative standard
+>   for PICTURE, `USAGE` and `SIGN`. It fixes the logical model and leaves most
+>   byte-level detail implementor-defined, which is why the rest of this list is
+>   needed. <https://www.iso.org/standard/51416.html>
+
+Prose rather than a table, because the useful part is the "normative for what",
+and that does not fit in a cell.
+
+The list is followed by a blockquote saying what happens when the sources
+disagree:
+
+> **Ambiguity:** where vendors differ this document does **not** choose a
+> winner; it records the fork as a setting and states who takes which side.
+
+A spec whose sources cannot conflict says that instead, in one line. Silence is
+not an option: an adopter who hits a contradiction needs to know whether they
+have found a bug in the spec or a fork the spec declined to resolve on purpose.
+
+### Traceability
+
+Two mechanisms:
+
+- **Inline `(#NN)` citations** closing a normative statement, naming the stories
+  the requirement lands on.
+- **`## Appendix: Mapping to Stories`**, a `| Section | Implemented by |` table
+  of anchor links against issue numbers.
+
+There are no bracketed requirement identifiers — no `[IR-1]`, no `[PLUGIN-7]`.
+They read as rigour and are not: a number is stable only until the requirement
+is split, and nothing checks that one is used exactly once.
+
+The table is the authoritative half. It also carries rows for stories that
+produced **no** section — the emitter, the parser, the published schema — mapped
+to what they did instead, so that the appendix answers "where did #NN land" as
+well as "who implements this section". A section and its row move together, in
+one change; a filled section whose row still says nothing is half a change.
+
+### What a spec does not carry
+
+**No version number, no date, no status badge, no changelog.** Git is the
+history and the Mapping to Stories table is the status; a hand-maintained `Last
+updated:` line is a claim that goes stale in silence. The IR's own version field
+is a different thing — a field in the protobuf, specified by `ir/SPEC.md`, which
+versions the interface rather than the document.
+
+**No reference by line number, to any file, ever.** Cite a section by name and
+link its anchor. A line number into a thousand-line document rots the moment
+either file is edited.
+
+**Lines wrapped at 80 columns**, tables exempted because there is nowhere to
+break them. Specs are reviewed as diffs, and a paragraph on a single line turns
+a one-word change into an unreadable hunk.
+
+## Stubs
+
+A spec that has been given its shape but not its content carries a `> **Stub.**`
+blockquote directly under the title, naming the story that writes it, and one
+HTML comment per empty heading naming what belongs there. The story that fills
+the document deletes the blockquote and the comments as it goes.
+
+A stub contains **no conformance keyword** outside its own conformance-language
+sentence. A stub is the outline nobody argued about; a normative claim in one is
+a requirement nobody reviewed.
+
+## `CLAUDE.md`
+
+cobol-go pairs each spec with a `CLAUDE.md` in the same directory, carrying what
+an implementer needs to know that is not a requirement on the interface. A spec
+directory here gains one once there is an implementation to guide, and not
+before — written against a stub it would be guidance about nothing.

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -1,0 +1,159 @@
+# The Base-Image Contract
+
+> **Stub.** #54 writes this document. `Scope`, `Governing sources` and `Out of
+> Scope` are settled (#15); the headings between them are its outline and are
+> empty on purpose. See [CONVENTIONS.md](../CONVENTIONS.md).
+
+## Overview
+
+Adding a generator to cpybkc means building an image: a multi-stage Dockerfile
+that compiles the generator, copies it onto a directory already on `PATH`, and
+inherits the cpybkc CLI as its entrypoint. That is the whole extension
+mechanism, and it is why this project has no plugin registry, no lockfile, no
+OCI fetching and no resolution protocol — `COPY` and `FROM` already are one.
+
+The consequence is that the published image is a **public contract**, not just a
+convenient way to ship a binary. A Dockerfile in somebody else's repository
+names a path in it, and that path cannot move without breaking their build. This
+document is what those Dockerfiles are entitled to rely on, and — just as
+importantly — what they are not.
+
+It is the deployment half of the [plugin contract](../plugin/SPEC.md). That
+document says a generator is discovered as `cpybkc-gen-<name>` somewhere on
+`PATH`, which is true on a laptop with no container in sight. This one says
+which directory is on that `PATH` inside the image, who owns it, and as which
+user the process reading it runs. How a plugin is invoked belongs there; where
+it goes belongs here.
+
+### Scope
+
+In scope: what the published image guarantees to an image built `FROM` it — the
+directory a generator is copied into, the entrypoint, the user and UID the
+process runs as and the guidance for overriding it with
+`--user $(id -u):$(id -g)`, whether a shell is present and what follows if it is
+not, the tags a derived image may pin to, and which of these are covered by a
+compatibility guarantee and which are implementation detail that may change
+without notice.
+
+Out of scope, with reasons, in [Out of Scope](#out-of-scope).
+
+### Governing sources
+
+- **OCI Image Format Specification** — normative for what an image is, and so
+  for what a guarantee about one can even be made about. It fixes the terms this
+  document uses for layers, manifests and platforms.
+  <https://github.com/opencontainers/image-spec/blob/main/spec.md>
+- **OCI Image Configuration** — normative for `Entrypoint`, `Cmd`, `User`, `Env`
+  and `WorkingDir`, which are precisely the fields a derived image inherits and
+  that this contract makes promises about.
+  <https://github.com/opencontainers/image-spec/blob/main/config.md>
+- **Dockerfile reference** — the reference for the `FROM`/`COPY --from` form the
+  worked example uses, and for how a derived image's `USER` and `ENTRYPOINT`
+  interact with the base image's.
+  <https://docs.docker.com/reference/dockerfile/>
+
+> **Ambiguity:** the OCI specification defines the artifact; the Dockerfile
+> reference describes one widely-used builder for it, and is not a standard.
+> Where they differ this document states the guarantee in OCI terms — those are
+> what a Podman or Buildah user gets too — and treats Dockerfile syntax as the
+> example rather than the promise.
+
+### Conformance language
+
+**MUST**, **MUST NOT**, **SHOULD** and **MAY** are normative requirements on the
+published cpybkc image and on any image built `FROM` it, interpreted as
+described in [CONVENTIONS.md](../CONVENTIONS.md). Everything else is
+descriptive.
+
+## The plugin directory
+
+<!-- #54: the one stable directory on PATH that a derived image copies a
+     generator into. It is a path in strangers' Dockerfiles, so state the
+     stability guarantee alongside it, not separately. -->
+
+## The entrypoint
+
+<!-- #54: the cpybkc CLI, and what a derived image must not do to it. -->
+
+## The user
+
+<!-- #54: a stable non-root UID, why it is pinned rather than allocated, the
+     ownership of the plugin directory and the output directory that follows
+     from it, and guidance on --user $(id -u):$(id -g) for writing files a
+     caller can then read. -->
+
+## Shell or no shell
+
+<!-- #54: whether the base image has one. If it does not, extension is
+     COPY-only — no RUN in a stage built FROM it — and that has to be said
+     plainly, because it is the difference between a Dockerfile that works and
+     one that fails on its second line. -->
+
+## Tags and what pinning one buys
+
+<!-- #54: which tags exist and what each promises across a rebuild. A derived
+     Dockerfile pins one, so the tag is as much a part of this contract as the
+     paths are. Published by #59. -->
+
+## Worked example: adding a generator
+
+<!-- #54: a complete multi-stage Dockerfile that builds a custom plugin and
+     copies it in, runnable as written. -->
+
+## Compatibility guarantees
+
+<!-- #54: what is covered, what is explicitly not, and how a covered thing
+     would change if it had to. -->
+
+## Out of Scope
+
+### How the image is built and published
+
+The build, the platform matrix, emulated testing, signing, provenance and SBOM
+generation are **not specified here**.
+
+Reason: none of it is visible to a Dockerfile that says `FROM`. This document
+describes what an image consumer may depend on; the machinery producing it
+(#55–#59) can be replaced wholesale without any of those promises changing, and
+a contract that described it would freeze an implementation by accident. What
+*is* in scope is anything a consumer can verify — the tags, and the fact that a
+signature exists for them.
+
+### The plugin CLI contract
+
+The `cpybkc-gen-<name>` naming convention, the argument vector, exit codes and
+determinism are **not specified here**.
+
+Reason: they are [`plugin/SPEC.md`](../plugin/SPEC.md)'s (#39), and they hold
+with no container involved. Restating them here would imply the contract is a
+property of the image, which would leave a plugin author running cpybkc from a
+Go install with no document that applies to them.
+
+### Also out of scope
+
+- **The Dagger module** (#61–#65) that runs cpybkc for a caller. It is a
+  convenience over this contract; what it needs to say, it says in its module
+  comment and `dagger call --help`.
+- **The registry.** That the image is published to `ghcr.io` (#59) is a fact
+  about where to find it, not a guarantee about what is inside it. A mirror
+  serving the same digest satisfies this contract identically.
+- **Base-image choice.** Which distroless or scratch base is used, and the
+  contents of the filesystem beyond what is promised above, are implementation
+  detail. Depending on them is what `Compatibility guarantees` exists to warn
+  against.
+
+## Appendix: Mapping to Stories
+
+| Section | Implemented by |
+|---|---|
+| [The plugin directory](#the-plugin-directory) | #54, #55 `container` |
+| [The entrypoint](#the-entrypoint) | #55 `container` |
+| [The user](#the-user) | #55 `container` |
+| [Shell or no shell](#shell-or-no-shell) | #55 `container` |
+| [Tags and what pinning one buys](#tags-and-what-pinning-one-buys) | #59 `container` |
+| [Worked example: adding a generator](#worked-example-adding-a-generator) | #54 `container` |
+| [Compatibility guarantees](#compatibility-guarantees) | #54, #58 `container` |
+| The IR proto shipped in the image — a consumer-visible file, sized here | #57 `container` |
+| Multi-platform build and s390x testing — out of scope, see above | #55, #56 `container` |
+| Signing, provenance and SBOM — verifiable, so the tags section cites them | #58 `container` |
+| Conventions this document follows | #15 `setup` |

--- a/docs/ir/SPEC.md
+++ b/docs/ir/SPEC.md
@@ -1,0 +1,174 @@
+# The Resolved Intermediate Representation
+
+> **Stub.** #16 writes this document. `Scope`, `Governing sources` and `Out of
+> Scope` are settled (#15); the headings between them are its outline and are
+> empty on purpose. See [CONVENTIONS.md](../CONVENTIONS.md).
+
+## Overview
+
+The IR is a data file's description after every question a copybook and a layout
+left open has been answered: offsets computed, encodings applied, sequencing
+compiled. It is what every generator plugin consumes, in any language, and it is
+the *only* thing they consume. A generator never reads a copybook, never reads a
+layout file, and never recomputes anything the IR already carries.
+
+That makes it the keystone of the four specs, and the reason it is written
+first. Fixing what a discriminator or a sequencing expression *means* before the
+[layout format](../layout/SPEC.md) fixes how one is spelled keeps the semantics
+from being back-derived from YAML keys, and keeps every generator from having to
+agree on a second reading of the same file.
+
+It is distinct from the [layout format](../layout/SPEC.md), which is the source
+an adopter writes, and from the [plugin contract](../plugin/SPEC.md), which
+governs how these bytes reach an executable and says nothing about what is in
+them. Syntax questions belong in the layout spec, delivery questions belong in
+the plugin spec, and what the thing *is* belongs here.
+
+### Scope
+
+In scope: what a resolved file layout contains and what each part of it means —
+field descriptors with their byte offsets, widths and applied encodings, record
+structure, compiled discriminators, the compiled sequencing automaton, and
+language-neutral names. Together with the protobuf schema that carries all of
+it, the version field that identifies it, and the compatibility policy that
+governs changing it.
+
+Out of scope, with reasons, in [Out of Scope](#out-of-scope).
+
+### Governing sources
+
+- **Protocol Buffers Language Guide (proto3)**, *including "Updating A Message
+  Type"* — normative for the schema language and for which schema edits are
+  wire-compatible. That section is the floor this document's own compatibility
+  policy is built on: protobuf says what a decoder tolerates, and the IR's
+  policy says what cpybkc additionally promises on top of it.
+  <https://protobuf.dev/programming-guides/proto3/>
+- **`descriptor.proto`** — the definition of `FileDescriptorSet`, which is what
+  plugin authors working in a language with no protobuf codegen read the IR
+  through (#19).
+  <https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/descriptor.proto>
+- **`cobol-go`'s `codec/SPEC.md`** — normative for the four encoding axes a
+  resolved field descriptor carries, and for the byte-level meaning of every
+  `USAGE` the IR can name. This document references it and restates none of it.
+  <https://github.com/Zaba505/cobol-go/blob/main/codec/SPEC.md>
+- **`cobol-go`'s root `SPEC.md`** — normative for COBOL source syntax, and so
+  for the form of the original names the IR carries alongside any override.
+  <https://github.com/Zaba505/cobol-go/blob/main/SPEC.md>
+
+> **Ambiguity:** these sources do not overlap — protobuf governs the container,
+> cobol-go governs what is inside it — so there is no conflict here to resolve.
+> Where the IR appears to disagree with `codec/SPEC.md` about a byte layout,
+> `codec/SPEC.md` wins and the IR has a bug.
+
+### Conformance language
+
+**MUST**, **MUST NOT**, **SHOULD** and **MAY** are normative requirements on the
+IR schema and on every producer and consumer of it, interpreted as described in
+[CONVENTIONS.md](../CONVENTIONS.md). Everything else is descriptive.
+
+## Structure
+
+<!-- #16: what a resolved layout is made of, top down — file, records, groups,
+     elementary fields — and what each descriptor carries. #17 defines the
+     protobuf that expresses it. -->
+
+## Offsets and widths
+
+<!-- #16: the IR carries pre-computed byte offsets and widths for every field,
+     and no generator ever recomputes them. Covers SYNCHRONIZED slack (#34) and
+     OCCURS DEPENDING ON (#35) as resolved facts rather than as rules a
+     generator applies. Computed by #32. -->
+
+## The encoding profile, applied
+
+<!-- #16: every field descriptor arrives with the four cobol-go axes already
+     applied, so no generator holds a copy of the profile or re-derives a
+     layout from it. Applied by #33. -->
+
+## Names
+
+<!-- #16: language-neutral — the original COBOL name plus an optional override
+     (#30). Identifier munging is the generator's responsibility, not the IR's
+     (#50). -->
+
+## The sequencing automaton
+
+<!-- #16: sequencing arrives as a compiled automaton, not as a source string a
+     generator would have to parse. Compiled by #36. -->
+
+## Discriminator predicates
+
+<!-- #16: discrimination arrives compiled into predicates over field values.
+     Compiled by #37. -->
+
+## Versioning and compatibility
+
+<!-- #16: the version field, the compatibility policy, and what constitutes a
+     breaking change. Two-sided assertions between generated code and the codec
+     it links are #53. -->
+
+## Why protobuf, and why no gRPC
+
+<!-- #16: protobuf is the schema language and nothing more — there is no
+     service definition, no server and no port. The plugin contract cites this
+     section rather than arguing it again. -->
+
+## Out of Scope
+
+### Layout source syntax
+
+The keys an adopter types, their nesting, their defaults, and the validation
+errors a bad layout file produces are **not specified here**.
+
+Reason: the IR is the resolved artifact, and its whole value is that no default
+survives into it. A document specifying both the source and the resolved form
+would have to describe every setting twice — once as written and once as
+resolved — and the two descriptions would drift, which is exactly the gap this
+split exists to prevent. The layout format is
+[`layout/SPEC.md`](../layout/SPEC.md) (#22). What the syntax there *means* is
+still this document's, and that asymmetry is deliberate.
+
+### Generator-specific options
+
+The `--opt k=v` pairs a plugin accepts, and their meanings, are **not part of
+the IR**.
+
+Reason: an option in the IR would make the resolved descriptor depend on which
+generators a project happens to run, so the same data file would resolve to
+different IR in two projects, and the conformance corpus (#66) could not compare
+them. Options travel with the invocation instead, in
+[`plugin/SPEC.md`](../plugin/SPEC.md) (#39).
+
+### How the IR is produced
+
+The algorithm that turns a copybook and a layout into IR is **not specified**.
+
+Reason: `resolve` (#32–#38) is an implementation, and its correctness criterion
+is that its output satisfies this document. Writing the algorithm down as well
+would be a second description of the same requirement, drifting from the code at
+the first optimisation, and no third party builds against it.
+
+### Also out of scope
+
+- **COBOL source syntax and byte-level data representation.** Both are
+  `cobol-go`'s, cited above and never restated. The IR names an encoding; what
+  the bytes of that encoding are is `codec/SPEC.md`'s answer.
+- **A transport.** protobuf here is a schema language. There is no gRPC service,
+  no server, no port and no lifecycle; the descriptor reaches a plugin as a file
+  on disk (#39).
+- **The conformance corpus** (#66–#68), which is test infrastructure under
+  `testdata/` and documented with the corpus.
+
+## Appendix: Mapping to Stories
+
+| Section | Implemented by |
+|---|---|
+| [Structure](#structure) | #17 `ir` |
+| [Offsets and widths](#offsets-and-widths) | #32, #34, #35 `resolve` |
+| [The encoding profile, applied](#the-encoding-profile-applied) | #33 `resolve` |
+| [Names](#names) | #30 `layout`, #38 `resolve` |
+| [The sequencing automaton](#the-sequencing-automaton) | #36 `resolve` |
+| [Discriminator predicates](#discriminator-predicates) | #37 `resolve` |
+| [Versioning and compatibility](#versioning-and-compatibility) | #17, #18 `ir` |
+| [Why protobuf, and why no gRPC](#why-protobuf-and-why-no-grpc) | #17, #19 `ir` |
+| Emitting the IR | #20, #21 `ir` |

--- a/docs/ir/SPEC.md
+++ b/docs/ir/SPEC.md
@@ -15,8 +15,8 @@ layout file, and never recomputes anything the IR already carries.
 That makes it the keystone of the four specs, and the reason it is written
 first. Fixing what a discriminator or a sequencing expression *means* before the
 [layout format](../layout/SPEC.md) fixes how one is spelled keeps the semantics
-from being back-derived from YAML keys, and keeps every generator from having to
-agree on a second reading of the same file.
+from being back-derived from whatever notation that format lands on, and keeps
+every generator from having to agree on a second reading of the same file.
 
 It is distinct from the [layout format](../layout/SPEC.md), which is the source
 an adopter writes, and from the [plugin contract](../plugin/SPEC.md), which
@@ -70,14 +70,34 @@ IR schema and on every producer and consumer of it, interpreted as described in
 
 <!-- #16: what a resolved layout is made of, top down — file, records, groups,
      elementary fields — and what each descriptor carries. #17 defines the
-     protobuf that expresses it. -->
+     protobuf that expresses it.
+
+     Open, and settled here rather than in #17: whether that structure is a tree
+     of nested messages or a flat set of typed nodes with references between
+     them — the shape RDF takes, minus RDF's untyped triples. The strongly typed
+     form of it in protobuf is one node message whose body is a oneof over the
+     member types, so a consumer switches on a closed set the schema already
+     enumerates rather than on a string. Nesting is easier to read; a node set
+     carries a graph without flattening it, survives a member being added, and
+     is the same shape the layout format is being argued into (see
+     layout/SPEC.md's Overview). protobuf either way — the question is the
+     message shape, not the encoding, and Why protobuf, and why no gRPC below
+     is unaffected. -->
 
 ## Offsets and widths
 
 <!-- #16: the IR carries pre-computed byte offsets and widths for every field,
      and no generator ever recomputes them. Covers SYNCHRONIZED slack (#34) and
      OCCURS DEPENDING ON (#35) as resolved facts rather than as rules a
-     generator applies. Computed by #32. -->
+     generator applies. Computed by #32.
+
+     Weigh keeping the offset at all against carrying only ordering and width,
+     from which it follows. This is where the IR parts company with the layout
+     format, which excludes derived quantities outright: the IR is the resolved
+     artifact and doing the sum once here is the reason generators exist in more
+     than one language. Against that, an offset field is a fact stated twice
+     that a producer can get wrong in a way no consumer can detect. If it stays,
+     say so as a decision with that cost named, not by omission. -->
 
 ## The encoding profile, applied
 

--- a/docs/layout/SPEC.md
+++ b/docs/layout/SPEC.md
@@ -11,6 +11,19 @@ what order they may appear, how to tell one from another, how the file is framed
 on disk, or how any of it is encoded — and every one of those is needed before a
 single byte can be read. The layout format is where an adopter states them.
 
+Nearly all of that is a *relationship*. Which record may follow which, which
+field decides between two of them, which may repeat and which may not: each is a
+statement about how records stand to one another, and together they are a graph
+over the file's records. That graph is the part a copybook has no way to hold
+and the part a generator cannot work without. The flat per-field data beside it
+— a name, a width — a copybook already carries.
+
+Because the format states relationships, it states sizes and stops. An offset is
+the sum of the widths before it; a record's length is the sum of its fields'.
+Writing either down as well would be a second statement of a fact already made,
+kept in step by hand, for the two to disagree about. What is derivable is
+derived — by `resolve`, once, into the IR.
+
 It is the source an adopter writes; the [resolved IR](../ir/SPEC.md) is what it
 becomes. The split is load-bearing: this document owns how a discriminator or a
 sequencing expression is **spelled**, and the IR owns what one **means**. A
@@ -25,29 +38,25 @@ questions belong there; questions about the file around the records belong here.
 
 ### Scope
 
-In scope: the YAML document an adopter writes to describe a data file, as five
+In scope: the document an adopter writes to describe a data file, as five
 separable layers — the encoding profile, physical framing, record definitions,
-discrimination, and sequencing — together with the keys of each layer, the rules
-that make a layout valid or invalid, the diagnostics an invalid one produces,
-and the JSON Schema that machine-checks all of it.
+discrimination, and sequencing — together with what each layer can express, the
+rules that make a layout valid or invalid, the diagnostics an invalid one
+produces, and the machine-readable schema that checks all of it.
 
 Five layers rather than one schema because they vary independently: a shop's
 encoding profile is a property of its mainframe and is the same across every
 file, while framing is a property of the dataset and discrimination is a
 property of the application.
 
+The concrete notation those layers are written in is **not** settled here. What
+a layout has to be able to say is #15's; which syntax says it is #22's, decided
+against [The surface syntax](#the-surface-syntax).
+
 Out of scope, with reasons, in [Out of Scope](#out-of-scope).
 
 ### Governing sources
 
-- **YAML 1.2.2**, *YAML Ain't Markup Language* — normative for the surface
-  syntax, and in particular for what a plain scalar means, which is where a
-  format that carries COBOL names, hex byte values and record counts is most
-  likely to be surprised. <https://yaml.org/spec/1.2.2/>
-- **JSON Schema 2020-12** — normative for the published schema (#23). The
-  dialect is named because a schema's meaning depends on it and consumers have
-  to know which validator to reach for.
-  <https://json-schema.org/draft/2020-12>
 - **z/OS DFSMS record formats** and ***Using Data Sets*** — normative for
   RECFM F/FB/V/VB/VBS/U, for the RDW and BDW that variable and blocked formats
   carry, and for how LRECL and BLKSIZE constrain them. This is the vocabulary
@@ -64,6 +73,11 @@ Out of scope, with reasons, in [Out of Scope](#out-of-scope).
   definition binds to, and so for what counts as a resolvable field name.
   <https://github.com/Zaba505/cobol-go/blob/main/SPEC.md>
 
+No source is listed here for the surface syntax, because none has been chosen.
+Whichever notation #22 lands on brings its own grammar with it, and that grammar
+joins this list in the same change — a syntax whose normative definition is left
+unnamed is a syntax every implementation reads slightly differently.
+
 > **Ambiguity:** the IBM documentation describes one implementation of record
 > formats, and files written by GnuCOBOL or Micro Focus on Linux do not always
 > match it — line-delimited "RECFM=V" being the common divergence. Where they
@@ -74,16 +88,27 @@ Out of scope, with reasons, in [Out of Scope](#out-of-scope).
 ### Conformance language
 
 **MUST**, **MUST NOT**, **SHOULD** and **MAY** are normative requirements on the
-layout format, on its JSON Schema, and on any implementation reading a layout
-file, interpreted as described in [CONVENTIONS.md](../CONVENTIONS.md).
+layout format, on its published schema, and on any implementation reading a
+layout file, interpreted as described in [CONVENTIONS.md](../CONVENTIONS.md).
 Everything else is descriptive.
 
-## Why YAML, and why a JSON Schema
+## The surface syntax
 
-<!-- #22: adopters hold this metadata already — in DB2 catalogs, in JCL, in a
-     spreadsheet — and will generate layout files from it rather than hand-write
-     them, so the format needs a machine-readable contract to target. #23
-     publishes the schema. -->
+<!-- #22: the notation, and the argument for it. Two requirements bound the
+     choice. First, adopters hold this metadata already — in DB2 catalogs, in
+     JCL, in a spreadsheet — and will generate layout files from it rather than
+     hand-write them, so whatever the notation is needs a machine-readable
+     contract they can target; #23 publishes that schema. Second, the thing
+     being written down is a graph over records (see the Overview), so the
+     notation is judged on how directly it states an edge — a syntax that can
+     only nest forces the graph into key paths and cross-references, and every
+     reader then has to reconstruct it.
+
+     Candidates, neither settled: an S-expression form of tagged nodes and
+     references, as z5labs/dfcad writes its entity graph over z5labs/sexpr-go
+     (https://github.com/z5labs/dfcad, SPEC.md there is the worked example);
+     or YAML with a published JSON Schema. Whichever wins, name its grammar in
+     Governing sources in the same change. -->
 
 ## The encoding profile
 
@@ -152,13 +177,17 @@ a sequencing expression accepts are **not specified here**.
 Reason: they are [`ir/SPEC.md`](../ir/SPEC.md)'s (#16), which is written first
 precisely so that the meanings are settled before the spelling. Splitting the
 other way — syntax owning semantics — would make the IR a transcription of
-whatever YAML happened to be convenient, and would leave a second generator with
-nowhere to look up what it is expected to do.
+whatever notation happened to be convenient, and would leave a second generator
+with nowhere to look up what it is expected to do.
 
 ### Also out of scope
 
 - **Byte-level field representation.** `codec/SPEC.md`'s, cited above. The
   encoding profile declares the axes; what the bytes then are is answered there.
+- **Derived quantities.** An offset, a record length, a total width — anything
+  computable from the sizes and the ordering a layout already states is not
+  something a layout file also carries. The reasoning is in the
+  [Overview](#overview); the computing is `resolve`'s (#32).
 - **Resolution** (#32–#38) — the stage that turns a layout and a copybook into
   IR is an implementation, and its contract is `ir/SPEC.md`.
 - **The `cpybkc.json` project manifest** (#40), which says which generators to
@@ -171,7 +200,7 @@ nowhere to look up what it is expected to do.
 
 | Section | Implemented by |
 |---|---|
-| [Why YAML, and why a JSON Schema](#why-yaml-and-why-a-json-schema) | #23 `layout` |
+| [The surface syntax](#the-surface-syntax) | #22, #23 `layout` |
 | [The encoding profile](#the-encoding-profile) | #25 `layout` |
 | [Physical framing](#physical-framing) | #26 `layout` |
 | [Record definitions](#record-definitions) | #27, #30 `layout` |

--- a/docs/layout/SPEC.md
+++ b/docs/layout/SPEC.md
@@ -1,0 +1,180 @@
+# The File Layout Format
+
+> **Stub.** #22 writes this document. `Scope`, `Governing sources` and `Out of
+> Scope` are settled (#15); the headings between them are its outline and are
+> empty on purpose. See [CONVENTIONS.md](../CONVENTIONS.md).
+
+## Overview
+
+A copybook describes a record. It cannot say which records a file contains, in
+what order they may appear, how to tell one from another, how the file is framed
+on disk, or how any of it is encoded — and every one of those is needed before a
+single byte can be read. The layout format is where an adopter states them.
+
+It is the source an adopter writes; the [resolved IR](../ir/SPEC.md) is what it
+becomes. The split is load-bearing: this document owns how a discriminator or a
+sequencing expression is **spelled**, and the IR owns what one **means**. A
+question about what happens when two discriminators match is an IR question even
+though the discriminators are written here.
+
+The record itself remains the copybook's, and the byte layout of the fields
+inside it remains [`cobol-go`'s `codec/SPEC.md`][codec-spec]'s. Field layout
+questions belong there; questions about the file around the records belong here.
+
+[codec-spec]: https://github.com/Zaba505/cobol-go/blob/main/codec/SPEC.md
+
+### Scope
+
+In scope: the YAML document an adopter writes to describe a data file, as five
+separable layers — the encoding profile, physical framing, record definitions,
+discrimination, and sequencing — together with the keys of each layer, the rules
+that make a layout valid or invalid, the diagnostics an invalid one produces,
+and the JSON Schema that machine-checks all of it.
+
+Five layers rather than one schema because they vary independently: a shop's
+encoding profile is a property of its mainframe and is the same across every
+file, while framing is a property of the dataset and discrimination is a
+property of the application.
+
+Out of scope, with reasons, in [Out of Scope](#out-of-scope).
+
+### Governing sources
+
+- **YAML 1.2.2**, *YAML Ain't Markup Language* — normative for the surface
+  syntax, and in particular for what a plain scalar means, which is where a
+  format that carries COBOL names, hex byte values and record counts is most
+  likely to be surprised. <https://yaml.org/spec/1.2.2/>
+- **JSON Schema 2020-12** — normative for the published schema (#23). The
+  dialect is named because a schema's meaning depends on it and consumers have
+  to know which validator to reach for.
+  <https://json-schema.org/draft/2020-12>
+- **z/OS DFSMS record formats** and ***Using Data Sets*** — normative for
+  RECFM F/FB/V/VB/VBS/U, for the RDW and BDW that variable and blocked formats
+  carry, and for how LRECL and BLKSIZE constrain them. This is the vocabulary
+  adopters already have from their own JCL, so the format uses their spelling
+  rather than inventing one.
+  <https://www.ibm.com/docs/en/zos/3.1.0?topic=sets-record-formats>
+  <https://www.ibm.com/docs/en/zos/3.1.0?topic=guide-using-data-sets>
+- **`cobol-go`'s `codec/SPEC.md`** — normative for the four axes an encoding
+  profile declares (charset, sign convention, byte order, float format) and for
+  the rule that none of them has a default. The profile layer is a way of
+  writing that structure down, not a second definition of it.
+  <https://github.com/Zaba505/cobol-go/blob/main/codec/SPEC.md>
+- **`cobol-go`'s root `SPEC.md`** — normative for the copybook syntax a record
+  definition binds to, and so for what counts as a resolvable field name.
+  <https://github.com/Zaba505/cobol-go/blob/main/SPEC.md>
+
+> **Ambiguity:** the IBM documentation describes one implementation of record
+> formats, and files written by GnuCOBOL or Micro Focus on Linux do not always
+> match it — line-delimited "RECFM=V" being the common divergence. Where they
+> differ this document does **not** choose a winner; it records the fork as a
+> setting and states who takes which side, which is the policy `codec/SPEC.md`
+> already applies to the encoding axes.
+
+### Conformance language
+
+**MUST**, **MUST NOT**, **SHOULD** and **MAY** are normative requirements on the
+layout format, on its JSON Schema, and on any implementation reading a layout
+file, interpreted as described in [CONVENTIONS.md](../CONVENTIONS.md).
+Everything else is descriptive.
+
+## Why YAML, and why a JSON Schema
+
+<!-- #22: adopters hold this metadata already — in DB2 catalogs, in JCL, in a
+     spreadsheet — and will generate layout files from it rather than hand-write
+     them, so the format needs a machine-readable contract to target. #23
+     publishes the schema. -->
+
+## The encoding profile
+
+<!-- #22: the four cobol-go axes, caller-declared with no default for any of
+     them. Every one fails silently when wrong, which is the argument
+     codec/SPEC.md makes and this layer inherits. Modelled by #25. -->
+
+## Physical framing
+
+<!-- #22: RECFM F/FB/V/VB/VBS/U, RDW and BDW, LRECL and BLKSIZE, line
+     delimiters, carriage control. Modelled by #26. -->
+
+## Record definitions
+
+<!-- #22: binding a record name to a copybook and an 01-level within it.
+     Includes fully-qualified renames (#30). Modelled by #27. -->
+
+## Discrimination
+
+<!-- #22: a closed set of strategies for v1 — see Out of Scope for why the set
+     is closed. Implemented by #28. -->
+
+## Sequencing
+
+<!-- #22: a regex-like algebra over record names. Parsed by #29, compiled to an
+     automaton by #36. -->
+
+## Validation and diagnostics
+
+<!-- #22: what makes a layout invalid, and the cross-file source spans an error
+     carries back to the layout and the copybook it came from (#24, #31). -->
+
+## Out of Scope
+
+### A general expression language
+
+Discrimination and sequencing are closed forms. There is no place in a layout
+file to write an arbitrary expression, call a function, or embed a script, and
+adding one is **not** a planned extension.
+
+Reason: two things break at once. Static analysis goes first — a closed set of
+discriminator strategies can be checked for overlap, for exhaustiveness, and for
+referring only to fields that exist at the offsets they claim, and an expression
+language reduces every one of those checks to "run it and see". Portability goes
+second: the resolved IR carries discrimination as a compiled predicate that
+every generator, in every language, must evaluate identically, and an expression
+language would either need an interpreter in each of them or would make the IR
+carry source that only one of them could run. The closed set is what lets the
+IR stay data.
+
+### The copybook language
+
+Level numbers, `PIC` clauses, `OCCURS`, `REDEFINES` — the contents of a copybook
+are **not specified here**.
+
+Reason: they are `cobol-go`'s, cited above. A layout file binds a record name to
+a copybook and an `01`-level inside it and stops there. Restating any of the
+copybook language would be a second reading of COBOL for the two repositories to
+disagree about, which is the outcome depending on `cobol-go` exists to prevent.
+
+### What the layers mean once resolved
+
+The semantics of a discriminator, the behaviour when two of them match, and what
+a sequencing expression accepts are **not specified here**.
+
+Reason: they are [`ir/SPEC.md`](../ir/SPEC.md)'s (#16), which is written first
+precisely so that the meanings are settled before the spelling. Splitting the
+other way — syntax owning semantics — would make the IR a transcription of
+whatever YAML happened to be convenient, and would leave a second generator with
+nowhere to look up what it is expected to do.
+
+### Also out of scope
+
+- **Byte-level field representation.** `codec/SPEC.md`'s, cited above. The
+  encoding profile declares the axes; what the bytes then are is answered there.
+- **Resolution** (#32–#38) — the stage that turns a layout and a copybook into
+  IR is an implementation, and its contract is `ir/SPEC.md`.
+- **The `cpybkc.json` project manifest** (#40), which says which generators to
+  run over which layouts. It is a build-configuration file, not a description of
+  a data file, and the two have different lifetimes.
+- **Copybook discovery** — where copybook files are found and how include paths
+  resolve is a CLI concern, not a property of the layout.
+
+## Appendix: Mapping to Stories
+
+| Section | Implemented by |
+|---|---|
+| [Why YAML, and why a JSON Schema](#why-yaml-and-why-a-json-schema) | #23 `layout` |
+| [The encoding profile](#the-encoding-profile) | #25 `layout` |
+| [Physical framing](#physical-framing) | #26 `layout` |
+| [Record definitions](#record-definitions) | #27, #30 `layout` |
+| [Discrimination](#discrimination) | #28 `layout` |
+| [Sequencing](#sequencing) | #29 `layout` |
+| [Validation and diagnostics](#validation-and-diagnostics) | #24, #31 `layout` |

--- a/docs/plugin/SPEC.md
+++ b/docs/plugin/SPEC.md
@@ -1,0 +1,178 @@
+# The Generator Plugin CLI Contract
+
+> **Stub.** #39 writes this document. `Scope`, `Governing sources` and `Out of
+> Scope` are settled (#15); the headings between them are its outline and are
+> empty on purpose. See [CONVENTIONS.md](../CONVENTIONS.md).
+
+## Overview
+
+A cpybkc generator is an executable, not a server. cpybkc finds it on `PATH`,
+runs it with a resolved descriptor and an output directory, and waits for it to
+exit; the generator writes files to disk and says what went wrong on stderr.
+That is the entire contract, and it is deliberately small enough that a
+generator can be a shell script.
+
+The alternative — a plugin that speaks gRPC, as `protoc`'s do — costs a socket,
+a port, a lifecycle and a protobuf runtime in every implementation language, to
+buy a structured response that a process writing files to a directory does not
+need. Inside a container it is strictly worse: two processes and a rendezvous
+where there was one process and a path.
+
+This document is the plugin author's half. What a plugin *receives* is the
+[resolved IR](../ir/SPEC.md), specified there and never restated here; where on
+`PATH` the published image keeps plugins is the [base-image
+contract](../container/SPEC.md)'s. What is in the descriptor belongs to the IR
+spec, which directory exists in the image belongs to the container spec, and how
+an executable is found and invoked belongs here.
+
+**protobuf is the IR's schema language and nothing more: there is no gRPC
+service, no server and no port.** The argument is in the IR spec, under [Why
+protobuf, and why no gRPC](../ir/SPEC.md#why-protobuf-and-why-no-grpc); it is
+repeated here because a plugin author arrives looking for a service definition
+and must not have to open another document to find out there is not one.
+
+### Scope
+
+In scope: how cpybkc discovers a generator and hands it work. The
+`cpybkc-gen-<name>` naming convention and its resolution against `PATH`; the
+argument vector — `--descriptor <path>` with `-` for stdin, `--out <dir>`, and
+repeated `--opt k=v`; the encoding and lifetime of the descriptor file; what a
+plugin may and may not do to the output directory; exit codes and the stderr
+diagnostic format; the determinism a plugin must exhibit; and the
+`--plugin-info` handshake by which a plugin declares what it supports.
+
+Out of scope, with reasons, in [Out of Scope](#out-of-scope).
+
+### Governing sources
+
+- **`plugin.proto`**, *the `protoc` compiler plugin contract* — cited as the
+  design this one deliberately does not follow. It is the reference point every
+  prospective plugin author already has, so the differences are stated against
+  it rather than described from nothing.
+  <https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/compiler/plugin.proto>
+- **POSIX.1-2024 Base Definitions, chapter 12**, *Utility Conventions* —
+  normative for the shape of the argument vector: option syntax, `--` handling,
+  and the meaning of `-` as an operand standing for standard input.
+  <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html>
+- **`SOURCE_DATE_EPOCH`**, *Reproducible Builds* — the reference for the
+  determinism requirements, and for why an embedded timestamp is the failure it
+  is: it turns every regeneration into a diff and makes generated output
+  useless as a thing to commit.
+  <https://reproducible-builds.org/docs/source-date-epoch/>
+- **Protocol Buffers Language Guide (proto3)** — normative for the wire encoding
+  of the descriptor file a plugin reads.
+  <https://protobuf.dev/programming-guides/proto3/>
+
+> **Ambiguity:** two names collide and neither is this document's to rename.
+> A **descriptor**, in `--descriptor`, is a resolved cpybkc IR message; a
+> **`FileDescriptorSet`** is protobuf's own reflection type, which cpybkc also
+> ships (#19, #57) so that plugin authors without protobuf codegen can read the
+> first one. Where this document says "the descriptor" it always means the IR.
+> POSIX is cited as the convention the argument vector follows, not as a
+> standard cpybkc claims conformance to.
+
+### Conformance language
+
+**MUST**, **MUST NOT**, **SHOULD** and **MAY** are normative requirements on a
+generator plugin and on the cpybkc CLI that invokes one, interpreted as
+described in [CONVENTIONS.md](../CONVENTIONS.md). Everything else is
+descriptive.
+
+## Discovery
+
+<!-- #39: the cpybkc-gen-<name> convention and how a name in the manifest
+     resolves to an executable on PATH. Implemented by #41. Open question for
+     #39: whether a non-POSIX host is supported at all — nothing in the backlog
+     commits either way, and the container contract is Linux-only. Decide it;
+     do not let it be decided by omission. -->
+
+## Invocation
+
+<!-- #39: --descriptor <path> with `-` for stdin, --out <dir>, repeated
+     --opt k=v. Implemented by #42. Record why a path is the default rather
+     than stdin: it makes the bytes a plugin receives reproducible and lets an
+     author re-run the failing invocation by hand. -->
+
+## The output directory
+
+<!-- #39: a plugin writes into a scratch directory it owns, and cpybkc merges
+     it atomically (#43); collisions between plugins are cpybkc's to detect
+     (#44) and stale files cpybkc's to prune (#45). State what that means for
+     the plugin: what it may assume about the directory it is given. -->
+
+## Exit codes and diagnostics
+
+<!-- #39: what a zero and a non-zero exit mean, and the stderr format cpybkc
+     expects a diagnostic in. -->
+
+## Determinism
+
+<!-- #39: identical descriptor and options produce byte-identical output. No
+     embedded timestamps, no hostnames, no map-iteration order. Enforced by
+     #47. -->
+
+## Capability negotiation
+
+<!-- #39: --plugin-info, by which a plugin declares what it supports before it
+     is handed work. Implemented by #46. -->
+
+## Out of Scope
+
+### What is in the descriptor
+
+The structure and meaning of the IR a plugin reads are **not specified here**.
+
+Reason: they are [`ir/SPEC.md`](../ir/SPEC.md)'s (#16), and the split is what
+lets the two evolve apart. The IR gains a field without this document changing;
+this document changes a flag without the IR moving. Restating any of the IR's
+shape here would produce a second description for a plugin author to find and
+for the two to disagree about.
+
+### Where plugins live in the published image
+
+The directory a derived image copies a generator into, the entrypoint, and the
+UID it runs as are **not specified here**.
+
+Reason: they are the [base-image contract](../container/SPEC.md)'s (#54). This
+document says a generator is found by name on `PATH`, which is true wherever
+cpybkc runs, including a developer's laptop with no container involved. Which
+directories are *on* that `PATH` inside the published image is a property of the
+image, and binding the two together would make a contract about executables
+depend on a contract about layers.
+
+### The `cpybkc.json` project manifest
+
+Which generators a project runs, over which layouts, with which options, is
+**not part of this contract**.
+
+Reason: different audience. The manifest (#40) is what a *user* writes to drive
+the CLI; this document is what a *plugin author* implements. A plugin never
+reads the manifest — it receives the options the manifest selected, already
+resolved, on its command line — so specifying the file here would put a
+build-configuration format in front of the one reader with no use for it.
+
+### Also out of scope
+
+- **A transport.** There is no gRPC service, no server, no port, no lifecycle.
+  Argued in the IR spec, restated in the overview above.
+- **What a generator emits.** `cpybkc-gen-go` (#48–#53) is one plugin among
+  many; its Go output is its own concern, and a contract that described it
+  would not be a contract a third-party generator could meet.
+- **Plugin distribution.** There is no plugin registry, no lockfile, no OCI
+  fetch and no resolution protocol. A plugin arrives on `PATH`, by whatever
+  means put it there; the container contract describes the one this project
+  supports.
+
+## Appendix: Mapping to Stories
+
+| Section | Implemented by |
+|---|---|
+| [Discovery](#discovery) | #41 `plugin` |
+| [Invocation](#invocation) | #42 `plugin` |
+| [The output directory](#the-output-directory) | #43, #44, #45 `plugin` |
+| [Exit codes and diagnostics](#exit-codes-and-diagnostics) | #39 `plugin` |
+| [Determinism](#determinism) | #47 `plugin` |
+| [Capability negotiation](#capability-negotiation) | #46 `plugin` |
+| The project manifest — out of scope, see above | #40 `plugin` |
+| A worked implementation of this contract | #48–#53 `gen-go` |
+| Conventions this document follows | #15 `setup` |


### PR DESCRIPTION
Closes #15

Settles where the four public specs live and what they share, before any of them
is written. No spec content: the stubs are deliberately empty of normative
claims.

## Acceptance criteria

- [x] **Docs layout decided and recorded in `README.md` or `CONTRIBUTING.md`** — `CONTRIBUTING.md` gains a `## Specs` section with `### Why docs/ and not beside the code`, and the rule is restated where a spec author will hit it, in `docs/CONVENTIONS.md`.
- [x] **Conformance language defined once and referenced by all four specs** — `docs/CONVENTIONS.md` → `## Conformance language`. Each `SPEC.md` carries a one-sentence `### Conformance language` linking `../CONVENTIONS.md`. `grep` confirms each stub contains exactly one line with a conformance keyword, and it is that sentence.
- [x] **Each spec exists as a stub with `Scope` and `Out of Scope`** — all four, with one `###` per non-trivial exclusion carrying an explicit `Reason:` paragraph, plus a catch-all `### Also out of scope`.
- [x] **Each spec states its governing sources** — bulleted, cobol-go's form, with an `> **Ambiguity:**` blockquote each. Every URL returned 200 when checked.
- [x] **`README.md` links all four** — a `## Specs` section, four links plus one to `CONVENTIONS.md`.

## Why `docs/` when cobol-go puts `SPEC.md` beside the package

cobol-go is the style model in every other respect, and this is the one place
these specs diverge from it. Three of the four specify things that are not Go
packages: a YAML format, a CLI contract for executables that may be shell
scripts, and an OCI image. Package-adjacency would have conjured an empty
`container/` package into existence to hold one markdown file, and scattered
four documents that are peers — a reader comparing what the plugin contract
promises against what the image provides should not need the package tree to
find both.

Each spec gets a directory rather than a bare file because they grow supporting
material: the layout format's JSON Schema (#23) belongs beside the layout spec
rather than in a second place kept in step with it.

## Why there is no `docs/README.md`

`README.md` links the four; a second list under `docs/` would be a second answer
to what the specs are. `docs/CONVENTIONS.md` says so explicitly, because
otherwise somebody adds the index in six months for the obvious reason and
nothing in the tree argues against it.

## The Scope pairs are the substance

The four `Scope`/`Out of Scope` pairs are drawn to tile with no gap and no
overlap. The boundaries, and where each one is written down:

| Boundary | Resolution |
|---|---|
| layout vs IR | The IR owns what a discriminator or sequencing expression **means**; the layout format owns how one is **spelled**. Stated from both sides. |
| IR vs `resolve` | `resolve` (#32–#38) gets no spec. Its correctness criterion is that its output satisfies `ir/SPEC.md`. |
| IR vs plugin | The IR owns the schema, the version field and the compatibility policy; the plugin contract owns how those bytes reach an executable. |
| "protobuf, no gRPC" | `ir/SPEC.md` argues it under its own heading; `plugin/SPEC.md` states it and links. #16 and #39 both require it, and it is a negative claim whose value is meeting the reader who arrived looking for a service definition — but it is argued once. |
| plugin vs container | `cpybkc-gen-<name>` discovery **on PATH** is the plugin contract, which holds with no container involved. **Which directory** is on that PATH in the published image is the container contract. |
| copybook syntax, byte layout | Neither. cobol-go's root `SPEC.md` and `codec/SPEC.md`, cited as governing sources and never restated. |
| `cpybkc.json` (#40) | Not the plugin contract: it is what a *user* writes to drive the CLI, not what a *plugin author* implements. Out of scope with that reason. |

## Repository change made alongside this

**#16 is now blocked by #15.** None of #16, #22, #39 or #54 was blocked by this
issue, so the backlog loop could have started the IR spec before the conventions
existed and #16 would have invented its own. #16 is the only root of the other
three — `#16 → {#22, #39}`, `#39 → #54` — so one edge orders all four behind it.

## What verified this, and what did not

`dagger call ci` passes (51.5s), and that means only that the Go tree is
unharmed: the pipeline is fmt, vet, golangci-lint and `go test -race`, and it
does not read `docs/`. Do not read the green check as review of the change.

What was actually checked:

- **Every relative link resolves from the file it appears in** — 35 links and
  reference definitions, walked programmatically. One was broken on the first
  pass: the conformance-sentence template inside `CONVENTIONS.md` had a live
  `../CONVENTIONS.md` link that resolved wrongly when read from `docs/`. It is
  now a fenced code block, which is what a template should have been.
- **Every in-document anchor resolves** — 0 broken, including the
  Mapping-to-Stories tables and the plugin spec's cross-file anchor into
  `ir/SPEC.md#why-protobuf-and-why-no-grpc`.
- **Every external URL returned 200.**
- **80-column wrap** — all new files clean. Five 81-character lines in
  `CONTRIBUTING.md` predate this change and are left alone.
- **No stub carries a normative claim** — one conformance-keyword line per stub,
  and it is that stub's conformance sentence.
- **Each stub's outline covers its issue's acceptance criteria**, one heading
  per criterion, re-read against #16, #22, #39 and #54.

## One thing left deliberately undecided

`plugin/SPEC.md`'s Discovery comment carries an open question for #39 rather
than an answer: whether a non-POSIX host is supported at all. Nothing in the
backlog commits either way and the container contract is Linux-only, so the stub
declines to settle it by omission.

## Follow-ups this surfaced, not done here

- **`docs` belongs in the root Dagger module's `+ignore` list.** `.dagger/main.go`
  already makes exactly this argument for `.git` — no check stage reads it, so
  leaving it in makes every commit a cache miss for all four stages. Left out
  because the ignore list is part of the module schema, so it needs
  `dagger develop` and the regenerated files in the same commit, which does not
  belong in a docs-only pull request.
- **A `dagger call docs` stage** mechanising the link walk and the wrap check.
  Per `.github/workflows/ci.yaml`'s own comment it arrives as a module function,
  never as raw steps beside `dagger call ci`.
- **`README.md` line 2 reads "files composed COBOL copybook records"** — missing
  an "of" that `doc.go` has. Left untouched rather than folded into an unrelated
  diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
