### PR TITLE
story(layout): publish a machine-readable schema for the layout format

### DIFF
--- a/.dagger/dagger.gen.go
+++ b/.dagger/dagger.gen.go
@@ -244,6 +244,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return (*Cpybkc).IrProtos(&parent), nil
+		case "LayoutArtifact":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Cpybkc).LayoutArtifact(&parent, ctx)
+		case "LayoutSchema":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Cpybkc).LayoutSchema(&parent), nil
 		case "Lint":
 			var parent Cpybkc
 			err = json.Unmarshal(parentJSON, &parent)

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -61,14 +61,16 @@
 //
 // # Why the release artifacts are built here
 //
-// IrDescriptorSet and IrProtos produce the two files a release attaches — the
-// IR's FileDescriptorSet and the schema sources (#19) — and they are functions
-// on this module for the same reason ProtoLint is: a recipe that only ever ran
-// inside .github/workflows/release.yaml would be a build nobody can reproduce
-// locally and one that first runs on a tag, where a failure is a release that
-// did not happen. Here, `dagger call ir-descriptor-set` is a command a
-// contributor runs, and IrArtifacts puts both builds inside Ci so the recipe is
-// exercised on every pull request rather than once per release.
+// IrDescriptorSet and IrProtos produce two of the three files a release
+// attaches — the IR's FileDescriptorSet and the schema sources (#19) — and
+// LayoutSchema produces the third, the published layout schema a shop's layout
+// generator targets (#23). They are functions on this module for the same reason
+// ProtoLint is: a recipe that only ever ran inside
+// .github/workflows/release.yaml would be a build nobody can reproduce locally
+// and one that first runs on a tag, where a failure is a release that did not
+// happen. Here, `dagger call ir-descriptor-set` is a command a contributor runs,
+// and IrArtifacts and LayoutArtifact put all three builds inside Ci so the
+// recipes are exercised on every pull request rather than once per release.
 //
 // They are also the seam the container work builds on: #57 copies the same file
 // into the published image, from this function rather than from a second
