### PR TITLE
story(issue-76): put value-dependent sequencing in scope, with registers

### DIFF
--- a/docs/ir/SPEC.md
+++ b/docs/ir/SPEC.md
@@ -25,9 +25,10 @@ the plugin spec, and what the thing *is* belongs here.
 In scope: what a resolved file layout contains and what each part of it means —
 field descriptors with their widths, their applied encodings and their place in
 the record's ordering, record structure, compiled discriminators, the compiled
-sequencing automaton, and language-neutral names. Together with the protobuf
-schema that carries all of it, the version field that identifies it, and the
-compatibility policy that governs changing it.
+sequencing automaton and the values it carries forward between records, and
+language-neutral names. Together with the protobuf schema that carries all of
+it, the version field that identifies it, and the compatibility policy that
+governs changing it.
 
 Out of scope, with reasons, in [Out of Scope](#out-of-scope).
 
@@ -91,10 +92,12 @@ prints as the record it describes. It loses on the shape of the thing being
 described, because a file is not a tree. Sequencing is a graph with cycles in it
 — that is what makes a file a stream rather than a fixed list. A discriminator
 points at a field in the record it selects. An `OCCURS DEPENDING ON` object may
-sit outside the group it counts, and in real layouts in another record entirely
-(#35). A tree carries each of those as a name path for the consumer to resolve,
-which puts name resolution — and the chance of two generators resolving one
-differently — into every language anyone writes a generator in.
+sit outside the group it counts, and where the count comes from an earlier
+record it is a register the automaton bound rather than a field of the record
+being read (#35, #77). A tree carries each of those as a name path for the
+consumer to resolve, which puts name resolution — and the chance of two
+generators resolving one differently — into every language anyone writes a
+generator in.
 
 The cost is real, and none of it is paid by the producer. A consumer **MUST**
 index the node list by identifier before it can walk anything. The JSON debug
@@ -118,8 +121,11 @@ names, field names, field numbers — is #17's.
 | **field** | An elementary item: its width, its four resolved encoding axes, its `USAGE`, the attributes that follow from its PICTURE — category, digits, scale, and whether and where a sign is held — its names, and its repetition. |
 | **slack** | A width, and nothing else: bytes that are part of the record and belong to no item. |
 | **predicate** | The identifier of the field it tests, and the test itself, as one member of a closed set. |
-| **state** | Whether the state accepts, and an ordered list of the identifiers of the transitions leaving it. |
-| **transition** | The identifiers of the predicate that selects it, the record it admits, and the state it moves to. |
+| **state** | Whether the state accepts, the identifiers of the guards qualifying that where it is conditional, and an ordered list of the identifiers of the transitions leaving it. |
+| **transition** | The identifiers of the predicate that selects it, the guards that make it eligible, the record it admits, the bindings it applies, and the state it moves to. |
+| **register** | The kind of value it holds — bytes, or an integer — and nothing else. |
+| **binding** | The identifier of the register it writes, and the value written, as one member of a closed set. |
+| **guard** | The identifier of the register it tests, and the test itself, as one member of a closed set. |
 
 ### Identity, ordering and determinism
 
@@ -129,8 +135,9 @@ names, field names, field numbers — is #17's.
   the identifiers and their order inside that promise alongside the contents.
 - An identifier means identity and nothing else. A consumer **MUST NOT** infer
   containment, ordering or position from one.
-- Every reference **MUST** resolve to a node in the same message, of the kind
-  the referring position requires.
+- Every reference **MUST** resolve to a node in the same message, of a kind the
+  referring position admits. Most positions admit exactly one; a repetition's
+  count admits a field or a register (#77).
 - A member list **MUST** be in record order — the order in which the members
   occupy bytes. Ordering is data here, not a convention a consumer restores by
   sorting: [Offsets and widths](#offsets-and-widths) makes it the only statement
@@ -157,10 +164,11 @@ a name. Each is COBOL knowledge. Each is specified somewhere a generator author
 may never have read. Each is a place where two languages' generators diverge
 without either one failing.
 
-Mapping identifiers to nodes, inverting a member list, and adding up the widths
-in front of a field are none of those. They are operations on the message in
-hand, they are identical in every language, and they need no COBOL. The IR
-abolishes the first list, not the second.
+Mapping identifiers to nodes, inverting a member list, adding up the widths in
+front of a field, and holding a value a binding told it to hold are none of
+those. They are operations on the message in hand, they are identical in every
+language, and they need no COBOL. The IR abolishes the first list, not the
+second.
 
 ## Offsets and widths
 
@@ -250,9 +258,30 @@ are measured from the first byte after it.
 ### A variable record is a sum with a variable term
 
 An item that repeats carries its repetition: a constant count, or — for `OCCURS
-DEPENDING ON` — a reference to the field node holding the count, which **MAY**
-be a field of another record (#35). Its extent is the width of one occurrence
-times that count.
+DEPENDING ON` — a reference to the count. Its extent is the width of one
+occurrence times that count.
+
+That reference **MUST** name either a field node contained in the record being
+read, at any depth, or a register node the automaton has bound. It **MUST NOT**
+name a field of another record (#35, #77). The withdrawn form was the honest
+shape of the problem and not a solution to it: naming a field of a record the
+consumer is no longer looking at names bytes it does not have, and no rule about
+references gives those bytes back.
+
+Where the count does come from an earlier record — a header saying how many
+entries a later record's table holds, which is ordinary in production layouts —
+the automaton binds that field into a register as it admits the header, and the
+repetition names the register. Which occurrence governs, in a file holding a
+thousand headers, is then not a question anyone has to answer twice: a register
+holds what the most recent binding put in it, so the count is the one from the
+nearest preceding record that bound it, along the path actually taken. [The
+automaton remembers, in
+registers](#the-automaton-remembers-in-registers) specifies that mechanism.
+
+A consumer **MUST** report a count it cannot decode as a number, or one that is
+negative, as malformed data, and **MUST NOT** read the group as absent instead
+(#35). A count field holding spaces is a real mainframe occurrence, and reading
+it as zero produces a record that parses and is wrong.
 
 Where the count is data-dependent, the sum above is data-dependent with it, and
 that is the whole of the model. A generator emits an addition it performs while
@@ -326,25 +355,208 @@ files one generator reads and another rejects.
 
 The file node names the start state. Each state carries its outgoing
 transitions, in order; each transition names the predicate that selects it, the
-record it admits, and the state to move to. A consumer reads a file by
-evaluating the current state's transitions in the order given, taking the first
-whose predicate matches, emitting the record that transition names, and moving
-to the state it names.
+record it admits, the state to move to, and — where the automaton has memory —
+the guards that make it eligible and the bindings it applies. A consumer reads a
+file by evaluating the current state's transitions in the order given, skipping
+any whose guards do not all hold, taking the first of the rest whose predicate
+matches, emitting the record that transition names, applying that transition's
+bindings, and moving to the state it names.
+
+Every transition consumes exactly one record. There is no transition that moves
+without reading, and no way to test something without consuming — which is what
+keeps a generated reader a loop over one record at a time, and is argued for
+under [No epsilon
+transitions](#no-epsilon-transitions-and-what-the-graph-pays-instead).
 
 A transition **MUST** be selected by a predicate and **MUST NOT** be labelled
 with a record name (#36). A record is what a transition *produces*, not what
 chooses it — a consumer cannot know which record it is looking at until a
 predicate has told it.
 
-A state carries whether it accepts. A consumer reaching end of input in a
-non-accepting state **MUST** report the file as truncated rather than returning
-the records it managed to read: an automaton whose accepting states nobody
-checks detects nothing.
+A state carries whether it accepts, and an accepting state **MAY** qualify that
+with guards: it accepts end of input only when all of them hold. A state that
+does not accept **MUST NOT** carry one. A consumer reaching end of input in a
+state that does not accept, or whose acceptance guards do not all hold, **MUST**
+report the file as truncated rather than returning the records it managed to
+read: an automaton whose accepting states nobody checks detects nothing.
+
+Guarded acceptance is what makes the last iteration of a count detectable. A
+state that reads details while a counter is positive would otherwise have to
+accept unconditionally, and would then accept a file stopping three details
+short of what its own header promised.
 
 The automaton is a graph, and a cycle in it is ordinary — a header followed by
 any number of details is a cycle. Ambiguity is not: `resolve` rejects an
 ambiguous grammar when it compiles one (#36), so the automaton reaching a plugin
-is unambiguous and a consumer is entitled to assume it.
+is unambiguous and a consumer is entitled to assume it. Which pairs of
+transitions that test is over, once guards are present, is [When two
+match](#when-two-match-and-when-none-does)'s.
+
+### The automaton remembers, in registers
+
+A file shape this project exists to read: a header carries a flag saying whether
+a later record type appears at all, and a count saying how many of another type
+follow. Both govern records other than the header, both are ordinary, and
+neither is expressible by a graph with no memory. Value-dependent sequencing is
+therefore **in scope**, and this is the mechanism (#76). How an adopter *spells*
+a count that lives in a header is the layout format's (#22, #29); what one means
+is here.
+
+The automaton **MAY** carry values forward in **registers**. A register node
+declares the kind of value it holds and nothing more. A **binding** on a
+transition writes one. A **guard** on a transition reads one and decides whether
+that transition is eligible at all. Nothing else reads or writes a register, and
+no register is derived from anything: every value in one was put there by a
+binding naming the field it came from.
+
+**What a register holds.** A register's kind is one member of a closed set:
+bytes, or an integer. A bytes register holds its source field's bytes as they
+appear in the record, so a guard over one is a byte comparison and needs no
+charset knowledge — the same reason a predicate tests bytes. An integer register
+holds a number, decoded from the source field by that field's own four encoding
+axes, because a count is arithmetic and the field holding one may be zoned,
+packed or binary. A producer **MUST NOT** bind a field whose value does not
+decode to the register's kind, and a consumer **MUST** report a source field it
+cannot decode as that kind as malformed data rather than substituting a zero or
+spaces.
+
+**What a binding writes.** A binding names the register it writes and the value
+written, one member of a closed set: the value of a field node contained in the
+record the transition admits, or the register's own value less one. The second
+member exists to count — a transition that admits one detail and takes one off
+the counter is how a run of *n* records is read without *n* states. A producer
+**MUST NOT** name a field of any other record in a binding, since the record the
+transition admits is the one the consumer has bytes for, and **MUST NOT** put
+two bindings writing one register on a single transition.
+
+Two further restrictions on a binding, each closing a hole that would otherwise
+be a silent wrong answer rather than an error. A binding **MUST NOT** name a
+field that repeats, or one contained in a group that repeats: a binding carries
+no occurrence number, and an unqualified reference to the third of forty entries
+is a value a consumer would have to invent. And a producer **MUST** guard a
+transition taking one off a register so that the register cannot run below zero;
+a consumer reaching one that would **MUST** report it rather than wrapping or
+clamping, since a counter that has gone negative is a `resolve` bug and every
+value read after it is fiction.
+
+Bindings apply when the transition is taken, after the record is admitted, and
+each reads the register file as it stood on entry to the state. So the order of
+one transition's bindings is not significant, and a transition may take one off
+a counter and rebind another register in the same step without the two
+interfering.
+
+**What a guard tests.** A guard names the register it tests and the test itself,
+one member of a closed set of three: the register equals a carried literal, the
+register is one of a carried set of literals, or the register holds an integer
+greater than zero. Guards are evaluated before the record in front of the
+consumer is examined at all, and against the register file as it stands on entry
+to the state, so a guard never reads what its own transition binds. All of a
+transition's guards **MUST** hold for it to be eligible, and their order is
+therefore not significant. A transition carrying none is always eligible, which
+is every transition in a file whose sequencing needs no memory.
+
+A guard over a bytes register carries its literal already padded to the width of
+the value it will be compared against, and a consumer **MUST** compare the whole
+of that value rather than a prefix of it. Padding a literal out to a field's
+width is a COBOL comparison rule, and applying it is the producer's work like
+every other (#37) — a consumer left to decide whether `Y` matches `Y ` is a
+consumer that decides differently in each language.
+
+Three tests, and no fourth. Conjunction is the list, disjunction is a second
+transition leaving the same state, and a state already *is* a disjunction — so
+the set needs neither. Its membership is settled here rather than deferred the
+way the predicate set's is (#22, #28), because a guard reads a value this
+document's own machinery put in a register: there is no layout-side strategy
+list for it to follow and nothing to wait for.
+
+**A register is read only where it has been written.** A producer **MUST**
+ensure that every path from the start state to a guard reading a register, to a
+state whose acceptance guards read one, or to a repetition naming one, passes
+through a binding of that register first (#36, #37). A consumer **MUST** treat a
+read of a register nothing has bound as a malformed descriptor, and **MUST NOT**
+supply a zero, an empty byte string, or the value of any other register: an IR
+that reached a generator with a register read before it was written is a bug in
+`resolve`, and the rule here is the one the [encoding
+profile](#the-encoding-profile-applied) already applies to an unset axis.
+
+**A register has no scope and no history.** There is one register file for the
+whole read, a register holds what the most recent binding put in it, and nothing
+saves or restores one. That is what answers the question a cross-record count
+raises — which of a thousand headers governs (#77): the nearest preceding record
+that bound the register, along the path actually taken.
+
+The cost is that a generated reader is no longer a table walk with nothing
+beside it. It carries a register file, and its loop grows two steps: check
+guards before matching bytes, apply bindings after admitting a record. That is
+still no COBOL and still nothing derived, which is the promise the automaton is
+carried compiled for (#36), but it is more than a `switch` inside a `for`, and a
+plugin author should expect to hold state. What it buys is a graph whose size
+follows the layout instead of the data: a `PIC 9(4)` count is one register and
+one guard, where unrolling it into states is ten thousand of them and everything
+that hangs off each.
+
+What a *writer* does with a bound register — a generated writer would have to
+put a count in a header matching the records it goes on to write — is not
+settled here, because whether writers are in this document's contract at all is
+#79's question. This section states the reading side, as the rest of the
+document does.
+
+### When a value becomes a state, and when it becomes a register
+
+An adopter can tell which shape a file needs by asking one question: does the
+value govern the record it sits in, or a later one?
+
+A flag deciding what the record *holding* it means becomes a branch, and needs
+no register. Two transitions admit the same header and move to different states,
+each selected by a predicate testing that flag; the dependence on the value has
+become the state the automaton is in, and everything downstream of it is an
+ordinary graph. This is the form that worked before this section existed, and it
+is still the form to prefer: a producer **SHOULD** compile a value tested only
+on the transition admitting the record that holds it as a branch rather than as
+a register, because a register the graph does not need is memory every consumer
+in every language carries for nothing.
+
+A value governing a record *other* than the one it sits in becomes a register. A
+count is always this shape — the header says four, and the fourth detail is four
+records away. A flag gating a record type that is otherwise indistinguishable
+from what would follow without it is this shape. And so is a second flag on one
+header, which a branch cannot reach at all: a transition is selected by one
+predicate testing one field, and there is nowhere to conjoin a second test onto
+it.
+
+Nothing falls between the two. A value in the record being discriminated that
+governs only that record is a branch; anything a later record's presence, count
+or extent depends on is a register; and a value in a record not yet read governs
+nothing, for the reason [A value the automaton has not read
+yet](#a-value-the-automaton-has-not-read-yet) gives.
+
+### No epsilon transitions, and what the graph pays instead
+
+A guarded transition consuming no record — an epsilon — was the obvious
+alternative, and it is deliberately absent. With one, a counted group would
+leave its loop by an epsilon guarded on the counter reaching zero, a conjunction
+would be a chain of them, and conditional acceptance would be an epsilon into an
+accepting state. The graph would be smaller and every transition would carry at
+most one guard.
+
+The cost falls on the consumer, which is the wrong place for it. An epsilon
+turns "evaluate the transitions, take one, consume a record" into "follow
+epsilons until none applies, then evaluate the transitions" — at end of input as
+well, where a consumer would have to walk epsilons before it could decide
+whether the file was truncated. It puts a second control-flow rule into every
+generated reader in every language, and it obliges `resolve` to prove the
+epsilon-only subgraph acyclic before a consumer may assume the walk terminates.
+Sequencing arrives compiled precisely so that a plugin author implements as
+little as possible.
+
+So the graph pays instead. A segment that may be skipped forces the state ahead
+of it to offer a transition for each record that can follow the skip, each
+carrying the guards that say the skipped segments are done: more transitions and
+more guards, all of them emitted by `resolve`, and none of them growing with the
+width of a count. What a state carries follows the number of segments that can
+be skipped past it, never the values in the file. That is the trade this
+document keeps making — cost in the producer, which is one program, over cost in
+the consumers, which are as many programs as there are languages.
 
 ## Discriminator predicates
 
@@ -360,6 +572,19 @@ record, at any depth, and **MUST NOT** name a field of any other (#37). Where
 those bytes are then follows from [Offsets and widths](#offsets-and-widths) —
 the target's position is the sum of the widths ahead of it in that record, and
 its extent is the target's own width.
+
+A predicate and a guard divide the two things a transition can be selected on,
+and neither reaches into the other's half. A predicate **MUST NOT** name a
+register, and a guard **MUST NOT** name a field node (#37). A predicate reads
+the bytes in front of the consumer; a guard reads what the automaton
+[remembers](#the-automaton-remembers-in-registers). Keeping them apart makes
+"guards first, then bytes" a shape rather than a rule, and leaves the overlap
+test below over predicates that all read the same record.
+
+A guard is not the way a predicate stops naming a field, either. Whether the
+predicate set admits a member testing something other than a field's bytes — a
+record's length, where it sits in the stream, nothing at all — is #80's
+question, and this section leaves it exactly where it was.
 
 A consumer evaluates a predicate against the bytes at the current read position,
 read as the record that transition would admit, and consumes nothing until a
@@ -392,8 +617,25 @@ question `layout/SPEC.md` defers to this document — what happens when two
 discriminators match — has an answer at the one place it is cheap: it does not
 arise, because such an IR is never produced.
 
-A consumer **MAY** therefore stop at the first predicate that matches. The
-evaluation order is normative all the same, so that two consumers handed the
+Guards narrow which pairs that rule is about. Two transitions leaving one state
+whose guards cannot hold at the same time are never both eligible, and their
+predicates **MAY** overlap freely — which is what makes a counted run of records
+expressible at all, since the transition reading another detail and the one
+moving past them can be selected by the very same test on the very same bytes,
+and only the counter separates them. For every other pair — both unguarded, or
+guarded compatibly — the rule above stands unchanged and a producer **MUST NOT**
+emit one.
+
+That check stays decidable because of what a guard is not. A flat conjunction of
+three tests over a fixed set of declared registers, with no arithmetic in it
+beyond taking one off a counter and no comparison of one register against
+another, makes "can these two guard lists hold at once" a question about
+literals and zero. [The automaton counts; it does not
+compute](#the-automaton-counts-it-does-not-compute) is where that restriction is
+stated as a restriction.
+
+A consumer **MAY** therefore stop at the first eligible predicate that matches.
+The evaluation order is normative all the same, so that two consumers handed the
 same bytes do the same work in the same order and report the same thing when
 something is wrong with them.
 
@@ -402,6 +644,14 @@ not describe. A consumer **MUST** report that rather than skipping ahead to a
 transition that matches later or falling through to a default. There is no
 default, and a file containing an undescribed record is a file the layout is
 wrong about.
+
+Where a transition's predicate *would* have matched and its guards excluded it,
+a consumer **SHOULD** report that instead, naming the register the guard tested.
+The two failures send an adopter to different places: an undescribed record
+means the layout is missing a record type, while a detail arriving after its
+counter reached zero means the file and its own header disagree about how many
+there are. Both are reported and neither is skipped; only the wording differs,
+and it is the wording that saves a day.
 
 ## Versioning and compatibility
 
@@ -437,8 +687,9 @@ Breaking, and requiring the version to advance:
 - Removing a field, or reusing its number for anything else.
 - Changing what an existing field means, including narrowing or widening the
   values it may hold.
-- Adding a node kind, or a member to any other closed set — a predicate kind,
-  for one. An old consumer sees an unset choice where a new one sees a member,
+- Adding a node kind, or a member to any other closed set — a predicate kind, a
+  guard test, a register's value kind, the value a binding may write. An old
+  consumer sees an unset choice where a new one sees a member,
   and generates code for a file it has silently misread. This is the standing
   cost of the flat node set, and it is why the kinds are enumerated before the
   first release instead of after it.
@@ -521,6 +772,46 @@ is that its output satisfies this document. Writing the algorithm down as well
 would be a second description of the same requirement, drifting from the code at
 the first optimisation, and no third party builds against it.
 
+### The automaton counts; it does not compute
+
+The register machinery is a counter, not a calculator. There is no addition, no
+scaling, no count that is the sum or the product of two fields, no comparison of
+one register against another, and no guard comparing a register to a field of
+the record in front of the consumer. `resolve` **MUST** reject a layout needing
+any of them, and **MUST** name the record and the field involved rather than
+reporting a generic ambiguity (#36, #37) — the pattern #35 already sets with its
+explicit unsupported error.
+
+Reason: two things have to stay true, and each of them fails at the same place.
+Overlap between two transitions has to be decidable, and it is decidable only
+while a guard is a flat conjunction of tests against literals and zero — a
+register compared against a field, or against another register, turns the check
+into "read a file and see". And a consumer has to evaluate the whole of it
+identically in every language one is written in, which is the argument
+`layout/SPEC.md` already makes when it closes discrimination against a general
+expression language. A cross-record equality check — a detail's key matching its
+header's — is a validation rule rather than a sequencing one, and adding it
+later costs a version under [Versioning and
+compatibility](#versioning-and-compatibility). That is a price worth paying over
+guessing at its shape now, and the diagnostic above is what keeps the bill
+visible: a layout that needs one is told so, instead of being told its
+discriminators overlap.
+
+### A value the automaton has not read yet
+
+Sequencing **MUST NOT** depend on a value in a record the consumer has not read.
+A trailer's record count cannot govern how many records precede it, and a
+repetition **MUST NOT** name a register no path binds before it.
+
+Reason: a consumer reads a stream forward, and one that could not decide a
+transition until a later record arrived would have to buffer an unbounded
+stretch of a file whose whole premise is that it does not fit in memory. Nor is
+this a check left to run time: `resolve` proves every read of a register is
+preceded, on every path, by a binding of it (#36), so what would have been a
+surprise halfway through a hundred-million-record file is a layout rejected
+before a byte is read. Checking a trailer's count against the records actually
+read is a generator's own business and nothing the automaton needs to carry.
+
 ### Also out of scope
 
 - **COBOL source syntax and byte-level data representation.** Both are
@@ -532,15 +823,65 @@ the first optimisation, and no third party builds against it.
 - **The conformance corpus** (#66–#68), which is test infrastructure under
   `testdata/` and documented with the corpus.
 
+## Appendix: A counted run, as nodes
+
+The shape the scope decision was made for, written out: a header carrying a
+detail count and a flag, a run of details the count governs, a summary record
+the flag governs, and any number of such groups in one file. Two registers —
+`count`, an integer; `flag`, bytes. The state names below are this appendix's;
+states carry identifiers and no names.
+
+**`start`** — does not accept.
+
+- On a record whose type code is `H`: admit the header, bind `count` from its
+  `DTL-COUNT` field and `flag` from its `SUM-FLAG` field, move to `group`.
+
+**`group`** — accepts, guarded by `count` equal to zero and `flag` one of `N` or
+a space.
+
+- Guarded by `count` greater than zero. On a record whose type code is `D`:
+  admit the detail, take one off `count`, stay in `group`.
+- Guarded by `count` equal to zero and `flag` equal to `Y`. On a record whose
+  type code is `S`: admit the summary, move to `summarised`.
+- Guarded by `count` equal to zero and `flag` one of `N` or a space. On a record
+  whose type code is `H`: admit the next header, rebind both registers, stay in
+  `group`.
+
+**`summarised`** — accepts.
+
+- On a record whose type code is `H`: admit the next header, rebind both
+  registers, move to `group`.
+
+Four things this detects that a memoryless graph could not, and one it does not:
+
+- **A file ending two details short.** End of input in `group` with `count` at
+  two: the acceptance guards do not hold, so the file is truncated.
+- **A missing summary where the flag says `Y`.** End of input in `group` with
+  the flag guard failing — also truncated, and distinguishable from the file
+  simply running out mid-run.
+- **A sixth detail where the header said five.** In `group` with `count` at
+  zero, the detail transition is ineligible and no other predicate matches. It
+  was a guard on `count` that excluded the transition that would have matched,
+  and that is what the consumer says rather than calling the record undescribed.
+- **A summary where the flag says `N`.** The same failure, on `flag`.
+- **A trailer count disagreeing with the records read.** Not this. Nothing above
+  looks backwards, and nothing needs to; see [A value the automaton has not read
+  yet](#a-value-the-automaton-has-not-read-yet).
+
+No transition here is an epsilon, and none is a special case. Every one consumes
+exactly one record, the guards on the third do what a chain of epsilons would
+have done, and the whole of it stays the same size whether `DTL-COUNT` is a
+`PIC 9(2)` or a `PIC 9(9)`.
+
 ## Appendix: Mapping to Stories
 
 | Section | Implemented by |
 |---|---|
 | [Structure](#structure) | #17 `ir` |
-| [Offsets and widths](#offsets-and-widths) | #32, #34, #35 `resolve` |
+| [Offsets and widths](#offsets-and-widths) | #32, #34, #35 `resolve`, #77 `ir` |
 | [The encoding profile, applied](#the-encoding-profile-applied) | #33 `resolve` |
 | [Names](#names) | #30 `layout`, #38 `resolve` |
-| [The sequencing automaton](#the-sequencing-automaton) | #36 `resolve` |
+| [The sequencing automaton](#the-sequencing-automaton) | #36 `resolve`, #76, #77 `ir` |
 | [Discriminator predicates](#discriminator-predicates) | #28 `layout`, #37 `resolve` |
 | [Versioning and compatibility](#versioning-and-compatibility) | #17, #18 `ir` |
 | [Why protobuf, and why no gRPC](#why-protobuf-and-why-no-grpc) | #17, #19 `ir` |


### PR DESCRIPTION
Closes #76
Closes #77

Value-dependent sequencing is **in scope**. It is a real production file shape —
a header flag saying whether a later record type appears at all, and a header
count saying how many of another type follow — and the two issues were the same
missing mechanism one layer apart, so they are decided together and in one
change.

The mechanism is the one #76 named: a binding on a transition, plus something
that reads one. The automaton gains three node kinds — **register**, **binding**,
**guard** — a transition gains guards and bindings, an accepting state gains
acceptance guards, and a repetition's count gains a second admissible target.

## Acceptance criteria, #76

- [x] **`ir/SPEC.md` states whether the sequencing automaton may depend on a value from a record other than the one being discriminated** — `The sequencing automaton` → *The automaton remembers, in registers*. It may.
- [x] **If in scope, the mechanism is settled before #17 fixes the schema** — settled here in full: what a register holds, what a binding writes, what a guard tests, when each is evaluated, and what `resolve` must prove. #17's body updated from eight node kinds to eleven, with #76 and #77 struck from its blockers.
- [x] **The single-flag branch that already works is documented as the supported form** — *When a value becomes a state, and when it becomes a register*, which is also the section an adopter can locate their own file on. The branch stays preferred, as a **SHOULD** on the producer.
- [x] **#36 updated to match** — rewritten: register automaton, guard-aware ambiguity rejection, definite assignment, no unrolling, and the unsupported cases rejected by name.
- [x] **(out-of-scope half) `resolve` rejects with a diagnostic naming the record and field rather than a generic ambiguity error** — there is still an unsupported side, and it keeps that requirement: `Out of Scope` → *The automaton counts; it does not compute*.

## Acceptance criteria, #77

- [x] **Specifies how a consumer obtains the value, or withdraws the MAY** — both, in the honest order. The **MAY** is withdrawn: a count reference **MUST NOT** name a field of another record, because naming a field of a record the consumer is no longer looking at names bytes it does not have. What replaces it is a register the automaton bound.
- [x] **The instance question is answered** — a register holds what the most recent binding put in it, so the count is the one from the nearest preceding record that bound it, along the path actually taken. A thousand headers need no rule of their own.
- [x] **#35's "may live in a different record entirely" updated to match** — done, plus an AC for a count that will not decode and one for a count field that repeats.
- [x] **Settled before #17** — as above.

## The three decisions

**Registers, not a bigger graph.** The dependence on an earlier value becomes
state only while the value is in the record being discriminated; past that,
unrolling is the only memoryless option and it dies on arithmetic — a `PIC 9(4)`
count is ten thousand states and everything hanging off each, and two counts in
one header is their product. A register makes the graph's size follow the layout
instead of the data. The cost is named where it falls: a generated reader is no
longer a table walk with nothing beside it, and a plugin author should expect to
hold state.

**No epsilon transitions.** The obvious alternative — a guarded transition
consuming no record — would have made the graph smaller and every guard single.
It puts a second control-flow rule into every generated reader in every
language, at end of input as well, and obliges `resolve` to prove an
epsilon-only subgraph acyclic before a consumer may assume the walk terminates.
So the graph pays instead: more transitions and more guards, all emitted by
`resolve`, none of them growing with the width of a count. Cost in the producer,
which is one program, over cost in the consumers, which are as many programs as
there are languages.

**Guards are not predicates.** A predicate reads the bytes in front of the
consumer; a guard reads what the automaton remembers; neither may name the
other's target. That keeps "guards first, then bytes" a shape rather than a rule,
leaves the overlap test over predicates that all read one record, and — the part
that matters for #80 — leaves the question of whether a *predicate* may test
something other than a field's bytes exactly where it was. The spec says so
explicitly, so #80 is not quietly half-answered.

The split also pays for itself immediately: two transitions whose guards cannot
hold at once may overlap freely, which is the only reason a counted run works at
all. The transition reading another detail and the one moving past them are
selected by the same test on the same bytes, and only the counter separates them.

## What is still out, and loudly

`Out of Scope` gains two entries with reasons, because the cost of leaving this
undecided was never a loud error:

- *The automaton counts; it does not compute* — no addition, no scaling, no
  count that is the sum of two fields, no register compared against another
  register or against a field. `resolve` **MUST** reject each and **MUST** name
  the record and the field, following #35's precedent. The reason is that
  overlap between two transitions has to stay decidable, and it is decidable
  only while a guard is a flat conjunction of tests against literals and zero.
- *A value the automaton has not read yet* — a trailer's count cannot govern the
  records before it. `resolve` proves every register read is preceded on every
  path by a binding, so this is a rejected layout rather than a surprise halfway
  through a hundred-million-record file.

## Three holes closed while reviewing the mechanism against real data

Each would have been a silently wrong answer rather than an error:

- **A binding naming a field that repeats.** A binding carries no occurrence
  number, so a reference to the third of forty entries is a value a consumer
  would have to invent. Forbidden.
- **A literal compared against a wider field.** Whether `Y` matches `Y ` is a
  COBOL comparison rule, and a consumer left to decide it decides differently in
  each language. The producer pads.
- **A counter running below zero.** Guarded by the producer, reported by the
  consumer, never wrapped or clamped.

## New appendix

*A counted run, as nodes* writes the whole shape out — two registers, three
states, five transitions — with the four failures it detects and the one it
does not. It is there because "this really does work without epsilons" is a
claim a reviewer should be able to check rather than take, and because #36 and
#17 now have a concrete target to test against.

## Backlog swept

Bodies rewritten where this decision made an acceptance criterion wrong:

- **#36** — register automaton, guard-aware ambiguity, definite assignment, no
  unrolling, branch-preferred **SHOULD**, and the by-name rejections.
- **#35** — cross-record count is a register, not a field reference; undecodable
  and negative counts; repeating count fields.
- **#37** — the predicate/guard split, the guard-disjoint exemption to overlap
  rejection, padded literals, and the guard-excluded diagnostic.
- **#17** — eleven node kinds, the three new ones spelled out, #76 and #77 off
  the blocker list, #78 and #80 still on it.
- **#29** — the sequencing algebra needs two forms it did not have: a repetition
  counted by a field of another record, and an element whose presence is one.
  Registers are compiler output and are not spelled in a layout file.
- **#52** — the generated reader carries a register file, and its two new
  failure cases.

Comments rather than rewrites on #22 (the `Sequencing` section it writes) and
#80 (why a guard is not its answer). #79 is closed, and the write-side answer it
would have carried is in this PR instead.

## What verified this, and what did not

`dagger call ci` passes, and that means only that the Go tree is unharmed — the
pipeline is fmt, vet, lint and `go test -race`, and it does not read `docs/`. Do
not read the green check as review.

What was actually checked, programmatically across all seven markdown files:

- **Every relative link and anchor resolves from the file it is written in**,
  including all seven new headings' anchors and `plugin/SPEC.md`'s cross-file
  link. No heading was renamed.
- **80-column wrap** — clean. The one 94-column line is the `descriptor.proto`
  autolink, unbreakable and unchanged from the stub.
- **Every conformance keyword is bolded and is one of the four** — 64
  occurrences on `main`, 97 here, and each of the 33 new ones read against who
  it binds: the schema, a producer, or a consumer.
- **The worked appendix was walked by hand** against every path — the counted
  run, an early end of input, a sixth detail where the header said five, a
  summary where the flag says `N` — and against the overlap rule at each of the
  three states.

## Reconciled with #81 mid-flight

#81 landed `Writing a file` on `main` while this branch was open, and its
*What the descriptor determines, a writer supplies* hands the cross-record
`OCCURS DEPENDING ON` count to **#77 "for both directions"** — which this PR
closes. So the rebase was not mechanical, and one subsection is new:

*A writer evaluates a guard, it never back-fills a count.*

- **A guard behaves identically in both directions.** A writer carries the same
  register file and fills it the same way, by reading values out of the record
  it has just emitted. A binding needs no inverse: a header's count field is a
  field of the header, and the caller supplied it.
- **A writer never back-fills.** Holding a group, counting it, and reaching back
  into the header is the shape everybody expects. Every argument #81 makes
  against inverting a predicate applies unchanged, and two more apply only here
  — it gives up the streaming property #52 requires, unbounded in exactly the
  case counts exist for, and the header is already gone.
- **Where a repetition's count is a register, the determination reverses.** #81
  has a writer supply an ODO count because the field is sitting there to be
  filled. A count in a register was filled two records ago, so the *occurrences*
  are what must agree with it: a writer emits exactly that many and reports a
  caller supplying a different number.
- **Three of #81's rules take guards into account** — the narrowed transition
  walk, closing in a state whose acceptance guards do not hold, and the ODO
  paragraph that pointed at #77.

#81's requirement on future predicate-set members — decidable by a writer from
the record it is emitting and its own position in the automaton — the guard set
meets already, and not by accident: a guard reads nothing but the register file,
and the register file is the one thing a reader and a writer hold identically at
the same point in a file.

The merge commit records this rather than hiding it, and the resulting tree is
identical to the rebase it replaces (`--force-with-lease` was declined, so main
came in as a merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
