### PR TITLE
story(issue-102): install the backlog plugin on the repo

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "z5labs-devex": {
+      "source": {
+        "source": "github",
+        "repo": "z5labs/devex"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "backlog@z5labs-devex": true
+  }
+}


### PR DESCRIPTION
Closes #102.

Enables `backlog@z5labs-devex` for everyone working in this repository by
tracking `.claude/settings.json`.

`enabledPlugins` names a plugin by its marketplace, so enabling it alone would
break on a fresh clone — the `z5labs-devex` marketplace would be unknown and the
plugin would not resolve. `extraKnownMarketplaces` declares the source alongside
it, so a clone picks up the backlog skills without anyone running
`/plugin marketplace add z5labs/devex` by hand.

Per-operator settings are unaffected: `.claude/settings.local.json` stays
ignored, so permissions and the unattended-run authorization remain personal to
each checkout.

No Go, Dagger, or spec files are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