@@ -142,12 +144,12 @@ func New(
 
 // Ci runs the whole pipeline: fmt, vet, golangci-lint and `go test -race`, as
 // the Z5Labs standard defines them, over each of this repository's two Go
-// modules, plus `buf lint` over the IR schema and a build of the two artifacts a
-// release publishes. This is the single entrypoint — CI is one `dagger call ci`
-// and stays one, because a workflow step that reran any of these stages would be
-// a second definition of them.
+// modules, plus `buf lint` over the IR schema and a build of the three artifacts
+// a release publishes. This is the single entrypoint — CI is one
+// `dagger call ci` and stays one, because a workflow step that reran any of
+// these stages would be a second definition of them.
 //
-// The four parts run concurrently and all are reported, for the reason the
+// The five parts run concurrently and all are reported, for the reason the
 // standard runs its own four that way: waiting on a Go stage to learn that the
 // schema is unlintable, or the reverse, is a second push to find out about the
 // second failure.
@@ -155,10 +157,10 @@ func New(
 // +check
 // +cache="session"
 func (m *Cpybkc) Ci(ctx context.Context) error {
-	var goErr, irErr, protoErr, artifactErr error
+	var goErr, irErr, protoErr, artifactErr, layoutErr error
 
 	var wg sync.WaitGroup
-	wg.Add(4)
+	wg.Add(5)
 
 	go func() {
 		defer wg.Done()
@@ -182,9 +184,14 @@ func (m *Cpybkc) Ci(ctx context.Context) error {
 		artifactErr = m.IrArtifacts(ctx)
 	}()
 
+	go func() {
+		defer wg.Done()
+		layoutErr = m.LayoutArtifact(ctx)
+	}()
+
 	wg.Wait()
 
-	return errors.Join(goErr, irErr, protoErr, artifactErr)
+	return errors.Join(goErr, irErr, protoErr, artifactErr, layoutErr)
 }
 
 // IrCi runs the same standard pipeline over irpb/, the published IR module.
@@ -408,6 +415,61 @@ func (m *Cpybkc) IrArtifacts(ctx context.Context) error {
 	}
 
 	return errors.Join(errs...)
+}
+
+// LayoutSchema builds the published layout schema — the released
+// layout-schema.sexpr — by checking that this repository's schema loads and
+// writing it out unchanged:
+//
+//	dagger call layout-schema export --path=layout-schema.sexpr
+//
+// It is the third asset a release attaches, and the one that is not about the
+// IR. docs/layout/SPEC.md's "The published schema" is the contract: the set of
+// form declarations a shop's layout generator targets, written in the notation
+// it describes. An adopter validating what they generated runs cpybkc, which
+// reads this same file.
+//
+// The bytes are the repository's schema/layout.sexpr byte for byte, because an
+// adopter's diagnostic and this repository's have to be about the same text. So
+// what the command adds is the check rather than a transformation, and
+// internal/tools/layout-schema carries the argument for why that check happens
+// on the way out as well as in the tests.
+//
+// It is a function on this module for the reason IrDescriptorSet is: a recipe
+// that only ever ran inside .github/workflows/release.yaml would be a build
+// nobody can reproduce locally and one that first runs on a tag, where a failure
+// is a release that did not happen.
+func (m *Cpybkc) LayoutSchema() *dagger.File {
+	const out = "/out/layout-schema.sexpr"
+
+	return dag.Go().
+		Container(m.Source).
+		WithExec([]string{"go", "run", "./internal/tools/layout-schema", "-o", out}).
+		File(out)
+}
+
+// LayoutArtifact builds the layout schema and fails if it is empty.
+//
+// It is IrArtifacts' counterpart for the layout half of what a release carries,
+// separate from it because the two are about different contracts and a run
+// failing on one should say which. Everything IrArtifacts' comment says about
+// why an artifact build belongs in Ci applies here unchanged, and the empty file
+// is the same failure: it is what a tool that created its parent directory and
+// exited would leave behind, and it uploads as happily as a good one.
+//
+// +check
+// +cache="session"
+func (m *Cpybkc) LayoutArtifact(ctx context.Context) error {
+	size, err := m.LayoutSchema().Size(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to build layout-schema.sexpr: %w", err)
+	}
+
+	if size == 0 {
+		return fmt.Errorf("layout-schema.sexpr built to an empty file")
+	}
+
+	return nil
 }
 
 // stage returns the check builder the standard pipeline builds on, bound to

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,11 +10,12 @@ name: Release
 # later, which is the shape a release with notes to write actually takes.
 #
 # There is no filter on which tag. This repository publishes two tag schemes —
-# vX.Y.Z for the CLI and irpb/vX.Y.Z for the IR module — and the IR is what both
-# of them ship, so both get the artifacts. The bytes are a function of the tag's
-# source, so each release's assets describe the schema that release carried, and
-# a reader who has found a release has the IR one download away without having to
-# know which of the two schemes is the one that publishes it.
+# vX.Y.Z for the CLI and irpb/vX.Y.Z for the IR module — and the contracts below
+# are what both of them ship, so both get the artifacts. The bytes are a function
+# of the tag's source, so each release's assets describe the interfaces that
+# release carried, and a reader who has found a release has them one download
+# away without having to know which of the two schemes is the one that publishes
+# them.
 on:
   release:
     types: [published]
@@ -24,7 +25,7 @@ permissions:
   contents: read
 
 jobs:
-  # The two IR artifacts, attached to the release.
+  # The three contract artifacts, attached to the release.
   #
   # ir.binpb is the protobuf FileDescriptorSet describing cpybkc.ir.v1.Descriptor
   # (#19), so that a plugin author whose language has no protobuf code generation
@@ -34,12 +35,20 @@ jobs:
   # the consumer who would rather generate bindings than decode against a
   # descriptor set. Neither substitutes for the other.
   #
+  # layout-schema.sexpr is the third and is for the other side of the pipeline:
+  # not the plugin author reading a resolved descriptor, but the adopter
+  # generating layout files from metadata they already hold (#23). It is
+  # docs/layout/SPEC.md's "The published schema" — the form declarations a layout
+  # generator targets and cpybkc's own validator reads — and it carries its
+  # version inside it rather than in its name, so that a file downloaded on its
+  # own still says which version of the format it describes.
+  #
   # The same ir.binpb bytes will ship inside the published image (#57). That is
   # two ways of getting one artifact rather than two artifacts, and what keeps it
   # so is that both come from `dagger call ir-descriptor-set` rather than from
   # two recipes that agree today.
-  ir-artifacts:
-    name: IR artifacts
+  artifacts:
+    name: Release artifacts
     runs-on: ubuntu-latest
     permissions:
       # Reading the source, and writing the assets onto the release. Nothing else
@@ -65,17 +74,18 @@ jobs:
               BIN_DIR="$HOME/.local/bin" sh
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      # The same two functions `dagger call ci` builds on every pull request and
-      # a contributor runs locally, so the released assets are produced by a
+      # The same three functions `dagger call ci` builds on every pull request
+      # and a contributor runs locally, so the released assets are produced by a
       # recipe that has already been exercised rather than by one that only ever
       # runs at release time.
-      - name: Build the IR artifacts
+      - name: Build the artifacts
         run: |
           dagger call ir-descriptor-set export --path "$RUNNER_TEMP/ir.binpb"
           dagger call ir-protos export --path "$RUNNER_TEMP/ir-protos.tar.gz"
+          dagger call layout-schema export --path "$RUNNER_TEMP/layout-schema.sexpr"
 
       # --clobber so that re-running a failed release job replaces the assets
-      # instead of failing on a name that is already taken. Both artifacts are a
+      # instead of failing on a name that is already taken. Every artifact is a
       # function of the tag's source, so a re-upload cannot change what they say.
       - name: Attach them to the release
         env:
@@ -84,4 +94,5 @@ jobs:
           gh release upload "${{ github.event.release.tag_name }}" \
             "$RUNNER_TEMP/ir.binpb" \
             "$RUNNER_TEMP/ir-protos.tar.gz" \
+            "$RUNNER_TEMP/layout-schema.sexpr" \
             --clobber

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## The pipeline
 
-fmt, vet, golangci-lint, `go test -race`, `buf lint` and the two artifacts a
+fmt, vet, golangci-lint, `go test -race`, `buf lint` and the three artifacts a
 release attaches are defined once, in the root Dagger module under
 [`.dagger/`](.dagger/). CI calls that module and so do you, which is the point:
 there is no arrangement of local commands that passes while CI fails, because
@@ -31,7 +31,8 @@ dagger call lint          # golangci-lint over ./... against .golangci.yml
 dagger call test          # go test -race ./...
 dagger call proto-lint    # buf lint over proto/ against buf.yaml
 dagger call ir-ci         # the whole standard again, over the irpb/ module
-dagger call ir-artifacts  # builds the two artifacts a release attaches
+dagger call ir-artifacts  # builds the two IR artifacts a release attaches
+dagger call layout-artifact  # builds the layout schema a release attaches
 ```
 
 The first four are not a second definition of the pipeline. Each drives the same
@@ -43,9 +44,10 @@ schema](#linting-the-ir-schema).
 
 `ir-ci` is not a stage but the whole standard a second time, over the second Go
 module; see [The IR module](#the-ir-module) for why there is one. `ir-artifacts`
-is not a stage either; see [The release artifacts](#the-release-artifacts).
+and `layout-artifact` are not stages either; see [The release
+artifacts](#the-release-artifacts).
 
-`dagger check` runs all eight as a checklist, if you would rather see them
+`dagger check` runs all nine as a checklist, if you would rather see them
 together than pick one.
 
 ### Getting the tools
@@ -218,12 +220,14 @@ kept in step by hand.
 
 ## The release artifacts
 
-Every published release carries two files describing the IR, for the plugin
-authors who are not importing `irpb`:
+Every published release carries three files. Two describe the IR, for the plugin
+authors who are not importing `irpb`; the third is the layout schema, for the
+shop generating layout files rather than writing them:
 
 ```sh
 dagger call ir-descriptor-set export --path=ir.binpb
 dagger call ir-protos export --path=ir-protos.tar.gz
+dagger call layout-schema export --path=layout-schema.sexpr
 ```
 
 `ir.binpb` is the protobuf `FileDescriptorSet` describing
@@ -234,21 +238,34 @@ rather compile them. [Reading a descriptor without generated
 code](docs/ir/SPEC.md#reading-a-descriptor-without-generated-code) is the
 contract for both, and it is the document to change if what they contain changes.
 
-Three properties are worth knowing before you touch either:
+`layout-schema.sexpr` is the machine-readable contract for the layout format:
+the set of form declarations a layout generator targets, written in the notation
+it describes. It is `schema/layout.sexpr` in the tree, published byte for byte,
+because an adopter's diagnostic and this repository's have to be about the same
+text. [The published schema](docs/layout/SPEC.md#the-published-schema) is the
+document to change if what it declares changes — including the version it
+carries, which moves with the format and not with the document.
 
-- **Neither is committed.** `ir.binpb` is computed from the descriptors
-  `protoc-gen-go` compiled into `irpb`, so it cannot drift from the schema; a
-  checked-in copy could. Changing `ir.proto` and regenerating `irpb/ir.pb.go`
-  changes what is published, in the same commit.
-- **Both are reproducible.** Two builds of one commit produce byte-identical
-  files — the encoding is deterministic and every tar field the filesystem could
-  have supplied is a constant — because an artifact that moved on a rebuild would
-  make a rebuild indistinguishable from a change to the contract.
-- **`dagger call ci` builds them.** `ir-artifacts` is in the pipeline so that the
-  recipe a release runs is exercised on every pull request, rather than for the
-  first time on a tag. What is in them is asserted by Go tests, in `irpb` and
-  beside each tool under `internal/tools/`; the pipeline stage only checks that
-  both commands run to completion and leave a file behind.
+Three properties are worth knowing before you touch any of them:
+
+- **Neither IR artifact is committed.** `ir.binpb` is computed from the
+  descriptors `protoc-gen-go` compiled into `irpb`, so it cannot drift from the
+  schema; a checked-in copy could. Changing `ir.proto` and regenerating
+  `irpb/ir.pb.go` changes what is published, in the same commit. The layout
+  schema is the other way round — it is a source file a person writes, so it is
+  committed, and `layout-schema` publishes it unchanged after checking that it
+  loads.
+- **All three are reproducible.** Two builds of one commit produce byte-identical
+  files — the encoding is deterministic, every tar field the filesystem could
+  have supplied is a constant, and the schema is copied rather than reformatted —
+  because an artifact that moved on a rebuild would make a rebuild
+  indistinguishable from a change to the contract.
+- **`dagger call ci` builds them.** `ir-artifacts` and `layout-artifact` are in
+  the pipeline so that the recipe a release runs is exercised on every pull
+  request, rather than for the first time on a tag. What is in them is asserted
+  by Go tests, in `irpb` and beside each tool under `internal/tools/`; the
+  pipeline stages only check that the commands run to completion and leave a file
+  behind.
 
 A `.proto` added under `proto/` that nothing reachable from
 `cpybkc.ir.v1.Descriptor` imports fails `TestPublishedFileDescriptorSetCoversTheSchema`.
@@ -256,8 +273,8 @@ That is deliberate: the IR is one message and everything in `proto/` is reachabl
 from it, so a file that is not is a mistake in the schema rather than something
 to exclude.
 
-`.github/workflows/release.yaml` attaches both to a release when one is
-published, building them with the same two calls above at the release's tag.
+`.github/workflows/release.yaml` attaches all three to a release when one is
+published, building them with the same three calls above at the release's tag.
 
 ## Specs
 

--- a/README.md
+++ b/README.md
@@ -22,13 +22,21 @@ A generator plugin written in Go imports the resolved IR from
 [`irpb`](irpb/) — `github.com/Zaba505/cpybkc/irpb`, a module of its own, so that
 building against the contract costs the protobuf runtime and nothing else.
 
-A plugin written in anything else takes one of the two artifacts attached to
+A plugin written in anything else takes one of the two IR artifacts attached to
 every release: `ir.binpb`, the protobuf `FileDescriptorSet` that lets any
 runtime decode a descriptor with no code generation in the build, or
 `ir-protos.tar.gz`, the schema sources for a build that would rather compile
 them. [Reading a descriptor without generated
 code](docs/ir/SPEC.md#reading-a-descriptor-without-generated-code) is the
 contract for both.
+
+A shop generating layout files from metadata it already holds takes the third
+asset, `layout-schema.sexpr` — the machine-readable contract for the layout
+format, written in the notation it describes and carrying the version of that
+format inside it. [The published
+schema](docs/layout/SPEC.md#the-published-schema) is what it is and what it
+deliberately leaves to the reader; `schema/layout.sexpr` is the same file in
+this repository.
 
 ## Contributing
 

--- a/docs/layout/SPEC.md
+++ b/docs/layout/SPEC.md
@@ -920,6 +920,111 @@ apart, or what an automaton does when no transition matches. Those are the IR's
 (#16), settled before this notation existed so that the meanings would not be
 back-derived from the spelling.
 
+## The published schema
+
+The schema is the machine-readable contract [The surface
+syntax](#the-surface-syntax)'s first requirement asks for: the thing a layout
+generator targets and a validator checks. It is `layout-schema.sexpr`, an asset
+on every release, and it is `schema/layout.sexpr` in this repository (#23).
+
+### It is written in the notation it describes
+
+The schema is a set of **form declarations**, written as tagged forms over
+[`z5labs/sexpr-go`](https://github.com/z5labs/sexpr-go)'s grammar — the same
+grammar, and the same shape, as the layouts it describes. That is the dialect,
+and naming it is not a formality: a schema means nothing without the language it
+is written in, and a consumer has to know what to reach for before it can read
+one.
+
+Its own vocabulary is nine tags, none of which appears in a layout: `schema`,
+`sort`, `reference`, `form`, `in`, `arity`, `layer`, `argument` and `child`. A
+`form` declaration states one layout form — where it may appear, how many times,
+its positional arguments in order, and the children it admits with their
+arities. A `sort` names what may stand in a position. A `reference` is a sort
+whose member is a symbol naming an argument of another form, which is how the
+schema says what a reference **MUST** name.
+
+Writing it in the notation rather than in a standard schema language is the
+trade [Tagged forms over
+S-expressions](#tagged-forms-over-s-expressions) argues for and it buys two
+things at that price. A generator targeting the schema emits the notation it
+already has an emitter for and reads the contract with the parser it already
+has. And a diagnostic about the schema and a diagnostic about a layout are the
+same kind of thing with the same kind of span on them, because both are
+positions into S-expression source.
+
+Arities are spelled `exactly-one`, `at-most-one`, `one-or-more`, `zero-or-more`
+and `two-or-more`, for this document's `1`, `0..1`, `1..n`, `0..n` and the two
+or more that `seq` and `alt` take. They are symbols rather than the notation
+above because `0..1` is not a lexeme the grammar admits — it opens like a number
+and is a malformed one.
+
+### The version is in the file, and it moves with the format
+
+The schema carries a single monotonic integer version, stated by the `schema`
+declaration it opens with. A consumer **MUST** read it before anything else, and
+**MUST** refuse a schema whose version it does not know rather than proceeding
+on the declarations it recognises.
+
+It is in the file rather than in its name or its path because a release asset
+travels alone: an adopter has the bytes and nothing around them, and a version
+written in a path is a version the download loses. It is one integer and not a
+major and a minor for the reason
+[`ir/SPEC.md`](../ir/SPEC.md#the-version-field) gives for the IR's — the only
+question a consumer can act on is whether it understands what is in front of it,
+and a minor number exists to let it answer "not entirely, but I will continue
+anyway".
+
+The version advances for every change to what a layout may say, and there is no
+additive change that leaves it alone. That is a property of the vocabulary
+rather than an omission: every set in this format is closed, so a form, a child
+or a value a reader has never seen is a diagnostic rather than something it can
+ignore. It is the same standing cost
+[`ir/SPEC.md`](../ir/SPEC.md#what-breaks-it) accepts for the flat node set,
+arriving from the source side, and it is why the sets are settled before the
+first release rather than grown afterwards. An edit changing no declaration — a
+comment, a reordering — leaves the version alone, because nothing a generator or
+a reader can observe has changed.
+
+The version is not this document's. A spec carries no version number
+([CONVENTIONS.md](../CONVENTIONS.md)); what is versioned is the interface, and
+the schema is where that number lives for this one.
+
+### What the schema does not say
+
+The schema states what a layout is **shaped** like. A layout it accepts is
+well-formed, not valid, and four classes of rule are deliberately outside it.
+
+**Conditional arities.** `lrecl` is required under `F` and `FB`, `max-segment`
+under `VBS`, `delimiter` and `placement` under `line-sequential`. The schema
+declares the widest form, exactly as [Physical framing](#physical-framing)'s
+table does, and the conditions are the layout reader's (#24).
+
+**Spellings admitted in order to be rejected by name.** `U` and `(blocks
+in-stream)` are members of their sets here, for the reason each is admitted at
+all: a format with no spelling for them would leave the adopter who has one
+describing their file as something else. What rejects them, with the diagnostic
+each is owed, is the reader.
+
+**Rules counting one form against another.** Exactly one `discriminate` per
+`record`, every `record` appearing somewhere in the sequencing expression, an
+`encoding-override` naming at least one axis. A declaration is about one form
+and its positions, so a rule relating two of them is the reader's. The one
+cross-form statement the schema does make is the reference, and it is the
+important one: a position declared to name a `record` **MUST** name one the
+layout defines, which is what makes a reference checkable rather than
+conventional.
+
+**Everything a copybook decides**, which is
+[Validation and diagnostics](#validation-and-diagnostics)'s second list entire.
+
+None of the four is a gap to be closed later by growing the vocabulary. A schema
+carrying a conditional arity would be a second statement of a rule the reader
+already enforces, kept in step by hand, for the two to disagree about — and the
+disagreement would surface as a layout the published schema accepts and the
+reader does not, which is the failure [The S-expression
+grammar](#the-s-expression-grammar) refuses one layer down.
+
 ## Validation and diagnostics
 
 A layout is checked in two places, and which place a check lands in follows from
@@ -951,6 +1056,15 @@ The split is not a policy. A check that needs a copybook cannot run before one
 has been read, and a check that does not **SHOULD** run in the reader, so that a
 layout with a misspelled tag is reported as a misspelled tag rather than as
 whatever it fails to resolve into.
+
+Most of the reader's list is [the published
+schema](#the-published-schema)'s rather than a second reading of this document.
+An unknown tag, an unknown child, a repeated child, a missing required child, a
+value outside a closed set and a reference naming no record are each something a
+declaration states, and the reader performs them by reading the schema rather
+than by carrying a copy of the tables above. What is left to it is what a
+declaration cannot say: the conditional arities, the spellings rejected by name,
+and the rules counting one form against another.
 
 ### Every diagnostic carries a span, and some carry two
 
@@ -1123,10 +1237,11 @@ computed once by `resolve`.
 
 | Section | Implemented by |
 |---|---|
-| [The surface syntax](#the-surface-syntax) | #22, #23 `layout` |
+| [The surface syntax](#the-surface-syntax) | #22 `layout` |
 | [The encoding profile](#the-encoding-profile) | #25 `layout` |
 | [Physical framing](#physical-framing) | #26 `layout` |
 | [Record definitions](#record-definitions) | #27, #30 `layout` |
 | [Discrimination](#discrimination) | #28 `layout` |
 | [Sequencing](#sequencing) | #29 `layout` |
+| [The published schema](#the-published-schema) | #23 `layout` |
 | [Validation and diagnostics](#validation-and-diagnostics) | #24, #31 `layout` |

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,13 @@ require github.com/Zaba505/cpybkc/irpb v0.0.0
 
 require google.golang.org/protobuf v1.36.11
 
+// The grammar underneath the layout format. docs/layout/SPEC.md delegates the
+// lexis and the parse of a layout file to it — what a symbol is, where a number
+// ends, what a comment attaches to, and the line and column every diagnostic is
+// built on — so this is the one reading of that grammar in the repository
+// rather than a second one beside the document's.
+require github.com/z5labs/sexpr-go v0.1.0
+
 // Local until irpb carries its first tag. A module cannot be required at a
 // version nobody has published, and irpb/v0.1.0 can only exist on a commit that
 // already contains irpb — so the first release of the IR module is necessarily

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/z5labs/sexpr-go v0.1.0 h1:UENE3/30CEyErOBEvdaU8dg35Lf0Uwho61nfHS4o2FA=
+github.com/z5labs/sexpr-go v0.1.0/go.mod h1:Wc8BqY+XK+FSP4kkP+FvrfrEuf0pp0roNYYWA5xmT40=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/layoutschema/doc.go
+++ b/internal/layoutschema/doc.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Package layoutschema reads the published layout schema and checks a layout
+// against it.
+//
+// The schema is schema/layout.sexpr, specified by docs/layout/SPEC.md's "The
+// published schema". It is a set of form declarations written in the notation
+// it describes — tagged forms over [github.com/z5labs/sexpr-go]'s grammar — and
+// this package is the validator that reads it. An adopter generating layouts
+// from metadata they already hold targets the schema and runs cpybkc to check
+// what they generated, which is the trade SPEC.md's "Tagged forms over
+// S-expressions" argues for: a notation that states an edge as an edge, at the
+// cost of no off-the-shelf validator.
+//
+// # What it checks, and what it leaves alone
+//
+// Everything here is driven by the schema. Nothing in this package knows that a
+// layout has an `encoding` form or that a `recfm` may say `VBS`; it knows how to
+// read a declaration and how to hold a layout to one. A form added to the schema
+// is checked without a line changing here, and that is the property that makes
+// the published file the contract rather than this code.
+//
+// So it reports exactly what a declaration can be wrong about: an unknown form,
+// a form in a context that does not admit it, a missing or repeated child, a
+// wrong number of arguments, a value outside a closed set, a reference naming no
+// record the layout defines, and the S-expression constructs SPEC.md's "What
+// this document delegates" excludes — improper lists, quote shorthands, `nil`,
+// `()` and booleans.
+//
+// It reports none of what a copybook decides, none of the conditional arities
+// framing carries, and none of the rules relating two forms. Those are the
+// layout reader's (#24) and `resolve`'s (#32–#38); SPEC.md's "What the schema
+// does not say" is the list and the reasoning. A layout this package accepts is
+// well-formed, not valid, and the distinction is deliberate: a schema that
+// carried the conditional rules would be a second statement of them beside the
+// reader's, for the two to disagree about.
+//
+// # Why diagnostics rather than an error
+//
+// [Schema.Check] returns every diagnostic it finds rather than the first,
+// because a generated layout is generated wrong in the same way in many places
+// at once, and a validator that reports one of them per run is a validator run
+// once per fault. Each carries the position of the sub-form that is wrong rather
+// than of the top-level form containing it, which is what SPEC.md's "Positions
+// survive" buys and what the layout reader's spans are built out of.
+package layoutschema

--- a/internal/layoutschema/schema.go
+++ b/internal/layoutschema/schema.go
@@ -1,0 +1,882 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layoutschema
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	sexpr "github.com/z5labs/sexpr-go"
+)
+
+// contextTopLevel is the context a form declared (in top-level) is reachable
+// from: the layout itself, rather than a sort or a parent form.
+const contextTopLevel = "top-level"
+
+// SchemaFile is where the published schema lives, relative to the repository
+// root, in the slash-separated spelling a repository path is written in.
+//
+// It is a constant here rather than a default in the tool that publishes it,
+// because the tests, the tool and the Dagger function that attaches the artifact
+// to a release all have to mean the same file, and a path repeated in three
+// places is a path two of them get wrong.
+const SchemaFile = "schema/layout.sexpr"
+
+// SchemaPath is [SchemaFile] under root, in the host's own path spelling.
+func SchemaPath(root string) string {
+	return filepath.Join(root, filepath.FromSlash(SchemaFile))
+}
+
+// The primitive sorts. A position may name one of these without anything having
+// declared it, which is what stops the schema needing a declaration for "a
+// symbol".
+const (
+	sortSymbol         = "symbol"
+	sortText           = "text"
+	sortNumber         = "number"
+	sortPositiveNumber = "positive-number"
+)
+
+// primitives is the set above, for the membership tests the loader makes.
+var primitives = []string{sortSymbol, sortText, sortNumber, sortPositiveNumber}
+
+// Schema is a loaded layout schema: the form declarations, the sorts their
+// positions are written against, and the version the file states.
+//
+// It is immutable once [Load] has returned. [Schema.Check] reads it and writes
+// nothing, so one loaded schema serves every layout a process validates.
+type Schema struct {
+	subject string
+	version int64
+
+	// sorts, by name. Populated by both (sort ...) and (reference ...), because
+	// a position names either the same way and neither the loader nor a
+	// declaration has a reason to tell them apart at the point of use.
+	sorts map[string]*sortDecl
+
+	// contextual holds every form declared (in ...), keyed by the context and
+	// the tag. Two forms may share a tag in different contexts — `one-of` is a
+	// discrimination strategy and a `when` match, with different arguments — so
+	// the tag alone is not the key.
+	contextual map[contextKey]*formDecl
+
+	// children holds every form declared without (in ...), by tag. A child is
+	// reachable only where a parent's (child ...) names it, and the arity is the
+	// parent's, which is why `charset` is declared once and is required under
+	// `encoding` and optional under `encoding-override`.
+	children map[string]*formDecl
+
+	// topLevel is the (in top-level) forms in declaration order, so that a
+	// report over them reads in the order the schema states them rather than in
+	// whichever order a map produced.
+	topLevel []*formDecl
+}
+
+// contextKey identifies a form by where it may appear as well as by its tag.
+type contextKey struct {
+	context string
+	tag     string
+}
+
+// formDecl is one (form ...) declaration.
+type formDecl struct {
+	tag   string
+	pos   sexpr.Pos
+	in    string // "" for a child form
+	arity arity  // the arity within `in`; only top-level forms carry one
+	layer string
+	args  []argDecl
+	// children, in declaration order, and childArity keyed by tag. The order is
+	// what a "missing required child" report is emitted in.
+	children   []string
+	childArity map[string]arity
+}
+
+// argDecl is one (argument <name> <sort> <arity>) declaration.
+type argDecl struct {
+	name  string
+	sort  sortRef
+	arity arity
+}
+
+// sortRef is what an argument's position admits: either a sort by name — a
+// primitive or one declared below — or a closed set written inline.
+//
+// Inline rather than named, for every closed set in the schema, because each is
+// used in exactly one position. A set named and referred to by name would be a
+// second place to look for what a `recfm` may say, and the indirection buys
+// nothing while that stays true.
+type sortRef struct {
+	name   string
+	values []string
+}
+
+// sortDecl is one (sort ...) or (reference ...) declaration.
+type sortDecl struct {
+	name string
+	pos  sexpr.Pos
+
+	// forms names the tags this sort admits as forms. It is kept in step with
+	// the (in ...) on each of those forms by a check in the loader rather than
+	// by hand: a sort listing a form that does not declare itself into it, or a
+	// form declaring itself into a sort that does not list it, is a schema this
+	// package refuses to load.
+	forms []string
+
+	// symbols names the bare symbols this sort admits — `single-record-type` is
+	// the only one today.
+	symbols []string
+
+	// include names other sorts whose members this one also admits.
+	include []string
+
+	// refForm and refArg are set only by (reference ...): the sort admits a
+	// symbol equal to that argument of some form with that tag in the same
+	// layout.
+	refForm string
+	refArg  string
+}
+
+// isReference reports whether this sort was declared by (reference ...).
+func (s *sortDecl) isReference() bool { return s.refForm != "" }
+
+// arity is how many times something may appear at a position.
+//
+// The spellings are symbols rather than SPEC.md's 1, 0..1, 1..n and 0..n
+// because `0..1` is not a lexeme the grammar admits — it begins like a number
+// and is a malformed one — so a schema written in SPEC.md's notation would not
+// parse.
+type arity struct {
+	spelling string
+	min      int
+	max      int // -1 for unbounded
+}
+
+// arities maps a spelling to what it means. It is the whole set; a spelling not
+// in it is a schema error rather than a default.
+var arities = map[string]arity{
+	"exactly-one":  {spelling: "exactly-one", min: 1, max: 1},
+	"at-most-one":  {spelling: "at-most-one", min: 0, max: 1},
+	"one-or-more":  {spelling: "one-or-more", min: 1, max: -1},
+	"zero-or-more": {spelling: "zero-or-more", min: 0, max: -1},
+	"two-or-more":  {spelling: "two-or-more", min: 2, max: -1},
+}
+
+// label renders an arity the way a diagnostic says it: "at most one" rather
+// than "at-most-one", so the message reads as a sentence.
+func (a arity) label() string { return strings.ReplaceAll(a.spelling, "-", " ") }
+
+// admits reports whether n occurrences satisfy this arity.
+func (a arity) admits(n int) bool {
+	if n < a.min {
+		return false
+	}
+
+	return a.max < 0 || n <= a.max
+}
+
+// repeatable reports whether this arity admits more than one.
+func (a arity) repeatable() bool { return a.max < 0 || a.max > 1 }
+
+// Subject is what the schema says it describes — `layout` for this one. It is
+// read rather than assumed so that a consumer handed the wrong file is told
+// which file it has.
+func (s *Schema) Subject() string { return s.subject }
+
+// Version is the schema version the file states.
+//
+// One monotonic integer, and the policy for advancing it is
+// docs/layout/SPEC.md's "The published schema". A consumer that does not know
+// the version in front of it refuses the schema rather than proceeding on the
+// declarations it recognises.
+func (s *Schema) Version() int64 { return s.version }
+
+// TopLevelForms returns the tags a layout may write at the top level, in the
+// order the schema declares them.
+func (s *Schema) TopLevelForms() []string {
+	tags := make([]string, 0, len(s.topLevel))
+	for _, form := range s.topLevel {
+		tags = append(tags, form.tag)
+	}
+
+	return tags
+}
+
+// Layers returns the layers the top-level forms are declared into, sorted.
+//
+// SPEC.md claims five separable layers, and a form belongs to exactly one of
+// them. This is what lets a test assert that the published schema covers every
+// layer rather than most of them.
+func (s *Schema) Layers() []string {
+	var layers []string
+
+	for _, form := range s.topLevel {
+		if form.layer != "" && !slices.Contains(layers, form.layer) {
+			layers = append(layers, form.layer)
+		}
+	}
+
+	slices.Sort(layers)
+
+	return layers
+}
+
+// Load reads a schema from r.
+//
+// It fails on anything it cannot make sense of rather than skipping it. The
+// schema is the contract, and a declaration silently ignored is a form a
+// generator targets and a validator never checks — the one failure mode this
+// package exists to remove.
+func Load(r io.Reader) (*Schema, error) {
+	file, err := sexpr.Parse(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse the schema: %w", err)
+	}
+
+	schema := &Schema{
+		sorts:      make(map[string]*sortDecl),
+		contextual: make(map[contextKey]*formDecl),
+		children:   make(map[string]*formDecl),
+	}
+
+	if err := schema.declare(file); err != nil {
+		return nil, err
+	}
+
+	return schema, schema.link()
+}
+
+// declare reads every top-level declaration in the file into the schema,
+// without resolving anything one declaration says about another. Resolution is
+// link's, because a schema is not required to declare a sort before the form
+// that names it.
+func (s *Schema) declare(file *sexpr.File) error {
+	seenHeader := false
+
+	for _, node := range file.Nodes {
+		list, ok := node.(sexpr.List)
+		if !ok {
+			return fmt.Errorf("%s: a schema is a list of declarations, and this is not one", at(posOf(node)))
+		}
+
+		tag, err := tagOf(list)
+		if err != nil {
+			return err
+		}
+
+		switch tag {
+		case "schema":
+			if seenHeader {
+				return fmt.Errorf("%s: a second (schema ...) declaration", at(list.Pos))
+			}
+
+			seenHeader = true
+
+			if err := s.declareHeader(list); err != nil {
+				return err
+			}
+		case "sort":
+			if err := s.declareSort(list); err != nil {
+				return err
+			}
+		case "reference":
+			if err := s.declareReference(list); err != nil {
+				return err
+			}
+		case "form":
+			if err := s.declareForm(list); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("%s: unknown declaration %q", at(list.Pos), tag)
+		}
+	}
+
+	if !seenHeader {
+		return fmt.Errorf("the schema states no (schema <name> <version>): nothing says which version this is")
+	}
+
+	return nil
+}
+
+// declareHeader reads (schema <name> <version>).
+func (s *Schema) declareHeader(list sexpr.List) error {
+	if len(list.Elements) != 3 {
+		return fmt.Errorf("%s: (schema ...) takes a name and a version", at(list.Pos))
+	}
+
+	name, ok := list.Elements[1].(sexpr.Symbol)
+	if !ok {
+		return fmt.Errorf("%s: a schema's name is a symbol", at(posOf(list.Elements[1])))
+	}
+
+	version, ok := list.Elements[2].(sexpr.Int)
+	if !ok {
+		return fmt.Errorf("%s: a schema's version is an integer", at(posOf(list.Elements[2])))
+	}
+
+	if version.Value < 1 {
+		return fmt.Errorf("%s: a schema's version starts at 1", at(version.Pos))
+	}
+
+	s.subject = name.Value
+	s.version = version.Value
+
+	return nil
+}
+
+// declareSort reads (sort <name> <member> ...).
+func (s *Schema) declareSort(list sexpr.List) error {
+	if len(list.Elements) < 2 {
+		return fmt.Errorf("%s: (sort ...) takes a name", at(list.Pos))
+	}
+
+	decl, err := s.newSort(list, 1)
+	if err != nil {
+		return err
+	}
+
+	for _, member := range list.Elements[2:] {
+		switch member := member.(type) {
+		case sexpr.Symbol:
+			decl.include = append(decl.include, member.Value)
+		case sexpr.List:
+			kind, err := tagOf(member)
+			if err != nil {
+				return err
+			}
+
+			name, err := symbolArg(member, 1, kind)
+			if err != nil {
+				return err
+			}
+
+			switch kind {
+			case "form":
+				decl.forms = append(decl.forms, name)
+			case "symbol":
+				decl.symbols = append(decl.symbols, name)
+			default:
+				return fmt.Errorf("%s: a sort's members are (form ...), (symbol ...) or the name of another sort, not %q", at(member.Pos), kind)
+			}
+		default:
+			return fmt.Errorf("%s: a sort's members are (form ...), (symbol ...) or the name of another sort", at(posOf(member)))
+		}
+	}
+
+	return nil
+}
+
+// declareReference reads (reference <sort> <form> <argument>).
+func (s *Schema) declareReference(list sexpr.List) error {
+	if len(list.Elements) != 4 {
+		return fmt.Errorf("%s: (reference ...) takes a sort, a form and the argument of that form it names", at(list.Pos))
+	}
+
+	decl, err := s.newSort(list, 1)
+	if err != nil {
+		return err
+	}
+
+	if decl.refForm, err = symbolArg(list, 2, "reference"); err != nil {
+		return err
+	}
+
+	decl.refArg, err = symbolArg(list, 3, "reference")
+
+	return err
+}
+
+// newSort registers a sort declared by list, naming it from the element at
+// index. Both (sort ...) and (reference ...) arrive here, so a name cannot be
+// declared once as each.
+func (s *Schema) newSort(list sexpr.List, index int) (*sortDecl, error) {
+	name, err := symbolArg(list, index, "sort")
+	if err != nil {
+		return nil, err
+	}
+
+	if slices.Contains(primitives, name) {
+		return nil, fmt.Errorf("%s: %q is a primitive sort and cannot be declared", at(list.Pos), name)
+	}
+
+	if _, exists := s.sorts[name]; exists {
+		return nil, fmt.Errorf("%s: sort %q is declared twice", at(list.Pos), name)
+	}
+
+	decl := &sortDecl{name: name, pos: list.Pos}
+	s.sorts[name] = decl
+
+	return decl, nil
+}
+
+// declareForm reads (form <tag> ...).
+func (s *Schema) declareForm(list sexpr.List) error {
+	tag, err := symbolArg(list, 1, "form")
+	if err != nil {
+		return err
+	}
+
+	decl := &formDecl{tag: tag, pos: list.Pos, childArity: make(map[string]arity)}
+
+	for _, clause := range list.Elements[2:] {
+		if err := s.declareFormClause(decl, clause); err != nil {
+			return err
+		}
+	}
+
+	if err := checkArgumentOrder(decl); err != nil {
+		return err
+	}
+
+	if decl.in == "" {
+		if _, exists := s.children[tag]; exists {
+			return fmt.Errorf("%s: child form %q is declared twice", at(list.Pos), tag)
+		}
+
+		s.children[tag] = decl
+
+		return nil
+	}
+
+	key := contextKey{context: decl.in, tag: tag}
+	if _, exists := s.contextual[key]; exists {
+		return fmt.Errorf("%s: form %q is declared twice in %s", at(list.Pos), tag, decl.in)
+	}
+
+	s.contextual[key] = decl
+
+	if decl.in == contextTopLevel {
+		s.topLevel = append(s.topLevel, decl)
+	}
+
+	return nil
+}
+
+// declareFormClause reads one clause of a (form ...) declaration.
+func (s *Schema) declareFormClause(decl *formDecl, node sexpr.Node) error {
+	clause, ok := node.(sexpr.List)
+	if !ok {
+		return fmt.Errorf("%s: a form's clauses are lists", at(posOf(node)))
+	}
+
+	kind, err := tagOf(clause)
+	if err != nil {
+		return err
+	}
+
+	switch kind {
+	case "in":
+		decl.in, err = symbolArg(clause, 1, kind)
+	case "layer":
+		decl.layer, err = symbolArg(clause, 1, kind)
+	case "arity":
+		decl.arity, err = arityArg(clause, 1)
+	case "argument":
+		err = s.declareArgument(decl, clause)
+	case "child":
+		err = declareChild(decl, clause)
+	default:
+		err = fmt.Errorf("%s: unknown clause %q in form %q", at(clause.Pos), kind, decl.tag)
+	}
+
+	return err
+}
+
+// declareArgument reads (argument <name> <sort> <arity>).
+func (s *Schema) declareArgument(decl *formDecl, clause sexpr.List) error {
+	if len(clause.Elements) != 4 {
+		return fmt.Errorf("%s: (argument ...) takes a name, a sort and an arity", at(clause.Pos))
+	}
+
+	name, err := symbolArg(clause, 1, "argument")
+	if err != nil {
+		return err
+	}
+
+	ref, err := sortRefOf(clause.Elements[2])
+	if err != nil {
+		return err
+	}
+
+	a, err := arityArg(clause, 3)
+	if err != nil {
+		return err
+	}
+
+	decl.args = append(decl.args, argDecl{name: name, sort: ref, arity: a})
+
+	return nil
+}
+
+// declareChild reads (child <tag> <arity>).
+func declareChild(decl *formDecl, clause sexpr.List) error {
+	if len(clause.Elements) != 3 {
+		return fmt.Errorf("%s: (child ...) takes a tag and an arity", at(clause.Pos))
+	}
+
+	tag, err := symbolArg(clause, 1, "child")
+	if err != nil {
+		return err
+	}
+
+	a, err := arityArg(clause, 2)
+	if err != nil {
+		return err
+	}
+
+	if _, exists := decl.childArity[tag]; exists {
+		return fmt.Errorf("%s: form %q admits child %q twice", at(clause.Pos), decl.tag, tag)
+	}
+
+	decl.children = append(decl.children, tag)
+	decl.childArity[tag] = a
+
+	return nil
+}
+
+// sortRefOf reads what an argument's position admits: a sort name, or an inline
+// (values ...) set.
+func sortRefOf(node sexpr.Node) (sortRef, error) {
+	switch node := node.(type) {
+	case sexpr.Symbol:
+		return sortRef{name: node.Value}, nil
+	case sexpr.List:
+		kind, err := tagOf(node)
+		if err != nil {
+			return sortRef{}, err
+		}
+
+		if kind != "values" {
+			return sortRef{}, fmt.Errorf("%s: an argument's sort is a name or an inline (values ...), not %q", at(node.Pos), kind)
+		}
+
+		if len(node.Elements) < 2 {
+			return sortRef{}, fmt.Errorf("%s: (values ...) with no members admits nothing", at(node.Pos))
+		}
+
+		ref := sortRef{}
+
+		for i := range node.Elements[1:] {
+			value, err := symbolArg(node, i+1, "values")
+			if err != nil {
+				return sortRef{}, err
+			}
+
+			ref.values = append(ref.values, value)
+		}
+
+		return ref, nil
+	default:
+		return sortRef{}, fmt.Errorf("%s: an argument's sort is a name or an inline (values ...)", at(posOf(node)))
+	}
+}
+
+// checkArgumentOrder refuses a form whose arguments cannot be matched
+// positionally without guessing.
+//
+// Arguments are consumed in order by count, so only the last may repeat and
+// only the last may be optional — anything else leaves two readings of the same
+// list. A form that both repeats its last argument and admits children is
+// refused for the same reason: there would be nothing to say where the
+// arguments stop and the children start.
+func checkArgumentOrder(decl *formDecl) error {
+	for i, arg := range decl.args {
+		if i == len(decl.args)-1 {
+			continue
+		}
+
+		if arg.arity.repeatable() || arg.arity.min == 0 {
+			return fmt.Errorf("%s: argument %q of form %q is %s, which only the last argument may be", at(decl.pos), arg.name, decl.tag, arg.arity.label())
+		}
+	}
+
+	if len(decl.args) == 0 || len(decl.children) == 0 {
+		return nil
+	}
+
+	if decl.args[len(decl.args)-1].arity.repeatable() {
+		return fmt.Errorf("%s: form %q repeats its last argument and admits children, so nothing says where the arguments stop", at(decl.pos), decl.tag)
+	}
+
+	return nil
+}
+
+// link resolves what one declaration says about another, once every declaration
+// has been read.
+//
+// Everything it checks is a way for the schema to be self-consistent and wrong:
+// a position naming a sort nobody declared, a sort and a form sharing a name so
+// that (in ...) is ambiguous, a form declaring itself into a sort that does not
+// list it, a child nothing admits. Each of those publishes a contract with a
+// hole in it, and the hole is invisible until a generator falls into it.
+func (s *Schema) link() error {
+	if err := s.linkNames(); err != nil {
+		return err
+	}
+
+	if err := s.linkSorts(); err != nil {
+		return err
+	}
+
+	return s.linkForms()
+}
+
+// linkNames refuses a schema in which a sort and a form share a name.
+//
+// (in <name>) names a sort or a parent form and is read as whichever exists, so
+// a name that is both makes the clause mean two things. Refusing the collision
+// is what lets the spelling stay one symbol.
+func (s *Schema) linkNames() error {
+	for _, name := range s.sortNames() {
+		if _, exists := s.children[name]; exists {
+			return fmt.Errorf("%s: %q is both a sort and a child form, so (in %s) is ambiguous", at(s.sorts[name].pos), name, name)
+		}
+	}
+
+	return nil
+}
+
+// sortNames returns every declared sort's name, sorted, so that a schema with
+// two problems fails on the same one every time it is loaded.
+func (s *Schema) sortNames() []string {
+	names := make([]string, 0, len(s.sorts))
+	for name := range s.sorts {
+		names = append(names, name)
+	}
+
+	slices.Sort(names)
+
+	return names
+}
+
+// linkSorts resolves each sort's members.
+func (s *Schema) linkSorts() error {
+	for _, name := range s.sortNames() {
+		decl := s.sorts[name]
+
+		for _, included := range decl.include {
+			if !s.knownSort(included) {
+				return fmt.Errorf("%s: sort %q includes %q, which nothing declares", at(decl.pos), decl.name, included)
+			}
+		}
+
+		if decl.isReference() {
+			form, exists := s.contextual[contextKey{context: contextTopLevel, tag: decl.refForm}]
+			if !exists {
+				return fmt.Errorf("%s: sort %q names %q, which is not a top-level form", at(decl.pos), decl.name, decl.refForm)
+			}
+
+			if !slices.ContainsFunc(form.args, func(arg argDecl) bool { return arg.name == decl.refArg }) {
+				return fmt.Errorf("%s: sort %q names argument %q of form %q, which has no such argument", at(decl.pos), decl.name, decl.refArg, decl.refForm)
+			}
+		}
+
+		for _, tag := range decl.forms {
+			if _, exists := s.contextual[contextKey{context: decl.name, tag: tag}]; !exists {
+				return fmt.Errorf("%s: sort %q lists form %q, which does not declare (in %s)", at(decl.pos), decl.name, tag, decl.name)
+			}
+		}
+	}
+
+	return nil
+}
+
+// linkForms resolves what each form's clauses name.
+func (s *Schema) linkForms() error {
+	admitted := make(map[string]bool)
+
+	for _, decl := range s.allForms() {
+		if err := s.linkForm(decl); err != nil {
+			return err
+		}
+
+		for _, tag := range decl.children {
+			admitted[tag] = true
+		}
+	}
+
+	tags := make([]string, 0, len(s.children))
+	for tag := range s.children {
+		tags = append(tags, tag)
+	}
+
+	slices.Sort(tags)
+
+	for _, tag := range tags {
+		if !admitted[tag] {
+			return fmt.Errorf("%s: child form %q is declared and no form admits it", at(s.children[tag].pos), tag)
+		}
+	}
+
+	return nil
+}
+
+// linkForm resolves one form's context, arity, layer, arguments and children.
+func (s *Schema) linkForm(decl *formDecl) error {
+	switch {
+	case decl.in == contextTopLevel:
+		if decl.arity.spelling == "" {
+			return fmt.Errorf("%s: top-level form %q states no arity", at(decl.pos), decl.tag)
+		}
+
+		if decl.layer == "" {
+			return fmt.Errorf("%s: top-level form %q states no layer", at(decl.pos), decl.tag)
+		}
+	case decl.in != "":
+		sort, exists := s.sorts[decl.in]
+		if !exists {
+			return fmt.Errorf("%s: form %q declares (in %s), which is not a sort", at(decl.pos), decl.tag, decl.in)
+		}
+
+		if !slices.Contains(sort.forms, decl.tag) {
+			return fmt.Errorf("%s: form %q declares (in %s), and sort %q does not list it", at(decl.pos), decl.tag, decl.in, decl.in)
+		}
+	default:
+		if decl.arity.spelling != "" {
+			return fmt.Errorf("%s: child form %q states an arity, which is the arity of the parent admitting it", at(decl.pos), decl.tag)
+		}
+	}
+
+	for _, arg := range decl.args {
+		if arg.sort.name != "" && !s.knownSort(arg.sort.name) {
+			return fmt.Errorf("%s: argument %q of form %q is of sort %q, which nothing declares", at(decl.pos), arg.name, decl.tag, arg.sort.name)
+		}
+	}
+
+	for _, tag := range decl.children {
+		if _, exists := s.children[tag]; !exists {
+			return fmt.Errorf("%s: form %q admits child %q, which is not declared as a child form", at(decl.pos), decl.tag, tag)
+		}
+	}
+
+	return nil
+}
+
+// allForms returns every declared form, contextual and child alike, in a stable
+// order so that two loads of one schema fail on the same declaration.
+func (s *Schema) allForms() []*formDecl {
+	forms := make([]*formDecl, 0, len(s.contextual)+len(s.children))
+
+	keys := make([]contextKey, 0, len(s.contextual))
+	for key := range s.contextual {
+		keys = append(keys, key)
+	}
+
+	slices.SortFunc(keys, func(a, b contextKey) int {
+		if a.context != b.context {
+			return strings.Compare(a.context, b.context)
+		}
+
+		return strings.Compare(a.tag, b.tag)
+	})
+
+	for _, key := range keys {
+		forms = append(forms, s.contextual[key])
+	}
+
+	tags := make([]string, 0, len(s.children))
+	for tag := range s.children {
+		tags = append(tags, tag)
+	}
+
+	slices.Sort(tags)
+
+	for _, tag := range tags {
+		forms = append(forms, s.children[tag])
+	}
+
+	return forms
+}
+
+// knownSort reports whether name is a primitive or a declared sort.
+func (s *Schema) knownSort(name string) bool {
+	if slices.Contains(primitives, name) {
+		return true
+	}
+
+	_, exists := s.sorts[name]
+
+	return exists
+}
+
+// tagOf returns the symbol a list opens with, which is what makes it a form.
+func tagOf(list sexpr.List) (string, error) {
+	if len(list.Elements) == 0 {
+		return "", fmt.Errorf("%s: the empty list has no tag", at(list.Pos))
+	}
+
+	symbol, ok := list.Elements[0].(sexpr.Symbol)
+	if !ok {
+		return "", fmt.Errorf("%s: a form opens with a symbol naming it", at(posOf(list.Elements[0])))
+	}
+
+	return symbol.Value, nil
+}
+
+// symbolArg reads the symbol at index, naming the clause it belongs to when it
+// is not one.
+func symbolArg(list sexpr.List, index int, clause string) (string, error) {
+	if index >= len(list.Elements) {
+		return "", fmt.Errorf("%s: (%s ...) is missing an argument", at(list.Pos), clause)
+	}
+
+	symbol, ok := list.Elements[index].(sexpr.Symbol)
+	if !ok {
+		return "", fmt.Errorf("%s: argument %d of (%s ...) is a symbol", at(posOf(list.Elements[index])), index, clause)
+	}
+
+	return symbol.Value, nil
+}
+
+// arityArg reads the arity spelling at index.
+func arityArg(list sexpr.List, index int) (arity, error) {
+	spelling, err := symbolArg(list, index, "arity")
+	if err != nil {
+		return arity{}, err
+	}
+
+	known, exists := arities[spelling]
+	if !exists {
+		return arity{}, fmt.Errorf("%s: unknown arity %q", at(list.Pos), spelling)
+	}
+
+	return known, nil
+}
+
+// posOf returns the position a node carries. Every node kind carries one, and
+// the switch is exhaustive because the interface is sealed by the package that
+// declares it.
+func posOf(node sexpr.Node) sexpr.Pos {
+	switch node := node.(type) {
+	case sexpr.Symbol:
+		return node.Pos
+	case sexpr.String:
+		return node.Pos
+	case sexpr.Int:
+		return node.Pos
+	case sexpr.Float:
+		return node.Pos
+	case sexpr.Bool:
+		return node.Pos
+	case sexpr.Nil:
+		return node.Pos
+	case sexpr.List:
+		return node.Pos
+	case sexpr.Quote:
+		return node.Pos
+	default:
+		return sexpr.Pos{}
+	}
+}
+
+// at renders a position the way every message in this package opens.
+func at(pos sexpr.Pos) string {
+	return fmt.Sprintf("line %d, column %d", pos.Line, pos.Column)
+}

--- a/internal/layoutschema/schema.go
+++ b/internal/layoutschema/schema.go
@@ -625,18 +625,88 @@ func (s *Schema) link() error {
 		return err
 	}
 
+	if err := s.linkIncludes(); err != nil {
+		return err
+	}
+
 	return s.linkForms()
 }
 
-// linkNames refuses a schema in which a sort and a form share a name.
+// linkNames refuses a schema in which a sort and a child form share a name.
 //
-// (in <name>) names a sort or a parent form and is read as whichever exists, so
-// a name that is both makes the clause mean two things. Refusing the collision
-// is what lets the spelling stay one symbol.
+// Nothing in this loader is ambiguous about such a name: (in ...) resolves
+// against the sorts alone, and a child is reached through its parent's
+// (child ...) rather than through a context. The collision costs the reader
+// instead, and the reader is a generator author holding the published file as
+// the contract. `(in charset)` would name the sort while `(child charset ...)`
+// named the form, and a diagnostic saying `charset` would say nothing about
+// which of the two it meant. One name for one thing is worth keeping while it
+// costs a check.
 func (s *Schema) linkNames() error {
 	for _, name := range s.sortNames() {
 		if _, exists := s.children[name]; exists {
-			return fmt.Errorf("%s: %q is both a sort and a child form, so (in %s) is ambiguous", at(s.sorts[name].pos), name, name)
+			return fmt.Errorf("%s: %q is both a sort and a child form, and one name in this schema names one thing", at(s.sorts[name].pos), name)
+		}
+	}
+
+	return nil
+}
+
+// linkIncludes refuses a sort that reaches itself through the sorts it
+// includes.
+//
+// A cycle is the one schema fault that would survive loading and then not
+// terminate: checking a value against a sort walks that sort's includes, so two
+// sorts including each other is an infinite descent at validation time rather
+// than a diagnostic. Catching it here is what lets the walk in validate.go stay
+// a plain recursion, and it is caught at the same point as every other way a
+// schema can parse and still be unusable.
+//
+// [Schema.linkSorts] has already rejected an include naming nothing, so
+// anything not in the sort table here is a primitive and has no includes of its
+// own.
+func (s *Schema) linkIncludes() error {
+	const (
+		unvisited = iota
+		onPath
+		settled
+	)
+
+	state := make(map[string]int, len(s.sorts))
+
+	var walk func(name string) error
+
+	walk = func(name string) error {
+		switch state[name] {
+		case onPath:
+			return fmt.Errorf("%s: sort %q includes itself, by way of the sorts it includes", at(s.sorts[name].pos), name)
+		case settled:
+			return nil
+		case unvisited:
+			// Walked below. Named rather than left as the default so that the
+			// three states a sort can be in are all in one place.
+		}
+
+		state[name] = onPath
+
+		for _, included := range s.sorts[name].include {
+			if _, exists := s.sorts[included]; !exists {
+				continue
+			}
+
+			if err := walk(included); err != nil {
+				return err
+			}
+		}
+
+		state[name] = settled
+
+		return nil
+	}
+
+	for _, name := range s.sortNames() {
+		if err := walk(name); err != nil {
+			return err
 		}
 	}
 

--- a/internal/layoutschema/schema_test.go
+++ b/internal/layoutschema/schema_test.go
@@ -1,0 +1,364 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layoutschema
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// TestThePublishedSchemaLoads is the floor under everything else here: the file
+// this repository publishes is one this package can read. It is separate from
+// the tests below so that a schema which fails to load reports that rather than
+// reporting whichever coverage check happened to run first.
+func TestThePublishedSchemaLoads(t *testing.T) {
+	schema := publishedSchema(t)
+
+	if got := schema.Subject(); got != "layout" {
+		t.Errorf("the schema describes %q, want %q", got, "layout")
+	}
+
+	if got := schema.Version(); got < 1 {
+		t.Errorf("the schema states version %d, want at least 1", got)
+	}
+}
+
+// TestThePublishedSchemaDeclaresTheTopLevelFormsTheSpecStates is the staleness
+// gate over the contract.
+//
+// docs/layout/SPEC.md's "The top-level forms" table is the normative list of
+// what a layout may write at its top level, and the schema is the machine-
+// readable statement of the same thing. Two statements of one fact drift, so
+// this reads the table out of the document and requires the published schema to
+// agree with it — on the forms, on which layer each belongs to, and on how many
+// of each a layout carries.
+//
+// A form added to SPEC.md and not to the schema fails here, which is the failure
+// worth catching: a generator targeting the schema would emit layouts missing a
+// form the document requires, and nothing else in this repository would notice.
+func TestThePublishedSchemaDeclaresTheTopLevelFormsTheSpecStates(t *testing.T) {
+	schema := publishedSchema(t)
+	stated := specTopLevelForms(t)
+
+	if got := schema.TopLevelForms(); !slices.Equal(sorted(got), sorted(keys(stated))) {
+		t.Fatalf("the schema and SPEC.md disagree about the top-level forms:\n schema: %v\n SPEC.md: %v", sorted(got), sorted(keys(stated)))
+	}
+
+	for _, form := range schema.topLevel {
+		row := stated[form.tag]
+
+		if want := strings.ReplaceAll(form.layer, "-", " "); want != row.layer {
+			t.Errorf("the schema puts %s in layer %q and SPEC.md puts it in %q", form.tag, want, row.layer)
+		}
+
+		// SPEC.md spells `discriminate`'s arity "one per `record`", which
+		// relates two forms and is the layout reader's to enforce. The schema
+		// states the half it can — that a layout carries at least one — so the
+		// notations do not line up and the row is checked for its layer alone.
+		want, ok := specArities[row.arity]
+		if !ok {
+			continue
+		}
+
+		if form.arity.spelling != want {
+			t.Errorf("the schema gives %s arity %q and SPEC.md gives it %q", form.tag, form.arity.spelling, row.arity)
+		}
+	}
+}
+
+// specArities maps SPEC.md's arity notation to the schema's spelling. The
+// schema cannot use SPEC.md's, because `0..1` begins like a number and is a
+// malformed one, so the grammar rejects it.
+var specArities = map[string]string{
+	"1":    "exactly-one",
+	"0..1": "at-most-one",
+	"1..n": "one-or-more",
+	"0..n": "zero-or-more",
+}
+
+// TestThePublishedSchemaCoversEveryLayer is the acceptance criterion the schema
+// exists for: it is the contract for the whole format, not for the parts that
+// were easy. SPEC.md's Scope claims five separable layers; a schema covering
+// four of them is one a generator can satisfy while emitting a layout nothing
+// can read.
+func TestThePublishedSchemaCoversEveryLayer(t *testing.T) {
+	want := []string{
+		"discrimination",
+		"encoding-profile",
+		"physical-framing",
+		"record-definitions",
+		"sequencing",
+	}
+
+	if got := publishedSchema(t).Layers(); !slices.Equal(got, want) {
+		t.Errorf("the schema covers %v, want %v", got, want)
+	}
+}
+
+// TestLoadRefusesASchemaItCannotHold covers the ways a schema can parse and
+// still be a contract with a hole in it. Every one of them publishes something
+// a generator can target and this package would never check, so each is a load
+// failure rather than a warning.
+func TestLoadRefusesASchemaItCannotHold(t *testing.T) {
+	testCases := []struct {
+		name   string
+		schema string
+	}{
+		{
+			name:   "no version",
+			schema: `(form encoding (in top-level) (arity exactly-one) (layer encoding-profile))`,
+		},
+		{
+			name:   "two headers",
+			schema: "(schema layout 1)\n(schema layout 2)",
+		},
+		{
+			name:   "unknown declaration",
+			schema: "(schema layout 1)\n(kind encoding)",
+		},
+		{
+			name:   "unknown clause",
+			schema: "(schema layout 1)\n(form encoding (in top-level) (arity exactly-one) (layer encoding-profile) (colour red))",
+		},
+		{
+			name:   "unknown arity",
+			schema: "(schema layout 1)\n(form encoding (in top-level) (arity three) (layer encoding-profile))",
+		},
+		{
+			name:   "top-level form with no layer",
+			schema: "(schema layout 1)\n(form encoding (in top-level) (arity exactly-one))",
+		},
+		{
+			name:   "top-level form with no arity",
+			schema: "(schema layout 1)\n(form encoding (in top-level) (layer encoding-profile))",
+		},
+		{
+			name:   "argument of an undeclared sort",
+			schema: "(schema layout 1)\n(form encoding (in top-level) (arity exactly-one) (layer encoding-profile) (argument item item-ref exactly-one))",
+		},
+		{
+			name:   "child nothing declares",
+			schema: "(schema layout 1)\n(form encoding (in top-level) (arity exactly-one) (layer encoding-profile) (child charset exactly-one))",
+		},
+		{
+			name:   "child no form admits",
+			schema: "(schema layout 1)\n(form encoding (in top-level) (arity exactly-one) (layer encoding-profile))\n(form charset (argument value symbol exactly-one))",
+		},
+		{
+			name:   "sort listing a form that does not declare itself into it",
+			schema: "(schema layout 1)\n(sort strategy (form equals))",
+		},
+		{
+			name:   "form declaring itself into a sort that does not list it",
+			schema: "(schema layout 1)\n(sort strategy (symbol single-record-type))\n(form equals (in strategy))",
+		},
+		{
+			name:   "a sort and a child form sharing a name",
+			schema: "(schema layout 1)\n(sort charset (symbol ascii))\n(form encoding (in top-level) (arity exactly-one) (layer encoding-profile) (child charset exactly-one))\n(form charset (argument value symbol exactly-one))",
+		},
+		{
+			name:   "a repeatable argument that is not the last",
+			schema: "(schema layout 1)\n(form record (in top-level) (arity exactly-one) (layer record-definitions) (argument name symbol one-or-more) (argument path text exactly-one))",
+		},
+		{
+			name:   "a repeatable argument beside children",
+			schema: "(schema layout 1)\n(form record (in top-level) (arity exactly-one) (layer record-definitions) (argument name symbol one-or-more) (child copybook exactly-one))\n(form copybook (argument path text exactly-one))",
+		},
+		{
+			name:   "a child form stating an arity",
+			schema: "(schema layout 1)\n(form encoding (in top-level) (arity exactly-one) (layer encoding-profile) (child charset exactly-one))\n(form charset (arity exactly-one) (argument value symbol exactly-one))",
+		},
+		{
+			name:   "a reference naming an argument the form does not have",
+			schema: "(schema layout 1)\n(reference record-name record label)\n(form record (in top-level) (arity exactly-one) (layer record-definitions) (argument name symbol exactly-one))",
+		},
+		{
+			name:   "a sort declared twice",
+			schema: "(schema layout 1)\n(sort literal text)\n(sort literal number)",
+		},
+		{
+			name:   "a primitive redeclared",
+			schema: "(schema layout 1)\n(sort symbol text)",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if _, err := Load(strings.NewReader(testCase.schema)); err == nil {
+				t.Error("Load accepted a schema it should have refused")
+			}
+		})
+	}
+}
+
+// specTopLevelForm is one row of SPEC.md's "The top-level forms" table.
+type specTopLevelForm struct {
+	arity string
+	layer string
+}
+
+// specTopLevelForms reads that table out of the document.
+//
+// It parses the markdown rather than holding a copy of the list, for the reason
+// the test above exists at all: a copy here would be a third statement of the
+// same fact, and would go stale in exactly the way this is meant to catch.
+func specTopLevelForms(t *testing.T) map[string]specTopLevelForm {
+	t.Helper()
+
+	rows := make(map[string]specTopLevelForm)
+
+	for _, line := range strings.Split(section(t, "### The top-level forms"), "\n") {
+		cells := tableRow(line)
+		if len(cells) != 3 || !strings.HasPrefix(cells[0], "`") {
+			continue
+		}
+
+		rows[strings.Trim(cells[0], "`")] = specTopLevelForm{arity: cells[1], layer: cells[2]}
+	}
+
+	if len(rows) == 0 {
+		t.Fatal("no table rows found under SPEC.md's \"The top-level forms\": the check would pass vacuously")
+	}
+
+	return rows
+}
+
+// tableRow splits a markdown table row into its cells, and returns nothing for
+// a line that is not one.
+func tableRow(line string) []string {
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, "|") || !strings.HasSuffix(line, "|") {
+		return nil
+	}
+
+	var cells []string
+	for _, cell := range strings.Split(strings.Trim(line, "|"), "|") {
+		cells = append(cells, strings.TrimSpace(cell))
+	}
+
+	return cells
+}
+
+// section returns the text of SPEC.md under heading, up to the next heading at
+// the same level or above.
+func section(t *testing.T, heading string) string {
+	t.Helper()
+
+	level := strings.IndexFunc(heading, func(r rune) bool { return r != '#' })
+
+	var (
+		body  []string
+		found bool
+	)
+
+	for _, line := range strings.Split(specText(t), "\n") {
+		if line == heading {
+			found = true
+
+			continue
+		}
+
+		if !found {
+			continue
+		}
+
+		if strings.HasPrefix(line, "#") && strings.IndexFunc(line, func(r rune) bool { return r != '#' }) <= level {
+			break
+		}
+
+		body = append(body, line)
+	}
+
+	if !found {
+		t.Fatalf("SPEC.md carries no heading %q", heading)
+	}
+
+	return strings.Join(body, "\n")
+}
+
+// specText reads docs/layout/SPEC.md.
+func specText(t *testing.T) string {
+	t.Helper()
+
+	b, err := os.ReadFile(filepath.Join(repoRoot(t), "docs", "layout", "SPEC.md"))
+	if err != nil {
+		t.Fatalf("read the layout SPEC: %v", err)
+	}
+
+	return string(b)
+}
+
+// publishedSchema loads schema/layout.sexpr — the file a release publishes and
+// this repository's own tests are held to, rather than a schema built here.
+func publishedSchema(t *testing.T) *Schema {
+	t.Helper()
+
+	f, err := os.Open(SchemaPath(repoRoot(t)))
+	if err != nil {
+		t.Fatalf("open the published schema: %v", err)
+	}
+
+	defer func() {
+		if err := f.Close(); err != nil {
+			t.Errorf("close the published schema: %v", err)
+		}
+	}()
+
+	schema, err := Load(f)
+	if err != nil {
+		t.Fatalf("load the published schema: %v", err)
+	}
+
+	return schema
+}
+
+// repoRoot walks up from the test's working directory to the directory holding
+// go.mod, which for this module is the repository root and so the directory
+// schema/ and docs/ sit in.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("working directory: %v", err)
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("no go.mod found above %q", dir)
+		}
+
+		dir = parent
+	}
+}
+
+// keys returns a map's keys.
+func keys[V any](m map[string]V) []string {
+	names := make([]string, 0, len(m))
+	for name := range m {
+		names = append(names, name)
+	}
+
+	return names
+}
+
+// sorted returns a sorted copy, so that a comparison of two lists is about
+// their members rather than about the order two sources happened to state them
+// in.
+func sorted(items []string) []string {
+	out := slices.Clone(items)
+	slices.Sort(out)
+
+	return out
+}

