### PR TITLE
story(ir): build a FileDescriptorSet for codegen-free plugin authors

### DIFF
--- a/.dagger/dagger.gen.go
+++ b/.dagger/dagger.gen.go
@@ -216,6 +216,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Cpybkc).Fmt(&parent, ctx)
+		case "IrArtifacts":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Cpybkc).IrArtifacts(&parent, ctx)
 		case "IrCi":
 			var parent Cpybkc
 			err = json.Unmarshal(parentJSON, &parent)
@@ -223,6 +230,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Cpybkc).IrCi(&parent, ctx)
+		case "IrDescriptorSet":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Cpybkc).IrDescriptorSet(&parent), nil
+		case "IrProtos":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Cpybkc).IrProtos(&parent), nil
 		case "Lint":
 			var parent Cpybkc
 			err = json.Unmarshal(parentJSON, &parent)

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -59,6 +59,22 @@
 // produces irpb/ir.pb.go, kept here because a generation recipe living anywhere
 // else is a second answer to how the committed stubs were made.
 //
+// # Why the release artifacts are built here
+//
+// IrDescriptorSet and IrProtos produce the two files a release attaches — the
+// IR's FileDescriptorSet and the schema sources (#19) — and they are functions
+// on this module for the same reason ProtoLint is: a recipe that only ever ran
+// inside .github/workflows/release.yaml would be a build nobody can reproduce
+// locally and one that first runs on a tag, where a failure is a release that
+// did not happen. Here, `dagger call ir-descriptor-set` is a command a
+// contributor runs, and IrArtifacts puts both builds inside Ci so the recipe is
+// exercised on every pull request rather than once per release.
+//
+// They are also the seam the container work builds on: #57 copies the same file
+// into the published image, from this function rather than from a second
+// invocation of protoc, which is what makes the release asset and the in-image
+// copy two ways of getting one artifact.
+//
 // Ci is what CI calls and what a contributor should run before pushing. The
 // stage functions are for narrowing down what Ci reported.
 package main
@@ -66,6 +82,8 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
+	"slices"
 	"sync"
 
 	"dagger/cpybkc/internal/dagger"
