### PR TITLE
story(ir): add --emit-ir for binary protobuf output

### DIFF
--- a/docs/ir/SPEC.md
+++ b/docs/ir/SPEC.md
@@ -3539,5 +3539,5 @@ records offer them.
 | The schema itself | #17 `ir` — [`proto/cpybkc/ir/v1/ir.proto`](../../proto/cpybkc/ir/v1/ir.proto) |
 | The schema, as Go | #18 `ir` — [`irpb/`](../../irpb), a module of its own |
 | The published artifacts | #19 `ir` — [`irpb/descriptor_set.go`](../../irpb/descriptor_set.go) computes the set, [`internal/tools/`](../../internal/tools) writes both files, `.dagger/main.go` builds them and `.github/workflows/release.yaml` attaches them |
-| Emitting the IR | #20, #21 `ir` |
+| Emitting the IR | #20, #21 `ir` — [`internal/emit/`](../../internal/emit) encodes a descriptor deterministically and writes it where `--emit-ir` names, a path or `-` for standard output |
 | Conventions this document follows | #15 `setup` |

--- a/internal/emit/emit.go
+++ b/internal/emit/emit.go
@@ -113,7 +113,17 @@ const (
 //
 // The bytes are deterministic; see the package documentation for what that
 // covers and what it leaves to the producer of the descriptor.
+//
+// A nil descriptor is an error. protobuf encodes one to zero bytes and reports
+// no failure, which would put an empty file where a descriptor was asked for
+// and leave the mistake to be found by whoever tries to decode it — a producer
+// that failed to build a descriptor and did not say so is the one thing this
+// package can still turn back into a failure.
 func Marshal(d *irpb.Descriptor) ([]byte, error) {
+	if d == nil {
+		return nil, fmt.Errorf("there is no descriptor to encode")
+	}
+
 	b, err := proto.MarshalOptions{Deterministic: true}.Marshal(d)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode the descriptor: %w", err)
@@ -135,6 +145,10 @@ func Marshal(d *irpb.Descriptor) ([]byte, error) {
 // parent is far more often a typo than an intention, and the caller that does
 // want a tree made — a pipeline naming an output path in a container filesystem
 // it owns — is the one place that knows it.
+//
+// Nothing is created or truncated until d has encoded, so a call that fails
+// leaves whatever was at dest alone rather than replacing a good descriptor
+// with a short one.
 func Write(dest string, out io.Writer, d *irpb.Descriptor) error {
 	if dest == "" {
 		return fmt.Errorf("--%s: name a file to write the descriptor to, or %q for standard output", Flag, Stdout)

--- a/internal/emit/emit.go
+++ b/internal/emit/emit.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Package emit writes a resolved IR descriptor where the CLI's --emit-ir flag
+// names, in the protobuf binary wire encoding a generator plugin is handed.
+//
+// # Why the flag exists
+//
+// The layout parser and the resolver live in the CLI, so a third party who
+// wants what they produce has exactly two ways to get it: write a generator
+// plugin, or ask the CLI for the descriptor and read it directly. --emit-ir is
+// the second, and it is the supported one — the reuse path for a consumer that
+// is not a code generator at all, and the tool's primary debugging surface when
+// a generator's output is wrong and the question is whether the IR or the
+// generator is at fault.
+//
+// It is stable in the sense that matters to somebody building on it: the flag
+// writes a [github.com/Zaba505/cpybkc/irpb.Descriptor] and nothing else, at the
+// version that message carries, encoded the one way this package encodes it.
+// What is *in* a descriptor is docs/ir/SPEC.md's to say and its own version
+// field's to move; a consumer whose build has no protobuf code generation in it
+// decodes the bytes with the published FileDescriptorSet
+// ([github.com/Zaba505/cpybkc/irpb.FileDescriptorSet]) and needs nothing from
+// this repository but the two artifacts a release attaches.
+//
+// # A path, and - for standard output
+//
+// The operand is a filesystem path, or [Stdout] — "-", POSIX's spelling for a
+// standard stream as an operand. Both are needed and neither is a convenience
+// over the other.
+//
+// A path is what lets a plugin author run a plugin by hand against the exact
+// bytes the CLI would have handed it. The file outlives the invocation that
+// wrote it, so a failing generation can be replayed against a descriptor
+// captured months earlier, and the answer is about those bytes rather than
+// about a pipeline nobody can reproduce.
+//
+// Standard output is what gets a descriptor out of a container without a bind
+// mount. `--emit-ir -` redirected on the host needs no writable volume, no
+// matching UID on an output directory and no second command to copy the file
+// back out — the difference between one `docker run` and a mount whose
+// ownership is the caller's problem to get right, on an image that deliberately
+// does not run as root.
+//
+// What standard output asks of its caller is that nothing else writes to that
+// stream while a descriptor is going to it. Diagnostics belong on stderr
+// whatever the destination is; a progress line interleaved into the wire
+// encoding produces a descriptor that fails to decode at whatever field the
+// line happened to land in, rather than anywhere near the mistake.
+//
+// # Determinism
+//
+// [Marshal] is the only place this repository encodes a descriptor, and it
+// encodes deterministically: equal descriptors produce equal bytes, so a
+// consumer that diffs two emissions is reading a change to the resolved layout
+// and never a change of encoder mood. Ordering *inside* the message — the node
+// identifiers and the order of the node list — is the producer's obligation and
+// is stated as one by docs/ir/SPEC.md, "Identity, ordering and determinism";
+// this package cannot supply it and does not pretend to. What it supplies is
+// the other half, so that identical descriptors cannot come out as different
+// files.
+//
+// The IR schema has no map field today, which is the one construct whose
+// encoding would otherwise follow Go's randomised map iteration. Setting the
+// option anyway is what keeps that a property of the encoder rather than a
+// silent requirement on the schema, discovered by whoever adds the first map
+// and diffs two runs.
+//
+// # It runs no generator
+//
+// Emitting is a terminal action, not a stage of generating. Nothing here loads
+// a plugin, resolves a name on PATH or starts a process, and a caller that was
+// asked for a descriptor and nothing else is finished once [Write] returns. The
+// obligation that survives into the CLI is the same one stated the other way
+// round: when --emit-ir is the only action requested, the command exits after
+// it rather than going on to invoke a generator whose output nobody asked for.
+package emit
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/Zaba505/cpybkc/irpb"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	// Flag is the name of the CLI flag this package is behind, without its
+	// leading dashes.
+	//
+	// It is spelled once, here, because the flag's name appears in the command
+	// that defines it, in the error a bad operand produces and in the tests
+	// that drive both. Three literals would be three places for it to be
+	// renamed in two of.
+	Flag = "emit-ir"
+
+	// Stdout is the --emit-ir operand asking for the descriptor on standard
+	// output rather than in a file.
+	//
+	// POSIX's Utility Conventions give "-" this meaning as an operand, which is
+	// the same reading the plugin contract's --descriptor takes (docs/plugin/
+	// SPEC.md). A dash is therefore never a relative path here, and a caller
+	// wanting a file of that name spells it "./-".
+	Stdout = "-"
+)
+
+// Marshal encodes d in the protobuf binary wire encoding: the form a generator
+// plugin is handed, the form --emit-ir writes, and the only form this
+// repository produces a descriptor in.
+//
+// The bytes are deterministic; see the package documentation for what that
+// covers and what it leaves to the producer of the descriptor.
+func Marshal(d *irpb.Descriptor) ([]byte, error) {
+	b, err := proto.MarshalOptions{Deterministic: true}.Marshal(d)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode the descriptor: %w", err)
+	}
+
+	return b, nil
+}
+
+// Write encodes d and writes it to dest, which is a filesystem path or [Stdout]
+// — in which case the bytes go to out and out alone.
+//
+// An existing file is replaced. A descriptor is derived entirely from its
+// inputs, so re-emitting after a layout changed is the whole point of the flag,
+// and refusing the second run would make the ordinary case the one that needs a
+// flag to get past.
+//
+// A path whose parent directory does not exist is an error rather than a
+// directory this creates. The operand is a path somebody typed, where a missing
+// parent is far more often a typo than an intention, and the caller that does
+// want a tree made — a pipeline naming an output path in a container filesystem
+// it owns — is the one place that knows it.
+func Write(dest string, out io.Writer, d *irpb.Descriptor) error {
+	if dest == "" {
+		return fmt.Errorf("--%s: name a file to write the descriptor to, or %q for standard output", Flag, Stdout)
+	}
+
+	b, err := Marshal(d)
+	if err != nil {
+		return err
+	}
+
+	if dest == Stdout {
+		if _, err := out.Write(b); err != nil {
+			return fmt.Errorf("failed to write the descriptor to standard output: %w", err)
+		}
+
+		return nil
+	}
+
+	if err := os.WriteFile(dest, b, 0o644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", dest, err)
+	}
+
+	return nil
+}

--- a/internal/emit/emit_test.go
+++ b/internal/emit/emit_test.go
@@ -1,0 +1,421 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package emit_test
+
+import (
+	"bytes"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/emit"
+	"github.com/Zaba505/cpybkc/irpb"
+)
+
+// descriptor builds the fixture every test below emits.
+//
+// It is built fresh on each call rather than shared, because two of the claims
+// under test — that equal descriptors encode equally, and that two runs agree —
+// are only worth anything if the values compared were assembled twice. A
+// package-level variable would let a cached encoding satisfy both.
+//
+// It carries a node of most kinds, with the references between them wired the
+// way a resolved layout would wire them, so that the encoding being exercised is
+// a whole message rather than a version field.
+func descriptor() *irpb.Descriptor {
+	return &irpb.Descriptor{
+		Version: irpb.IrVersion_IR_VERSION_1,
+		Nodes: []*irpb.Node{
+			{
+				Id: 1,
+				Kind: &irpb.Node_File{File: &irpb.File{
+					Framing:      &irpb.File_Unframed{Unframed: &irpb.Unframed{}},
+					StartStateId: 2,
+				}},
+			},
+			{
+				Id: 2,
+				Kind: &irpb.Node_State{State: &irpb.State{
+					Accepts:       true,
+					TransitionIds: []uint64{3},
+				}},
+			},
+			{
+				Id: 3,
+				Kind: &irpb.Node_Transition{Transition: &irpb.Transition{
+					RecordId:    4,
+					NextStateId: 2,
+					BindingIds:  []uint64{8},
+				}},
+			},
+			{
+				Id: 4,
+				Kind: &irpb.Node_Record{Record: &irpb.Record{
+					RootId: 5,
+					Names:  &irpb.Names{Original: "DETAIL-RECORD"},
+				}},
+			},
+			{
+				Id: 5,
+				Kind: &irpb.Node_Group{Group: &irpb.Group{
+					MemberIds: []uint64{6, 9},
+					Names:     &irpb.Names{Original: "DETAIL"},
+				}},
+			},
+			{
+				Id: 6,
+				Kind: &irpb.Node_Field{Field: &irpb.Field{
+					Width: 8,
+					Encoding: &irpb.Encoding{
+						Charset:        irpb.Charset_CHARSET_ASCII,
+						SignConvention: irpb.SignConvention_SIGN_CONVENTION_EBCDIC,
+						ByteOrder:      irpb.ByteOrder_BYTE_ORDER_BIG_ENDIAN,
+						FloatFormat:    irpb.FloatFormat_FLOAT_FORMAT_IBM_HFP,
+					},
+					Usage: irpb.Usage_USAGE_DISPLAY,
+					Picture: &irpb.Picture{
+						Category:     irpb.Category_CATEGORY_NUMERIC,
+						Digits:       8,
+						Scale:        -2,
+						Signed:       true,
+						SignPosition: irpb.SignPosition_SIGN_POSITION_TRAILING,
+					},
+					Names: &irpb.Names{Original: "DTL-AMOUNT"},
+				}},
+			},
+			{
+				Id:   7,
+				Kind: &irpb.Node_Register{Register: &irpb.Register{Kind: irpb.RegisterKind_REGISTER_KIND_INTEGER}},
+			},
+			{
+				Id: 8,
+				Kind: &irpb.Node_Binding{Binding: &irpb.Binding{
+					RegisterId: 7,
+					Value:      &irpb.Binding_Decrement{Decrement: &irpb.Decrement{}},
+				}},
+			},
+			{
+				Id:   9,
+				Kind: &irpb.Node_Slack{Slack: &irpb.Slack{Width: 2}},
+			},
+		},
+	}
+}
+
+// TestMarshalIsDeterministic is the acceptance criterion at the encoder: equal
+// descriptors produce equal bytes, every time.
+//
+// Both halves matter. Encoding one value repeatedly catches an encoder that
+// varies between calls; encoding a value assembled a second time catches one
+// that depends on how the message was built — a cached size, an interned
+// string, the iteration order of anything a future schema adds — which is the
+// case a consumer diffing two emissions of an unchanged layout actually hits.
+func TestMarshalIsDeterministic(t *testing.T) {
+	want, err := emit.Marshal(descriptor())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if len(want) == 0 {
+		t.Fatal("encoding the fixture produced no bytes, so nothing below is comparing anything")
+	}
+
+	d := descriptor()
+	for i := range 64 {
+		got, err := emit.Marshal(d)
+		if err != nil {
+			t.Fatalf("marshal, call %d: %v", i, err)
+		}
+
+		if !bytes.Equal(got, want) {
+			t.Fatalf("call %d encoded the same descriptor to different bytes: %d then %d", i, len(want), len(got))
+		}
+	}
+
+	for i := range 64 {
+		got, err := emit.Marshal(descriptor())
+		if err != nil {
+			t.Fatalf("marshal a rebuilt descriptor, call %d: %v", i, err)
+		}
+
+		if !bytes.Equal(got, want) {
+			t.Fatalf("descriptor %d, rebuilt from the same values, encoded differently: %d bytes against %d", i, len(got), len(want))
+		}
+	}
+}
+
+// TestMarshalDistinguishesDescriptorsThatDiffer is the other direction, without
+// which every byte comparison above would be satisfied by an encoder that
+// returned a constant.
+func TestMarshalDistinguishesDescriptorsThatDiffer(t *testing.T) {
+	base, err := emit.Marshal(descriptor())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	changed := descriptor()
+	changed.Nodes[5].GetField().Width = 9
+
+	got, err := emit.Marshal(changed)
+	if err != nil {
+		t.Fatalf("marshal the changed descriptor: %v", err)
+	}
+
+	if bytes.Equal(got, base) {
+		t.Fatal("a descriptor whose field width changed encoded to the same bytes, so the encoding is not carrying the change")
+	}
+}
+
+// TestWriteToAPathWritesTheEncodedDescriptor asserts the file holds the
+// encoding and nothing else. A trailing newline, a text framing, or anything
+// else added on the way past would be a file no protobuf runtime can decode.
+func TestWriteToAPathWritesTheEncodedDescriptor(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "ir.binpb")
+
+	if err := emit.Write(dest, io.Discard, descriptor()); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read %s: %v", dest, err)
+	}
+
+	want, err := emit.Marshal(descriptor())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if !bytes.Equal(got, want) {
+		t.Fatalf("the file is not the encoded descriptor: %d bytes on disk, %d bytes encoded", len(got), len(want))
+	}
+}
+
+// TestWriteToStdoutWritesTheSameBytes covers the operand that gets a descriptor
+// out of a container without a bind mount. The stream and the file have to be
+// the same bytes, or a caller redirecting the one would be reading something
+// subtly other than what a plugin is handed.
+func TestWriteToStdoutWritesTheSameBytes(t *testing.T) {
+	var out bytes.Buffer
+
+	if err := emit.Write(emit.Stdout, &out, descriptor()); err != nil {
+		t.Fatalf("write to %q: %v", emit.Stdout, err)
+	}
+
+	dest := filepath.Join(t.TempDir(), "ir.binpb")
+	if err := emit.Write(dest, io.Discard, descriptor()); err != nil {
+		t.Fatalf("write to a path: %v", err)
+	}
+
+	want, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read %s: %v", dest, err)
+	}
+
+	if !bytes.Equal(out.Bytes(), want) {
+		t.Fatalf("the stream and the file disagree: %d bytes on the stream, %d in the file", out.Len(), len(want))
+	}
+}
+
+// TestWriteToAPathLeavesTheStreamUntouched is the same requirement from the
+// other side. A caller running `--emit-ir out.binpb` with its standard output
+// going somewhere that matters must not find a descriptor in it as well.
+func TestWriteToAPathLeavesTheStreamUntouched(t *testing.T) {
+	var out bytes.Buffer
+
+	dest := filepath.Join(t.TempDir(), "ir.binpb")
+	if err := emit.Write(dest, &out, descriptor()); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if out.Len() != 0 {
+		t.Fatalf("writing to %s also put %d bytes on the stream", dest, out.Len())
+	}
+}
+
+// TestWriteIsReproducible is the acceptance criterion where a user meets it:
+// two emissions of one descriptor are byte-identical files, so a descriptor
+// committed beside a fixture stays a diff of the layout rather than of the run.
+func TestWriteIsReproducible(t *testing.T) {
+	dir := t.TempDir()
+
+	first := filepath.Join(dir, "first.binpb")
+	if err := emit.Write(first, io.Discard, descriptor()); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+
+	second := filepath.Join(dir, "second.binpb")
+	if err := emit.Write(second, io.Discard, descriptor()); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+
+	a, err := os.ReadFile(first)
+	if err != nil {
+		t.Fatalf("read %s: %v", first, err)
+	}
+
+	b, err := os.ReadFile(second)
+	if err != nil {
+		t.Fatalf("read %s: %v", second, err)
+	}
+
+	if len(a) == 0 {
+		t.Fatal("the first emission is empty")
+	}
+
+	if !bytes.Equal(a, b) {
+		t.Fatalf("two emissions of one descriptor differ: %d bytes then %d", len(a), len(b))
+	}
+}
+
+// TestWriteReplacesAnExistingFile keeps re-emitting the ordinary case. A layout
+// changes and the descriptor beside it is regenerated; refusing that, or
+// appending to it, would make the common path the one that needs an argument.
+func TestWriteReplacesAnExistingFile(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "ir.binpb")
+
+	if err := os.WriteFile(dest, bytes.Repeat([]byte{0xff}, 4096), 0o644); err != nil {
+		t.Fatalf("seed %s: %v", dest, err)
+	}
+
+	if err := emit.Write(dest, io.Discard, descriptor()); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read %s: %v", dest, err)
+	}
+
+	want, err := emit.Marshal(descriptor())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if !bytes.Equal(got, want) {
+		t.Fatalf("the replaced file is not the encoded descriptor: %d bytes on disk, %d encoded", len(got), len(want))
+	}
+}
+
+// TestWriteRejectsBadDestinations keeps the failure modes failures. Silently
+// writing nowhere is the one outcome a caller would not notice, and it is
+// exactly what an unset flag looks like to this function.
+func TestWriteRejectsBadDestinations(t *testing.T) {
+	dir := t.TempDir()
+
+	notADir := filepath.Join(dir, "file")
+	if err := os.WriteFile(notADir, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("seed %s: %v", notADir, err)
+	}
+
+	testCases := []struct {
+		name string
+		dest string
+		want string
+	}{
+		{
+			name: "unset",
+			dest: "",
+			want: emit.Flag,
+		},
+		{
+			name: "a directory that does not exist",
+			dest: filepath.Join(dir, "nope", "ir.binpb"),
+			want: "ir.binpb",
+		},
+		{
+			name: "a parent that is not a directory",
+			dest: filepath.Join(notADir, "ir.binpb"),
+			want: "ir.binpb",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := emit.Write(testCase.dest, io.Discard, descriptor())
+			if err == nil {
+				t.Fatalf("writing to %q succeeded", testCase.dest)
+			}
+
+			if !strings.Contains(err.Error(), testCase.want) {
+				t.Errorf("the error does not name %q, so it does not say what to fix: %v", testCase.want, err)
+			}
+		})
+	}
+}
+
+// TestWriteReportsAStreamItCannotWrite covers the redirection that fails —
+// a full disk, a closed pipe — which is the failure mode the stdout operand
+// adds and the one a caller redirecting into a file has to hear about.
+func TestWriteReportsAStreamItCannotWrite(t *testing.T) {
+	err := emit.Write(emit.Stdout, failingWriter{}, descriptor())
+	if err == nil {
+		t.Fatal("writing to a stream that fails succeeded")
+	}
+
+	if !strings.Contains(err.Error(), "standard output") {
+		t.Errorf("the error does not say where the write failed: %v", err)
+	}
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, io.ErrClosedPipe
+}
+
+// TestTheFlagBindsToADestination drives the operand the way the command will:
+// one flag, whose value is handed to [emit.Write] unchanged.
+//
+// It is here because [emit.Flag] and [emit.Stdout] are a contract with a
+// command that does not exist yet — the CLI's first command lands with the
+// argument vector (#42) — and a constant nothing parses is a name that can be
+// wrong without anything saying so.
+func TestTheFlagBindsToADestination(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "ir.binpb")
+
+	testCases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "a path",
+			args: []string{"--" + emit.Flag, dest},
+			want: dest,
+		},
+		{
+			name: "standard output",
+			args: []string{"--" + emit.Flag, emit.Stdout},
+			want: emit.Stdout,
+		},
+		{
+			name: "not requested",
+			args: nil,
+			want: "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			flags := flag.NewFlagSet("cpybkc", flag.ContinueOnError)
+			flags.SetOutput(io.Discard)
+
+			got := flags.String(emit.Flag, "", "write the resolved IR to this path, or "+emit.Stdout+" for standard output")
+
+			if err := flags.Parse(testCase.args); err != nil {
+				t.Fatalf("parse %v: %v", testCase.args, err)
+			}
+
+			if *got != testCase.want {
+				t.Fatalf("--%s parsed to %q, want %q", emit.Flag, *got, testCase.want)
+			}
+		})
+	}
+}