--- a/internal/layoutschema/schema_test.go
+++ b/internal/layoutschema/schema_test.go
@@ -183,6 +183,16 @@ func TestLoadRefusesASchemaItCannotHold(t *testing.T) {
 			schema: "(schema layout 1)\n(sort literal text)\n(sort literal number)",
 		},
 		{
+			// The one fault that would otherwise survive loading and then not
+			// terminate: checking a value against a sort walks its includes.
+			name:   "two sorts including each other",
+			schema: "(schema layout 1)\n(sort literal match)\n(sort match literal)",
+		},
+		{
+			name:   "a sort including itself",
+			schema: "(schema layout 1)\n(sort literal literal)",
+		},
+		{
 			name:   "a primitive redeclared",
 			schema: "(schema layout 1)\n(sort symbol text)",
 		},

--- a/internal/layoutschema/testdata/invalid/boolean.sexpr
+++ b/internal/layoutschema/testdata/invalid/boolean.sexpr
@@ -1,0 +1,18 @@
+;; want: no position in a layout takes a boolean
+(encoding
+  (charset cp037)
+  (sign-convention ebcdic)
+  (byte-order big-endian)
+  (float-format hfp))
+
+(framing
+  (recfm FB)
+  (lrecl 80)
+  (blocks #t))
+
+(record TRANSACTION
+  (copybook "cpy/txn.cpy" TRANSACTION-REC))
+
+(discriminate TRANSACTION single-record-type)
+
+(sequence (* TRANSACTION))

--- a/internal/layoutschema/testdata/invalid/empty-list.sexpr
+++ b/internal/layoutschema/testdata/invalid/empty-list.sexpr
@@ -1,0 +1,19 @@
+;; want: the empty list has no meaning in a layout
+()
+
+(encoding
+  (charset cp037)
+  (sign-convention ebcdic)
+  (byte-order big-endian)
+  (float-format hfp))
+
+(framing
+  (recfm FB)
+  (lrecl 80))
+
+(record TRANSACTION
+  (copybook "cpy/txn.cpy" TRANSACTION-REC))
+
+(discriminate TRANSACTION single-record-type)
+
+(sequence (* TRANSACTION))

--- a/internal/layoutschema/testdata/invalid/form-in-the-wrong-sort.sexpr
+++ b/internal/layoutschema/testdata/invalid/form-in-the-wrong-sort.sexpr
@@ -1,0 +1,17 @@
+;; want: expression of form "sequence" is
+(encoding
+  (charset cp037)
+  (sign-convention ebcdic)
+  (byte-order big-endian)
+  (float-format hfp))
+
+(framing
+  (recfm FB)
+  (lrecl 80))
+
+(record TRANSACTION
+  (copybook "cpy/txn.cpy" TRANSACTION-REC))
+
+(discriminate TRANSACTION single-record-type)
+
+(sequence (equals (item TRANSACTION TX-TYPE) "01"))

--- a/internal/layoutschema/testdata/invalid/improper-list.sexpr
+++ b/internal/layoutschema/testdata/invalid/improper-list.sexpr
@@ -1,0 +1,17 @@
+;; want: an improper list has no meaning in a layout
+(encoding
+  (charset cp037)
+  (sign-convention ebcdic)
+  (byte-order big-endian)
+  (float-format hfp))
+
+(framing
+  (recfm FB)
+  (lrecl 80))
+
+(record TRANSACTION
+  (copybook "cpy/txn.cpy" TRANSACTION-REC))
+
+(discriminate TRANSACTION single-record-type)
+
+(sequence (* TRANSACTION) . TRANSACTION)

--- a/internal/layoutschema/testdata/invalid/missing-argument.sexpr
+++ b/internal/layoutschema/testdata/invalid/missing-argument.sexpr
@@ -1,0 +1,17 @@
+;; want: form "equals" takes exactly one for its value argument
+(encoding
+  (charset cp037)
+  (sign-convention ebcdic)
+  (byte-order big-endian)
+  (float-format hfp))
+
+(framing
+  (recfm FB)
+  (lrecl 80))
+
+(record TRANSACTION
+  (copybook "cpy/txn.cpy" TRANSACTION-REC))
+
+(discriminate TRANSACTION (equals (item TRANSACTION TX-TYPE)))
+
+(sequence (* TRANSACTION))

--- a/internal/layoutschema/testdata/invalid/missing-required-child.sexpr
+++ b/internal/layoutschema/testdata/invalid/missing-required-child.sexpr
@@ -1,0 +1,16 @@
+;; want: form "encoding" takes exactly one float-format
+(encoding
+  (charset cp037)
+  (sign-convention ebcdic)
+  (byte-order big-endian))
+
+(framing
+  (recfm FB)
+  (lrecl 80))
+
+(record TRANSACTION
+  (copybook "cpy/txn.cpy" TRANSACTION-REC))
+
+(discriminate TRANSACTION single-record-type)
+
+(sequence (* TRANSACTION))

--- a/internal/layoutschema/testdata/invalid/missing-top-level-form.sexpr
+++ b/internal/layoutschema/testdata/invalid/missing-top-level-form.sexpr
@@ -1,0 +1,15 @@
+;; want: a layout carries exactly one sequence form
+(encoding
+  (charset cp037)
+  (sign-convention ebcdic)
+  (byte-order big-endian)
+  (float-format hfp))
+
+(framing
+  (recfm FB)
+  (lrecl 80))
+
+(record TRANSACTION
+  (copybook "cpy/txn.cpy" TRANSACTION-REC))
+
+(discriminate TRANSACTION single-record-type)

--- a/internal/layoutschema/testdata/invalid/nil.sexpr
+++ b/internal/layoutschema/testdata/invalid/nil.sexpr
@@ -1,0 +1,17 @@
+;; want: nil has no meaning in a layout
+(encoding
+  (charset cp037)
+  (sign-convention ebcdic)
+  (byte-order big-endian)
+  (float-format hfp))
+
+(framing
+  (recfm FB)
+  (lrecl nil))
+
+(record TRANSACTION
+  (copybook "cpy/txn.cpy" TRANSACTION-REC))
+
+(discriminate TRANSACTION single-record-type)
+
+(sequence (* TRANSACTION))

--- a/internal/layoutschema/testdata/invalid/non-positive-number.sexpr
+++ b/internal/layoutschema/testdata/invalid/non-positive-number.sexpr
@@ -1,0 +1,17 @@
+;; want: value of form "lrecl" is a positive integer
+(encoding
+  (charset cp037)
+  (sign-convention ebcdic)
+  (byte-order big-endian)
+  (float-format hfp))
+
+(framing
+  (recfm FB)
+  (lrecl 0))
+
+(record TRANSACTION
+  (copybook "cpy/txn.cpy" TRANSACTION-REC))
+
+(discriminate TRANSACTION single-record-type)
+
+(sequence (* TRANSACTION))

--- a/internal/layoutschema/testdata/invalid/quote-shorthand.sexpr
+++ b/internal/layoutschema/testdata/invalid/quote-shorthand.sexpr
@@ -1,0 +1,17 @@
+;; want: a quote shorthand has no meaning in a layout
+(encoding
+  (charset cp037)
+  (sign-convention ebcdic)
+  (byte-order big-endian)
+  (float-format hfp))
+
+(framing
+  (recfm FB)
+  (lrecl 80))
+
+'(record TRANSACTION
+  (copybook "cpy/txn.cpy" TRANSACTION-REC))
+
+(discriminate TRANSACTION single-record-type)
+
+(sequence (* TRANSACTION))

--- a/internal/layoutschema/testdata/invalid/repeated-child.sexpr
+++ b/internal/layoutschema/testdata/invalid/repeated-child.sexpr
@@ -1,0 +1,18 @@
+;; want: form "framing" takes at most one lrecl
+(encoding
+  (charset cp037)
+  (sign-convention ebcdic)
+  (byte-order big-endian)
+  (float-format hfp))
+
+(framing
+  (recfm FB)
+  (lrecl 80)
+  (lrecl 80))
+
+(record TRANSACTION
+  (copybook "cpy/txn.cpy" TRANSACTION-REC))
+
+(discriminate TRANSACTION single-record-type)
+
+(sequence (* TRANSACTION))

--- a/internal/layoutschema/testdata/invalid/repeated-top-level-form.sexpr
+++ b/internal/layoutschema/testdata/invalid/repeated-top-level-form.sexpr
@@ -1,0 +1,21 @@
+;; want: a layout carries exactly one framing form
+(encoding
+  (charset cp037)
+  (sign-convention ebcdic)
+  (byte-order big-endian)
+  (float-format hfp))
+
+(framing
+  (recfm FB)
+  (lrecl 80))
+
+(record TRANSACTION
+  (copybook "cpy/txn.cpy" TRANSACTION-REC))
+
+(discriminate TRANSACTION single-record-type)
+
+(sequence (* TRANSACTION))
+
+(framing
+  (recfm F)
+  (lrecl 80))

--- a/internal/layoutschema/testdata/invalid/text-where-a-symbol-belongs.sexpr
+++ b/internal/layoutschema/testdata/invalid/text-where-a-symbol-belongs.sexpr
@@ -1,0 +1,17 @@
+;; want: name of form "record" is a symbol
+(encoding
+  (charset cp037)
+  (sign-convention ebcdic)
+  (byte-order big-endian)
+  (float-format hfp))
+
+(framing
+  (recfm FB)
+  (lrecl 80))
+
+(record "TRANSACTION"
+  (copybook "cpy/txn.cpy" TRANSACTION-REC))
+
+(discriminate TRANSACTION single-record-type)
+
+(sequence (* TRANSACTION))

--- a/internal/layoutschema/testdata/invalid/too-few-subexpressions.sexpr
+++ b/internal/layoutschema/testdata/invalid/too-few-subexpressions.sexpr
@@ -1,0 +1,17 @@
+;; want: form "seq" takes two or more for its subexpression argument
+(encoding
+  (charset cp037)
+  (sign-convention ebcdic)
+  (byte-order big-endian)
+  (float-format hfp))
+
+(framing
+  (recfm FB)
+  (lrecl 80))
+
+(record TRANSACTION
+  (copybook "cpy/txn.cpy" TRANSACTION-REC))
+
+(discriminate TRANSACTION single-record-type)
+
+(sequence (seq TRANSACTION))

--- a/internal/layoutschema/testdata/invalid/unknown-child.sexpr
+++ b/internal/layoutschema/testdata/invalid/unknown-child.sexpr
@@ -1,0 +1,18 @@
+;; want: form "framing" has no child "padding"
+(encoding
+  (charset cp037)
+  (sign-convention ebcdic)
+  (byte-order big-endian)
+  (float-format hfp))
+
+(framing
+  (recfm FB)
+  (lrecl 80)
+  (padding 4))
+
+(record TRANSACTION
+  (copybook "cpy/txn.cpy" TRANSACTION-REC))
+
+(discriminate TRANSACTION single-record-type)
+
+(sequence (* TRANSACTION))

--- a/internal/layoutschema/testdata/invalid/unknown-record-reference.sexpr
+++ b/internal/layoutschema/testdata/invalid/unknown-record-reference.sexpr
@@ -1,0 +1,17 @@
+;; want: the name of a record form this layout defines
+(encoding
+  (charset cp037)
+  (sign-convention ebcdic)
+  (byte-order big-endian)
+  (float-format hfp))
+
+(framing
+  (recfm FB)
+  (lrecl 80))
+
+(record TRANSACTION
+  (copybook "cpy/txn.cpy" TRANSACTION-REC))
+
+(discriminate TRANSACTON single-record-type)
+
+(sequence (* TRANSACTION))

--- a/internal/layoutschema/testdata/invalid/unknown-top-level-form.sexpr
+++ b/internal/layoutschema/testdata/invalid/unknown-top-level-form.sexpr
@@ -1,0 +1,19 @@
+;; want: unknown top-level form "profile"
+(profile ebcdic)
+
+(encoding
+  (charset cp037)
+  (sign-convention ebcdic)
+  (byte-order big-endian)
+  (float-format hfp))
+
+(framing
+  (recfm FB)
+  (lrecl 80))
+
+(record TRANSACTION
+  (copybook "cpy/txn.cpy" TRANSACTION-REC))
+
+(discriminate TRANSACTION single-record-type)
+
+(sequence (* TRANSACTION))

--- a/internal/layoutschema/testdata/invalid/value-outside-closed-set.sexpr
+++ b/internal/layoutschema/testdata/invalid/value-outside-closed-set.sexpr
@@ -1,0 +1,17 @@
+;; want: value of form "recfm" is
+(encoding
+  (charset cp037)
+  (sign-convention ebcdic)
+  (byte-order big-endian)
+  (float-format hfp))
+
+(framing
+  (recfm FX)
+  (lrecl 80))
+
+(record TRANSACTION
+  (copybook "cpy/txn.cpy" TRANSACTION-REC))
+
+(discriminate TRANSACTION single-record-type)
+
+(sequence (* TRANSACTION))

--- a/internal/layoutschema/testdata/valid/fixed-length.sexpr
+++ b/internal/layoutschema/testdata/valid/fixed-length.sexpr
@@ -1,0 +1,19 @@
+;; A fixed-length dataset carrying one record type and nothing to tell it apart
+;; from — the shape `single-record-type` exists for.
+(encoding
+  (charset cp037)
+  (sign-convention ebcdic)
+  (byte-order big-endian)
+  (float-format hfp))
+
+(framing
+  (recfm FB)
+  (lrecl 80)
+  (blksize 27920))
+
+(record TRANSACTION
+  (copybook "cpy/txn.cpy" TRANSACTION-REC))
+
+(discriminate TRANSACTION single-record-type)
+
+(sequence (* TRANSACTION))

--- a/internal/layoutschema/testdata/valid/line-sequential.sexpr
+++ b/internal/layoutschema/testdata/valid/line-sequential.sexpr
@@ -1,0 +1,26 @@
+;; A line-delimited extract written on Linux: a header, a run of details and
+;; footers in any order, and a rename carried through to generated code.
+(encoding
+  (charset ascii)
+  (sign-convention ascii-zone-37)
+  (byte-order little-endian)
+  (float-format ieee-754))
+
+(framing
+  (recfm line-sequential)
+  (delimiter (bytes "0A"))
+  (placement terminator))
+
+(record HEADER (copybook "cpy/export.cpy" HEADER-REC))
+(record DETAIL (copybook "cpy/export.cpy" DETAIL-REC))
+(record FOOTER (copybook "cpy/export.cpy" FOOTER-REC))
+
+(rename (item DETAIL D-KEY D-CUST-NO) "CustomerNumber")
+
+(discriminate HEADER (equals (item HEADER H-TYPE) "H"))
+(discriminate DETAIL (one-of (item DETAIL D-TYPE) "D" "E"))
+(discriminate FOOTER (equals (item FOOTER F-TYPE) (bytes "C6")))
+
+(sequence
+  (seq HEADER
+       (+ (alt DETAIL FOOTER))))

--- a/internal/layoutschema/testdata/valid/spanned.sexpr
+++ b/internal/layoutschema/testdata/valid/spanned.sexpr
@@ -1,0 +1,35 @@
+;; A spanned dataset: a per-item encoding override, an OCCURS DEPENDING ON
+;; reading, a counted run and a conditional trailer.
+(encoding
+  (charset cp1047)
+  (sign-convention translated-ebcdic)
+  (byte-order big-endian)
+  (float-format hfp))
+
+(encoding-override (item BATCH-HEADER BH-PARTNER-REF)
+  (charset ascii)
+  (sign-convention ebcdic))
+
+(framing
+  (recfm VBS)
+  (lrecl 32760)
+  (blksize 27998)
+  (blocks deblocked)
+  (max-segment 4096))
+
+(copybook-reading
+  (occurs-depending-on odoslide))
+
+(record BATCH-HEADER (copybook "cpy/batch.cpy" BATCH-HEADER-REC))
+(record BATCH-ITEM   (copybook "cpy/batch.cpy" BATCH-ITEM-REC))
+(record BATCH-AUDIT  (copybook "cpy/batch.cpy" BATCH-AUDIT-REC))
+
+(discriminate BATCH-HEADER (equals (item BATCH-HEADER BH-TYPE) 1))
+(discriminate BATCH-ITEM   (equals (item BATCH-ITEM BI-TYPE) (bytes "F2")))
+(discriminate BATCH-AUDIT  (one-of (item BATCH-AUDIT BA-TYPE) "98" "99"))
+
+(sequence
+  (seq BATCH-HEADER
+       (times BATCH-ITEM (item BATCH-HEADER BH-ITEM-COUNT))
+       (when (item BATCH-HEADER BH-AUDIT-FLAG) (one-of "Y" "A")
+             (? BATCH-AUDIT))))

--- a/internal/layoutschema/validate.go
+++ b/internal/layoutschema/validate.go
@@ -1,0 +1,465 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layoutschema
+
+import (
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+
+	sexpr "github.com/z5labs/sexpr-go"
+)
+
+// Diagnostic is one thing wrong with a layout, and where.
+//
+// The position is the sub-form that is wrong rather than the top-level form
+// containing it, which is what docs/layout/SPEC.md's "Every diagnostic carries a
+// span" requires of every diagnostic this project emits. There is no severity:
+// the schema describes what a layout may be, so everything reported here is a
+// layout the schema does not admit.
+type Diagnostic struct {
+	Pos     sexpr.Pos
+	Message string
+}
+
+// String renders a diagnostic as one line, opening with the position for the
+// reason every compiler does: the file an adopter has to edit is the first
+// thing they need from it.
+func (d Diagnostic) String() string {
+	return fmt.Sprintf("%s: %s", at(d.Pos), d.Message)
+}
+
+// Validate parses a layout from r and checks it against the schema.
+//
+// A parse failure is an error rather than a diagnostic. It comes from the
+// grammar this format delegates to, carries that package's own position, and
+// stops there being a layout to check at all — so reporting it beside a list of
+// forms the checker never saw would claim a coverage this call does not have.
+func (s *Schema) Validate(r io.Reader) ([]Diagnostic, error) {
+	file, err := sexpr.Parse(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse the layout: %w", err)
+	}
+
+	return s.Check(file), nil
+}
+
+// Check holds a parsed layout to the schema and returns every diagnostic it
+// finds, in the order the layout states the forms they are about.
+func (s *Schema) Check(file *sexpr.File) []Diagnostic {
+	check := &checker{schema: s, declared: make(map[string][]string)}
+
+	check.collectReferents(file)
+	check.topLevel(file)
+
+	return check.diagnostics
+}
+
+// checker holds the state one Check accumulates.
+type checker struct {
+	schema      *Schema
+	diagnostics []Diagnostic
+
+	// declared holds, per reference sort, the names that sort may name. It is
+	// gathered from the whole layout before anything is checked, so that a
+	// reference to a record defined further down the file resolves — the forms
+	// of a layout are a set, and nothing in the format orders them.
+	declared map[string][]string
+}
+
+// report records a diagnostic.
+func (c *checker) report(pos sexpr.Pos, format string, args ...any) {
+	c.diagnostics = append(c.diagnostics, Diagnostic{Pos: pos, Message: fmt.Sprintf(format, args...)})
+}
+
+// collectReferents gathers the names every reference sort may name.
+//
+// It is driven by the (reference ...) declarations rather than by knowing that
+// a layout has records, so a second kind of reference added to the schema is
+// collected without a line changing here.
+func (c *checker) collectReferents(file *sexpr.File) {
+	for _, name := range c.schema.sortNames() {
+		decl := c.schema.sorts[name]
+		if !decl.isReference() {
+			continue
+		}
+
+		form, exists := c.schema.contextual[contextKey{context: contextTopLevel, tag: decl.refForm}]
+		if !exists {
+			continue
+		}
+
+		index := slices.IndexFunc(form.args, func(arg argDecl) bool { return arg.name == decl.refArg })
+		if index < 0 {
+			continue
+		}
+
+		for _, node := range file.Nodes {
+			list, ok := node.(sexpr.List)
+			if !ok || len(list.Elements) <= index+1 {
+				continue
+			}
+
+			if tag, ok := list.Elements[0].(sexpr.Symbol); !ok || tag.Value != decl.refForm {
+				continue
+			}
+
+			if referent, ok := list.Elements[index+1].(sexpr.Symbol); ok {
+				c.declared[name] = append(c.declared[name], referent.Value)
+			}
+		}
+	}
+}
+
+// topLevel checks each of the layout's top-level forms, and then how many of
+// each it carries.
+func (c *checker) topLevel(file *sexpr.File) {
+	counts := make(map[string]int)
+
+	for _, node := range file.Nodes {
+		list, ok := c.formNode(node, "a layout is a list of forms")
+		if !ok {
+			continue
+		}
+
+		tag, ok := list.Elements[0].(sexpr.Symbol)
+		if !ok {
+			c.report(posOf(list.Elements[0]), "a form opens with a symbol naming it")
+
+			continue
+		}
+
+		decl, exists := c.schema.contextual[contextKey{context: contextTopLevel, tag: tag.Value}]
+		if !exists {
+			c.report(tag.Pos, "unknown top-level form %q; a layout carries %s", tag.Value, and(c.schema.TopLevelForms()))
+
+			continue
+		}
+
+		counts[tag.Value]++
+
+		c.form(list, decl)
+	}
+
+	for _, decl := range c.schema.topLevel {
+		if decl.arity.admits(counts[decl.tag]) {
+			continue
+		}
+
+		// A missing form has no position of its own, so the diagnostic carries
+		// the start of the file: that is where the reader has to add one.
+		c.report(sexpr.Pos{Line: 1, Column: 1}, "a layout carries %s %s form, and this one carries %d", decl.arity.label(), decl.tag, counts[decl.tag])
+	}
+}
+
+// form checks one form against its declaration: its positional arguments in
+// order, then the children that follow them.
+func (c *checker) form(list sexpr.List, decl *formDecl) {
+	rest := c.arguments(list, decl)
+
+	if len(decl.children) == 0 {
+		for _, extra := range rest {
+			c.report(posOf(extra), "form %q takes %s, and this is one argument too many", decl.tag, arguments(decl))
+		}
+
+		return
+	}
+
+	c.children(rest, list.Pos, decl)
+}
+
+// arguments checks the positional arguments of a form and returns whatever
+// followed them.
+//
+// They are consumed in order by count, which is what [checkArgumentOrder]
+// guarantees is possible: every argument but the last takes exactly one node,
+// and a repeatable last argument takes everything left. A form that admits
+// children has no repeatable argument, so what is left when this returns is its
+// children and nothing else.
+func (c *checker) arguments(list sexpr.List, decl *formDecl) []sexpr.Node {
+	rest := list.Elements[1:]
+
+	for i, arg := range decl.args {
+		want := 1
+		if i == len(decl.args)-1 && arg.arity.repeatable() {
+			want = len(rest)
+		}
+
+		if have := min(want, len(rest)); want > len(rest) || !arg.arity.admits(have) {
+			c.report(list.Pos, "form %q takes %s for its %s argument, and this one has %d", decl.tag, arg.arity.label(), arg.name, have)
+
+			return nil
+		}
+
+		for _, node := range rest[:want] {
+			c.value(node, arg.sort, fmt.Sprintf("%s of form %q", arg.name, decl.tag))
+		}
+
+		rest = rest[want:]
+	}
+
+	return rest
+}
+
+// children checks the children that follow a form's arguments.
+func (c *checker) children(nodes []sexpr.Node, pos sexpr.Pos, decl *formDecl) {
+	counts := make(map[string]int)
+
+	for _, node := range nodes {
+		list, ok := c.formNode(node, fmt.Sprintf("form %q takes children", decl.tag))
+		if !ok {
+			continue
+		}
+
+		tag, ok := list.Elements[0].(sexpr.Symbol)
+		if !ok {
+			c.report(posOf(list.Elements[0]), "a form opens with a symbol naming it")
+
+			continue
+		}
+
+		child, exists := c.schema.children[tag.Value]
+		if _, admitted := decl.childArity[tag.Value]; !exists || !admitted {
+			c.report(tag.Pos, "form %q has no child %q; it admits %s", decl.tag, tag.Value, and(decl.children))
+
+			continue
+		}
+
+		counts[tag.Value]++
+
+		c.form(list, child)
+	}
+
+	for _, tag := range decl.children {
+		if decl.childArity[tag].admits(counts[tag]) {
+			continue
+		}
+
+		c.report(pos, "form %q takes %s %s, and this one has %d", decl.tag, decl.childArity[tag].label(), tag, counts[tag])
+	}
+}
+
+// value checks one node against the sort its position admits. where names the
+// position, so that a diagnostic says which argument of which form is wrong
+// rather than only what was found.
+func (c *checker) value(node sexpr.Node, ref sortRef, where string) {
+	if !c.admissible(node, where) {
+		return
+	}
+
+	if ref.name == "" {
+		symbol, ok := node.(sexpr.Symbol)
+		if !ok || !slices.Contains(ref.values, symbol.Value) {
+			c.report(posOf(node), "%s is one of %s", where, and(ref.values))
+		}
+
+		return
+	}
+
+	c.namedSort(node, ref.name, where)
+}
+
+// namedSort checks a node against a primitive or a declared sort.
+func (c *checker) namedSort(node sexpr.Node, name string, where string) {
+	if c.satisfies(node, name) {
+		return
+	}
+
+	c.report(posOf(node), "%s is %s", where, c.describe(name))
+}
+
+// satisfies reports whether node stands in a position of the named sort. It
+// reports rather than diagnoses, because a sort that includes another has to be
+// able to try a member and move on.
+func (c *checker) satisfies(node sexpr.Node, name string) bool {
+	switch name {
+	case sortSymbol:
+		_, ok := node.(sexpr.Symbol)
+
+		return ok
+	case sortText:
+		_, ok := node.(sexpr.String)
+
+		return ok
+	case sortNumber:
+		switch node.(type) {
+		case sexpr.Int, sexpr.Float:
+			return true
+		default:
+			return false
+		}
+	case sortPositiveNumber:
+		number, ok := node.(sexpr.Int)
+
+		return ok && number.Value > 0
+	}
+
+	decl, exists := c.schema.sorts[name]
+	if !exists {
+		return false
+	}
+
+	if decl.isReference() {
+		symbol, ok := node.(sexpr.Symbol)
+
+		return ok && slices.Contains(c.declared[name], symbol.Value)
+	}
+
+	if symbol, ok := node.(sexpr.Symbol); ok {
+		if slices.Contains(decl.symbols, symbol.Value) {
+			return true
+		}
+	}
+
+	if list, ok := node.(sexpr.List); ok && len(list.Elements) > 0 {
+		if tag, ok := list.Elements[0].(sexpr.Symbol); ok && slices.Contains(decl.forms, tag.Value) {
+			// The form is checked here rather than by the caller, because this
+			// is the only point at which the sort that admitted it is known,
+			// and the sort is what says which declaration of a tag applies.
+			c.form(list, c.schema.contextual[contextKey{context: name, tag: tag.Value}])
+
+			return true
+		}
+	}
+
+	for _, included := range decl.include {
+		if c.satisfies(node, included) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// describe renders what a sort admits, for a diagnostic that has to say what
+// was expected rather than only that something was not it.
+func (c *checker) describe(name string) string {
+	switch name {
+	case sortSymbol:
+		return "a symbol"
+	case sortText:
+		return "text"
+	case sortNumber:
+		return "a number"
+	case sortPositiveNumber:
+		return "a positive integer"
+	}
+
+	decl, exists := c.schema.sorts[name]
+	if !exists {
+		return fmt.Sprintf("of sort %q, which the schema does not declare", name)
+	}
+
+	if decl.isReference() {
+		return fmt.Sprintf("the name of a %s form this layout defines", decl.refForm)
+	}
+
+	var admits []string
+
+	for _, tag := range decl.forms {
+		admits = append(admits, "("+tag+" ...)")
+	}
+
+	admits = append(admits, decl.symbols...)
+
+	for _, included := range decl.include {
+		admits = append(admits, c.describe(included))
+	}
+
+	return and(admits)
+}
+
+// admissible reports whether a node is one the layout format admits at all,
+// diagnosing it when it is not.
+//
+// These are the constructs docs/layout/SPEC.md's "What this document delegates"
+// excludes: legal S-expressions with no meaning in a layout. Each is rejected by
+// name rather than by failing to match a sort, because "a construct with no
+// meaning that nevertheless parses is a construct two generators will emit
+// differently, and there is nothing for a diagnostic to say about it".
+func (c *checker) admissible(node sexpr.Node, where string) bool {
+	switch node := node.(type) {
+	case sexpr.Quote:
+		c.report(node.Pos, "%s: a quote shorthand has no meaning in a layout", where)
+	case sexpr.Nil:
+		c.report(node.Pos, "%s: nil has no meaning in a layout; absence is expressed by omitting a child", where)
+	case sexpr.Bool:
+		c.report(node.Pos, "%s: no position in a layout takes a boolean", where)
+	case sexpr.List:
+		if len(node.Elements) == 0 {
+			c.report(node.Pos, "%s: the empty list has no meaning in a layout; every form has a tag", where)
+
+			return false
+		}
+
+		if node.Tail != nil {
+			c.report(node.Pos, "%s: an improper list has no meaning in a layout", where)
+
+			return false
+		}
+
+		return true
+	default:
+		return true
+	}
+
+	return false
+}
+
+// formNode narrows a node to the list a form is, diagnosing everything a form
+// cannot be. context opens the message, so that the same rejection reads
+// differently at the top level and inside a form.
+func (c *checker) formNode(node sexpr.Node, context string) (sexpr.List, bool) {
+	if !c.admissible(node, context) {
+		return sexpr.List{}, false
+	}
+
+	list, ok := node.(sexpr.List)
+	if !ok {
+		c.report(posOf(node), "%s, and this is not one", context)
+
+		return sexpr.List{}, false
+	}
+
+	return list, true
+}
+
+// arguments renders a form's argument list the way a diagnostic names it.
+func arguments(decl *formDecl) string {
+	if len(decl.args) == 0 {
+		return "no arguments"
+	}
+
+	names := make([]string, 0, len(decl.args))
+
+	for _, arg := range decl.args {
+		if arg.arity.repeatable() {
+			names = append(names, arg.name+" ...")
+
+			continue
+		}
+
+		names = append(names, arg.name)
+	}
+
+	return strings.Join(names, ", ")
+}
+
+// and joins a list the way a sentence does, so that a diagnostic naming what is
+// admitted reads as one.
+func and(items []string) string {
+	switch len(items) {
+	case 0:
+		return "nothing"
+	case 1:
+		return items[0]
+	case 2:
+		return items[0] + " or " + items[1]
+	default:
+		return strings.Join(items[:len(items)-1], ", ") + " or " + items[len(items)-1]
+	}
+}

--- a/internal/layoutschema/validate_test.go
+++ b/internal/layoutschema/validate_test.go
@@ -1,0 +1,253 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layoutschema
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestValidLayoutsValidate is half of the acceptance criterion the corpus
+// exists for. Every layout under testdata/valid is one the schema admits, and a
+// diagnostic on any of them is the schema being wrong about the format rather
+// than the layout being wrong about the schema.
+//
+// Between them the three cover every top-level form, every closed value set,
+// every discrimination strategy, every sequencing operator and all three
+// literal spellings — which is what makes "the schema covers every layer" a
+// claim this suite tests rather than one it asserts.
+func TestValidLayoutsValidate(t *testing.T) {
+	schema := publishedSchema(t)
+
+	for _, name := range layouts(t, "valid") {
+		t.Run(name, func(t *testing.T) {
+			diagnostics, err := schema.Validate(bytes.NewReader(layout(t, "valid", name)))
+			if err != nil {
+				t.Fatalf("validate: %v", err)
+			}
+
+			for _, diagnostic := range diagnostics {
+				t.Errorf("unexpected diagnostic: %s", diagnostic)
+			}
+		})
+	}
+}
+
+// TestInvalidLayoutsAreRejected is the other half, and the more load-bearing
+// one: a validator that accepts everything passes the test above.
+//
+// Each file breaks exactly one rule the schema states, and carries the
+// diagnostic it expects on its first line as `;; want: <text>`. The expectation
+// travels with the example rather than sitting in a table here, so a rule and
+// the message it produces are read together.
+func TestInvalidLayoutsAreRejected(t *testing.T) {
+	schema := publishedSchema(t)
+
+	for _, name := range layouts(t, "invalid") {
+		t.Run(name, func(t *testing.T) {
+			source := layout(t, "invalid", name)
+
+			want, ok := strings.CutPrefix(strings.SplitN(string(source), "\n", 2)[0], ";; want: ")
+			if !ok {
+				t.Fatalf("%s carries no `;; want:` line saying which diagnostic it expects", name)
+			}
+
+			diagnostics, err := schema.Validate(bytes.NewReader(source))
+			if err != nil {
+				t.Fatalf("validate: %v", err)
+			}
+
+			if len(diagnostics) == 0 {
+				t.Fatalf("the schema accepted %s, which should have failed on %q", name, want)
+			}
+
+			for _, diagnostic := range diagnostics {
+				if strings.Contains(diagnostic.Message, want) {
+					return
+				}
+			}
+
+			t.Errorf("no diagnostic on %s contains %q; got:\n%s", name, want, strings.Join(messages(diagnostics), "\n"))
+		})
+	}
+}
+
+// TestTheSpecsWorkedExampleValidates is the staleness gate over the format
+// itself.
+//
+// docs/layout/SPEC.md's "A layout, end to end" appendix is the layout the
+// document shows an adopter, and it is the one layout in this repository nobody
+// wrote to satisfy the schema. Reading it out of the document rather than
+// copying it here is the point: a change to the notation that the appendix
+// followed and the schema did not would otherwise be invisible until an adopter
+// pasted the example into a file.
+func TestTheSpecsWorkedExampleValidates(t *testing.T) {
+	example := fencedBlock(t, section(t, "## Appendix: A layout, end to end"))
+
+	diagnostics, err := publishedSchema(t).Validate(strings.NewReader(example))
+	if err != nil {
+		t.Fatalf("validate the SPEC's example: %v", err)
+	}
+
+	for _, diagnostic := range diagnostics {
+		t.Errorf("the schema rejects SPEC.md's own worked example: %s", diagnostic)
+	}
+}
+
+// TestADiagnosticPointsAtTheSubFormThatIsWrong asserts the property SPEC.md
+// requires of every diagnostic this project emits: the span is the sub-form
+// that is wrong, not the top-level form containing it. A validator reporting
+// the enclosing form is one that sends a reader to the top of a page to find a
+// fault three lines down.
+func TestADiagnosticPointsAtTheSubFormThatIsWrong(t *testing.T) {
+	const source = `(encoding
+  (charset cp037)
+  (sign-convention ebcdic)
+  (byte-order sideways)
+  (float-format hfp))
+`
+
+	diagnostics, err := publishedSchema(t).Validate(strings.NewReader(source))
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+
+	found := false
+
+	for _, diagnostic := range diagnostics {
+		if !strings.Contains(diagnostic.Message, "byte-order") {
+			continue
+		}
+
+		found = true
+
+		if diagnostic.Pos.Line != 4 {
+			t.Errorf("the diagnostic points at line %d, want line 4 — the sub-form that is wrong", diagnostic.Pos.Line)
+		}
+	}
+
+	if !found {
+		t.Errorf("no diagnostic about the byte-order axis; got:\n%s", strings.Join(messages(diagnostics), "\n"))
+	}
+}
+
+// TestValidateReportsEveryFaultRatherThanTheFirst is why Check returns a slice.
+// A generated layout is generated wrong in the same way in many places at once,
+// and a validator reporting one fault per run is a validator run once per fault.
+func TestValidateReportsEveryFaultRatherThanTheFirst(t *testing.T) {
+	const source = `(encoding
+  (charset cp037)
+  (sign-convention sideways)
+  (byte-order upwards)
+  (float-format hfp))
+`
+
+	diagnostics, err := publishedSchema(t).Validate(strings.NewReader(source))
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+
+	var axes int
+
+	for _, diagnostic := range diagnostics {
+		if strings.Contains(diagnostic.Message, "sign-convention") || strings.Contains(diagnostic.Message, "byte-order") {
+			axes++
+		}
+	}
+
+	if axes != 2 {
+		t.Errorf("reported %d of the two bad axes; got:\n%s", axes, strings.Join(messages(diagnostics), "\n"))
+	}
+}
+
+// TestValidateFailsOnSourceThatIsNotSExpressions keeps a parse failure an error
+// rather than a diagnostic. It comes from the grammar this format delegates to
+// and leaves no layout to check, so reporting it as one finding among a list
+// would claim a coverage the call does not have.
+func TestValidateFailsOnSourceThatIsNotSExpressions(t *testing.T) {
+	if _, err := publishedSchema(t).Validate(strings.NewReader("(encoding")); err == nil {
+		t.Error("Validate accepted source the grammar cannot parse")
+	}
+}
+
+// fencedBlock returns the first fenced code block in body.
+func fencedBlock(t *testing.T, body string) string {
+	t.Helper()
+
+	var (
+		block []string
+		open  bool
+	)
+
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+			if open {
+				return strings.Join(block, "\n")
+			}
+
+			open = true
+
+			continue
+		}
+
+		if open {
+			block = append(block, line)
+		}
+	}
+
+	t.Fatal("no fenced code block found")
+
+	return ""
+}
+
+// layouts returns the names of every layout in one of the corpus directories.
+func layouts(t *testing.T, kind string) []string {
+	t.Helper()
+
+	entries, err := os.ReadDir(filepath.Join("testdata", kind))
+	if err != nil {
+		t.Fatalf("read testdata/%s: %v", kind, err)
+	}
+
+	var names []string
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			names = append(names, entry.Name())
+		}
+	}
+
+	if len(names) == 0 {
+		t.Fatalf("testdata/%s is empty: the check would pass vacuously", kind)
+	}
+
+	return names
+}
+
+// layout reads one layout out of the corpus.
+func layout(t *testing.T, kind, name string) []byte {
+	t.Helper()
+
+	b, err := os.ReadFile(filepath.Join("testdata", kind, name))
+	if err != nil {
+		t.Fatalf("read testdata/%s/%s: %v", kind, name, err)
+	}
+
+	return b
+}
+
+// messages renders a run of diagnostics for a failure message.
+func messages(diagnostics []Diagnostic) []string {
+	out := make([]string, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		out = append(out, "  "+diagnostic.String())
+	}
+
+	return out
+}

