### PR TITLE
story(issue-82): decide whether slack bytes survive a read

### DIFF
--- a/docs/ir/SPEC.md
+++ b/docs/ir/SPEC.md
@@ -256,10 +256,13 @@ and not a reference: a producer **MUST** resolve it away (#32), and the graph
 carries what is left. Each alternative a discriminator can select becomes its
 own record node with its own containment order, the items those alternatives
 share appear in each, and bytes the chosen alternative does not occupy are slack
-under the rule below. Two layouts overlaying the same bytes are two paths
-through the automaton, which is the shape the IR already has. The alternative
-was a node kind whose only purpose is to be collapsed by every consumer in every
-language before it could compute a single offset.
+under the rule below. Those bytes are not padding: in a file written by a
+program that used another variant they hold that variant's data, which is why
+[Slack survives a read](#slack-survives-a-read) has a consumer keep them rather
+than fill them. Two layouts overlaying the same bytes are two paths through the
+automaton, which is the shape the IR already has. The alternative was a node
+kind whose only purpose is to be collapsed by every consumer in every language
+before it could compute a single offset.
 
 The cost is duplication, and the IR does not soften it. A dozen record types
 sharing a thirty-item prefix carry that prefix a dozen times, and nothing says
@@ -287,6 +290,109 @@ Framing bytes are not slack. A descriptor word or a delimiter belongs to the
 dataset rather than to the record's data, and it is described by the file node
 ([Physical framing](#physical-framing)); positions here are measured from the
 first byte of the record's data, whatever stands in front of it.
+
+A slack node says how many bytes and never which, and a consumer holds the bytes
+themselves all the same. That is the section below, and it binds a reader rather
+than a writer: a writer has nowhere to get those bytes from if the read did not
+keep them.
+
+### Slack survives a read
+
+What turns on the answer is the most ordinary batch job there is — read a file,
+change one field of one record, write it back — so it is settled here, beside
+the node, rather than in [Writing a file](#writing-a-file), where a reader's
+author has no reason to look (#82).
+
+A consumer **MUST** retain the bytes of every slack node of a record it reads,
+alongside the values of that record's items, and a writer **MUST** emit exactly
+those bytes for that slack node. Retention is per occurrence, as an item's value
+is: a slack node inside a group that repeats stands for one run of bytes in each
+occurrence rather than one run in the record. A writer **MUST** emit a slack
+node's width exactly, and **MUST** report a retained run of any other length
+rather than truncating or padding it to fit.
+
+Where a record carries no retained bytes for a slack node — one its caller built
+rather than read, or an occurrence its caller added to a record it did read — a
+writer fills them, and [What the descriptor determines, a writer
+supplies](#what-the-descriptor-determines-a-writer-supplies) says with what.
+Those bytes were never in a file, so there is nothing there to keep.
+
+The bytes travel with the record. A generator **MUST NOT** oblige its caller to
+supply them, or to carry them across from the record a reader handed it to the
+record it hands a writer: a record read and passed back unchanged writes the
+bytes it was read from, with nothing asked of the code in between. Whether they
+are visible in the record's public shape is the generator's, like every other
+question about the call ([Also out of scope](#also-out-of-scope)) — a generator
+**MAY** surface them, for a caller diffing two files or logging what it did not
+understand, and one that hides them entirely satisfies this section. What no
+generator **MAY** do is make surfacing them the mechanism by which they survive.
+A caller obliged to copy a field across is a caller that forgets.
+
+**What is in those bytes.** Three things produce slack and they are not the same
+kind of thing. A `SYNCHRONIZED` alignment gap holds nothing anybody wrote: COBOL
+says nowhere what is in one, and nothing downstream reads it. The bytes a
+record's items do not reach in a fixed-length dataset ([Four framings, and none
+of them is a RECFM](#four-framings-and-none-of-them-is-a-recfm)) hold whatever
+the program that wrote the file left there, which on these files is spaces. And
+the tail of a `REDEFINES` alternative holds *another alternative's data*
+([Members never overlap, and `REDEFINES` is resolved
+away](#members-never-overlap-and-redefines-is-resolved-away)) — laid down by a
+program that used the other variant, on a record the one being read does not
+describe.
+
+A rule filling slack with a constant leaves the first alone, which is the one it
+was written for, and destroys the third while rewriting the second. What makes
+retention worth a requirement on every consumer is that nothing fails while that
+happens. A job reads a record, changes one field and writes it back: the
+truncation rule does not fire, the no-match rule does not fire, and the file
+reads back as the records that were written, because the bytes that went missing
+belonged to no item of any record anybody read. What is gone is the other
+variant's payload, and the program that put it there finds out later, from a
+record this job never looked at. The fixed-length case is the same failure with
+a smaller loss and a wider blast radius: a file whose padding was spaces on
+Monday holds `0x00` on Tuesday, in every record a job passed over.
+
+That failure is also why the rule lands before the first release rather than
+after. Retention is a requirement on every consumer and not a field on a node,
+so a consumer that has not heard of it cannot ignore it and stay correct — which
+is [Versioning and compatibility](#versioning-and-compatibility)'s test for a
+breaking change, whatever protobuf would make of one that alters no schema at
+all.
+
+**One answer for all three, so the node carries no kind.** The three could have
+been told apart, by a member on the slack node saying which produced it, and
+under retention nothing would read it. Retaining an alignment gap costs what
+retaining anything costs and loses nothing, since what is retained is what was
+there. A consumer filling one kind with zero and keeping the other two would
+have to know which it held in order to write a file that differs from its input
+in the one place nobody can name a better value for.
+
+The member would not be free, either. It is a closed set, so a producer of slack
+nobody anticipated is breaking to admit afterwards — and the question was posed
+as a fork between two producers when the fixed-length pad, which is neither,
+turns out to be the common one. Nor is attribution as crisp as three names make
+it sound. Two runs of slack that abut are one run of bytes in the file, and
+nothing in this document distinguishes one slack node of eight bytes from two of
+five and three; a kind would make that distinction load-bearing for the
+first time, and a `REDEFINES` alternative shorter than its sibling and followed
+by an aligned item puts exactly those two runs next to each other. A producer
+coalescing them would be dropping something, and one that did not would be
+emitting more nodes than the record has runs of bytes.
+
+Retaining the record's whole bytes instead — every byte, covered by an item or
+not — was the other alternative, and it fails the test this document keeps
+applying. It states every byte twice, once as an item's value and once in the
+run, so a writer handed a record whose caller changed one field has two answers
+for those bytes and needs a rule saying which wins. Retaining exactly the bytes
+no item covers leaves every byte of a record with one source.
+
+The cost is memory, it lands on every consumer in every language, and it is not
+softened here. A reader holds a copy of bytes most callers will never look at —
+eight in every record of an eighty-byte fixed-length file is a tenth of it — and
+a copy rather than a window onto the input, since a streaming reader reuses the
+buffer it read into. It is charged on the reading side because there is nowhere
+else to charge it: a writer holding a record and a descriptor knows how many
+bytes no item covers and cannot know what was in them.
 
 ### A variable record is a sum with a variable term
 
@@ -495,13 +601,14 @@ that its record types account for all of LRECL, since the next record starts at
 that fixed distance regardless: a record type whose items stop at 72 bytes of an
 80-byte record carries the remaining 8 as slack, and a layout in which it does
 not describes a file whose reader misaligns after the first record (#26, #34).
-Those 8 bytes are then bytes a writer fills in rather than bytes its caller
-supplies ([What the descriptor determines, a writer
-supplies](#what-the-descriptor-determines-a-writer-supplies)), which is a
-consequence worth knowing before it is met: an adopter who wants them to hold
-spaces declares a trailing item and supplies it, rather than leaving them to
-slack. Whether slack should carry more than a width is #82's, and fixed-length
-padding is the shape that makes that question common rather than rare.
+Those 8 bytes are then bytes no item covers, and what becomes of them is [Slack
+survives a read](#slack-survives-a-read)'s: a record read from such a file
+carries them and a writer puts them back, so a job that reads this file and
+writes it out again leaves whatever the program before it left there. A record
+its caller built rather than read has nothing to put back and gets zero bytes,
+which is common enough on a fixed-length dataset to be worth stating where the
+padding is introduced: an adopter who wants those 8 to hold spaces declares a
+trailing item and supplies it, rather than leaving them to slack (#82).
 
 ### The extent governs, and framing is checked against it
 
@@ -1160,12 +1267,11 @@ The fourth does both again for what the automaton remembers, where a guard is a
 test like a predicate is and a count in a register is determined like a count in
 a field (#76, #77).
 
-Byte identity is a stronger claim, and this document does not make it. Bytes no
-item covers are not carried through a read, which [What the descriptor
-determines, a writer
-supplies](#what-the-descriptor-determines-a-writer-supplies) takes up; and
-whether a value has exactly one valid encoding is `codec/SPEC.md`'s question
-rather than this one's.
+Byte identity is a stronger claim, and one thing stands between this document
+and it. Bytes no item covers do survive a read ([Slack survives a
+read](#slack-survives-a-read)), so a record read and written back unchanged is
+byte-identical wherever encoding a value reproduces the bytes it was decoded
+from — and whether it does is `codec/SPEC.md`'s question rather than this one's.
 
 ### A writer walks the same automaton
 
@@ -1316,25 +1422,25 @@ so the occurrences are what has to agree with it. [A writer evaluates a guard,
 it never back-fills a
 count](#a-writer-evaluates-a-guard-it-never-back-fills-a-count) states that.
 
-Slack is determined here, because nothing else determines it. A slack node
-carries a width and no content ([Slack is a node, not a
-rule](#slack-is-a-node-not-a-rule)), and a writer still has to put something in
-those bytes: a writer **MUST** emit them as zero bytes. A character fill is the
-obvious alternative and cannot be specified — charset is per field ([The
-encoding profile, applied](#the-encoding-profile-applied)) and slack is not a
-field, so there is no charset to resolve a space against. Zero is the byte that
-names none. Carrying the fill on the slack node instead would move the same
+Slack is determined by the record where the record was read, and here where it
+was not. A writer emits the bytes retained for a slack node ([Slack survives a
+read](#slack-survives-a-read)); where a record carries none, because its caller
+built it rather than read it, a writer **MUST** emit zero bytes. A character
+fill is the obvious alternative and cannot be specified — charset is per field
+([The encoding profile, applied](#the-encoding-profile-applied)) and slack is
+not a field, so there is no charset to resolve a space against. Zero is the byte
+that names none. Carrying the fill on the slack node instead would move the same
 invented constant one stage earlier, to where `resolve` has no source for it
 either: neither a copybook nor a layout says what an alignment gap contains.
 
-The cost is where a round trip stops being byte-exact, and it is stated rather
-than left to be discovered. Bytes no item covers do not survive a read — a
-`SYNCHRONIZED` alignment gap, or the tail of a `REDEFINES` alternative that
-resolution turned to slack ([Members never overlap, and `REDEFINES` is resolved
-away](#members-never-overlap-and-redefines-is-resolved-away)) — so a record read
-and written back is byte-identical only where its items cover every byte of it.
-#51's round-trip criterion is where somebody meets this. It is a limit of what a
-width alone can carry, not a bug in a generator.
+The invention is confined to bytes that were never in a file, which is what
+keeps #51's round-trip criterion — decode then encode reproduces the original
+bytes — true of a record carrying slack rather than only of one whose items
+cover every byte. A caller that wants a constructed record's slack to hold
+something other than zero declares a trailing item and supplies it, as [Four
+framings, and none of them is a
+RECFM](#four-framings-and-none-of-them-is-a-recfm) says for the fixed-length
+padding that raises this most often (#82).
 
 ### A writer evaluates a guard, it never back-fills a count
 
@@ -1699,13 +1805,13 @@ have done, and the whole of it stays the same size whether `DTL-COUNT` is a
 | Section | Implemented by |
 |---|---|
 | [Structure](#structure) | #17 `ir` |
-| [Offsets and widths](#offsets-and-widths) | #32, #34, #35 `resolve`, #77, #84 `ir` |
+| [Offsets and widths](#offsets-and-widths) | #32, #34, #35 `resolve`, #77, #82, #84 `ir` |
 | [Physical framing](#physical-framing) | #78 `ir`, #26 `layout`, #52 `gen-go` |
 | [The encoding profile, applied](#the-encoding-profile-applied) | #33 `resolve` |
 | [Names](#names) | #30 `layout`, #38 `resolve` |
 | [The sequencing automaton](#the-sequencing-automaton) | #36 `resolve`, #76, #77, #84 `ir` |
 | [Discriminator predicates](#discriminator-predicates) | #28 `layout`, #37 `resolve`, #84 `ir` |
-| [Writing a file](#writing-a-file) | #51, #52 `gen-go` |
+| [Writing a file](#writing-a-file) | #79, #82 `ir`, #51, #52 `gen-go` |
 | [Versioning and compatibility](#versioning-and-compatibility) | #17, #18 `ir` |
 | [Why protobuf, and why no gRPC](#why-protobuf-and-why-no-grpc) | #17, #19 `ir` |
 | Emitting the IR | #20, #21 `ir` |

--- a/docs/ir/SPEC.md
+++ b/docs/ir/SPEC.md
@@ -256,11 +256,19 @@ and not a reference: a producer **MUST** resolve it away (#32), and the graph
 carries what is left. Each alternative a discriminator can select becomes its
 own record node with its own containment order, the items those alternatives
 share appear in each, and bytes the chosen alternative does not occupy are slack
-under the rule below. Those bytes are not padding: in a file written by a
-program that used another variant they hold that variant's data, which is why
-[Slack survives a read](#slack-survives-a-read) has a consumer keep them rather
-than fill them. Two layouts overlaying the same bytes are two paths through the
-automaton, which is the shape the IR already has. The alternative was a node
+under the rule below. That last needs saying as a requirement rather than as an
+observation, because splitting the alternatives is what discards the storage the
+copybook gave them jointly: a producer **MUST** emit, in each alternative's
+record node, a slack node covering every byte of the redefined item's storage
+that the alternative's own items do not occupy (#32, #34). Left declarative it
+would be circular — a record's extent is the sum of its items *and* its slack,
+so an alternative emitted without one has no byte that no item occupies, and
+satisfies the rule below by having nothing to satisfy it about. Those bytes are
+not padding: in a file written by a program that used another variant they hold
+that variant's data, which is why [Slack survives a
+read](#slack-survives-a-read) has a consumer keep them rather than fill them.
+Two layouts overlaying the same bytes are two paths through the automaton, which
+is the shape the IR already has. The alternative was a node
 kind whose only purpose is to be collapsed by every consumer in every language
 before it could compute a single offset.
 
@@ -281,7 +289,13 @@ warning is about a record described by a copybook. It does not apply to a record
 described by the IR, and this is why.
 
 Any byte of a record that no item occupies **MUST** appear in the containment
-order as a slack node carrying its width (#34). Alignment then stops being a
+order as a slack node carrying its width, and a producer **MUST** emit one node
+per maximal run of such bytes, so that two runs of different origin that abut
+are one node and not two (#34). The second half costs nothing today and stops
+costing something later: [Slack survives a
+read](#slack-survives-a-read) makes a record carry one run of bytes per slack
+node, so how a producer divides a run of eight into nodes would otherwise decide
+the shape of every record a generator emits. Alignment then stops being a
 rule a generator applies and becomes bytes a generator already has, and the sum
 above is literally true with `SYNCHRONIZED` present. A generator **MUST NOT**
 implement an alignment rule, because there is nothing left for one to do.
@@ -304,16 +318,39 @@ the node, rather than in [Writing a file](#writing-a-file), where a reader's
 author has no reason to look (#82).
 
 A consumer **MUST** retain the bytes of every slack node of a record it reads,
-alongside the values of that record's items, and a writer **MUST** emit exactly
-those bytes for that slack node. Retention is per occurrence, as an item's value
-is: a slack node inside a group that repeats stands for one run of bytes in each
-occurrence rather than one run in the record. A writer **MUST** emit a slack
-node's width exactly, and **MUST** report a retained run of any other length
-rather than truncating or padding it to fit.
+alongside the values of that record's items. What it retains **MUST** be those
+bytes as they stood when the record was read, and **MUST** stay those bytes for
+as long as the record can be handed to a writer: a consumer **MUST NOT** retain
+them as a view of input it may overwrite, and **MUST NOT** re-read them from the
+input when a writer asks. Retention is per occurrence, as an item's value is: a
+slack node inside a group that repeats stands for one run of bytes in each
+occurrence rather than one run in the record.
 
-Where a record carries no retained bytes for a slack node — one its caller built
-rather than read, or an occurrence its caller added to a record it did read — a
-writer fills them, and [What the descriptor determines, a writer
+The lifetime is normative because the alternative conforms to everything else. A
+streaming reader over a reused buffer that keeps a window onto it satisfies a
+rule saying only *what* to retain, and then every record it hands a writer
+carries the *next* record's slack — an error no width check and no framing check
+can see, on a file that reads back as the records that were written.
+
+A writer pairs runs to nodes and occurrences by position: it **MUST** emit, for
+the *k*th occurrence of a slack node, the *k*th run the record carries for that
+node, and **MUST** emit the node's width exactly. A run of any other length is
+an error a writer **MUST** report rather than truncate or pad to fit — and a run
+of no bytes is one of those rather than an absent one, so a consumer **MUST**
+keep an absent run and an empty one distinguishable wherever it carries a
+record. Runs beyond a record's occurrences are discarded.
+
+Position is what ties a run to its place, and nothing else does: a slack node
+has no name, and the IR gives a caller no offset to recognise one by. So the
+pairing is stated rather than left to follow from the retention rule, which
+fixes only how many runs there are. A caller that reorders, removes or inserts
+occurrences moves values and does not move runs with them, and two generators
+left to decide that for themselves emit different files from one descriptor and
+one set of caller operations.
+
+Where a record carries no run for a slack node, or has more occurrences of one
+than it carries runs, a writer fills what is left over, and [What the descriptor
+determines, a writer
 supplies](#what-the-descriptor-determines-a-writer-supplies) says with what.
 Those bytes were never in a file, so there is nothing there to keep.
 
@@ -327,6 +364,19 @@ question about the call ([Also out of scope](#also-out-of-scope)) — a generato
 understand, and one that hides them entirely satisfies this section. What no
 generator **MAY** do is make surfacing them the mechanism by which they survive.
 A caller obliged to copy a field across is a caller that forgets.
+
+What retention protects is a record that reaches a writer as the record a reader
+produced. A caller that builds a *new* record out of a read one's values hands a
+writer a record carrying nothing, and its slack is filled like any constructed
+record's. That is the ordinary shape of a job that transforms rather than edits,
+and it includes the one case this section would most like to have: converting a
+record from one `REDEFINES` alternative to another is building a record, and a
+program doing exactly that is what laid the sibling's payload down in the first
+place. So the loss described below is not abolished, only moved to where a job
+is making a new record rather than editing one — and it is not softened here. An
+adopter whose job builds declares the bytes it means to keep as an item and
+supplies them, which is the same answer [Four framings, and none of them is a
+RECFM](#four-framings-and-none-of-them-is-a-recfm) gives for a fixed-length pad.
 
 **What is in those bytes.** Three things produce slack and they are not the same
 kind of thing. A `SYNCHRONIZED` alignment gap holds nothing anybody wrote: COBOL
@@ -371,13 +421,13 @@ The member would not be free, either. It is a closed set, so a producer of slack
 nobody anticipated is breaking to admit afterwards — and the question was posed
 as a fork between two producers when the fixed-length pad, which is neither,
 turns out to be the common one. Nor is attribution as crisp as three names make
-it sound. Two runs of slack that abut are one run of bytes in the file, and
-nothing in this document distinguishes one slack node of eight bytes from two of
-five and three; a kind would make that distinction load-bearing for the
-first time, and a `REDEFINES` alternative shorter than its sibling and followed
-by an aligned item puts exactly those two runs next to each other. A producer
-coalescing them would be dropping something, and one that did not would be
-emitting more nodes than the record has runs of bytes.
+it sound. A producer emits one slack node per maximal run of uncovered bytes
+([Slack is a node, not a rule](#slack-is-a-node-not-a-rule)), and a `REDEFINES`
+alternative shorter than its sibling and followed by an aligned item puts a tail
+and an alignment gap into a single run of them. A kind would have to split that
+node by cause, against the rule that made it one node, and a consumer would then
+hold two runs of bytes where the file has one — bought for a distinction nothing
+reads.
 
 Retaining the record's whole bytes instead — every byte, covered by an item or
 not — was the other alternative, and it fails the test this document keeps
@@ -387,12 +437,16 @@ for those bytes and needs a rule saying which wins. Retaining exactly the bytes
 no item covers leaves every byte of a record with one source.
 
 The cost is memory, it lands on every consumer in every language, and it is not
-softened here. A reader holds a copy of bytes most callers will never look at —
-eight in every record of an eighty-byte fixed-length file is a tenth of it — and
-a copy rather than a window onto the input, since a streaming reader reuses the
-buffer it read into. It is charged on the reading side because there is nowhere
-else to charge it: a writer holding a record and a descriptor knows how many
-bytes no item covers and cannot know what was in them.
+softened here. A reader holds bytes most callers will never look at — eight in
+every record of an eighty-byte fixed-length file — and it holds them per
+occurrence where a slack node sits inside a table, so an alignment gap in a
+five-hundred-entry table is five hundred runs and not one. What that costs turns
+on a representation this document leaves to the generator, and its two ends are
+far apart: a run held inline in a fixed-width field of the record costs
+nothing a reader was not already paying, and one allocated per run per record
+costs an allocation per run per record. It is charged on the reading side
+because there is nowhere else to charge it: a writer holding a record and a
+descriptor knows how many bytes no item covers and cannot know what was in them.
 
 ### A variable record is a sum with a variable term
 
@@ -672,9 +726,9 @@ has no file-level charset for one to inherit from — deliberately, since a reco
 whose fields disagree about charset is the ordinary case here. [What the
 descriptor determines, a writer
 supplies](#what-the-descriptor-determines-a-writer-supplies) hits the same wall
-from the other side when it fills slack with zero rather than with a space. The
-difference is that slack could take the byte that names nothing, and a delimiter
-cannot: it is the byte the file actually holds.
+from the other side when it fills a constructed record's slack with zero rather
+than with a space. The difference is that slack could take the byte that names
+nothing, and a delimiter cannot: it is the byte the file actually holds.
 
 Naming a character would not have picked one byte even with a charset to resolve
 it against. A mainframe line-delimited file ends its records with `0x15` or with
@@ -1267,11 +1321,23 @@ The fourth does both again for what the automaton remembers, where a guard is a
 test like a predicate is and a count in a register is determined like a count in
 a field (#76, #77).
 
-Byte identity is a stronger claim, and one thing stands between this document
-and it. Bytes no item covers do survive a read ([Slack survives a
+Byte identity is a stronger claim, and this document makes it of a record and
+not of a file. Bytes no item covers do survive a read ([Slack survives a
 read](#slack-survives-a-read)), so a record read and written back unchanged is
 byte-identical wherever encoding a value reproduces the bytes it was decoded
-from — and whether it does is `codec/SPEC.md`'s question rather than this one's.
+from — `codec/SPEC.md`'s question rather than this one's — and wherever every
+item of it has a value a generator can use, which [Ordering and width, and no
+offset](#ordering-and-width-and-no-offset) says is not every item: a
+numeric-edited or `POINTER` item carries a width here and no value, so a writer
+has no more source for its bytes than it had for slack, and this document has
+not given it one.
+
+A *file* is not byte-identical, and two of its own rules are why. Under
+**optional terminator** a writer emits a final delimiter the input may not have
+carried, and under **segmented** it lays a record into as few segments as the
+largest allows whatever the input did ([Where framing is consumed, and where it
+is emitted](#where-framing-is-consumed-and-where-it-is-emitted)). Both are
+deliberate, and neither is slack's.
 
 ### A writer walks the same automaton
 
@@ -1433,10 +1499,11 @@ that names none. Carrying the fill on the slack node instead would move the same
 invented constant one stage earlier, to where `resolve` has no source for it
 either: neither a copybook nor a layout says what an alignment gap contains.
 
-The invention is confined to bytes that were never in a file, which is what
-keeps #51's round-trip criterion — decode then encode reproduces the original
-bytes — true of a record carrying slack rather than only of one whose items
-cover every byte. A caller that wants a constructed record's slack to hold
+The invention is confined to bytes that were never in a file, so slack is no
+longer what stands between a record carrying it and #51's round-trip criterion —
+decode then encode reproduces the original bytes. What still stands there is
+named in [Writing a file](#writing-a-file)'s preamble, and none of it is
+slack's. A caller that wants a constructed record's slack to hold
 something other than zero declares a trailing item and supplies it, as [Four
 framings, and none of them is a
 RECFM](#four-framings-and-none-of-them-is-a-recfm) says for the fixed-length


### PR DESCRIPTION
Closes #82.

A slack node carries a width and no content, and #79 had to say what a writer puts in those bytes to put writers inside the IR's contract at all. The only answer available was a constant: zero. This settles what a *reader* does with them, which is the half that decides whether the constant is ever reached.

## The decision

Slack bytes survive a read. A consumer **MUST** retain the bytes of every slack node of a record it reads, one run per slack node per occurrence, and **MUST** retain them as they stood when the record was read, for as long as the record can be handed to a writer — not as a view of input it may overwrite, and not re-read from the input when a writer asks. A writer pairs runs to nodes and occurrences **by position** and emits each node's width exactly. Zero bytes are invented only where a record carries no run for a node, or has more occurrences of one than it carries runs.

The rule lives in a new subsection under *Offsets and widths* — **Slack survives a read** — directly after *Slack is a node, not a rule*, and not in *Writing a file*. The obligation is a reader's: a writer has nowhere to get those bytes from if the read did not keep them, and a reader's author has no reason to read the writing section.

**Where the bytes live.** They travel with the record. A generator **MUST NOT** oblige its caller to supply them or carry them across. Whether they are visible in the record's public shape stays the generator's — a generator **MAY** surface them and one that hides them entirely conforms. What none may do is make surfacing them the mechanism by which they survive.

**What retention does not protect**, stated rather than papered over: a job that *builds* a new record from a read one's values gets zero-filled slack. That includes converting a record from one `REDEFINES` alternative to another — awkwardly, since a program doing exactly that is what laid the sibling's payload down.

## Why, and what the case is

Read-modify-write is the case, named in the document so an adopter can tell whether their file is affected: read a file, change one field of one record, write it back. Under a constant fill that zeroes every byte no item of the selected alternative covers, and nothing fails while it happens — the truncation rule does not fire, the no-match rule does not fire, and the file reads back as the records that were written, because the bytes that went missing belonged to no item of any record anybody read.

**There are three producers of slack, not two.** A `SYNCHRONIZED` alignment gap holds nothing anybody wrote. A `REDEFINES` tail holds *another alternative's data*. And the pad on a fixed-length record whose items stop short of LRECL holds whatever the program that wrote the file left there, which on these files is spaces — the shape #78 already flagged as making this common rather than rare, and the one the issue's two-way framing did not have.

Settled now rather than later because retention is a requirement on every consumer and not a field on a node, so a consumer that has not heard of it cannot ignore it and stay correct — the versioning policy's own test for breaking, whatever protobuf would make of a change that alters no schema at all.

## Why the slack node gains no kind

All three producers get the same answer, so the node still carries a width and nothing else. Under retention nothing would read a kind: retaining an alignment gap costs what retaining anything costs and loses nothing.

Nor is attribution crisp. A producer emits one slack node per **maximal** run, and a `REDEFINES` alternative shorter than its sibling followed by an aligned item puts a tail and an alignment gap into a single run. A kind would have to split that node by cause, against the rule that made it one node, for a distinction nothing reads.

**Rejected alternative:** retaining the record's whole bytes. It states every byte twice, so a writer handed a record whose caller changed a field has two answers for those bytes. Retaining exactly the bytes no item covers leaves every byte with one source.

**The cost is stated, not hidden:** memory, on every consumer in every language, per occurrence where a slack node sits inside a table — an alignment gap in a five-hundred-entry table is five hundred runs. What that costs turns on a representation left to the generator, and its two ends are far apart.

## What the adversarial review changed

Five isolated reviewers, one scenario each, blind to each other: read-modify-write over `REDEFINES`, an `OCCURS DEPENDING ON` table, a third-party generator in another language, a 100M-record streaming reader, and an ETL rebuild path. All five endorsed retention and the no-kind argument. Seven findings landed.

**A retained run was bound to nothing** — reached independently by four reviewers from four scenarios. The rule fixed *how many* runs a record carries and never *which run belongs where*, so a caller sorting, filtering or inserting occurrences left two conforming generators emitting different files from one descriptor. Hence positional pairing, and the deletion of the "an occurrence its caller added" clause: it named a fact no record carries, and #52 carried an acceptance criterion asserting behaviour the spec could not deliver.

**Retention's lifetime was descriptive, not normative.** The one sentence carrying it — *a copy rather than a window onto the input* — sat in the cost paragraph, which `CONVENTIONS.md` makes non-normative. A streaming reader keeping a window onto its reused buffer satisfied every **MUST**, passed every fixture #52 mandates, and handed each record the *next* record's slack. Now normative, and stated once rather than twice.

**The rule making a `REDEFINES` tail slack was circular.** A record's extent is the sum of its items *and* its slack, so an alternative emitted without a slack node has no byte that no item occupies and satisfies the rule vacuously. The only text closing that loop was declarative. A producer **MUST** now emit the tail node explicitly — the premise of this whole change, promoted to a requirement.

**Granularity became load-bearing in this change, and the change claimed it hadn't.** Retention makes a record carry one run per slack node, so how a producer divides uncovered bytes decides every generated record's shape. Hence one node per maximal run; the no-kind argument is rebuilt on it and is stronger for it.

**Byte identity was overclaimed**, reached by four reviewers. Now scoped to a record, naming what still stands in the way: `codec/SPEC.md`'s re-encoding question, items the IR gives a generator no usable value for (numeric-edited, national, `INDEX`, `POINTER` — no more source for their bytes than slack had), and two of this document's own framing rules, the final delimiter under **optional terminator** and re-segmentation under **segmented**.

**An empty retained run** is a wrong-length run, not an absent one — otherwise a writer either refuses every constructed record or silently accepts a truncated one, and both readings were defensible.

Also: a stale cross-reference in *A delimiter is bytes, not a character* still said a writer fills slack with zero; every other pointer had been updated.

## Filed rather than fixed here

**#92** — a fixed-length dataset cannot carry a variable-extent record. `pad` is one number and `fixed + width × count + pad` cannot equal LRECL at two counts, so *Four framings*' account-for-all-of-LRECL requirement is unsatisfiable for any record type with an `OCCURS DEPENDING ON` table, and a reader misaligns after record one with nothing in the file to disagree. Pre-existing and larger than #82; blocked on #87, which may dissolve it.

**Tempered:** the #87 sliding-versus-maximum contingency is real but the document currently reads sliding and the answer is #87's. And the claim that a read-only reader holds "800MB of dead padding" is wrong — the live set is one record, as that reviewer concedes two findings later.

## Backlog

- **#52** gains retention, the copy-not-window fixture (a test writing each record inside the iteration that read it cannot detect the violation), positional pairing, the empty-run rule, a read-modify-write fixture, and the note that byte round-trips are record-level because this writer's own framing rules break file-level identity.
- **#51** gains retention on decode/encode and coverage of all three producers; its "unconditional" round-trip claim is struck and replaced with the two things that still stand in the way.
- **#49** gains storage for the retained bytes, with the caller not made responsible for them — and a `blocked_by` edge, since the structs are where the bytes live.
- **#34** gains the maximal-run rule and the explicit `REDEFINES` tail node; its "adjacent runs are indifferent" note is corrected, since retention made granularity observable.
- **#17** drops #82 as a blocker — the answer adds no field — and is down to #80, #87, #90 and now #92.
- **#26** records that the LRECL pad it validates survives a read.

Also in the *Mapping to Stories* table: #79 was missing from the *Writing a file* row it produced, and is added alongside #82.

`dagger call ci` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