--- a/internal/emit/emit_test.go
+++ b/internal/emit/emit_test.go
@@ -350,6 +350,37 @@ func TestWriteRejectsBadDestinations(t *testing.T) {
 	}
 }
 
+// TestNoDescriptorIsAnError covers the one input protobuf would accept and
+// encode to nothing at all. An emission that produced a zero-length file and
+// reported success would send whoever ran it looking at their consumer, and the
+// existing file it replaced on the way would already be gone — so the second
+// half asserts that dest is untouched as well.
+func TestNoDescriptorIsAnError(t *testing.T) {
+	if _, err := emit.Marshal(nil); err == nil {
+		t.Error("encoding no descriptor succeeded")
+	}
+
+	dest := filepath.Join(t.TempDir(), "ir.binpb")
+
+	seed := bytes.Repeat([]byte{0xff}, 16)
+	if err := os.WriteFile(dest, seed, 0o644); err != nil {
+		t.Fatalf("seed %s: %v", dest, err)
+	}
+
+	if err := emit.Write(dest, io.Discard, nil); err == nil {
+		t.Fatalf("writing no descriptor to %s succeeded", dest)
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read %s: %v", dest, err)
+	}
+
+	if !bytes.Equal(got, seed) {
+		t.Errorf("the failed write replaced %s anyway: %d bytes where %d were", dest, len(got), len(seed))
+	}
+}
+
 // TestWriteReportsAStreamItCannotWrite covers the redirection that fails —
 // a full disk, a closed pipe — which is the failure mode the stdout operand
 // adds and the one a caller redirecting into a file has to hear about.