--- a/internal/tools/layout-schema/main.go
+++ b/internal/tools/layout-schema/main.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Command layout-schema writes the published layout schema — the released
+// layout-schema.sexpr — to a file, after checking that it loads.
+//
+// It is the third artifact a release carries, beside the IR's ir.binpb and
+// ir-protos.tar.gz, and it is for a different consumer than either: not a plugin
+// author decoding a resolved descriptor, but the adopter generating layout files
+// from metadata they already hold. docs/layout/SPEC.md's "The published schema"
+// is what this file is; the schema is the contract a generator targets and
+// cpybkc's own validator reads.
+//
+// # Why a command rather than an upload of the file
+//
+// The bytes it writes are the bytes of schema/layout.sexpr, unchanged. What this
+// adds is the check: it loads the schema through
+// [github.com/Zaba505/cpybkc/internal/layoutschema] first, and refuses to write
+// anything if it will not load.
+//
+// That is worth a command because of what the failure looks like otherwise. A
+// schema with a form declaring itself into a sort nothing lists, or a child no
+// form admits, parses as S-expressions and publishes as happily as a good one —
+// and the hole is invisible until a generator falls into it, at which point the
+// artifact naming the version it fell out of has already shipped. The Go tests
+// hold the published schema to docs/layout/SPEC.md on every pull request; this
+// holds it once more at the point the bytes leave the repository, on the path
+// that runs when nobody is watching.
+//
+// It transforms nothing on the way out for the reason the format exists: an
+// adopter's diagnostic and this repository's diagnostic have to be about the
+// same text, and a published artifact rewritten from a parse would be a second
+// spelling of one schema.
+//
+// It lives under internal/ for the reason ir-protos does: nothing outside this
+// repository has a reason to run it, and cmd/ is where a shipped command goes.
+//
+//	go run ./internal/tools/layout-schema -o layout-schema.sexpr
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Zaba505/cpybkc/internal/layoutschema"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "layout-schema: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// run is separated from main so that the exit path is the only thing main owns,
+// and so that a test can drive the whole program without ending the test binary.
+func run(args []string) error {
+	flags := flag.NewFlagSet("layout-schema", flag.ContinueOnError)
+	out := flags.String("o", "", "path to write the schema to (required)")
+	source := flags.String("schema", layoutschema.SchemaFile, "the schema to publish")
+
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+
+	if *out == "" {
+		return fmt.Errorf("-o is required: name the file to write")
+	}
+
+	if rest := flags.Args(); len(rest) > 0 {
+		return fmt.Errorf("unexpected arguments %v", rest)
+	}
+
+	b, err := os.ReadFile(*source)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", *source, err)
+	}
+
+	// Loaded and thrown away. Nothing here needs the parsed schema; what is
+	// needed is the assurance that it parses and hangs together, which is the
+	// whole reason this artifact goes through a program rather than a copy.
+	if _, err := layoutschema.Load(bytes.NewReader(b)); err != nil {
+		return fmt.Errorf("%s is not a schema this repository can load: %w", *source, err)
+	}
+
+	// The parent directory is created rather than required, for the reason
+	// ir-protos gives: the caller is a pipeline naming a path in a fresh
+	// container filesystem.
+	if dir := filepath.Dir(*out); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("failed to create %s: %w", dir, err)
+		}
+	}
+
+	if err := os.WriteFile(*out, b, 0o644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", *out, err)
+	}
+
+	return nil
+}

