### PR TITLE
story(ir): add --emit-ir=json with normalized output

### DIFF
--- a/docs/ir/SPEC.md
+++ b/docs/ir/SPEC.md
@@ -170,8 +170,9 @@ generators resolving one differently — into every language anyone writes a
 generator in.
 
 The cost is real, and none of it is paid by the producer. A consumer **MUST**
-index the node list by identifier before it can walk anything. The JSON debug
-form (#21) is markedly harder to read than a nested one would be. And adding a
+index the node list by identifier before it can walk anything. The [JSON
+rendering](#a-descriptor-is-readable-by-a-person) (#21) is markedly harder to
+read than a nested one would be. And adding a
 kind to the set is a breaking change rather than an addition, for the reason
 [Versioning and compatibility](#versioning-and-compatibility) gives. The set is
 closed to buy something specific for that price: a consumer switches over
@@ -3070,8 +3071,9 @@ document that defines the message rather than by reading to the end and finding
 no service in it.
 
 What that buys is an IR that is a thing at rest. It can be written to a file
-(#20), converted to JSON and read (#21), committed, diffed, and replayed against
-a plugin by hand a year later. None of those is available to a protocol.
+(#20), [rendered as JSON and read](#a-descriptor-is-readable-by-a-person) (#21),
+committed, diffed, and replayed against a plugin by hand a year later. None of
+those is available to a protocol.
 
 ## Reading a descriptor without generated code
 
@@ -3143,6 +3145,60 @@ The runnable form is `Example_readADescriptorWithoutGeneratedCode` in
 rather than a listing here so that the example is checked on every run: the four
 calls above are the shape, and a worked example that had rotted would be worse
 than none.
+
+## A descriptor is readable by a person
+
+The encoding above is protobuf, which nobody reads. cpybkc **MUST** therefore
+also render a descriptor as JSON, and that rendering is the debugging surface:
+the answer to *what was this generator actually handed*, which is the first
+question asked whenever generated code is wrong. It is what `--emit-ir` writes
+when `--emit-ir-format json` asks for it (#21), to the same destinations the
+binary form goes to.
+
+It is also the interop path for a consumer whose language's protobuf support is
+too weak to be worth fighting. That consumer is the same one
+[Reading a descriptor without generated code](#reading-a-descriptor-without-generated-code)
+serves, arriving with less: no code generation, and no dynamic decode either.
+
+### The binary form is canonical
+
+The rendering is **one-way**, and no consumer is entitled to be handed one. A
+generator plugin is handed the binary encoding — what a plugin reads is the
+[plugin contract](../plugin/SPEC.md)'s to fix (#39) — and a plugin accepting
+either form would have to sniff which one it had, which is a decision about
+bytes that every generator would then make for itself and some would make
+differently. So a producer **MUST NOT** write a rendering where a descriptor is
+called for, and a consumer **MUST NOT** rely on one to round-trip: nothing in
+this document defines a JSON *encoding* of a descriptor, and every requirement
+it makes is a requirement about the binary form.
+
+That is why the two are not a pair of equals with a default between them. A
+tool offering both **MUST** produce the binary form where nothing asks
+otherwise, so that the form somebody depends on is the form they get by not
+deciding, and the rendering is the one that has to be asked for by name (#21).
+
+### The rendering is normalized
+
+Two renderings of one descriptor **MUST** be byte-identical, and a rendering
+**MUST NOT** vary with the build of the tool that produced it (#21). That is
+[Identity, ordering and determinism](#identity-ordering-and-determinism)'s
+promise carried one step further out, and it is here for the reason that
+promise is: a rendering is a thing to commit beside a layout, diff against last
+week's, and paste into an issue, and one that churned on an upgrade could not be
+any of the three.
+
+It is worth stating because the obvious implementation does not satisfy it. A
+JSON printer is entitled to vary its insignificant whitespace, and Go's
+`protojson` varies it deliberately — per binary, to stop anyone depending on its
+exact output — so a rendering re-emitted after an upgrade would differ on every
+line with nothing in it that anybody changed. cpybkc normalizes the whitespace
+before writing.
+
+A rendering **MUST** use protobuf's own field names — `start_state_id`, not
+`startStateId`. Anyone reading a descriptor is reading it beside this document
+and beside [`ir.proto`](../../proto/cpybkc/ir/v1/ir.proto), and a
+lowerCamelCase rendering would make them translate every name back before they
+could look one up.
 
 ## Out of Scope
 
@@ -3536,8 +3592,9 @@ records offer them.
 | [Versioning and compatibility](#versioning-and-compatibility) | #17, #18 `ir` |
 | [Why protobuf, and why no gRPC](#why-protobuf-and-why-no-grpc) | #17, #19 `ir` |
 | [Reading a descriptor without generated code](#reading-a-descriptor-without-generated-code) | #19 `ir`, #57 `container` |
+| [A descriptor is readable by a person](#a-descriptor-is-readable-by-a-person) | #21 `ir` |
 | The schema itself | #17 `ir` — [`proto/cpybkc/ir/v1/ir.proto`](../../proto/cpybkc/ir/v1/ir.proto) |
 | The schema, as Go | #18 `ir` — [`irpb/`](../../irpb), a module of its own |
 | The published artifacts | #19 `ir` — [`irpb/descriptor_set.go`](../../irpb/descriptor_set.go) computes the set, [`internal/tools/`](../../internal/tools) writes both files, `.dagger/main.go` builds them and `.github/workflows/release.yaml` attaches them |
-| Emitting the IR | #20, #21 `ir` — [`internal/emit/`](../../internal/emit) encodes a descriptor deterministically and writes it where `--emit-ir` names, a path or `-` for standard output |
+| Emitting the IR | #20, #21 `ir` — [`internal/emit/`](../../internal/emit) encodes a descriptor deterministically, in either form, and writes it where `--emit-ir` names, a path or `-` for standard output |
 | Conventions this document follows | #15 `setup` |

--- a/internal/emit/emit.go
+++ b/internal/emit/emit.go
@@ -4,7 +4,8 @@
 // https://opensource.org/licenses/MIT
 
 // Package emit writes a resolved IR descriptor where the CLI's --emit-ir flag
-// names, in the protobuf binary wire encoding a generator plugin is handed.
+// names: in the protobuf binary wire encoding a generator plugin is handed, or
+// — where --emit-ir-format asks for it — as the JSON a person reads.
 //
 // # Why the flag exists
 //
@@ -18,7 +19,8 @@
 //
 // It is stable in the sense that matters to somebody building on it: the flag
 // writes a [github.com/Zaba505/cpybkc/irpb.Descriptor] and nothing else, at the
-// version that message carries, encoded the one way this package encodes it.
+// version that message carries, encoded the one way this package encodes the
+// [Format] it was asked for.
 // What is *in* a descriptor is docs/ir/SPEC.md's to say and its own version
 // field's to move; a consumer whose build has no protobuf code generation in it
 // decodes the bytes with the published FileDescriptorSet
@@ -52,21 +54,66 @@
 //
 // # Determinism
 //
-// [Marshal] is the only place this repository encodes a descriptor, and it
-// encodes deterministically: equal descriptors produce equal bytes, so a
-// consumer that diffs two emissions is reading a change to the resolved layout
-// and never a change of encoder mood. Ordering *inside* the message — the node
-// identifiers and the order of the node list — is the producer's obligation and
-// is stated as one by docs/ir/SPEC.md, "Identity, ordering and determinism";
-// this package cannot supply it and does not pretend to. What it supplies is
-// the other half, so that identical descriptors cannot come out as different
-// files.
+// [Marshal] is the only place this repository encodes a descriptor for a
+// consumer, and it encodes deterministically: equal descriptors produce equal
+// bytes, so a consumer that diffs two emissions is reading a change to the
+// resolved layout and never a change of encoder mood. Ordering *inside* the
+// message — the node identifiers and the order of the node list — is the
+// producer's obligation and is stated as one by docs/ir/SPEC.md, "Identity,
+// ordering and determinism"; this package cannot supply it and does not pretend
+// to. What it supplies is the other half, so that identical descriptors cannot
+// come out as different files.
 //
 // The IR schema has no map field today, which is the one construct whose
 // encoding would otherwise follow Go's randomised map iteration. Setting the
 // option anyway is what keeps that a property of the encoder rather than a
 // silent requirement on the schema, discovered by whoever adds the first map
 // and diffs two runs.
+//
+// [MarshalJSON] owes the same promise and pays more for it; see "Normalized,
+// because protojson is not" below.
+//
+// # Two forms, and which one is canonical
+//
+// The binary encoding is canonical. It is what a plugin is handed
+// (docs/plugin/SPEC.md), what a consumer decodes, and what every requirement
+// docs/ir/SPEC.md makes of a descriptor is a requirement about. [FormatJSON]
+// asks for protojson instead, and that form is debug and interop output: for
+// reading a descriptor beside the specification when a generator's output is
+// wrong, and for the consumer whose language has protobuf tooling too weak to
+// decode the binary form comfortably.
+//
+// The JSON is one-way. Nothing in this repository reads it back, no plugin is
+// handed one, and this package will not decode one — a plugin accepting both
+// would have to sniff which it had, which is the position docs/plugin/SPEC.md
+// takes and the reason the two forms are not interchangeable. So the JSON is
+// not a second wire encoding that the descriptor's version field governs, and a
+// descriptor reconstructed from a rendering is nobody's guarantee.
+//
+// The default is therefore the canonical form. A caller who says nothing gets
+// the bytes a plugin is handed, and the debug form is the one you have to ask
+// for by name.
+//
+// # Normalized, because protojson is not
+//
+// [MarshalJSON]'s bytes are a function of the descriptor and of nothing else —
+// in particular, not of the build that produced them. protojson deliberately
+// varies its insignificant whitespace, emitting an extra space after a comma or
+// after a "key:" chosen by a hash of the running binary, precisely so that
+// nobody depends on its exact output. That is fixed within one cpybkc and
+// different in the next, so a rendering committed beside a layout would diff on
+// every line after an upgrade with nothing in it that anybody changed.
+//
+// So the rendering is re-indented through encoding/json before it is returned,
+// which rewrites every byte of whitespace between tokens and leaves the token
+// sequence alone. The output is then pinned to what protojson *said* rather
+// than to how it spaced it. Everything else protojson already guarantees:
+// fields come in field-number order, and the schema has no map field whose keys
+// would need sorting.
+//
+// The property cannot be observed by rendering twice in one test binary — the
+// spacing is chosen once per process — which is why the normalization is tested
+// directly, against both shapes protojson emits, written out by hand.
 //
 // # It runs no generator
 //
@@ -79,11 +126,14 @@
 package emit
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 
 	"github.com/Zaba505/cpybkc/irpb"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -105,11 +155,68 @@ const (
 	// SPEC.md). A dash is therefore never a relative path here, and a caller
 	// wanting a file of that name spells it "./-".
 	Stdout = "-"
+
+	// FormatFlag is the name of the CLI flag selecting which [Format] --emit-ir
+	// writes, without its leading dashes.
+	//
+	// It is a flag of its own rather than a value of --emit-ir, and the reason
+	// is that --emit-ir's operand is already spoken for: it is the destination
+	// (#20), so `--emit-ir=json` names a file called "json" and cannot also name
+	// an encoding. A format and a destination are two answers, so they are two
+	// flags — which is also what lets either form go to either destination
+	// rather than making JSON a synonym for standard output.
+	FormatFlag = "emit-ir-format"
 )
 
+// Format is the encoding --emit-ir writes a descriptor in.
+//
+// The set is closed, and closed by the same argument docs/ir/SPEC.md closes the
+// node kinds with: a caller that meets an encoding this package does not
+// produce should be told so, rather than handed the default and left to work
+// out later which bytes it got.
+//
+// It satisfies flag.Value, so a command binds the flag with flag.Var and the
+// rejection of an unknown spelling happens once, here, at parse time.
+type Format string
+
+const (
+	// FormatBinary is the protobuf binary wire encoding: the canonical form, the
+	// bytes a plugin is handed, and what --emit-ir writes when nothing asks
+	// otherwise.
+	FormatBinary Format = "binary"
+
+	// FormatJSON is protojson, normalized: debug and interop output, one-way,
+	// and never what a plugin is handed. See the package documentation, "Two
+	// forms, and which one is canonical".
+	FormatJSON Format = "json"
+)
+
+// String returns the format as it is spelled on the command line, so that a
+// usage message and an error report the name a caller would type.
+func (f Format) String() string {
+	return string(f)
+}
+
+// Set parses the --emit-ir-format operand, and is what makes an unrecognised
+// encoding a parse failure rather than a silent fallback to [FormatBinary].
+//
+// A caller who asked for JSON and quietly received protobuf would find out at
+// whatever reads the file, which is the wrong end of the pipeline to discover a
+// misspelling from.
+func (f *Format) Set(s string) error {
+	switch parsed := Format(s); parsed {
+	case FormatBinary, FormatJSON:
+		*f = parsed
+
+		return nil
+	default:
+		return fmt.Errorf("%q is not a format; write %q or %q", s, FormatBinary, FormatJSON)
+	}
+}
+
 // Marshal encodes d in the protobuf binary wire encoding: the form a generator
-// plugin is handed, the form --emit-ir writes, and the only form this
-// repository produces a descriptor in.
+// plugin is handed, the form --emit-ir writes by default, and the canonical
+// form of a descriptor.
 //
 // The bytes are deterministic; see the package documentation for what that
 // covers and what it leaves to the producer of the descriptor.
@@ -132,8 +239,92 @@ func Marshal(d *irpb.Descriptor) ([]byte, error) {
 	return b, nil
 }
 
-// Write encodes d and writes it to dest, which is a filesystem path or [Stdout]
-// — in which case the bytes go to out and out alone.
+// MarshalJSON renders d as protojson, normalized: the debug and interop form
+// [FormatJSON] asks for, and never the form a plugin is handed.
+//
+// The rendering uses protobuf's own field names — start_state_id, not
+// startStateId — because a descriptor is read beside docs/ir/SPEC.md and
+// proto/cpybkc/ir/v1/ir.proto, and a lowerCamelCase rendering would make the
+// reader translate every name back before they could look one up.
+//
+// Two renderings of one descriptor are the same bytes, and so are two
+// renderings by different builds of cpybkc; the package documentation,
+// "Normalized, because protojson is not", says what that costs and why the
+// obvious implementation does not provide it.
+//
+// The bytes end in exactly one newline, because unlike the binary form this one
+// is a text file: it is committed, diffed and pasted into an issue, and a
+// rendering without a final newline reports itself as a change in every diff
+// that touches it and leaves a shell prompt mid-line.
+//
+// A nil descriptor is an error, for the reason [Marshal] gives — protojson
+// renders one as "{}" without complaint, which is a rendering of nothing that
+// looks like a rendering of an empty descriptor.
+func MarshalJSON(d *irpb.Descriptor) ([]byte, error) {
+	if d == nil {
+		return nil, fmt.Errorf("there is no descriptor to render")
+	}
+
+	b, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(d)
+	if err != nil {
+		return nil, fmt.Errorf("failed to render the descriptor as JSON: %w", err)
+	}
+
+	indented, err := indentJSON(b)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(indented, '\n'), nil
+}
+
+// jsonIndent is the indentation a rendered descriptor is written with. Two
+// spaces, which is what the layout format and the project manifest a reader
+// meets in the same sitting are indented with.
+const jsonIndent = "  "
+
+// indentJSON reformats valid JSON into one canonical indented shape, discarding
+// whatever insignificant whitespace it arrived carrying.
+//
+// This is the step that makes [MarshalJSON]'s output a function of the
+// descriptor rather than of the binary that rendered it. It is a function of
+// its own, and tested as one, because the property it supplies cannot be
+// observed through protojson from inside a single test binary.
+func indentJSON(b []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, b, "", jsonIndent); err != nil {
+		return nil, fmt.Errorf("failed to normalize the rendered descriptor: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// encode encodes d in the format asked for.
+//
+// An unrecognised format is an error rather than a fallback to [FormatBinary].
+// [Format.Set] already rejects one at parse time, so reaching here means a
+// caller assembled a Format some other way, and the failure it is about to
+// cause — a consumer handed bytes in an encoding it did not ask for — is worth
+// less than the failure of being told.
+func encode(d *irpb.Descriptor, format Format) ([]byte, error) {
+	switch format {
+	case FormatBinary:
+		return Marshal(d)
+	case FormatJSON:
+		return MarshalJSON(d)
+	default:
+		return nil, fmt.Errorf("--%s: %q is not a format; write %q or %q", FormatFlag, format, FormatBinary, FormatJSON)
+	}
+}
+
+// Write encodes d in format and writes it to dest, which is a filesystem path
+// or [Stdout] — in which case the bytes go to out and out alone.
+//
+// The format is a parameter rather than a default this function supplies,
+// because the two forms are not interchangeable (see the package documentation,
+// "Two forms, and which one is canonical") and a caller that never says which
+// one it wants is a caller that has not decided. The command line is where the
+// default lives: --emit-ir-format is bound to [FormatBinary].
 //
 // An existing file is replaced. A descriptor is derived entirely from its
 // inputs, so re-emitting after a layout changed is the whole point of the flag,
@@ -149,12 +340,12 @@ func Marshal(d *irpb.Descriptor) ([]byte, error) {
 // Nothing is created or truncated until d has encoded, so a call that fails
 // leaves whatever was at dest alone rather than replacing a good descriptor
 // with a short one.
-func Write(dest string, out io.Writer, d *irpb.Descriptor) error {
+func Write(dest string, out io.Writer, d *irpb.Descriptor, format Format) error {
 	if dest == "" {
 		return fmt.Errorf("--%s: name a file to write the descriptor to, or %q for standard output", Flag, Stdout)
 	}
 
-	b, err := Marshal(d)
+	b, err := encode(d, format)
 	if err != nil {
 		return err
 	}

--- a/internal/emit/emit_test.go
+++ b/internal/emit/emit_test.go
@@ -7,6 +7,7 @@ package emit_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"flag"
 	"io"
 	"os"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/Zaba505/cpybkc/internal/emit"
 	"github.com/Zaba505/cpybkc/irpb"
+	"google.golang.org/protobuf/proto"
 )
 
 // descriptor builds the fixture every test below emits.
@@ -172,28 +174,360 @@ func TestMarshalDistinguishesDescriptorsThatDiffer(t *testing.T) {
 	}
 }
 
-// TestWriteToAPathWritesTheEncodedDescriptor asserts the file holds the
-// encoding and nothing else. A trailing newline, a text framing, or anything
-// else added on the way past would be a file no protobuf runtime can decode.
+// goldenJSON is the rendering of [descriptor], written out in full.
+//
+// Every part of it is something a reader depends on and a change to it is a
+// change to what somebody is reading, which is what makes a golden the right
+// shape here rather than a set of assertions about it:
+//
+//   - protobuf's own field names — start_state_id, not startStateId — so a name
+//     on screen is the name in proto/cpybkc/ir/v1/ir.proto and in
+//     docs/ir/SPEC.md.
+//   - enums by name rather than by number, so CHARSET_ASCII reads as itself.
+//   - identifiers as quoted strings, which is protojson's rendering of a 64-bit
+//     integer and surprising enough to be worth pinning: a consumer of the
+//     rendering that expected 1 rather than "1" learns it from here.
+//   - two-space indentation, protobuf's field-number ordering, and one final
+//     newline.
+const goldenJSON = `{
+  "version": "IR_VERSION_1",
+  "nodes": [
+    {
+      "id": "1",
+      "file": {
+        "unframed": {},
+        "start_state_id": "2"
+      }
+    },
+    {
+      "id": "2",
+      "state": {
+        "accepts": true,
+        "transition_ids": [
+          "3"
+        ]
+      }
+    },
+    {
+      "id": "3",
+      "transition": {
+        "record_id": "4",
+        "next_state_id": "2",
+        "binding_ids": [
+          "8"
+        ]
+      }
+    },
+    {
+      "id": "4",
+      "record": {
+        "root_id": "5",
+        "names": {
+          "original": "DETAIL-RECORD"
+        }
+      }
+    },
+    {
+      "id": "5",
+      "group": {
+        "member_ids": [
+          "6",
+          "9"
+        ],
+        "names": {
+          "original": "DETAIL"
+        }
+      }
+    },
+    {
+      "id": "6",
+      "field": {
+        "width": 8,
+        "encoding": {
+          "charset": "CHARSET_ASCII",
+          "sign_convention": "SIGN_CONVENTION_EBCDIC",
+          "byte_order": "BYTE_ORDER_BIG_ENDIAN",
+          "float_format": "FLOAT_FORMAT_IBM_HFP"
+        },
+        "usage": "USAGE_DISPLAY",
+        "picture": {
+          "category": "CATEGORY_NUMERIC",
+          "digits": 8,
+          "scale": -2,
+          "signed": true,
+          "sign_position": "SIGN_POSITION_TRAILING"
+        },
+        "names": {
+          "original": "DTL-AMOUNT"
+        }
+      }
+    },
+    {
+      "id": "7",
+      "register": {
+        "kind": "REGISTER_KIND_INTEGER"
+      }
+    },
+    {
+      "id": "8",
+      "binding": {
+        "register_id": "7",
+        "decrement": {}
+      }
+    },
+    {
+      "id": "9",
+      "slack": {
+        "width": 2
+      }
+    }
+  ]
+}
+`
+
+// TestMarshalJSONRendersTheGolden is the golden test the JSON form is worth
+// having: the rendering of a known descriptor, byte for byte.
+//
+// It fails on a change to the field names, to the indentation, to the ordering
+// and to protojson's own spacing, which is the point — every one of those is a
+// change to a file people commit and diff, and none of them would fail a test
+// that merely checked the output parsed.
+func TestMarshalJSONRendersTheGolden(t *testing.T) {
+	got, err := emit.MarshalJSON(descriptor())
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+
+	if string(got) != goldenJSON {
+		t.Errorf("the rendering is not the golden\n got:\n%s\nwant:\n%s", got, goldenJSON)
+	}
+
+	if !json.Valid(got) {
+		t.Errorf("the rendering is not valid JSON:\n%s", got)
+	}
+}
+
+// TestMarshalJSONIsStableAcrossRuns is the acceptance criterion at the
+// renderer, and it is the same pair of loops [TestMarshalIsDeterministic] runs
+// for the binary form: rendering one value repeatedly catches a renderer that
+// varies between calls, and rendering a value assembled again catches one that
+// depends on how the message was built.
+//
+// What neither loop can catch is the whitespace protojson chooses per process,
+// because both run inside one process. That property is asserted directly, on
+// the function that supplies it, in normalize_test.go.
+func TestMarshalJSONIsStableAcrossRuns(t *testing.T) {
+	want, err := emit.MarshalJSON(descriptor())
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+
+	if len(want) == 0 {
+		t.Fatal("rendering the fixture produced no bytes, so nothing below is comparing anything")
+	}
+
+	d := descriptor()
+	for i := range 64 {
+		got, err := emit.MarshalJSON(d)
+		if err != nil {
+			t.Fatalf("render, call %d: %v", i, err)
+		}
+
+		if !bytes.Equal(got, want) {
+			t.Fatalf("call %d rendered the same descriptor differently:\n got:\n%s\nwant:\n%s", i, got, want)
+		}
+	}
+
+	for i := range 64 {
+		got, err := emit.MarshalJSON(descriptor())
+		if err != nil {
+			t.Fatalf("render a rebuilt descriptor, call %d: %v", i, err)
+		}
+
+		if !bytes.Equal(got, want) {
+			t.Fatalf("descriptor %d, rebuilt from the same values, rendered differently:\n got:\n%s\nwant:\n%s", i, got, want)
+		}
+	}
+}
+
+// TestMarshalJSONDistinguishesDescriptorsThatDiffer is the other direction,
+// without which every comparison above would be satisfied by a renderer that
+// returned a constant.
+func TestMarshalJSONDistinguishesDescriptorsThatDiffer(t *testing.T) {
+	base, err := emit.MarshalJSON(descriptor())
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+
+	changed := descriptor()
+	changed.Nodes[5].GetField().Width = 9
+
+	got, err := emit.MarshalJSON(changed)
+	if err != nil {
+		t.Fatalf("render the changed descriptor: %v", err)
+	}
+
+	if bytes.Equal(got, base) {
+		t.Fatal("a descriptor whose field width changed rendered identically, so the rendering is not carrying the change")
+	}
+}
+
+// TestTheTwoFormsAreNotInterchangeable states the thing the package
+// documentation argues: JSON is a rendering, not a second encoding a consumer
+// may be handed instead. A consumer that read one where it expected the other
+// has to fail rather than half-succeed, and these bytes cannot be confused.
+func TestTheTwoFormsAreNotInterchangeable(t *testing.T) {
+	binary, err := emit.Marshal(descriptor())
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	rendered, err := emit.MarshalJSON(descriptor())
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+
+	if bytes.Equal(binary, rendered) {
+		t.Fatal("the two forms produced the same bytes")
+	}
+
+	if json.Valid(binary) {
+		t.Error("the binary encoding parses as JSON, so a consumer could not tell which form it was handed")
+	}
+
+	if err := proto.Unmarshal(rendered, &irpb.Descriptor{}); err == nil {
+		t.Error("the rendering decodes as a descriptor, so a consumer could not tell which form it was handed")
+	}
+}
+
+// TestTheFormatFlagBindsToAFormat drives the format the way the command will:
+// one flag, bound with flag.Var so that the parse is where a misspelling is
+// caught.
+//
+// It is here for the reason [TestTheFlagBindsToADestination] is — the flag name
+// and the two spellings are a contract with a command that does not exist yet
+// (#42) — plus one this flag adds: the default is the canonical form, and a
+// caller who says nothing must not silently receive the debug one.
+func TestTheFormatFlagBindsToAFormat(t *testing.T) {
+	testCases := []struct {
+		name    string
+		args    []string
+		want    emit.Format
+		wantErr bool
+	}{
+		{
+			name: "not requested",
+			args: nil,
+			want: emit.FormatBinary,
+		},
+		{
+			name: "binary, asked for by name",
+			args: []string{"--" + emit.FormatFlag, emit.FormatBinary.String()},
+			want: emit.FormatBinary,
+		},
+		{
+			name: "json",
+			args: []string{"--" + emit.FormatFlag + "=" + emit.FormatJSON.String()},
+			want: emit.FormatJSON,
+		},
+		{
+			name:    "a format this package does not produce",
+			args:    []string{"--" + emit.FormatFlag, "yaml"},
+			want:    emit.FormatBinary,
+			wantErr: true,
+		},
+		{
+			name:    "an empty format",
+			args:    []string{"--" + emit.FormatFlag, ""},
+			want:    emit.FormatBinary,
+			wantErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			flags := flag.NewFlagSet("cpybkc", flag.ContinueOnError)
+			flags.SetOutput(io.Discard)
+
+			got := emit.FormatBinary
+			flags.Var(&got, emit.FormatFlag, "write the resolved IR in this format")
+
+			err := flags.Parse(testCase.args)
+			if testCase.wantErr {
+				if err == nil {
+					t.Fatalf("parsing %v succeeded, so an unknown format reaches the emission", testCase.args)
+				}
+			} else if err != nil {
+				t.Fatalf("parse %v: %v", testCase.args, err)
+			}
+
+			if got != testCase.want {
+				t.Fatalf("--%s parsed to %q, want %q", emit.FormatFlag, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestWriteRejectsAnUnknownFormat covers the format that did not come through
+// the flag. Falling back to the binary form would hand a caller bytes in an
+// encoding it did not ask for, and nothing downstream would say so.
+func TestWriteRejectsAnUnknownFormat(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "ir")
+
+	err := emit.Write(dest, io.Discard, descriptor(), emit.Format("yaml"))
+	if err == nil {
+		t.Fatal("writing in an unknown format succeeded")
+	}
+
+	if !strings.Contains(err.Error(), emit.FormatFlag) {
+		t.Errorf("the error does not name --%s, so it does not say what to fix: %v", emit.FormatFlag, err)
+	}
+
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Errorf("the rejected write created %s anyway", dest)
+	}
+}
+
+// formats pairs every [emit.Format] with the function that produces it, so that
+// a test claiming something about "the emission" runs over both rather than
+// over whichever one was written first.
+//
+// It is the guard on adding a third: a format that reaches [emit.Write] and not
+// this map is a format nothing below checks ever gets to disk.
+func formats() map[emit.Format]func(*irpb.Descriptor) ([]byte, error) {
+	return map[emit.Format]func(*irpb.Descriptor) ([]byte, error){
+		emit.FormatBinary: emit.Marshal,
+		emit.FormatJSON:   emit.MarshalJSON,
+	}
+}
+
+// TestWriteToAPathWritesTheEncodedDescriptor asserts the file holds what the
+// format encoded and nothing else. Anything added on the way past — a framing,
+// a second newline — is a file whose reader disagrees with this package about
+// where the descriptor ends.
 func TestWriteToAPathWritesTheEncodedDescriptor(t *testing.T) {
-	dest := filepath.Join(t.TempDir(), "ir.binpb")
+	for format, marshal := range formats() {
+		t.Run(format.String(), func(t *testing.T) {
+			dest := filepath.Join(t.TempDir(), "ir")
 
-	if err := emit.Write(dest, io.Discard, descriptor()); err != nil {
-		t.Fatalf("write: %v", err)
-	}
+			if err := emit.Write(dest, io.Discard, descriptor(), format); err != nil {
+				t.Fatalf("write: %v", err)
+			}
 
-	got, err := os.ReadFile(dest)
-	if err != nil {
-		t.Fatalf("read %s: %v", dest, err)
-	}
+			got, err := os.ReadFile(dest)
+			if err != nil {
+				t.Fatalf("read %s: %v", dest, err)
+			}
 
-	want, err := emit.Marshal(descriptor())
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
+			want, err := marshal(descriptor())
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
 
-	if !bytes.Equal(got, want) {
-		t.Fatalf("the file is not the encoded descriptor: %d bytes on disk, %d bytes encoded", len(got), len(want))
+			if !bytes.Equal(got, want) {
+				t.Fatalf("the file is not the encoded descriptor: %d bytes on disk, %d bytes encoded", len(got), len(want))
+			}
+		})
 	}
 }
 
@@ -202,24 +536,28 @@ func TestWriteToAPathWritesTheEncodedDescriptor(t *testing.T) {
 // the same bytes, or a caller redirecting the one would be reading something
 // subtly other than what a plugin is handed.
 func TestWriteToStdoutWritesTheSameBytes(t *testing.T) {
-	var out bytes.Buffer
+	for format := range formats() {
+		t.Run(format.String(), func(t *testing.T) {
+			var out bytes.Buffer
 
-	if err := emit.Write(emit.Stdout, &out, descriptor()); err != nil {
-		t.Fatalf("write to %q: %v", emit.Stdout, err)
-	}
+			if err := emit.Write(emit.Stdout, &out, descriptor(), format); err != nil {
+				t.Fatalf("write to %q: %v", emit.Stdout, err)
+			}
 
-	dest := filepath.Join(t.TempDir(), "ir.binpb")
-	if err := emit.Write(dest, io.Discard, descriptor()); err != nil {
-		t.Fatalf("write to a path: %v", err)
-	}
+			dest := filepath.Join(t.TempDir(), "ir")
+			if err := emit.Write(dest, io.Discard, descriptor(), format); err != nil {
+				t.Fatalf("write to a path: %v", err)
+			}
 
-	want, err := os.ReadFile(dest)
-	if err != nil {
-		t.Fatalf("read %s: %v", dest, err)
-	}
+			want, err := os.ReadFile(dest)
+			if err != nil {
+				t.Fatalf("read %s: %v", dest, err)
+			}
 
-	if !bytes.Equal(out.Bytes(), want) {
-		t.Fatalf("the stream and the file disagree: %d bytes on the stream, %d in the file", out.Len(), len(want))
+			if !bytes.Equal(out.Bytes(), want) {
+				t.Fatalf("the stream and the file disagree: %d bytes on the stream, %d in the file", out.Len(), len(want))
+			}
+		})
 	}
 }
 
@@ -227,15 +565,19 @@ func TestWriteToStdoutWritesTheSameBytes(t *testing.T) {
 // other side. A caller running `--emit-ir out.binpb` with its standard output
 // going somewhere that matters must not find a descriptor in it as well.
 func TestWriteToAPathLeavesTheStreamUntouched(t *testing.T) {
-	var out bytes.Buffer
+	for format := range formats() {
+		t.Run(format.String(), func(t *testing.T) {
+			var out bytes.Buffer
 
-	dest := filepath.Join(t.TempDir(), "ir.binpb")
-	if err := emit.Write(dest, &out, descriptor()); err != nil {
-		t.Fatalf("write: %v", err)
-	}
+			dest := filepath.Join(t.TempDir(), "ir")
+			if err := emit.Write(dest, &out, descriptor(), format); err != nil {
+				t.Fatalf("write: %v", err)
+			}
 
-	if out.Len() != 0 {
-		t.Fatalf("writing to %s also put %d bytes on the stream", dest, out.Len())
+			if out.Len() != 0 {
+				t.Fatalf("writing to %s also put %d bytes on the stream", dest, out.Len())
+			}
+		})
 	}
 }
 
@@ -243,34 +585,38 @@ func TestWriteToAPathLeavesTheStreamUntouched(t *testing.T) {
 // two emissions of one descriptor are byte-identical files, so a descriptor
 // committed beside a fixture stays a diff of the layout rather than of the run.
 func TestWriteIsReproducible(t *testing.T) {
-	dir := t.TempDir()
+	for format := range formats() {
+		t.Run(format.String(), func(t *testing.T) {
+			dir := t.TempDir()
 
-	first := filepath.Join(dir, "first.binpb")
-	if err := emit.Write(first, io.Discard, descriptor()); err != nil {
-		t.Fatalf("first write: %v", err)
-	}
+			first := filepath.Join(dir, "first")
+			if err := emit.Write(first, io.Discard, descriptor(), format); err != nil {
+				t.Fatalf("first write: %v", err)
+			}
 
-	second := filepath.Join(dir, "second.binpb")
-	if err := emit.Write(second, io.Discard, descriptor()); err != nil {
-		t.Fatalf("second write: %v", err)
-	}
+			second := filepath.Join(dir, "second")
+			if err := emit.Write(second, io.Discard, descriptor(), format); err != nil {
+				t.Fatalf("second write: %v", err)
+			}
 
-	a, err := os.ReadFile(first)
-	if err != nil {
-		t.Fatalf("read %s: %v", first, err)
-	}
+			a, err := os.ReadFile(first)
+			if err != nil {
+				t.Fatalf("read %s: %v", first, err)
+			}
 
-	b, err := os.ReadFile(second)
-	if err != nil {
-		t.Fatalf("read %s: %v", second, err)
-	}
+			b, err := os.ReadFile(second)
+			if err != nil {
+				t.Fatalf("read %s: %v", second, err)
+			}
 
-	if len(a) == 0 {
-		t.Fatal("the first emission is empty")
-	}
+			if len(a) == 0 {
+				t.Fatal("the first emission is empty")
+			}
 
-	if !bytes.Equal(a, b) {
-		t.Fatalf("two emissions of one descriptor differ: %d bytes then %d", len(a), len(b))
+			if !bytes.Equal(a, b) {
+				t.Fatalf("two emissions of one descriptor differ: %d bytes then %d", len(a), len(b))
+			}
+		})
 	}
 }
 
@@ -284,7 +630,7 @@ func TestWriteReplacesAnExistingFile(t *testing.T) {
 		t.Fatalf("seed %s: %v", dest, err)
 	}
 
-	if err := emit.Write(dest, io.Discard, descriptor()); err != nil {
+	if err := emit.Write(dest, io.Discard, descriptor(), emit.FormatBinary); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 
@@ -338,7 +684,7 @@ func TestWriteRejectsBadDestinations(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			err := emit.Write(testCase.dest, io.Discard, descriptor())
+			err := emit.Write(testCase.dest, io.Discard, descriptor(), emit.FormatBinary)
 			if err == nil {
 				t.Fatalf("writing to %q succeeded", testCase.dest)
 			}
@@ -356,28 +702,32 @@ func TestWriteRejectsBadDestinations(t *testing.T) {
 // existing file it replaced on the way would already be gone — so the second
 // half asserts that dest is untouched as well.
 func TestNoDescriptorIsAnError(t *testing.T) {
-	if _, err := emit.Marshal(nil); err == nil {
-		t.Error("encoding no descriptor succeeded")
-	}
+	for format, marshal := range formats() {
+		t.Run(format.String(), func(t *testing.T) {
+			if _, err := marshal(nil); err == nil {
+				t.Error("encoding no descriptor succeeded")
+			}
 
-	dest := filepath.Join(t.TempDir(), "ir.binpb")
+			dest := filepath.Join(t.TempDir(), "ir")
 
-	seed := bytes.Repeat([]byte{0xff}, 16)
-	if err := os.WriteFile(dest, seed, 0o644); err != nil {
-		t.Fatalf("seed %s: %v", dest, err)
-	}
+			seed := bytes.Repeat([]byte{0xff}, 16)
+			if err := os.WriteFile(dest, seed, 0o644); err != nil {
+				t.Fatalf("seed %s: %v", dest, err)
+			}
 
-	if err := emit.Write(dest, io.Discard, nil); err == nil {
-		t.Fatalf("writing no descriptor to %s succeeded", dest)
-	}
+			if err := emit.Write(dest, io.Discard, nil, format); err == nil {
+				t.Fatalf("writing no descriptor to %s succeeded", dest)
+			}
 
-	got, err := os.ReadFile(dest)
-	if err != nil {
-		t.Fatalf("read %s: %v", dest, err)
-	}
+			got, err := os.ReadFile(dest)
+			if err != nil {
+				t.Fatalf("read %s: %v", dest, err)
+			}
 
-	if !bytes.Equal(got, seed) {
-		t.Errorf("the failed write replaced %s anyway: %d bytes where %d were", dest, len(got), len(seed))
+			if !bytes.Equal(got, seed) {
+				t.Errorf("the failed write replaced %s anyway: %d bytes where %d were", dest, len(got), len(seed))
+			}
+		})
 	}
 }
 
@@ -385,7 +735,7 @@ func TestNoDescriptorIsAnError(t *testing.T) {
 // a full disk, a closed pipe — which is the failure mode the stdout operand
 // adds and the one a caller redirecting into a file has to hear about.
 func TestWriteReportsAStreamItCannotWrite(t *testing.T) {
-	err := emit.Write(emit.Stdout, failingWriter{}, descriptor())
+	err := emit.Write(emit.Stdout, failingWriter{}, descriptor(), emit.FormatBinary)
 	if err == nil {
 		t.Fatal("writing to a stream that fails succeeded")
 	}

--- a/internal/emit/normalize_test.go
+++ b/internal/emit/normalize_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// This file is in package emit rather than emit_test, which is the exception in
+// this repository and is here for one reason: the property it asserts is the
+// whole of what makes [MarshalJSON]'s output worth committing, and it cannot be
+// observed from outside.
+//
+// protojson chooses its extra whitespace from a hash of the running binary, so
+// it is fixed for the life of a test process and different in the next build. A
+// test that rendered twice and compared would therefore pass in every build,
+// including the ones where the output had changed. The only way to fail on that
+// is to hand the normalizer both spacings by hand, which means calling it
+// directly.
+package emit
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestIndentJSONIgnoresTheWhitespaceItIsHanded is the assertion the paragraph
+// above exists for.
+//
+// The two inputs are the two shapes protojson emits — a space after a comma,
+// and a second space after a "key": — written out rather than produced, so that
+// a regression fails every time instead of in half of all builds.
+func TestIndentJSONIgnoresTheWhitespaceItIsHanded(t *testing.T) {
+	compact := []byte(`{"version":"IR_VERSION_1","nodes":[{"id":"1","slack":{"width":2}}]}`)
+	spaced := []byte(`{"version":  "IR_VERSION_1", "nodes": [{"id":  "1", "slack": {"width":  2}}]}`)
+
+	fromCompact, err := indentJSON(compact)
+	if err != nil {
+		t.Fatalf("normalize the compact form: %v", err)
+	}
+
+	fromSpaced, err := indentJSON(spaced)
+	if err != nil {
+		t.Fatalf("normalize the spaced form: %v", err)
+	}
+
+	if !bytes.Equal(fromCompact, fromSpaced) {
+		t.Errorf("the output depends on the whitespace it was handed\n from compact:\n%s\n from spaced:\n%s", fromCompact, fromSpaced)
+	}
+}
+
+// TestIndentJSONLeavesContentAlone is the other half. Whitespace inside a
+// string is a COBOL name or a value, not spacing between tokens, and a
+// normalizer that reformatted it would be changing the descriptor rather than
+// the rendering of one.
+func TestIndentJSONLeavesContentAlone(t *testing.T) {
+	got, err := indentJSON([]byte(`{"names":{"original":"DTL  AMOUNT, LOW"}}`))
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+
+	if !bytes.Contains(got, []byte(`"DTL  AMOUNT, LOW"`)) {
+		t.Errorf("the string's own spacing was rewritten:\n%s", got)
+	}
+}
+
+// TestIndentJSONReportsWhatItCannotParse keeps a failure a failure. Every input
+// this package hands it came from protojson and is valid, so reaching the error
+// means something upstream is broken and returning the bytes unchanged would
+// hide it.
+func TestIndentJSONReportsWhatItCannotParse(t *testing.T) {
+	if _, err := indentJSON([]byte(`{"unterminated":`)); err == nil {
+		t.Error("normalizing invalid JSON succeeded")
+	}
+}


### PR DESCRIPTION
Closes #21

Adds the JSON form of the resolved IR: the debug and interop output `docs/ir/SPEC.md` has been promising since #17 ("The JSON debug form (#21)"), normalized so that two emissions of one descriptor are the same bytes in every build.

```
$ cpybkc --emit-ir - --emit-ir-format json
{
  "version": "IR_VERSION_1",
  "nodes": [
    {
      "id": "1",
      "file": {
        "unframed": {},
        "start_state_id": "2"
      }
    },
    ...
  ]
}
```

## Acceptance criteria

- [x] **`--emit-ir=json` emits protojson.** Spelled `--emit-ir-format json`, for the reason under Judgment calls below — `--emit-ir`'s operand is already the destination (#20). `emit.MarshalJSON` renders it, `emit.Write` dispatches on `emit.Format`.
- [x] **Output is normalized so identical inputs produce byte-identical JSON.** protojson's output is re-indented through `encoding/json` before it is returned, which discards the whitespace protojson varies per binary and leaves the token sequence alone. Field names are protobuf's own (`start_state_id`, not `startStateId`).
- [x] **A golden test asserts byte stability across repeated runs.** `TestMarshalJSONRendersTheGolden` pins the whole rendering of the package's fixture descriptor byte for byte; `TestMarshalJSONIsStableAcrossRuns` renders 64 times, and 64 more times from a descriptor rebuilt from the same values. `TestWriteIsReproducible` now runs over both formats, so the file on disk is covered too.
- [x] **Documented as debug/interop output, with the binary form named as canonical.** New `docs/ir/SPEC.md` section *A descriptor is readable by a person*, with subsections *The binary form is canonical* and *The rendering is normalized*, plus its row in the Mapping to Stories appendix and links from the two places that already cited #21. The package documentation carries the implementer-facing version.

## Judgment calls

**The flag is `--emit-ir-format json`, not `--emit-ir=json`.** The story spells it the second way, and that spelling is not available: #20 landed `--emit-ir <path>`, whose operand is the destination, so `--emit-ir=json` names a file called `json` and cannot also name an encoding. A format and a destination are two answers, so they are two flags — which is also what lets either form go to a path or to `-`, rather than making JSON a synonym for standard output. `emit.FormatFlag` carries the name, and its doc comment carries this paragraph.

**The default is the canonical form.** `emit.Format` has no useful zero value and `emit.Write` takes it as a parameter rather than defaulting: a caller that never said which form it wanted has not decided, and the two are not interchangeable. The default lives on the command line, bound to `FormatBinary`, and the spec now states that as a requirement on any tool offering both — the form somebody depends on is the one they get by not deciding.

**`Format` satisfies `flag.Value`.** An unknown spelling fails at parse time with an error naming the two that exist, rather than falling back to binary and handing a caller bytes in an encoding it did not ask for. `emit.Write` rejects one too, for a `Format` assembled some other way.

**The JSON ends in exactly one newline; the binary form still ends where the message does.** The rendering is a text file — committed, diffed, pasted into an issue — and one without a final newline reports itself as a change in every diff that touches it.

**One test file is in `package emit`.** `internal/emit/normalize_test.go` tests `indentJSON` directly, which is the exception to this repository's external-test convention and is explained at the top of the file: protojson picks its extra whitespace from a hash of the running binary, so it is fixed for the life of a test process. A test that rendered twice and compared would pass in every build, including the ones where the output had changed. The only thing that fails on that is handing the normalizer both spacings by hand.

**No `README.md` change.** There is no CLI yet (#42), and #20 did not document the flag there either; the user-facing text lands with the command.

## Verification

`dagger call ci` passes — fmt, vet, `golangci-lint` and `go test -race` over both modules, `buf lint`, and the artifact build. `internal/emit` coverage 92.5%.

One note on the tooling rather than the code: the first `dagger call ci` after an aborted `dagger call lint` failed with `resolve ID input "engineResult(...)": missing shared result`, a stale entry in the engine's session cache rather than anything in this branch. Restarting the engine container cleared it and the run is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