--- a/ir_module_test.go
+++ b/ir_module_test.go
@@ -26,11 +26,14 @@ const irModulePath = "github.com/Zaba505/cpybkc/irpb"
 // here, and its package path is the published module's rather than any path
 // inside this one.
 //
-// It exists because nothing else in this module imports the IR yet. When
-// resolve assembles a descriptor (#38) and --emit-ir writes one (#20), ordinary
-// use will assert the same thing far better and this test can go. Until then the
-// requirement in go.mod would otherwise be a line no build depends on, which
+// It was written because nothing else in this module imported the IR, which
+// made the requirement in go.mod a line no build depended on and so a line
 // `go mod tidy` removes without anybody noticing that the arrow went with it.
+// That hazard is gone: internal/emit encodes and writes a descriptor (#20), so
+// the import is load-bearing and the arrow is asserted by the build. What is
+// left here is the same claim stated in one place rather than inferred from an
+// import, and it goes when resolve assembles a descriptor (#38) and the whole
+// CLI puts one through this module in the ordinary way.
 func TestTheCLIConsumesThePublishedIRModule(t *testing.T) {
 	d := &irpb.Descriptor{Version: irpb.IrVersion_IR_VERSION_1}
 


### PR DESCRIPTION
Closes #20

`internal/emit` is the one place this repository encodes a resolved IR descriptor and
the one place it writes one out. It encodes deterministically, and it takes either a
filesystem path or `-` for standard output — the operand that gets a descriptor out of
a container with no bind mount, no writable volume and no UID to match on an output
directory.

## Acceptance criteria

- [x] **`--emit-ir <path>` writes the serialized IR; `-` writes to stdout.**
  `emit.Write(dest, out, d)` is that behaviour: `dest` is a path, or `emit.Stdout` —
  `"-"`, POSIX's spelling for a standard stream as an operand — in which case the bytes
  go to `out` and nowhere else. The flag's own name is `emit.Flag`, spelled once so the
  command, its diagnostics and its tests cannot disagree about it.
  `TestWriteToAPathWritesTheEncodedDescriptor`, `TestWriteToStdoutWritesTheSameBytes`
  (the stream and the file are byte-for-byte the same descriptor),
  `TestWriteToAPathLeavesTheStreamUntouched` and `TestTheFlagBindsToADestination`, which
  parses `--emit-ir <path>` and `--emit-ir -` through a real `flag.FlagSet` the way the
  command will. What is **not** here is the command that binds it; see *One thing this
  PR does not do*.
- [x] **Output is deterministic: identical inputs produce byte-identical output.**
  `emit.Marshal` is the only encode, and it marshals with `Deterministic: true`.
  `TestMarshalIsDeterministic` encodes one descriptor 64 times *and* encodes 64
  independently rebuilt copies of it, because the case a user hits — diffing two
  emissions of an unchanged layout — is the second one; `TestWriteIsReproducible` makes
  the same comparison over two files on disk; and
  `TestMarshalDistinguishesDescriptorsThatDiffer` is the other direction, without which
  every byte comparison above would be satisfied by an encoder returning a constant.
  Ordering *inside* the message — identifiers, and the order of the node list — is the
  producer's, stated as such by [Identity, ordering and
  determinism](docs/ir/SPEC.md#identity-ordering-and-determinism) and assigned to #38.
  This is the other half, and the package comment says which half it is.
- [x] **Exits without invoking any generator when `--emit-ir` is the only action
  requested.** Emitting is a terminal action: nothing in `internal/emit` loads a plugin,
  resolves a name on `PATH` or starts a process, and the package imports `irpb`, the
  protobuf runtime and four standard-library packages. A caller asked for a descriptor
  and nothing else is finished when `Write` returns. The obligation on the command —
  exit after emitting rather than going on to generate — is written into the package
  comment, and #42 (*invoke plugins with the resolved descriptor*, blocked by this
  issue) is where there is finally a generator invocation for it to bind.