--- a/internal/tools/layout-schema/main_test.go
+++ b/internal/tools/layout-schema/main_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/layoutschema"
+)
+
+// TestRunPublishesTheSchemaOnDisk is the staleness gate: the artifact a release
+// attaches is the file this repository holds to docs/layout/SPEC.md, byte for
+// byte. A published schema that had been reformatted, or built from somewhere
+// else, would be a second spelling of the contract for an adopter's diagnostic
+// and this repository's to disagree about.
+func TestRunPublishesTheSchemaOnDisk(t *testing.T) {
+	root := repoRoot(t)
+	out := filepath.Join(t.TempDir(), "layout-schema.sexpr")
+
+	if err := run([]string{"-schema", layoutschema.SchemaPath(root), "-o", out}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	want, err := os.ReadFile(layoutschema.SchemaPath(root))
+	if err != nil {
+		t.Fatalf("read the published schema: %v", err)
+	}
+
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read %s: %v", out, err)
+	}
+
+	if !bytes.Equal(got, want) {
+		t.Errorf("the artifact is %d bytes and the schema is %d: the published file is the schema unchanged", len(got), len(want))
+	}
+}
+
+// TestRunRefusesASchemaThatWillNotLoad is why this is a program rather than an
+// upload of a file. A schema with a hole in it parses as S-expressions and
+// publishes as happily as a good one, and the hole is invisible until a
+// generator falls into it — by which time the artifact has shipped.
+func TestRunRefusesASchemaThatWillNotLoad(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "broken.sexpr")
+	out := filepath.Join(dir, "layout-schema.sexpr")
+
+	// Parses, and declares a form into a sort that does not list it.
+	const broken = "(schema layout 1)\n(sort strategy (symbol single-record-type))\n(form equals (in strategy))\n"
+
+	if err := os.WriteFile(source, []byte(broken), 0o644); err != nil {
+		t.Fatalf("write the broken schema: %v", err)
+	}
+
+	if err := run([]string{"-schema", source, "-o", out}); err == nil {
+		t.Fatal("run published a schema that does not load")
+	}
+
+	if _, err := os.Stat(out); err == nil {
+		t.Error("run wrote an artifact for a schema it refused")
+	}
+}
+
+// TestRunRejectsBadUsage keeps the failure modes failures, for the reason
+// ir-protos' copy of this test gives: a release job that uploads nothing and
+// reports success is the one outcome nobody notices.
+func TestRunRejectsBadUsage(t *testing.T) {
+	testCases := []struct {
+		name string
+		args []string
+	}{
+		{name: "no output path", args: nil},
+		{name: "empty output path", args: []string{"-o", ""}},
+		{name: "unexpected operand", args: []string{"-o", filepath.Join(t.TempDir(), "a.sexpr"), "extra"}},
+		{name: "missing schema", args: []string{"-o", filepath.Join(t.TempDir(), "b.sexpr"), "-schema", filepath.Join(t.TempDir(), "nowhere.sexpr")}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if err := run(testCase.args); err == nil {
+				t.Error("run accepted arguments it should have refused")
+			}
+		})
+	}
+}
+
+// repoRoot walks up from the test's working directory to the directory holding
+// go.mod, which for this module is the repository root and so the directory
+// schema/ sits in.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("working directory: %v", err)
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("no go.mod found above %q", dir)
+		}
+
+		dir = parent
+	}
+}