@@ -124,11 +142,12 @@ func New(
 
 // Ci runs the whole pipeline: fmt, vet, golangci-lint and `go test -race`, as
 // the Z5Labs standard defines them, over each of this repository's two Go
-// modules, plus `buf lint` over the IR schema. This is the single entrypoint —
-// CI is one `dagger call ci` and stays one, because a workflow step that reran
-// any of these stages would be a second definition of them.
+// modules, plus `buf lint` over the IR schema and a build of the two artifacts a
+// release publishes. This is the single entrypoint — CI is one `dagger call ci`
+// and stays one, because a workflow step that reran any of these stages would be
+// a second definition of them.
 //
-// The three parts run concurrently and all are reported, for the reason the
+// The four parts run concurrently and all are reported, for the reason the
 // standard runs its own four that way: waiting on a Go stage to learn that the
 // schema is unlintable, or the reverse, is a second push to find out about the
 // second failure.
@@ -136,10 +155,10 @@ func New(
 // +check
 // +cache="session"
 func (m *Cpybkc) Ci(ctx context.Context) error {
-	var goErr, irErr, protoErr error
+	var goErr, irErr, protoErr, artifactErr error
 
 	var wg sync.WaitGroup
-	wg.Add(3)
+	wg.Add(4)
 
 	go func() {
 		defer wg.Done()
@@ -158,9 +177,14 @@ func (m *Cpybkc) Ci(ctx context.Context) error {
 		protoErr = m.ProtoLint(ctx)
 	}()
 
+	go func() {
+		defer wg.Done()
+		artifactErr = m.IrArtifacts(ctx)
+	}()
+
 	wg.Wait()
 
-	return errors.Join(goErr, irErr, protoErr)
+	return errors.Join(goErr, irErr, protoErr, artifactErr)
 }
 
 // IrCi runs the same standard pipeline over irpb/, the published IR module.
@@ -277,6 +301,113 @@ func (m *Cpybkc) ProtoGen() *dagger.Directory {
 		WithWorkdir("/src").
 		WithExec([]string{"buf", "generate"}).
 		Directory("/src/irpb")
+}
+
+// IrDescriptorSet builds the IR's protobuf FileDescriptorSet — the published
+// ir.binpb — by compiling this repository and asking irpb for it:
+//
+//	dagger call ir-descriptor-set export --path=ir.binpb
+//
+// It is what the release workflow attaches to a release, and what the base image
+// will copy in at the path docs/container/SPEC.md fixes (#57). Both forms are
+// two ways of getting one artifact rather than two artifacts, which only holds
+// while there is one recipe; this is it.
+//
+// It is a function on this module rather than steps in a workflow for the reason
+// .github/workflows/ci.yaml already gives: repo-specific work lands here and is
+// invoked with `dagger call`, so a contributor produces the same bytes CI does
+// with the same command, and there is no second recipe living in YAML that
+// nobody can run locally.
+//
+// dag.Go().Container is the escape hatch the standard Go module offers for
+// exactly this — a command its typed helpers do not cover. Using it rather than
+// a container of this module's own keeps the toolchain version read out of
+// go.mod, where this repository's toolchain version already lives, instead of
+// pinning a golang: tag here that could drift from it.
+//
+// The bytes are a function of the schema: irpb.MarshalFileDescriptorSet encodes
+// deterministically and the file order is fixed by the protos' imports, so two
+// runs over an unchanged tree produce an identical artifact. That is what makes
+// the published file comparable across releases at all.
+func (m *Cpybkc) IrDescriptorSet() *dagger.File {
+	const out = "/out/ir.binpb"
+
+	return dag.Go().
+		Container(m.Source).
+		WithExec([]string{"go", "run", "./internal/tools/ir-descriptor-set", "-o", out}).
+		File(out)
+}
+
+// IrProtos builds the IR schema sources — the published ir-protos.tar.gz —
+// preserving each file's path under proto/:
+//
+//	dagger call ir-protos export --path=ir-protos.tar.gz
+//
+// It is the other artifact a release carries, and it is for the consumer
+// IrDescriptorSet is not for: the one whose build can run protoc and would
+// rather generate bindings than decode dynamically. internal/tools/ir-protos
+// carries the argument for why it is an archive and not the one .proto file.
+//
+// Its bytes are a function of the schema too — every tar field the filesystem
+// could have supplied is a constant and the entries are sorted — so the same
+// commit archives to the same artifact.
+func (m *Cpybkc) IrProtos() *dagger.File {
+	const out = "/out/ir-protos.tar.gz"
+
+	return dag.Go().
+		Container(m.Source).
+		WithExec([]string{"go", "run", "./internal/tools/ir-protos", "-o", out}).
+		File(out)
+}
+
+// IrArtifacts builds both release artifacts and fails if either is empty.
+//
+// It is in Ci so that the recipe a release runs is exercised on every pull
+// request. Without it the only thing that ever runs `go run
+// ./internal/tools/ir-descriptor-set` in a container is the release workflow, on
+// a tag, once — and a build tool that has never been run outside a test is one
+// whose first real invocation is the one nobody can retry.
+//
+// The Go tests own the artifacts' contents and their determinism, which is why
+// this asserts nothing about either. What it asserts is the part they cannot:
+// that the two commands run to completion in a container built from go.mod and
+// leave a file behind. An empty file is the failure worth naming, because it is
+// what a tool that wrote its parent directory and exited would produce, and it
+// uploads as happily as a good one.
+//
+// +check
+// +cache="session"
+func (m *Cpybkc) IrArtifacts(ctx context.Context) error {
+	artifacts := map[string]*dagger.File{
+		"ir.binpb":         m.IrDescriptorSet(),
+		"ir-protos.tar.gz": m.IrProtos(),
+	}
+
+	names := make([]string, 0, len(artifacts))
+	for name := range artifacts {
+		names = append(names, name)
+	}
+
+	// Sorted, so that two runs failing on two different artifacts report them in
+	// the same order rather than in whichever order the map produced.
+	slices.Sort(names)
+
+	var errs []error
+
+	for _, name := range names {
+		size, err := artifacts[name].Size(ctx)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to build %s: %w", name, err))
+
+			continue
+		}
+
+		if size == 0 {
+			errs = append(errs, fmt.Errorf("%s built to an empty file", name))
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 // stage returns the check builder the standard pipeline builds on, bound to

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,12 +53,15 @@ jobs:
     name: ci
     runs-on: ubuntu-latest
     permissions:
-      # Reading the source is all the pipeline does. No `packages: write`,
-      # because nothing is pushed; no `id-token: write`, because nothing is
-      # attested — the module produces no artifact to sign. Both grants belong
-      # to the change that gives it one, next to the stage that needs them,
-      # rather than being held here in advance against a job that would not
-      # notice them missing.
+      # Reading the source is all the pipeline does. It now builds the two IR
+      # artifacts a release attaches (#19), but it builds them inside the engine
+      # and throws them away — nothing here uploads, pushes or signs anything.
+      # So no `contents: write`, which belongs to release.yaml's job because
+      # that is where an asset is attached; no `packages: write`, because
+      # nothing is pushed; and no `id-token: write`, because nothing is attested
+      # yet (#58). Each grant belongs to the change that gives it a use, next to
+      # the step that needs it, rather than being held here in advance against a
+      # job that would not notice it missing.
       contents: read
     steps:
       # A shallow checkout on purpose. The module excludes .git from the source

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,87 @@
+name: Release
+
+# A published release is the trigger, not a pushed tag. The distinction matters
+# for what this workflow does: it uploads assets onto a release object, and a
+# release object only exists once somebody has published one. Firing on the tag
+# would mean racing the person who is about to create the release, and losing
+# that race means uploading to a release that is not there yet.
+#
+# `published` covers both a release created straight away and a draft released
+# later, which is the shape a release with notes to write actually takes.
+#
+# There is no filter on which tag. This repository publishes two tag schemes —
+# vX.Y.Z for the CLI and irpb/vX.Y.Z for the IR module — and the IR is what both
+# of them ship, so both get the artifacts. The bytes are a function of the tag's
+# source, so each release's assets describe the schema that release carried, and
+# a reader who has found a release has the IR one download away without having to
+# know which of the two schemes is the one that publishes it.
+on:
+  release:
+    types: [published]
+
+# The floor for every job. The one job that has to write says so itself.
+permissions:
+  contents: read
+
+jobs:
+  # The two IR artifacts, attached to the release.
+  #
+  # ir.binpb is the protobuf FileDescriptorSet describing cpybkc.ir.v1.Descriptor
+  # (#19), so that a plugin author whose language has no protobuf code generation
+  # in the build can fetch one file and decode a descriptor dynamically — see
+  # docs/ir/SPEC.md, "Reading a descriptor without generated code".
+  # ir-protos.tar.gz is the schema itself, at the paths a compiler expects, for
+  # the consumer who would rather generate bindings than decode against a
+  # descriptor set. Neither substitutes for the other.
+  #
+  # The same ir.binpb bytes will ship inside the published image (#57). That is
+  # two ways of getting one artifact rather than two artifacts, and what keeps it
+  # so is that both come from `dagger call ir-descriptor-set` rather than from
+  # two recipes that agree today.
+  ir-artifacts:
+    name: IR artifacts
+    runs-on: ubuntu-latest
+    permissions:
+      # Reading the source, and writing the assets onto the release. Nothing else
+      # in this workflow needs either, which is why the grant is on the job
+      # rather than at the top of the file.
+      contents: write
+    steps:
+      # At the release's tag, not at whatever main has moved to since. The
+      # artifacts are a function of the source, so an asset built from a
+      # different commit would describe an IR that release never shipped.
+      - name: Check out the release's tag
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      # Pinned to the engineVersion the module itself declares, read out of
+      # dagger.json rather than repeated here — the same step, for the same
+      # reason, as ci.yaml's.
+      - name: Install the Dagger CLI
+        run: |
+          curl -fsSL https://dl.dagger.io/dagger/install.sh \
+            | DAGGER_VERSION="$(jq -r .engineVersion dagger.json | tr -d v)" \
+              BIN_DIR="$HOME/.local/bin" sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # The same two functions `dagger call ci` builds on every pull request and
+      # a contributor runs locally, so the released assets are produced by a
+      # recipe that has already been exercised rather than by one that only ever
+      # runs at release time.
+      - name: Build the IR artifacts
+        run: |
+          dagger call ir-descriptor-set export --path "$RUNNER_TEMP/ir.binpb"
+          dagger call ir-protos export --path "$RUNNER_TEMP/ir-protos.tar.gz"
+
+      # --clobber so that re-running a failed release job replaces the assets
+      # instead of failing on a name that is already taken. Both artifacts are a
+      # function of the tag's source, so a re-upload cannot change what they say.
+      - name: Attach them to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            "$RUNNER_TEMP/ir.binpb" \
+            "$RUNNER_TEMP/ir-protos.tar.gz" \
+            --clobber

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,11 @@
 
 ## The pipeline
 
-fmt, vet, golangci-lint, `go test -race` and `buf lint` are defined once, in the
-root Dagger module under [`.dagger/`](.dagger/). CI calls that module and so do
-you, which is the point: there is no arrangement of local commands that passes
-while CI fails, because they are the same functions.
+fmt, vet, golangci-lint, `go test -race`, `buf lint` and the two artifacts a
+release attaches are defined once, in the root Dagger module under
+[`.dagger/`](.dagger/). CI calls that module and so do you, which is the point:
+there is no arrangement of local commands that passes while CI fails, because
+they are the same functions.
 
 Run the whole thing before pushing:
 
@@ -15,7 +16,8 @@ dagger call ci
 
 That is the same call CI makes, with no arguments on either side. It runs the
 four Go stages in parallel and reports every failure, not just the first, and it
-runs the schema lint and the IR module's own stages alongside them.
+runs the schema lint, the IR module's own stages and a build of the [release
+artifacts](#the-release-artifacts) alongside them.
 
 ### Running one stage
 
@@ -23,12 +25,13 @@ runs the schema lint and the IR module's own stages alongside them.
 it reported.
 
 ```sh
-dagger call fmt         # gofmt, reported as a diff of what it would rewrite
-dagger call vet         # go vet ./...
-dagger call lint        # golangci-lint over ./... against .golangci.yml
-dagger call test        # go test -race ./...
-dagger call proto-lint  # buf lint over proto/ against buf.yaml
-dagger call ir-ci       # the whole standard again, over the irpb/ module
+dagger call fmt           # gofmt, reported as a diff of what it would rewrite
+dagger call vet           # go vet ./...
+dagger call lint          # golangci-lint over ./... against .golangci.yml
+dagger call test          # go test -race ./...
+dagger call proto-lint    # buf lint over proto/ against buf.yaml
+dagger call ir-ci         # the whole standard again, over the irpb/ module
+dagger call ir-artifacts  # builds the two artifacts a release attaches
 ```
 
 The first four are not a second definition of the pipeline. Each drives the same
@@ -39,9 +42,10 @@ standard has no protobuf stage to wrap; see [Linting the IR
 schema](#linting-the-ir-schema).
 
 `ir-ci` is not a stage but the whole standard a second time, over the second Go
-module; see [The IR module](#the-ir-module) for why there is one.
+module; see [The IR module](#the-ir-module) for why there is one. `ir-artifacts`
+is not a stage either; see [The release artifacts](#the-release-artifacts).
 
-`dagger check` runs all seven as a checklist, if you would rather see them
+`dagger check` runs all eight as a checklist, if you would rather see them
 together than pick one.
 
 ### Getting the tools
@@ -211,6 +215,49 @@ tags. If the schema ever breaks its wire format and becomes package
 `cpybkc.ir.v2`, the Go module becomes `github.com/Zaba505/cpybkc/irpb/v2` under
 Go's major-version rule, and the two version suffixes agree without either being
 kept in step by hand.
+
+## The release artifacts
+
+Every published release carries two files describing the IR, for the plugin
+authors who are not importing `irpb`:
+
+```sh
+dagger call ir-descriptor-set export --path=ir.binpb
+dagger call ir-protos export --path=ir-protos.tar.gz
+```
+
+`ir.binpb` is the protobuf `FileDescriptorSet` describing
+`cpybkc.ir.v1.Descriptor`, which is what lets a runtime with no code generation
+in the build decode a descriptor dynamically. `ir-protos.tar.gz` is the schema
+sources at the paths their protobuf packages require, for a build that would
+rather compile them. [Reading a descriptor without generated
+code](docs/ir/SPEC.md#reading-a-descriptor-without-generated-code) is the
+contract for both, and it is the document to change if what they contain changes.
+
+Three properties are worth knowing before you touch either:
+
+- **Neither is committed.** `ir.binpb` is computed from the descriptors
+  `protoc-gen-go` compiled into `irpb`, so it cannot drift from the schema; a
+  checked-in copy could. Changing `ir.proto` and regenerating `irpb/ir.pb.go`
+  changes what is published, in the same commit.
+- **Both are reproducible.** Two builds of one commit produce byte-identical
+  files — the encoding is deterministic and every tar field the filesystem could
+  have supplied is a constant — because an artifact that moved on a rebuild would
+  make a rebuild indistinguishable from a change to the contract.
+- **`dagger call ci` builds them.** `ir-artifacts` is in the pipeline so that the
+  recipe a release runs is exercised on every pull request, rather than for the
+  first time on a tag. What is in them is asserted by Go tests, in `irpb` and
+  beside each tool under `internal/tools/`; the pipeline stage only checks that
+  both commands run to completion and leave a file behind.
+
+A `.proto` added under `proto/` that nothing reachable from
+`cpybkc.ir.v1.Descriptor` imports fails `TestPublishedFileDescriptorSetCoversTheSchema`.
+That is deliberate: the IR is one message and everything in `proto/` is reachable
+from it, so a file that is not is a mistake in the schema rather than something
+to exclude.
+
+`.github/workflows/release.yaml` attaches both to a release when one is
+published, building them with the same two calls above at the release's tag.
 
 ## Specs
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ A generator plugin written in Go imports the resolved IR from
 [`irpb`](irpb/) — `github.com/Zaba505/cpybkc/irpb`, a module of its own, so that
 building against the contract costs the protobuf runtime and nothing else.
 
+A plugin written in anything else takes one of the two artifacts attached to
+every release: `ir.binpb`, the protobuf `FileDescriptorSet` that lets any
+runtime decode a descriptor with no code generation in the build, or
+`ir-protos.tar.gz`, the schema sources for a build that would rather compile
+them. [Reading a descriptor without generated
+code](docs/ir/SPEC.md#reading-a-descriptor-without-generated-code) is the
+contract for both.
+
 ## Contributing
 
 `dagger call ci` runs fmt, vet, lint and `go test -race` — the same call CI

--- a/docs/ir/SPEC.md
+++ b/docs/ir/SPEC.md
@@ -3073,6 +3073,77 @@ What that buys is an IR that is a thing at rest. It can be written to a file
 (#20), converted to JSON and read (#21), committed, diffed, and replayed against
 a plugin by hand a year later. None of those is available to a protocol.
 
+## Reading a descriptor without generated code
+
+The section above claims self-description. This is the artifact that delivers
+it, and what a consumer may assume about it.
+
+A `FileDescriptorSet` describing this schema is published with every release, as
+the asset **`ir.binpb`** (#19). It is protobuf's own reflection type, encoded in
+the protobuf binary wire format, and every protobuf runtime can build message
+types out of one at run time. A consumer holding it needs no `.proto` file, no
+compiler and no build step to decode a descriptor.
+
+The schema sources are published beside it, as **`ir-protos.tar.gz`**, each file
+at the path its protobuf package requires. That is for the consumer whose build
+*can* run a compiler and would rather generate bindings; the two are
+alternatives, and neither is derived from the other. The published image
+carries the same `ir.binpb` bytes at a path the [container
+contract](../container/SPEC.md) fixes (#57) — one artifact reachable two ways,
+not two artifacts.
+
+### What the set contains
+
+The set **MUST** carry the file defining `cpybkc.ir.v1.Descriptor` and the
+transitive closure of that file's imports, and **MUST NOT** carry anything else.
+The root is the message a plugin is handed, so a schema file this project might
+add that nothing reachable from `Descriptor` imports is not part of the IR, and
+is not published as though it were.
+
+It **MUST** be self-contained: every path named as a dependency by a file in the
+set is a file the set also carries. A consumer's registry fails on the other
+arrangement, and it fails naming a file the consumer has never heard of.
+
+Files **MUST** appear in dependency order — a file only after every file it
+imports. A consumer that walks the set once, building each file's types as it
+goes, is the shape most dynamic protobuf APIs make easiest, and the other order
+fails it at a type reference rather than at a file.
+
+The encoded bytes **MUST** be a function of the schema alone: two builds of one
+commit produce one artifact, and the artifact changes only when the schema does.
+Otherwise a rebuild is indistinguishable from a change to the contract, and an
+adopter diffing two releases learns nothing.
+
+### What is deliberately absent
+
+Comments and source positions. The set carries field numbers, types, names and
+nesting — everything a decode needs — and no `SourceCodeInfo`, so it describes
+the schema rather than the document. The prose is this specification's, and a
+copy of it inside a binary artifact would be a second one to keep current. A
+reader who wants the comments wants `ir-protos.tar.gz`.
+
+### Reading one
+
+Four calls, in every runtime that has them, whatever they are spelled:
+
+1. Decode `ir.binpb` into a `FileDescriptorSet`.
+2. Build a type registry — a file or descriptor pool — from it.
+3. Look up `cpybkc.ir.v1.Descriptor` by name.
+4. Make a dynamic message of that type and decode the file cpybkc passed as
+   `--descriptor` into it.
+
+Everything this document requires of a consumer still binds one that arrived
+this way. In particular it **MUST** read the version field before anything else
+and **MUST** refuse a version it does not understand ([The version
+field](#the-version-field)) — a dynamic decode makes an unknown version easier
+to read, not less binding, because nothing failed to compile on the way in.
+
+The runnable form is `Example_readADescriptorWithoutGeneratedCode` in
+[`irpb/descriptor_set_test.go`](../../irpb/descriptor_set_test.go). It is a test
+rather than a listing here so that the example is checked on every run: the four
+calls above are the shape, and a worked example that had rotted would be worse
+than none.
+
 ## Out of Scope
 
 ### Layout source syntax
@@ -3464,7 +3535,9 @@ records offer them.
 | [Writing a file](#writing-a-file) | #79, #80, #82, #88, #89, #90 `ir`, #51, #52 `gen-go` |
 | [Versioning and compatibility](#versioning-and-compatibility) | #17, #18 `ir` |
 | [Why protobuf, and why no gRPC](#why-protobuf-and-why-no-grpc) | #17, #19 `ir` |
+| [Reading a descriptor without generated code](#reading-a-descriptor-without-generated-code) | #19 `ir`, #57 `container` |
 | The schema itself | #17 `ir` — [`proto/cpybkc/ir/v1/ir.proto`](../../proto/cpybkc/ir/v1/ir.proto) |
 | The schema, as Go | #18 `ir` — [`irpb/`](../../irpb), a module of its own |
+| The published artifacts | #19 `ir` — [`irpb/descriptor_set.go`](../../irpb/descriptor_set.go) computes the set, [`internal/tools/`](../../internal/tools) writes both files, `.dagger/main.go` builds them and `.github/workflows/release.yaml` attaches them |
 | Emitting the IR | #20, #21 `ir` |
 | Conventions this document follows | #15 `setup` |

--- a/internal/tools/ir-descriptor-set/main.go
+++ b/internal/tools/ir-descriptor-set/main.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Command ir-descriptor-set writes the IR's protobuf FileDescriptorSet — the
+// published ir.binpb — to a file.
+//
+// It is the pipeline's hands and nothing more. What the set contains, what order
+// it is in and why its bytes are stable is
+// [github.com/Zaba505/cpybkc/irpb.FileDescriptorSet]'s to say; this program
+// exists so that a Dagger function has something to run, and so that the
+// artifact is produced by compiling this repository rather than by somebody
+// remembering to run protoc and commit the output. There is no committed .binpb
+// for that reason: the set is a function of proto/, and the only way to keep a
+// second copy of it honest is not to have one.
+//
+// It lives under internal/ deliberately. It is not part of cpybkc's published
+// surface, nothing outside this repository has a reason to run it, and putting
+// it under cmd/ would make a build tool look like a shipped command — which
+// matters more here than usual, because cmd/ is empty and the first thing to
+// land there decides what a reader expects to find in it.
+//
+//	go run ./internal/tools/ir-descriptor-set -o ir.binpb
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Zaba505/cpybkc/irpb"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "ir-descriptor-set: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// run is separated from main so that the exit path is the only thing main owns,
+// and so that a test can drive the whole program without ending the test binary.
+func run(args []string) error {
+	flags := flag.NewFlagSet("ir-descriptor-set", flag.ContinueOnError)
+	out := flags.String("o", "", "path to write the FileDescriptorSet to (required)")
+
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+
+	if *out == "" {
+		return fmt.Errorf("-o is required: name the file to write")
+	}
+
+	if rest := flags.Args(); len(rest) > 0 {
+		return fmt.Errorf("unexpected arguments %v", rest)
+	}
+
+	b, err := irpb.MarshalFileDescriptorSet()
+	if err != nil {
+		return err
+	}
+
+	// The parent directory is created rather than required, because the caller
+	// is a pipeline naming an output path in a fresh container filesystem —
+	// /out/ir.binpb has no /out until something makes one, and failing there
+	// would be this program reporting on the shape of its caller's environment
+	// instead of doing its job.
+	if dir := filepath.Dir(*out); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("failed to create %s: %w", dir, err)
+		}
+	}
+
+	if err := os.WriteFile(*out, b, 0o644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", *out, err)
+	}
+
+	return nil
+}

--- a/internal/tools/ir-descriptor-set/main_test.go
+++ b/internal/tools/ir-descriptor-set/main_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/irpb"
+)
+
+// TestRunWritesThePublishedBytes asserts the whole of what this program is for:
+// the file on disk is what irpb publishes, byte for byte. Anything this tool did
+// to the bytes on the way past — a trailing newline, a re-encode with different
+// options — would make the released artifact differ from the set every test in
+// irpb checks.
+func TestRunWritesThePublishedBytes(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "ir.binpb")
+
+	if err := run([]string{"-o", out}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read %s: %v", out, err)
+	}
+
+	want, err := irpb.MarshalFileDescriptorSet()
+	if err != nil {
+		t.Fatalf("marshal the published set: %v", err)
+	}
+
+	if !bytes.Equal(got, want) {
+		t.Fatalf("the written artifact is not the published set: %d bytes on disk, %d bytes published", len(got), len(want))
+	}
+}
+
+// TestRunIsReproducible is the acceptance criterion, checked where the artifact
+// is actually produced. irpb already asserts that two encodings agree; this
+// asserts that two runs of the program that writes the release asset agree too,
+// which is the claim a consumer comparing two downloads is relying on.
+func TestRunIsReproducible(t *testing.T) {
+	dir := t.TempDir()
+
+	first := filepath.Join(dir, "first", "ir.binpb")
+	if err := run([]string{"-o", first}); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+
+	second := filepath.Join(dir, "second", "ir.binpb")
+	if err := run([]string{"-o", second}); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+
+	a := readFile(t, first)
+	b := readFile(t, second)
+
+	if len(a) == 0 {
+		t.Fatal("the artifact is empty")
+	}
+
+	if !bytes.Equal(a, b) {
+		t.Fatalf("two runs over the same schema produced different artifacts: %d bytes then %d bytes", len(a), len(b))
+	}
+}
+
+// TestRunCreatesTheParentDirectory covers the case the pipeline actually hits:
+// an output path under a directory that does not exist yet, because the
+// container's filesystem has no /out until something makes one.
+func TestRunCreatesTheParentDirectory(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "out", "nested", "ir.binpb")
+
+	if err := run([]string{"-o", out}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if _, err := os.Stat(out); err != nil {
+		t.Fatalf("stat %s: %v", out, err)
+	}
+}
+
+// TestRunRejectsBadUsage keeps the failure modes failures. A missing -o that
+// silently wrote nothing would leave a release job green with no asset to
+// upload, which is the one outcome nobody would notice.
+func TestRunRejectsBadUsage(t *testing.T) {
+	testCases := []struct {
+		name string
+		args []string
+	}{
+		{name: "no output path", args: nil},
+		{name: "empty output path", args: []string{"-o", ""}},
+		{name: "unexpected operand", args: []string{"-o", filepath.Join(t.TempDir(), "ir.binpb"), "extra"}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if err := run(testCase.args); err == nil {
+				t.Error("run accepted arguments it should have refused")
+			}
+		})
+	}
+}
+
+func readFile(t *testing.T, path string) []byte {
+	t.Helper()
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	return b
+}

--- a/internal/tools/ir-protos/main.go
+++ b/internal/tools/ir-protos/main.go
@@ -1,0 +1,247 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Command ir-protos writes the IR schema sources — the published
+// ir-protos.tar.gz — to a file.
+//
+// It is the other half of what a release carries for a consumer who is not
+// importing [github.com/Zaba505/cpybkc/irpb]. ir.binpb is for the plugin author
+// whose language cannot run protoc; this is for the one who can, and who wants
+// to generate bindings from the schema rather than decode against a
+// FileDescriptorSet. Neither substitutes for the other, and both are attached to
+// every release so that a version of the IR is one download away in whichever
+// form the consumer's build already understands.
+//
+// # Why an archive rather than the file
+//
+// proto/ holds exactly one .proto today, so a single attached ir.proto would
+// have been simpler and would have been wrong. A .proto's path is part of its
+// identity: it is the name a FileDescriptorProto carries, the string an import
+// in another schema resolves, and — because buf.yaml enforces
+// PACKAGE_DIRECTORY_MATCH — the directory layout the protobuf package name
+// requires. Flattening cpybkc/ir/v1/ir.proto to ir.proto hands a consumer a file
+// that compiles and produces descriptors naming a path this project does not
+// publish. The archive carries the layout, so unpacking it yields an include
+// root a compiler can be pointed at directly:
+//
+//	tar xf ir-protos.tar.gz && protoc -I. --python_out=. cpybkc/ir/v1/ir.proto
+//
+// It also means a second .proto arrives in the artifact without anything here
+// changing, which is the same reason the Dagger function that regenerates the Go
+// stubs returns a directory.
+//
+// # Why the bytes are stable
+//
+// Every field a tar header could take from the filesystem — modification time,
+// owner, group, permissions beyond the mode written here — is set to a constant,
+// and the entries are emitted in sorted order rather than in the order a
+// directory read happened to return. What is left is a function of the file
+// names and the file contents, so two builds of one commit produce one artifact.
+// The gzip layer contributes no timestamp and no original file name for the same
+// reason; its compressed output is fixed by the Go release the pipeline's
+// container pins, which is where this repository's toolchain version already
+// lives.
+//
+// It lives under internal/ for the reason ir-descriptor-set does: nothing
+// outside this repository has a reason to run it, and cmd/ is where a shipped
+// command goes.
+//
+//	go run ./internal/tools/ir-protos -o ir-protos.tar.gz
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"time"
+)
+
+// epoch is the modification time every entry carries.
+//
+// A constant rather than SOURCE_DATE_EPOCH, because there is no timestamp in
+// this artifact that means anything: the archive holds source files whose
+// history is git's, and a build time recorded here would be the one field
+// distinguishing two builds of the same commit. Zero is the conventional choice
+// and the one a reader recognises as deliberate.
+var epoch = time.Unix(0, 0).UTC()
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "ir-protos: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// run is separated from main so that the exit path is the only thing main owns,
+// and so that a test can drive the whole program without ending the test binary.
+func run(args []string) error {
+	flags := flag.NewFlagSet("ir-protos", flag.ContinueOnError)
+	out := flags.String("o", "", "path to write the archive to (required)")
+	source := flags.String("source", "proto", "the schema root to archive; its layout is preserved inside the archive")
+
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+
+	if *out == "" {
+		return fmt.Errorf("-o is required: name the file to write")
+	}
+
+	if rest := flags.Args(); len(rest) > 0 {
+		return fmt.Errorf("unexpected arguments %v", rest)
+	}
+
+	// The parent directory is created rather than required, for the reason
+	// ir-descriptor-set gives: the caller is a pipeline naming a path in a fresh
+	// container filesystem.
+	if dir := filepath.Dir(*out); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("failed to create %s: %w", dir, err)
+		}
+	}
+
+	// Built in memory and written once, so that a failure part-way through
+	// leaves no half-written archive for a release job to upload. The IR schema
+	// is kilobytes; buffering it is cheaper than the ordering this would
+	// otherwise need.
+	var buf bytes.Buffer
+
+	if err := writeArchive(&buf, os.DirFS(*source)); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(*out, buf.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", *out, err)
+	}
+
+	return nil
+}
+
+// writeArchive writes every .proto under schema to w as a gzipped tar,
+// preserving each file's path relative to schema.
+//
+// It takes an [io/fs.FS] rather than a directory name so that the determinism
+// the package comment claims can be asserted against a tree a test builds,
+// rather than only against the one on disk beside it.
+//
+// Only .proto files are archived. The schema root holds nothing else today, and
+// naming what goes in rather than what stays out is what keeps a future
+// generated file or an editor's leavings from being published as part of the
+// contract.
+func writeArchive(w io.Writer, schema fs.FS) error {
+	names, err := protoFiles(schema)
+	if err != nil {
+		return err
+	}
+
+	if len(names) == 0 {
+		return fmt.Errorf("no .proto files found: an empty archive would be published as though it were the schema")
+	}
+
+	// BestCompression rather than the default, because the artifact is written
+	// once per release and downloaded many times, and because a fixed level is
+	// one more thing the output does not vary with.
+	gz, err := gzip.NewWriterLevel(w, gzip.BestCompression)
+	if err != nil {
+		return fmt.Errorf("failed to start the gzip stream: %w", err)
+	}
+
+	// Neither field is set from the artifact being written: a name here would
+	// record whatever the caller passed to -o, and a modification time would be
+	// the build's clock.
+	gz.Name = ""
+	gz.ModTime = time.Time{}
+
+	archive := tar.NewWriter(gz)
+
+	for _, name := range names {
+		if err := writeEntry(archive, schema, name); err != nil {
+			return err
+		}
+	}
+
+	if err := archive.Close(); err != nil {
+		return fmt.Errorf("failed to finish the archive: %w", err)
+	}
+
+	if err := gz.Close(); err != nil {
+		return fmt.Errorf("failed to finish the gzip stream: %w", err)
+	}
+
+	return nil
+}
+
+// protoFiles returns every .proto under schema, as slash-separated paths
+// relative to it, in sorted order.
+//
+// [io/fs.WalkDir] already walks lexically, so the sort is belt and braces — but
+// the ordering is what makes the archive a function of its contents rather than
+// of a directory read, and a property that load-bearing is worth stating where a
+// reader can see it.
+func protoFiles(schema fs.FS) ([]string, error) {
+	var names []string
+
+	err := fs.WalkDir(schema, ".", func(name string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if entry.IsDir() || path.Ext(name) != ".proto" {
+			return nil
+		}
+
+		names = append(names, name)
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to read the schema root: %w", err)
+	}
+
+	slices.Sort(names)
+
+	return names, nil
+}
+
+// writeEntry writes one file into the archive under a header carrying nothing
+// the filesystem supplied.
+//
+// The header's Format is left unset, so the tar writer picks the narrowest
+// encoding each header fits in — USTAR for the paths this schema has, PAX for
+// one long enough to need it. That is a function of the header, so it costs
+// nothing in determinism and it means a deeply nested .proto is archived rather
+// than refused.
+func writeEntry(archive *tar.Writer, schema fs.FS, name string) error {
+	b, err := fs.ReadFile(schema, name)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", name, err)
+	}
+
+	header := &tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     name,
+		Size:     int64(len(b)),
+		Mode:     0o644,
+		ModTime:  epoch,
+	}
+
+	if err := archive.WriteHeader(header); err != nil {
+		return fmt.Errorf("failed to write the header for %s: %w", name, err)
+	}
+
+	if _, err := archive.Write(b); err != nil {
+		return fmt.Errorf("failed to write %s: %w", name, err)
+	}
+
+	return nil
+}

--- a/internal/tools/ir-protos/main_test.go
+++ b/internal/tools/ir-protos/main_test.go
@@ -1,0 +1,239 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+	"testing/fstest"
+)
+
+// TestArchiveIsReproducible is the acceptance criterion for this artifact: the
+// same schema produces the same bytes. It archives one tree twice through two
+// independent writers, because a producer that memoised its output would pass a
+// comparison of one run against itself while still varying between builds.
+func TestArchiveIsReproducible(t *testing.T) {
+	schema := fstest.MapFS{
+		"cpybkc/ir/v1/ir.proto": &fstest.MapFile{Data: []byte("syntax = \"proto3\";\n")},
+		"cpybkc/ir/v1/b.proto":  &fstest.MapFile{Data: []byte("syntax = \"proto3\";\n")},
+	}
+
+	first := archive(t, schema)
+	second := archive(t, schema)
+
+	if len(first) == 0 {
+		t.Fatal("the archive is empty")
+	}
+
+	if !bytes.Equal(first, second) {
+		t.Fatalf("two archives of the same schema differ: %d bytes then %d bytes", len(first), len(second))
+	}
+}
+
+// TestArchiveCarriesNothingFromTheFilesystem asserts what makes the property
+// above hold across machines rather than only across two calls in one process.
+// A modification time, an owner or a group taken from the tree being archived
+// would make the artifact a function of the checkout as well as of the schema,
+// and the two builds that disagree would be on different machines, where nobody
+// is comparing.
+func TestArchiveCarriesNothingFromTheFilesystem(t *testing.T) {
+	for _, header := range headers(t, archive(t, fstest.MapFS{
+		"cpybkc/ir/v1/ir.proto": &fstest.MapFile{Data: []byte("syntax = \"proto3\";\n")},
+	})) {
+		if got := header.ModTime.Unix(); got != 0 {
+			t.Errorf("%s carries modification time %d, want 0", header.Name, got)
+		}
+
+		if header.Uid != 0 || header.Gid != 0 {
+			t.Errorf("%s carries uid/gid %d/%d, want 0/0", header.Name, header.Uid, header.Gid)
+		}
+
+		if header.Uname != "" || header.Gname != "" {
+			t.Errorf("%s carries owner names %q/%q, want empty", header.Name, header.Uname, header.Gname)
+		}
+
+		if got := header.Mode; got != 0o644 {
+			t.Errorf("%s carries mode %o, want 644", header.Name, got)
+		}
+	}
+}
+
+// TestArchivePreservesTheSchemaLayout asserts the reason this is an archive at
+// all. A .proto's path is part of its identity — it is the name a
+// FileDescriptorProto carries and the string an import resolves — so an entry
+// flattened to its base name would hand a consumer a file that compiles into
+// descriptors naming a path this project does not publish.
+func TestArchivePreservesTheSchemaLayout(t *testing.T) {
+	schema := fstest.MapFS{
+		"cpybkc/ir/v1/ir.proto":    &fstest.MapFile{Data: []byte("a")},
+		"cpybkc/ir/v1/other.proto": &fstest.MapFile{Data: []byte("b")},
+		"README.md":                &fstest.MapFile{Data: []byte("not a schema")},
+	}
+
+	want := []string{"cpybkc/ir/v1/ir.proto", "cpybkc/ir/v1/other.proto"}
+
+	if got := entryNames(t, archive(t, schema)); !slices.Equal(got, want) {
+		t.Errorf("archived %v, want %v: only .proto files are published, at their schema-relative paths and in sorted order", got, want)
+	}
+}
+
+// TestArchiveRefusesASchemaRootWithNoProtos keeps a misdirected -source from
+// producing a well-formed empty archive. That failure is invisible at the point
+// it happens and arrives as a consumer's release download containing nothing.
+func TestArchiveRefusesASchemaRootWithNoProtos(t *testing.T) {
+	if err := writeArchive(io.Discard, fstest.MapFS{"README.md": &fstest.MapFile{Data: []byte("x")}}); err == nil {
+		t.Error("writeArchive accepted a schema root holding no .proto files")
+	}
+}
+
+// TestRunArchivesTheSchemaOnDisk is the staleness gate. Everything above works
+// on a tree a test built, which cannot notice that the artifact has stopped
+// covering the schema this repository actually publishes. So this one runs the
+// program over proto/ and requires the archive to hold every .proto in it and
+// nothing else.
+//
+// It is here rather than in irpb because proto/ is not in that module. A test
+// there could only reach this directory by climbing out of its own module, which
+// works in a checkout and not in the module zip a plugin author downloads.
+func TestRunArchivesTheSchemaOnDisk(t *testing.T) {
+	root := repoRoot(t)
+	out := filepath.Join(t.TempDir(), "ir-protos.tar.gz")
+
+	if err := run([]string{"-source", filepath.Join(root, "proto"), "-o", out}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	want, err := protoFiles(os.DirFS(filepath.Join(root, "proto")))
+	if err != nil {
+		t.Fatalf("read proto/: %v", err)
+	}
+
+	if len(want) == 0 {
+		t.Fatal("no .proto files found under proto/: the check would pass vacuously")
+	}
+
+	b, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read %s: %v", out, err)
+	}
+
+	if got := entryNames(t, b); !slices.Equal(got, want) {
+		t.Errorf("the published archive does not cover proto/:\n got: %v\nwant: %v", got, want)
+	}
+}
+
+// TestRunRejectsBadUsage keeps the failure modes failures, for the reason
+// ir-descriptor-set's copy of this test gives: a release job that uploads
+// nothing and reports success is the one outcome nobody notices.
+func TestRunRejectsBadUsage(t *testing.T) {
+	testCases := []struct {
+		name string
+		args []string
+	}{
+		{name: "no output path", args: nil},
+		{name: "empty output path", args: []string{"-o", ""}},
+		{name: "unexpected operand", args: []string{"-o", filepath.Join(t.TempDir(), "a.tar.gz"), "extra"}},
+		{name: "missing schema root", args: []string{"-o", filepath.Join(t.TempDir(), "b.tar.gz"), "-source", filepath.Join(t.TempDir(), "nowhere")}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if err := run(testCase.args); err == nil {
+				t.Error("run accepted arguments it should have refused")
+			}
+		})
+	}
+}
+
+// archive writes schema through writeArchive and returns the bytes.
+func archive(t *testing.T, schema fs.FS) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	if err := writeArchive(&buf, schema); err != nil {
+		t.Fatalf("writeArchive: %v", err)
+	}
+
+	return buf.Bytes()
+}
+
+// headers reads every tar header out of a gzipped archive.
+func headers(t *testing.T, b []byte) []*tar.Header {
+	t.Helper()
+
+	gz, err := gzip.NewReader(bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("open the gzip stream: %v", err)
+	}
+
+	var got []*tar.Header
+
+	reader := tar.NewReader(gz)
+
+	for {
+		header, err := reader.Next()
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			t.Fatalf("read the archive: %v", err)
+		}
+
+		got = append(got, header)
+	}
+
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close the gzip stream: %v", err)
+	}
+
+	return got
+}
+
+// entryNames reads the entry paths out of a gzipped archive, in the order they
+// were written.
+func entryNames(t *testing.T, b []byte) []string {
+	t.Helper()
+
+	var names []string
+	for _, header := range headers(t, b) {
+		names = append(names, header.Name)
+	}
+
+	return names
+}
+
+// repoRoot walks up from the test's working directory to the directory holding
+// go.mod, which for this module is the repository root and so the directory
+// proto/ sits in.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("working directory: %v", err)
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("no go.mod found above %q", dir)
+		}
+
+		dir = parent
+	}
+}

--- a/ir_descriptor_set_test.go
+++ b/ir_descriptor_set_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package cpybkc_test
+
+import (
+	"io/fs"
+	"os"
+	"path"
+	"slices"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/irpb"
+)
+
+// TestPublishedFileDescriptorSetCoversTheSchema is the staleness gate on the
+// published ir.binpb.
+//
+// The set is computed from the descriptors protoc-gen-go compiled into irpb, so
+// it cannot drift from them. What it can do is quietly stop covering proto/,
+// which is what happens when a new IR message lands in a file nothing in the
+// descriptor's import graph reaches: the artifact still builds, still decodes
+// and still looks complete, and a consumer decoding dynamically meets a field
+// whose type it does not describe.
+//
+// So the assertion is an equality against the directory rather than against
+// another copy of the same descriptors, and it carries no exclusions. proto/ is
+// the IR and the IR defines exactly one message a plugin consumes, so there is
+// nothing a file there can be that the descriptor does not reach — a .proto that
+// fails this is a mistake in the schema, not something a later change should be
+// able to name its way past.
+//
+// It lives in this module rather than in irpb because proto/ is not part of that
+// module. A test there could reach this directory only by climbing out of its
+// own module root, which works in a checkout and not in the module zip a plugin
+// author downloads. This module already asserts cross-module facts about irpb —
+// see TestTheCLIConsumesThePublishedIRModule — and its root is the directory
+// proto/ sits in.
+func TestPublishedFileDescriptorSetCoversTheSchema(t *testing.T) {
+	want, err := schemaFiles()
+	if err != nil {
+		t.Fatalf("read proto/: %v", err)
+	}
+
+	if len(want) == 0 {
+		t.Fatal("no .proto files found under proto/: the check would pass vacuously")
+	}
+
+	var got []string
+	for _, file := range irpb.FileDescriptorSet().GetFile() {
+		got = append(got, file.GetName())
+	}
+
+	slices.Sort(got)
+
+	if !slices.Equal(got, want) {
+		t.Errorf("the published FileDescriptorSet does not cover proto/:\n got: %v\nwant: %v\n\nA .proto reachable from cpybkc.ir.v1.Descriptor is published automatically; one that is not reachable is a mistake.", got, want)
+	}
+}
+
+// TestSchemaRootIsWhereTheGateLooks keeps the check above honest about where it
+// is looking, so a moved proto/ shows up as this failure rather than as an empty
+// glob somewhere else.
+func TestSchemaRootIsWhereTheGateLooks(t *testing.T) {
+	info, err := os.Stat("proto")
+	if err != nil {
+		t.Fatalf("stat proto/: %v", err)
+	}
+
+	if !info.IsDir() {
+		t.Fatal("proto/ is not a directory")
+	}
+}
+
+// schemaFiles returns every .proto under proto/, as the slash-separated paths
+// relative to it that a FileDescriptorProto carries in its name field, sorted.
+//
+// The path is the comparison and not the base name: buf.yaml enforces
+// PACKAGE_DIRECTORY_MATCH, so the directory layout under proto/ is what the
+// protobuf package name requires, and a set naming a file by any other path
+// would not be describing the schema this repository publishes.
+func schemaFiles() ([]string, error) {
+	var names []string
+
+	err := fs.WalkDir(os.DirFS("proto"), ".", func(name string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if entry.IsDir() || path.Ext(name) != ".proto" {
+			return nil
+		}
+
+		names = append(names, name)
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	slices.Sort(names)
+
+	return names, nil
+}

--- a/irpb/descriptor_set.go
+++ b/irpb/descriptor_set.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package irpb
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+// FileDescriptorSet returns the IR's self-description: the protobuf
+// FileDescriptorSet describing a [Descriptor], and so the thing that lets a
+// consumer decode one with no generated code at all.
+//
+// It exists for the plugin author whose language has weak protobuf tooling, or
+// none in the build. protobuf's one real disadvantage against a self-describing
+// format is that a reader normally needs the schema compiled in ahead of time; a
+// FileDescriptorSet closes it, because every runtime worth the name can build a
+// message type out of one at run time and decode against it. [docs/ir/SPEC.md]'s
+// "Why protobuf, and why no gRPC" is where that trade is argued and "Reading a
+// descriptor without generated code" is what this function ships.
+//
+// # Why it is computed rather than committed
+//
+// The set is derived, on every call, from the descriptors protoc-gen-go compiled
+// into this package — the same descriptors this package marshals a descriptor
+// with. There is no .binpb checked into the repository and no protoc invocation
+// anybody has to remember, so there is no second copy of the IR that could
+// describe a version of it that no longer exists. Changing
+// proto/cpybkc/ir/v1/ir.proto and regenerating ir.pb.go changes what this
+// returns in the same commit, because it is one input read twice rather than two
+// artifacts kept in step by hand.
+//
+// # What is in it, and what is deliberately not
+//
+// [Descriptor] is the only root. It is what a plugin is handed — the IR defines
+// exactly one message a generator consumes — so the set is its file plus the
+// transitive closure of that file's imports, and nothing else. Naming the root
+// as a type rather than as a path is what keeps that true: a file added to
+// proto/ that nothing reachable from [Descriptor] imports is not published, and
+// the test that fails when one appears is in the module that can see the
+// directory.
+//
+// Comments and source positions are not in it. protoc-gen-go does not compile
+// SourceCodeInfo into the descriptors this is derived from, so what is published
+// describes the schema and not the document: field numbers, types, names and
+// nesting, which is everything a decode needs and nothing a reader of
+// ir.proto would go looking for. [docs/ir/SPEC.md] is the prose, and a copy of
+// it embedded in an artifact would be a second one to keep current.
+//
+// # Order
+//
+// Files are emitted in dependency order: a file appears only after every file it
+// imports. That is what `protoc --include_imports` produces and what a consumer
+// walking the set linearly — building each file's types as it goes, which is the
+// shape of most dynamic protobuf APIs — needs in order to resolve a type
+// reference the first time it meets one. Within that, the order is fixed by the
+// import declarations themselves, so the output is a function of the schema and
+// not of a map iteration.
+//
+// [docs/ir/SPEC.md]: https://github.com/Zaba505/cpybkc/blob/main/docs/ir/SPEC.md
+func FileDescriptorSet() *descriptorpb.FileDescriptorSet {
+	set := &descriptorpb.FileDescriptorSet{}
+	appendFileWithImports(set, make(map[string]struct{}), descriptorFileDescriptor())
+	return set
+}
+
+// MarshalFileDescriptorSet encodes [FileDescriptorSet] into the protobuf binary
+// wire encoding, which is the form every dynamic protobuf runtime reads a
+// FileDescriptorSet in and the form the published ir.binpb artifact holds.
+//
+// The bytes are deterministic. The artifact is attached to a release and copied
+// into the published image (#57), and a set whose bytes moved between two builds
+// of the same schema would make every rebuild look like a change to the
+// contract. Field order is protobuf's own, the file order is fixed by
+// [FileDescriptorSet], and the deterministic option pins the one construct — a
+// map field — whose encoding would otherwise follow Go's randomised map
+// iteration.
+func MarshalFileDescriptorSet() ([]byte, error) {
+	b, err := proto.MarshalOptions{Deterministic: true}.Marshal(FileDescriptorSet())
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode the IR FileDescriptorSet: %w", err)
+	}
+
+	return b, nil
+}
+
+// descriptorFileDescriptor returns the file [Descriptor] is defined in.
+//
+// It is read off the message rather than named as a string so that the root of
+// the set is the descriptor type itself. A path like "cpybkc/ir/v1/ir.proto"
+// written here would be a second place the IR's shape is recorded, and would go
+// on compiling after the file it names had been renamed or the message moved out
+// of it.
+func descriptorFileDescriptor() protoreflect.FileDescriptor {
+	return new(Descriptor).ProtoReflect().Descriptor().ParentFile()
+}
+
+// appendFileWithImports appends fd's imports, transitively and depth first,
+// before appending fd itself — which is what puts the result in the dependency
+// order [FileDescriptorSet] documents.
+//
+// seen is keyed by path and marked on entry, so a file reached through two
+// import chains is emitted once, at its first and deepest position. Marking on
+// entry rather than on append also means a cyclic import graph terminates
+// instead of recursing forever; protobuf forbids one, and relying on that to
+// stay true is a worse bargain than one map write.
+func appendFileWithImports(set *descriptorpb.FileDescriptorSet, seen map[string]struct{}, fd protoreflect.FileDescriptor) {
+	if _, ok := seen[fd.Path()]; ok {
+		return
+	}
+
+	seen[fd.Path()] = struct{}{}
+
+	imports := fd.Imports()
+	for i := range imports.Len() {
+		appendFileWithImports(set, seen, imports.Get(i).FileDescriptor)
+	}
+
+	set.File = append(set.File, protodesc.ToFileDescriptorProto(fd))
+}

--- a/irpb/descriptor_set_test.go
+++ b/irpb/descriptor_set_test.go
@@ -1,0 +1,465 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package irpb_test
+
+import (
+	"bytes"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/irpb"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+const (
+	// irProtoPath is the schema's path as protobuf knows it — the import path a
+	// FileDescriptorProto carries in its name field, which is the directory
+	// layout under proto/ that buf.yaml's PACKAGE_DIRECTORY_MATCH enforces
+	// rather than anything this module chose.
+	irProtoPath = "cpybkc/ir/v1/ir.proto"
+
+	// descriptorFullName is the one message a generator plugin is handed, as a
+	// dynamic consumer names it: the protobuf package and the message, never a
+	// Go type. It is what such a consumer looks up in the registry it builds
+	// out of the published set.
+	descriptorFullName = "cpybkc.ir.v1.Descriptor"
+)
+
+// TestFileDescriptorSetCarriesTheSchema is the guard that keeps every other
+// assertion here from passing vacuously. An empty set satisfies "is
+// self-contained", "is in dependency order" and "publishes no service", and it
+// satisfies them by describing nothing.
+func TestFileDescriptorSetCarriesTheSchema(t *testing.T) {
+	names := fileNames(irpb.FileDescriptorSet())
+
+	if len(names) == 0 {
+		t.Fatal("the published FileDescriptorSet carries no files")
+	}
+
+	if !slices.Contains(names, irProtoPath) {
+		t.Fatalf("the set does not carry the descriptor's own file %q; it carries %v", irProtoPath, names)
+	}
+}
+
+// TestFileDescriptorSetIsInDependencyOrder asserts the ordering
+// irpb.FileDescriptorSet's doc comment promises. A consumer that walks the set
+// once, building each file's types as it goes — which is what most dynamic
+// protobuf APIs make easy — fails outright on the other order, and it fails at
+// the type reference rather than at the file, so the diagnostic points nowhere
+// useful.
+func TestFileDescriptorSetIsInDependencyOrder(t *testing.T) {
+	var placed []string
+
+	for _, file := range irpb.FileDescriptorSet().GetFile() {
+		for _, dep := range file.GetDependency() {
+			if !slices.Contains(placed, dep) {
+				t.Errorf("%s is emitted before its import %s", file.GetName(), dep)
+			}
+		}
+
+		placed = append(placed, file.GetName())
+	}
+}
+
+// TestFileDescriptorSetIsSelfContained asserts the set resolves on its own. A
+// set naming an import it does not carry is the classic way this artifact
+// breaks: it decodes, it looks complete, and it fails only in the consumer's
+// registry, with an error naming a file they have never heard of.
+func TestFileDescriptorSetIsSelfContained(t *testing.T) {
+	set := irpb.FileDescriptorSet()
+
+	carried := make(map[string]struct{}, len(set.GetFile()))
+	for _, file := range set.GetFile() {
+		carried[file.GetName()] = struct{}{}
+	}
+
+	for _, file := range set.GetFile() {
+		for _, dep := range file.GetDependency() {
+			if _, ok := carried[dep]; !ok {
+				t.Errorf("%s imports %s, which the set does not carry", file.GetName(), dep)
+			}
+		}
+	}
+
+	if _, err := protodesc.NewFiles(set); err != nil {
+		t.Fatalf("the published set does not resolve on its own: %v", err)
+	}
+}
+
+// TestPublishedSetHasNoServiceDefinition guards the decision docs/ir/SPEC.md's
+// "Why protobuf, and why no gRPC" records. The IR defines no service, so
+// publishing one in the IR's own self-description would contradict the
+// specification in the artifact a plugin author reads instead of the
+// specification.
+func TestPublishedSetHasNoServiceDefinition(t *testing.T) {
+	for _, file := range irpb.FileDescriptorSet().GetFile() {
+		if services := file.GetService(); len(services) > 0 {
+			t.Errorf("%s publishes %d service definition(s); the IR defines no service", file.GetName(), len(services))
+		}
+	}
+}
+
+// TestPublishedSetCarriesNoSourceCodeInfo asserts what irpb.FileDescriptorSet
+// says is deliberately absent. SourceCodeInfo is the comments and the line and
+// column spans of every declaration; it is not needed to decode anything, it
+// would multiply the artifact's size, and it would put a copy of ir.proto's
+// prose — which restates docs/ir/SPEC.md — inside a binary nobody would think
+// to update.
+func TestPublishedSetCarriesNoSourceCodeInfo(t *testing.T) {
+	for _, file := range irpb.FileDescriptorSet().GetFile() {
+		if info := file.GetSourceCodeInfo(); info != nil {
+			t.Errorf("%s carries SourceCodeInfo (%d locations); the published set describes the schema, not the document", file.GetName(), len(info.GetLocation()))
+		}
+	}
+}
+
+// TestMarshalFileDescriptorSetIsDeterministic asserts what the artifact's
+// consumers depend on: two encodings of the same schema produce the same bytes.
+// The set is attached to a release and copied into the published image, so bytes
+// that moved between two builds would make a rebuild indistinguishable from a
+// change to the contract.
+func TestMarshalFileDescriptorSetIsDeterministic(t *testing.T) {
+	first, err := irpb.MarshalFileDescriptorSet()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if len(first) == 0 {
+		t.Fatal("encoded an empty FileDescriptorSet")
+	}
+
+	second, err := irpb.MarshalFileDescriptorSet()
+	if err != nil {
+		t.Fatalf("marshal again: %v", err)
+	}
+
+	if !bytes.Equal(first, second) {
+		t.Fatalf("two encodings of the same set differ: %d bytes then %d bytes", len(first), len(second))
+	}
+}
+
+// TestMarshalledSetIsWhatTheArtifactHolds checks the encoded form decodes back
+// to the same set, which is the only thing standing between an artifact written
+// to disk and one a consumer can use.
+func TestMarshalledSetIsWhatTheArtifactHolds(t *testing.T) {
+	b, err := irpb.MarshalFileDescriptorSet()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got descriptorpb.FileDescriptorSet
+	if err := proto.Unmarshal(b, &got); err != nil {
+		t.Fatalf("decode the encoded set: %v", err)
+	}
+
+	if !proto.Equal(&got, irpb.FileDescriptorSet()) {
+		t.Fatal("the encoded set does not decode back to the set that was encoded")
+	}
+}
+
+// TestDynamicDecodeLeavesNothingUndescribed is the end-to-end half of the
+// staleness gate. It decodes a descriptor through the published set alone and
+// asserts two things a file-level comparison cannot: that nothing in the
+// descriptor landed in the dynamic message's unknown fields — every byte this
+// module writes is described by what is published — and that re-encoding the
+// dynamic message reproduces the descriptor exactly, which is the property a
+// consumer relies on when it reads a descriptor, edits nothing and hands it on.
+func TestDynamicDecodeLeavesNothingUndescribed(t *testing.T) {
+	descriptor, err := proto.MarshalOptions{Deterministic: true}.Marshal(exampleDescriptor())
+	if err != nil {
+		t.Fatalf("encode descriptor: %v", err)
+	}
+
+	msg := newDynamicDescriptor(t)
+	if err := proto.Unmarshal(descriptor, msg); err != nil {
+		t.Fatalf("decode descriptor dynamically: %v", err)
+	}
+
+	assertNoUnknownFields(t, msg.ProtoReflect())
+
+	roundTripped, err := proto.MarshalOptions{Deterministic: true}.Marshal(msg)
+	if err != nil {
+		t.Fatalf("re-encode descriptor: %v", err)
+	}
+
+	if !bytes.Equal(descriptor, roundTripped) {
+		t.Fatalf("dynamic round trip changed the descriptor: %d bytes in, %d bytes out", len(descriptor), len(roundTripped))
+	}
+}
+
+// newDynamicDescriptor builds a message type for the IR's Descriptor out of the
+// published bytes and nothing else — the exact path a plugin author with no
+// generated code takes.
+func newDynamicDescriptor(t *testing.T) *dynamicpb.Message {
+	t.Helper()
+
+	irBinpb, err := irpb.MarshalFileDescriptorSet()
+	if err != nil {
+		t.Fatalf("marshal the published set: %v", err)
+	}
+
+	var set descriptorpb.FileDescriptorSet
+	if err := proto.Unmarshal(irBinpb, &set); err != nil {
+		t.Fatalf("decode the published set: %v", err)
+	}
+
+	files, err := protodesc.NewFiles(&set)
+	if err != nil {
+		t.Fatalf("build a type registry from the published set: %v", err)
+	}
+
+	desc, err := files.FindDescriptorByName(descriptorFullName)
+	if err != nil {
+		t.Fatalf("find %s in the published set: %v", descriptorFullName, err)
+	}
+
+	md, ok := desc.(protoreflect.MessageDescriptor)
+	if !ok {
+		t.Fatalf("%s resolved to %T, not a message", descriptorFullName, desc)
+	}
+
+	return dynamicpb.NewMessage(md)
+}
+
+// assertNoUnknownFields walks a decoded message and reports any bytes the
+// published set had no field for. Unknown fields are how a stale set fails
+// quietly: the decode succeeds, the message looks plausible, and the parts the
+// consumer never heard of are simply not there.
+func assertNoUnknownFields(t *testing.T, msg protoreflect.Message) {
+	t.Helper()
+
+	if unknown := msg.GetUnknown(); len(unknown) > 0 {
+		t.Errorf("%s carries %d bytes the published FileDescriptorSet does not describe", msg.Descriptor().FullName(), len(unknown))
+	}
+
+	msg.Range(func(fd protoreflect.FieldDescriptor, value protoreflect.Value) bool {
+		switch {
+		case fd.IsList() && fd.Message() != nil:
+			list := value.List()
+			for i := range list.Len() {
+				assertNoUnknownFields(t, list.Get(i).Message())
+			}
+		case fd.IsMap() && fd.MapValue().Message() != nil:
+			value.Map().Range(func(_ protoreflect.MapKey, v protoreflect.Value) bool {
+				assertNoUnknownFields(t, v.Message())
+
+				return true
+			})
+		case !fd.IsList() && !fd.IsMap() && fd.Message() != nil:
+			assertNoUnknownFields(t, value.Message())
+		}
+
+		return true
+	})
+}
+
+// fileNames names what a set carried, for a diagnostic that says which files
+// turned up rather than how many.
+func fileNames(set *descriptorpb.FileDescriptorSet) []string {
+	names := make([]string, 0, len(set.GetFile()))
+	for _, file := range set.GetFile() {
+		names = append(names, file.GetName())
+	}
+
+	return names
+}
+
+// exampleDescriptor is a descriptor of the shape cpybkc emits, kept as small as
+// a conforming one can be: an unframed file, one accepting state reached by one
+// transition, and a record whose top-level group holds a single DISPLAY field.
+//
+// It exercises every part of the schema a dynamic consumer meets on its first
+// descriptor — the version enum, the flat node set, a oneof, a nested message
+// and an optional string — so that a set which described any of them wrongly
+// would fail the round trip above rather than decoding into a plausible-looking
+// message.
+func exampleDescriptor() *irpb.Descriptor {
+	return &irpb.Descriptor{
+		Version: irpb.IrVersion_IR_VERSION_1,
+		Nodes: []*irpb.Node{
+			{
+				Id: 0,
+				Kind: &irpb.Node_File{
+					File: &irpb.File{
+						Framing:      &irpb.File_Unframed{Unframed: &irpb.Unframed{}},
+						StartStateId: 1,
+					},
+				},
+			},
+			{
+				Id: 1,
+				Kind: &irpb.Node_State{
+					State: &irpb.State{
+						Accepts:       true,
+						TransitionIds: []uint64{2},
+					},
+				},
+			},
+			{
+				Id: 2,
+				Kind: &irpb.Node_Transition{
+					Transition: &irpb.Transition{
+						RecordId:    3,
+						NextStateId: 1,
+					},
+				},
+			},
+			{
+				Id: 3,
+				Kind: &irpb.Node_Record{
+					Record: &irpb.Record{
+						RootId: 4,
+						Names:  &irpb.Names{Original: "CUSTOMER-RECORD"},
+					},
+				},
+			},
+			{
+				Id: 4,
+				Kind: &irpb.Node_Group{
+					Group: &irpb.Group{
+						MemberIds: []uint64{5},
+						Names:     &irpb.Names{Original: "CUSTOMER-RECORD"},
+					},
+				},
+			},
+			{
+				Id: 5,
+				Kind: &irpb.Node_Field{
+					Field: &irpb.Field{
+						Width: 8,
+						Encoding: &irpb.Encoding{
+							Charset:        irpb.Charset_CHARSET_CP037,
+							SignConvention: irpb.SignConvention_SIGN_CONVENTION_EBCDIC,
+							ByteOrder:      irpb.ByteOrder_BYTE_ORDER_BIG_ENDIAN,
+							FloatFormat:    irpb.FloatFormat_FLOAT_FORMAT_IBM_HFP,
+						},
+						Usage: irpb.Usage_USAGE_DISPLAY,
+						Picture: &irpb.Picture{
+							Category: irpb.Category_CATEGORY_NUMERIC,
+							Digits:   8,
+						},
+						Names: &irpb.Names{
+							Original:     "CUST-ID",
+							OverrideName: proto.String("CustomerID"),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// Example_readADescriptorWithoutGeneratedCode is the worked example
+// docs/ir/SPEC.md's "Reading a descriptor without generated code" points at: a
+// consumer reads a descriptor through the published FileDescriptorSet alone,
+// with no code generated from proto/ anywhere in it.
+//
+// Everything below the marked line uses only protobuf's own runtime — the
+// descriptor types, a registry built from the published bytes, and a dynamic
+// message — so it transliterates directly into any language whose protobuf
+// runtime can load a FileDescriptorSet, which is every one of them. In practice
+// the consumer's first two lines are a read of the ir.binpb release asset and a
+// read of the file cpybkc passed as --descriptor; they are spelled as in-process
+// calls here so that the example runs as a test and cannot rot.
+func Example_readADescriptorWithoutGeneratedCode() {
+	// The producer half. cpybkc encodes a descriptor and publishes the set that
+	// describes it; a plugin author writes neither of these two statements.
+	descriptor, err := proto.Marshal(exampleDescriptor())
+	if err != nil {
+		panic(err)
+	}
+
+	irBinpb, err := irpb.MarshalFileDescriptorSet()
+	if err != nil {
+		panic(err)
+	}
+
+	// ---- The consumer half: no generated code past this line. ----
+
+	var set descriptorpb.FileDescriptorSet
+	if err := proto.Unmarshal(irBinpb, &set); err != nil {
+		panic(err)
+	}
+
+	files, err := protodesc.NewFiles(&set)
+	if err != nil {
+		panic(err)
+	}
+
+	desc, err := files.FindDescriptorByName("cpybkc.ir.v1.Descriptor")
+	if err != nil {
+		panic(err)
+	}
+
+	md := desc.(protoreflect.MessageDescriptor)
+
+	msg := dynamicpb.NewMessage(md)
+	if err := proto.Unmarshal(descriptor, msg); err != nil {
+		panic(err)
+	}
+
+	// The IR version comes first, always: docs/ir/SPEC.md makes reading it
+	// before anything else a consumer's first obligation, and a version this
+	// consumer does not know is a descriptor it must refuse rather than walk.
+	version := msg.Get(md.Fields().ByName("version")).Enum()
+	fmt.Println("ir version:", md.Fields().ByName("version").Enum().Values().ByNumber(version).Name())
+
+	// A descriptor is a flat set of nodes referring to each other by
+	// identifier, so a consumer indexes it before it walks anything.
+	nodes := msg.Get(md.Fields().ByName("nodes")).List()
+
+	byID := make(map[uint64]protoreflect.Message, nodes.Len())
+	for i := range nodes.Len() {
+		node := nodes.Get(i).Message()
+		byID[node.Get(node.Descriptor().Fields().ByName("id")).Uint()] = node
+	}
+
+	for i := range nodes.Len() {
+		node := nodes.Get(i).Message()
+
+		kind := node.WhichOneof(node.Descriptor().Oneofs().ByName("kind"))
+		if kind == nil || kind.Name() != "record" {
+			continue
+		}
+
+		record := node.Get(kind).Message()
+		fmt.Println("record:", name(record))
+
+		group := byID[record.Get(record.Descriptor().Fields().ByName("root_id")).Uint()]
+		groupKind := group.Get(group.Descriptor().Fields().ByName("group")).Message()
+
+		members := groupKind.Get(groupKind.Descriptor().Fields().ByName("member_ids")).List()
+		for j := range members.Len() {
+			member := byID[members.Get(j).Uint()]
+			field := member.Get(member.Descriptor().Fields().ByName("field")).Message()
+
+			width := field.Get(field.Descriptor().Fields().ByName("width")).Uint()
+			fmt.Printf("  field %s: %d bytes\n", name(field), width)
+		}
+	}
+
+	// Output:
+	// ir version: IR_VERSION_1
+	// record: CUSTOMER-RECORD
+	//   field CUST-ID: 8 bytes
+}
+
+// name reads the copybook spelling out of any message carrying a Names.
+//
+// It is part of the consumer half above: the names field is a nested message
+// with the original spelling in it, and reaching through one is the shape of
+// almost every read a generator performs.
+func name(msg protoreflect.Message) string {
+	names := msg.Get(msg.Descriptor().Fields().ByName("names")).Message()
+
+	return names.Get(names.Descriptor().Fields().ByName("original")).String()
+}

--- a/irpb/descriptor_set_test.go
+++ b/irpb/descriptor_set_test.go
@@ -400,7 +400,10 @@ func Example_readADescriptorWithoutGeneratedCode() {
 		panic(err)
 	}
 
-	md := desc.(protoreflect.MessageDescriptor)
+	md, ok := desc.(protoreflect.MessageDescriptor)
+	if !ok {
+		panic("cpybkc.ir.v1.Descriptor is not a message")
+	}
 
 	msg := dynamicpb.NewMessage(md)
 	if err := proto.Unmarshal(descriptor, msg); err != nil {


### PR DESCRIPTION
Closes #19

A plugin author whose language has weak protobuf tooling can now read a descriptor
dynamically, with no build step at all. This publishes the IR's `FileDescriptorSet` —
protobuf's one real gap against a self-describing format — as `ir.binpb`, with the schema
sources beside it as `ir-protos.tar.gz`.

## Acceptance criteria

- [x] **`FileDescriptorSet` produced as a build artifact.** `irpb.FileDescriptorSet` computes
  it from the descriptors `protoc-gen-go` compiled into `irpb` — the same descriptors this
  repository marshals a descriptor with — and `dagger call ir-descriptor-set` is the pipeline
  function that emits it. Nothing is committed and nobody runs `protoc` by hand, so there is
  no second copy of the IR that could describe a version of it that no longer exists.
- [x] **Reproducible: identical `.proto` inputs produce byte-identical output.**
  `MarshalFileDescriptorSet` encodes deterministically and the file order is fixed by the
  protos' imports. Asserted in `irpb` (`TestMarshalFileDescriptorSetIsDeterministic`) and
  again where the artifact is actually written (`TestRunIsReproducible`). Verified across two
  toolchains as well — see *Verified* below.
- [x] **A worked example reads an IR message dynamically using only the descriptor set.**
  `Example_readADescriptorWithoutGeneratedCode` in `irpb/descriptor_set_test.go` — a runnable
  test, so the example is checked rather than asserted — plus the prose section in
  `docs/ir/SPEC.md` and a pointer from the README.
- [x] **Attached to releases alongside the `.proto` sources.**
  `.github/workflows/release.yaml` fires on `release: published`, checks out the release's
  tag, builds both artifacts with the same Dagger functions `ci` already exercises, and
  uploads `ir.binpb` and `ir-protos.tar.gz`.

Three staleness gates keep the published set honest as the schema moves:
`TestPublishedFileDescriptorSetCoversTheSchema` fails when a `.proto` on disk is not in the
set (or vice versa); `TestDynamicDecodeLeavesNothingUndescribed` decodes a descriptor through
the published bytes alone and fails on any byte the set does not describe;
`TestFileDescriptorSetIsSelfContained` fails on an import the set does not carry.

## Judgment calls that shaped the public API

**`irpb` is where the set is computed.** It is the module holding the compiled-in
descriptors, and `protodesc`, `descriptorpb` and `dynamicpb` are all in
`google.golang.org/protobuf`, so `irpb/go.mod` still requires exactly one module and
`TestModuleDependsOnlyOnTheProtobufRuntime` still passes.

**`cpybkc.ir.v1.Descriptor` is the only root**, named as a type rather than as a path. The
set is its file plus the transitive closure of that file's imports, so a `.proto` added under
`proto/` that nothing reachable from `Descriptor` imports is not published — and fails the
coverage gate rather than being silently excluded.

**Files are emitted in dependency order**, matching `protoc --include_imports`. A consumer
that walks the set once, building each file's types as it goes, is the common shape of a
dynamic protobuf API, and the other order fails it at a type reference rather than at a file.

**The `.proto` sources ship as an archive, not as a bare `ir.proto`.** A `.proto`'s path is
part of its identity — it is the name a `FileDescriptorProto` carries, and `buf.yaml`'s
`PACKAGE_DIRECTORY_MATCH` makes the layout under `proto/` what the package name requires.
Flattening `cpybkc/ir/v1/ir.proto` to `ir.proto` would hand a consumer a file that compiles
into descriptors naming a path this project does not publish. The archive is written in Go
with every tar field the filesystem could have supplied set to a constant, so it is
reproducible for the same reason `ir.binpb` is.

**The coverage gate lives in the root module, not in `irpb`.** `proto/` is not part of
`irpb`, and a test there could reach it only by climbing out of its own module root — which
works in a checkout and not in the module zip a plugin author downloads.

**The emitting tools live under `internal/`.** Nothing outside this repository has a reason
to run them, and `cmd/` is empty, so the first thing to land there should be a shipped
command rather than a build tool.

**`docs/ir/SPEC.md` does not name an in-image path.** That path is a promise a `COPY --from`
depends on and it is `docs/container/SPEC.md`'s to fix (#57); two documents naming it would
be two places to change it, and one would be missed.

**The release workflow filters no tags.** This repository publishes `vX.Y.Z` and
`irpb/vX.Y.Z`, and the IR is what both ship, so both carry the artifacts. The bytes are a
function of the tag's source, so each release's assets describe the schema that release
carried.

## One thing this PR does not do

The published image does not exist yet — #57 is the story that ships the IR proto and the
descriptor set inside it — so nothing here performs a `COPY`. `docs/ir/SPEC.md`'s new mapping
row assigns the section to #19 **and** #57 jointly, and this PR delivers #19's half: the
artifacts, their contract, and `dag.Cpybkc().IrDescriptorSet()` for #57's image build to
consume, which is what keeps the release asset and the in-image copy two ways of getting one
artifact.

## Verified

- `dagger call ci` — the whole pipeline, locally, green.
- `dagger call ir-descriptor-set export` and `dagger call ir-protos export` produce 5311 and
  14314 bytes, **byte-identical** to a local `go run` of the same tools on the host
  toolchain, which is the determinism claim exercised across two toolchains rather than
  across two calls in one process.
- `tar tzvf ir-protos.tar.gz` lists `cpybkc/ir/v1/ir.proto` at epoch, uid/gid 0.

One note on the environment rather than on the change: `dagger call ci` failed twice
mid-review with `resolve result 20137: missing shared result`, an engine-side stale-ID error
that also broke `dagger call lint` on its own. Restarting the local `dagger-engine-v0.21.8`
container cleared it, and the run above is from after that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