- [x] **Documented as the stable third-party integration path.** The package comment
  says what the flag is for, why a path and stdout are both needed and neither replaces
  the other, what "stable" covers (a `Descriptor`, at the version that message carries,
  encoded the one way this repository encodes it) and what it does not (what is *in* a
  descriptor, which is `docs/ir/SPEC.md`'s and its version field's). `docs/ir/SPEC.md`
  already introduces the flag as the thing that makes the IR a value at rest, under [Why
  protobuf, and why no gRPC](docs/ir/SPEC.md#why-protobuf-and-why-no-grpc); its *Mapping
  to Stories* row for *Emitting the IR* now points at the code, which is the form
  `CONVENTIONS.md` prescribes for a story that produces no section.
- [x] **Streams cleanly out of the container without a bind mount.** `-` writes the
  encoding to the stream and nothing else — no trailing newline, no framing — so
  `docker run … --emit-ir - > ir.binpb` is the whole recipe.
  `TestWriteToStdoutWritesTheSameBytes` asserts the stream equals the file byte for
  byte, `TestWriteToAPathLeavesTheStreamUntouched` asserts the converse, and
  `TestWriteReportsAStreamItCannotWrite` keeps a failed redirection an error rather than
  a truncated descriptor. The obligation this puts on the command — that diagnostics go
  to stderr, always, because a progress line interleaved into the wire encoding fails to
  decode at whatever field it landed in rather than anywhere near the mistake — is
  stated in the package comment. The image itself is #55's.

## Judgment calls that shaped the public API

**No `cmd/` in this PR, and that is the whole shape of it.** `go.mod`'s comment on the
`replace` is explicit that the first *installable* CLI command and that line cannot both
exist, and `irpb` has no tag yet; `CONTRIBUTING.md` says a command landing under `cmd/`
moves the Dagger archetype from `GoLib` to `GoApp` and pulls the multi-platform image
build and the publish half of the standard pipeline in with it (#55, #59); and
`internal/tools/ir-descriptor-set` says in as many words that `cmd/` is empty and the
first thing to land there decides what a reader expects to find in it. Three separate
places in this repository say the same thing, so #20 lands the mechanism and its
contract and leaves the argument vector to the story that owns it.

**`internal/`, not an exported package.** The stable third-party path is the *flag*, not
a Go API: a third party runs the CLI and reads bytes, or imports `irpb` and writes a
plugin. Exporting this would publish a second surface for the same job from the module
that is the CLI.

**A path is not created, a file is replaced.** `--emit-ir` names a path somebody typed,
where a missing parent directory is far more often a typo than an intention — the
opposite of `internal/tools/ir-descriptor-set`, which does create one because its caller
is a pipeline naming a path in a container filesystem it owns. Re-emitting over an
existing file is allowed, because regenerating after a layout changed is the ordinary
case and refusing it would put a flag in front of the common path.

**`Deterministic: true` on a schema with no map field.** The IR has none today, so the
option changes no byte. Setting it is what keeps determinism a property of the encoder
rather than a silent requirement on the schema, to be discovered by whoever adds the
first map and diffs two runs.

**`ir_module_test.go`'s comment, not the test.** That test existed because nothing in
this module imported the IR, which made the `require` a line `go mod tidy` would remove.
`internal/emit` imports it in ordinary code now, so the hazard is gone and the comment
saying otherwise was false; the test is left standing for the claim it states in one
place, with the note that it goes when #38 puts a descriptor through the whole CLI.

## One thing this PR does not do

There is no `cpybkc` command, so `--emit-ir` is not yet a flag anybody can type. What
lands here is the flag's name, its operand, its semantics, its determinism and its
documentation, exercised through a `flag.FlagSet` in the tests exactly as the command
will bind them. #42 is blocked by this issue precisely because it is where the descriptor
these bytes are reaches a plugin, and #21 (`--emit-ir=json`) builds its normalized form
on the same encode.

## Verified

- `dagger call ci` — green, from the worktree, in 55.6s.
- `gofmt -l .` — no output; `go vet ./...`; `go test -race ./...` — all four packages ok.

One note on the environment rather than on the change: `dagger call lint` first failed
with `resolve result 12970: missing shared result`, the same engine-side stale-ID error
#107 hit. Restarting the local `dagger-engine-v0.21.8` container cleared it, and the
`dagger call ci` above is from after that. A tool artifact; nothing was edited around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