--- a/schema/layout.sexpr
+++ b/schema/layout.sexpr
@@ -1,0 +1,242 @@
+;; The published schema for the cpybkc file layout format.
+;;
+;; This is the machine-readable contract a generator targets and cpybkc's own
+;; validator checks a layout against. It is the artifact docs/layout/SPEC.md's
+;; "The published schema" specifies; that section is normative and this file is
+;; what it describes.
+;;
+;; It is written in the notation it describes — tagged forms over z5labs/sexpr-go's
+;; grammar — because a generator that can emit a layout can already read this, and
+;; a diagnostic about the schema and a diagnostic about a layout are then the same
+;; kind of thing with the same kind of span on it.
+;;
+;; The vocabulary is small and closed. Nine tags appear at the top of this file
+;; and nowhere in a layout: schema, sort, reference, form, in, arity, layer,
+;; argument, child. Everything else here is the name of a layout form, of one of
+;; its arguments, or of a value it may hold.
+;;
+;;   (schema <name> <version>)   what is described, and which version of it
+;;   (sort <name> <member> ...)  a name for what may stand in a position
+;;   (reference <sort> <form> <argument>)
+;;                               a sort whose member is a symbol naming that
+;;                               argument of some <form> in the same layout
+;;   (form <tag> ...)            one layout form: where it may appear, how many
+;;                               times, its positional arguments in order, and
+;;                               the children it admits
+;;
+;; A form carrying (in ...) is reachable from a context: `top-level`, meaning
+;; the layout itself, or the name of a sort. A form carrying no (in ...) is a
+;; child, reachable only where a parent's (child ...) names it. Arity always
+;; sits at the position rather than on the form, which is why `charset` is
+;; required under `encoding` and optional under `encoding-override` without
+;; being declared twice.
+;;
+;; Arities are spelled `exactly-one`, `at-most-one`, `one-or-more`,
+;; `zero-or-more` and `two-or-more`, for SPEC.md's 1, 0..1, 1..n, 0..n and the
+;; two-or-more `seq` and `alt` take. They are symbols rather than SPEC.md's
+;; digits because `0..1` is not a lexeme the grammar admits.
+;;
+;; Argument sorts are a primitive — `symbol`, `text`, `number`,
+;; `positive-number` — a sort declared below, or an inline closed set written
+;; `(values ...)`. Each closed set is inline because each is used in exactly one
+;; position; a set named and referred to by name would be a second place to look
+;; for what a `recfm` may say.
+;;
+;; What this file does not carry, and where each lands instead, is
+;; docs/layout/SPEC.md's "What the schema does not say". In short: conditional
+;; arities, spellings admitted in order to be rejected by name, rules relating
+;; two forms, and everything needing a copybook are the layout reader's and
+;; `resolve`'s. A layout this schema accepts is well-formed, not valid.
+
+(schema layout 1)
+
+;;; Sorts --------------------------------------------------------------------
+
+;; An item reference — SPEC.md's "An item reference" — wherever one appears.
+(sort item-ref (form item))
+
+;; A run of bytes given literally, with no charset and no padding.
+(sort byte-string (form bytes))
+
+;; A discriminator literal: text, a number, or bytes. Which one it is decides
+;; what it is compared against, and that resolution is `resolve`'s.
+(sort literal text number byte-string)
+
+;; What `when` tests a value against: one literal, or one of several.
+(sort match literal (form one-of))
+
+;; A discrimination strategy. The set is closed for v1.
+(sort strategy (form equals) (form one-of) (symbol single-record-type))
+
+;; A sequencing expression: a record name, or one of the seven operators. The
+;; set is closed for the same reason the strategies are.
+(sort expression
+  record-name
+  (form seq)
+  (form alt)
+  (form *)
+  (form +)
+  (form ?)
+  (form times)
+  (form when))
+
+;; A symbol naming a record the same layout defines.
+(reference record-name record name)
+
+;;; References and literals --------------------------------------------------
+
+;; (item <record-name> <name> ...) — the record, then the path from its
+;; top-level item down to the item named, one name per level, outermost first.
+;; The top-level item's own name is not repeated.
+(form item (in item-ref)
+  (argument record record-name exactly-one)
+  (argument name symbol one-or-more))
+
+;; (bytes "F0F1") — hexadecimal digits in pairs. That the text is hexadecimal,
+;; and that a byte string of no bytes is a diagnostic, are the reader's.
+(form bytes (in byte-string)
+  (argument hex text exactly-one))
+
+;;; The encoding profile ------------------------------------------------------
+
+(form encoding (in top-level) (arity exactly-one) (layer encoding-profile)
+  (child charset exactly-one)
+  (child sign-convention exactly-one)
+  (child byte-order exactly-one)
+  (child float-format exactly-one))
+
+(form encoding-override (in top-level) (arity zero-or-more) (layer encoding-profile)
+  (argument item item-ref exactly-one)
+  (child charset at-most-one)
+  (child sign-convention at-most-one)
+  (child byte-order at-most-one)
+  (child float-format at-most-one))
+
+;; `charset` takes a symbol and not a closed set. The charsets are
+;; `cobol-go`'s `codec/SPEC.md`'s, and a code page added to that axis would
+;; otherwise have to be added here before an adopter could name it.
+(form charset
+  (argument value symbol exactly-one))
+
+(form sign-convention
+  (argument value (values ebcdic ascii-zone-37 translated-ebcdic realia) exactly-one))
+
+(form byte-order
+  (argument value (values big-endian little-endian) exactly-one))
+
+(form float-format
+  (argument value (values ieee-754 hfp) exactly-one))
+
+;;; Physical framing ----------------------------------------------------------
+
+;; Which children this form requires follows from the `recfm` value: `lrecl` is
+;; required under F and FB, `max-segment` under VBS, `delimiter` and `placement`
+;; under line-sequential. The table below is the widest form, exactly as
+;; SPEC.md's is, and the conditions are the reader's.
+(form framing (in top-level) (arity exactly-one) (layer physical-framing)
+  (child recfm exactly-one)
+  (child lrecl at-most-one)
+  (child blksize at-most-one)
+  (child blocks at-most-one)
+  (child max-segment at-most-one)
+  (child delimiter at-most-one)
+  (child placement at-most-one))
+
+;; U is a spelling this schema admits and `resolve` rejects by name, so that an
+;; adopter who has one is told what is wrong with it rather than left describing
+;; their file as something else.
+(form recfm
+  (argument value (values F FB V VB VBS U line-sequential) exactly-one))
+
+(form lrecl
+  (argument value positive-number exactly-one))
+
+(form blksize
+  (argument value positive-number exactly-one))
+
+;; `in-stream` is admitted on the same terms as U.
+(form blocks
+  (argument value (values deblocked in-stream) exactly-one))
+
+(form max-segment
+  (argument value positive-number exactly-one))
+
+(form delimiter
+  (argument value byte-string exactly-one))
+
+(form placement
+  (argument value (values terminator separator optional-terminator) exactly-one))
+
+;;; Record definitions --------------------------------------------------------
+
+(form record (in top-level) (arity one-or-more) (layer record-definitions)
+  (argument name symbol exactly-one)
+  (child copybook exactly-one))
+
+(form copybook
+  (argument path text exactly-one)
+  (argument top-level-name symbol exactly-one))
+
+;; The substitute name is text and is carried verbatim: it is language-neutral,
+;; and turning a name into an identifier is a generator's work.
+(form rename (in top-level) (arity zero-or-more) (layer record-definitions)
+  (argument item item-ref exactly-one)
+  (argument name text exactly-one))
+
+(form copybook-reading (in top-level) (arity at-most-one) (layer record-definitions)
+  (child occurs-depending-on exactly-one))
+
+(form occurs-depending-on
+  (argument value (values odoslide noodoslide) exactly-one))
+
+;;; Discrimination ------------------------------------------------------------
+
+;; SPEC.md requires exactly one `discriminate` per `record`. This schema states
+;; the half of that it can — that a layout carries at least one — because the
+;; other half relates two forms and is the reader's.
+(form discriminate (in top-level) (arity one-or-more) (layer discrimination)
+  (argument record record-name exactly-one)
+  (argument strategy strategy exactly-one))
+
+(form equals (in strategy)
+  (argument item item-ref exactly-one)
+  (argument value literal exactly-one))
+
+(form one-of (in strategy)
+  (argument item item-ref exactly-one)
+  (argument value literal one-or-more))
+
+;;; Sequencing ----------------------------------------------------------------
+
+(form sequence (in top-level) (arity exactly-one) (layer sequencing)
+  (argument expression expression exactly-one))
+
+(form seq (in expression)
+  (argument subexpression expression two-or-more))
+
+(form alt (in expression)
+  (argument subexpression expression two-or-more))
+
+(form * (in expression)
+  (argument subexpression expression exactly-one))
+
+(form + (in expression)
+  (argument subexpression expression exactly-one))
+
+(form ? (in expression)
+  (argument subexpression expression exactly-one))
+
+(form times (in expression)
+  (argument subexpression expression exactly-one)
+  (argument count item-ref exactly-one))
+
+(form when (in expression)
+  (argument item item-ref exactly-one)
+  (argument value match exactly-one)
+  (argument subexpression expression exactly-one))
+
+;; `one-of` again, in the position `when` tests against. It is the same tag in a
+;; different sort and not the strategy above: there is no item reference on it,
+;; because `when` has already named the item.
+(form one-of (in match)
+  (argument value literal one-or-more))


### PR DESCRIPTION
Closes #23

The surface syntax chosen in #22 rests on two recorded requirements, and the first of them is that adopters hold this metadata already and will generate layout files far more often than they hand-write one — so the notation needs a machine-readable contract a generator can target. This publishes it.

## What the schema is

`schema/layout.sexpr`, published on every release as `layout-schema.sexpr`, and specified by a new `## The published schema` section in `docs/layout/SPEC.md`.

It is a set of **form declarations** written in the notation it describes — tagged forms over [`z5labs/sexpr-go`](https://github.com/z5labs/sexpr-go)'s grammar. That is the dialect, and it is named in the spec because a schema means nothing without the language it is written in. Its own vocabulary is nine tags that never appear in a layout: `schema`, `sort`, `reference`, `form`, `in`, `arity`, `layer`, `argument`, `child`.

Per form it states where the form may appear, how many times, its positional arguments in order, and the children it admits with their arities. A `sort` names what may stand in a position; a `reference` is a sort whose member names an argument of another form, which is how the schema says what a reference must name.

## Acceptance criteria

- [x] **The schema form follows the surface syntax chosen in #22, and its dialect or grammar language is named.** It is tagged forms over `z5labs/sexpr-go`'s grammar, named in `The published schema` → *It is written in the notation it describes*. It is not a JSON Schema and not a shape language; #22 excluded both branches.
- [x] **The schema covers every layer of the layout spec.** All eight top-level forms across the five layers, with every closed value set, every discrimination strategy, every sequencing operator and all three literal spellings. `TestThePublishedSchemaCoversEveryLayer` asserts the five layers; `TestThePublishedSchemaDeclaresTheTopLevelFormsTheSpecStates` reads SPEC.md's own top-level form table and requires the schema to agree with it on the forms, their layers and their arities.
- [x] **Schema versioned alongside the spec.** `(schema layout 1)`, one monotonic integer, with the policy for advancing it in `The published schema` → *The version is in the file, and it moves with the format*. In the file rather than in the path, because a release asset travels alone.
- [x] **Valid and invalid example layouts under `testdata/` validate and fail as expected.** Three valid layouts and eighteen invalid ones under `internal/layoutschema/testdata/`. Each invalid file carries the diagnostic it expects on its first line as `;; want: …`, so the rule and the message it produces are read together.
- [x] **Published as a release artifact.** `dagger call layout-schema export --path=layout-schema.sexpr`, attached by `.github/workflows/release.yaml` alongside the two IR artifacts, and built inside `Ci` by `LayoutArtifact` so the recipe a release runs is exercised on every pull request rather than for the first time on a tag.

## Judgment calls that shaped the contract

**The validator is schema-driven, not schema-shaped.** `internal/layoutschema` knows how to read a declaration and how to hold a layout to one; it does not know that a layout has an `encoding` form or that a `recfm` may say `VBS`. A form added to the schema is checked without a line changing in Go, which is what makes the published file the contract rather than the code.

**The schema states shape, and stops there.** A layout it accepts is well-formed, not valid. Four classes of rule are deliberately outside it and named in `What the schema does not say`: the conditional framing arities (SPEC.md's own table gives the widest form and leaves the conditions to prose, and the schema does the same), the spellings admitted in order to be rejected by name (`U`, `(blocks in-stream)`), the rules counting one form against another (one `discriminate` per `record`), and everything a copybook decides. Each of those would otherwise be a second statement of a rule #24 and #32–#38 already own, kept in step by hand.

The one cross-form statement it does make is the reference: a position declared to name a `record` must name one the layout defines. That is the half of "what each reference must name" a declaration can carry, and it is what makes a reference checkable rather than conventional.

**Arities are spelled `exactly-one` and `at-most-one` rather than `1` and `0..1`.** `0..1` opens like a number and is a malformed one, so a schema written in SPEC.md's notation would not parse. The test that compares the two maps between them.

**Two namespaces, and a load-time guard.** Forms are named by tag and sorts by name, and `one-of` is declared twice — once as a discrimination strategy taking an item reference, once as a `when` match taking none. `(in …)` names a sort or a parent form, so `Load` refuses a schema in which a sort and a child form share a name rather than letting the clause mean two things.

**Every redundancy the schema carries is checked rather than trusted.** A sort listing a form that does not declare itself into it, a form declaring itself into a sort that does not list it, a child no form admits, a repeatable argument that is not the last: each is a load failure, because each publishes a contract with a hole in it that is invisible until a generator falls into it.

**The artifact is the file, byte for byte.** `internal/tools/layout-schema` loads the schema and refuses to write anything if it will not load, then copies it out unchanged. An adopter's diagnostic and this repository's have to be about the same text, so a published artifact rewritten from a parse would be a second spelling of one schema.

## How it was verified

- `dagger call ci` — green. The first two runs failed with `resolve result …: missing shared result`, a stale entry in the local Dagger engine cache rather than anything in the tree; `dagger core engine local-cache prune` cleared it and the run after it was a real 59s pipeline.
- 40 tests in `internal/layoutschema` and `internal/tools/layout-schema`, including the two staleness gates that read `docs/layout/SPEC.md` — the top-level form table, and the worked example in `Appendix: A layout, end to end`, which is validated where it sits rather than copied into `testdata/`.
- `dagger call layout-schema export` produces a file byte-identical to `schema/layout.sexpr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)