### PR TITLE
story(layout): parse layout files into a positioned AST

### DIFF
--- a/internal/layout/ast.go
+++ b/internal/layout/ast.go
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layout
+
+import "fmt"
+
+// Pos is where something was written: the file, and the line and column within
+// it.
+//
+// The line and the column are the grammar's, counted from one.
+// [github.com/z5labs/sexpr-go] carries them on every token, which is the
+// property docs/layout/SPEC.md's "Positions survive" chose the notation for.
+// The file is added as the AST is built, because a reader parses bytes and has
+// no name to attach to them.
+type Pos struct {
+	// File is the name the layout was read under. It is whatever the caller
+	// passed [Parse] — a path, or something else naming the source — and is
+	// empty only when the caller named nothing.
+	File string
+
+	// Line and Column are one-based, counted by the grammar.
+	Line   int
+	Column int
+}
+
+// String renders a position the way a compiler does, so that an editor and a
+// terminal both know what to do with it. A position with no file renders as
+// line and column alone rather than as a leading colon.
+func (p Pos) String() string {
+	if p.File == "" {
+		return fmt.Sprintf("%d:%d", p.Line, p.Column)
+	}
+
+	return fmt.Sprintf("%s:%d:%d", p.File, p.Line, p.Column)
+}
+
+// Node is one node of a layout AST.
+//
+// The set is closed — a [Form], and the four kinds of value a form's positions
+// take — and the unexported method is what closes it: nothing outside this
+// package can add a node kind, so a type switch over the five is exhaustive and
+// stays exhaustive.
+//
+// Every node answers [Node.Position], which is the acceptance criterion this
+// AST exists for and also a working convenience: a caller asking where
+// something is never has to switch on its kind to find out.
+type Node interface {
+	// Position is where the node was written.
+	Position() Pos
+
+	// node keeps the set of node kinds closed to this package.
+	node()
+}
+
+// Form is a tagged form: a tag naming a relation, and the nodes that follow it.
+//
+// `(discriminate ORDER-HEADER (equals (item ORDER-HEADER OH-REC-TYPE) "10"))`
+// is one Form whose tag is `discriminate` and whose elements are a [Symbol] and
+// another Form. Which of those elements are the form's arguments and which are
+// its children is the published schema's to say, per tag, so this type keeps
+// them in one slice in source order rather than splitting them on a rule it
+// would be a second statement of.
+type Form struct {
+	// Pos is the opening parenthesis.
+	Pos Pos
+
+	// Tag names the relation the form states.
+	Tag string
+
+	// TagPos is the tag itself, which is a position of its own because a
+	// diagnostic about a tag has to point at the tag rather than at the form
+	// opened by it.
+	TagPos Pos
+
+	// Elements are the nodes after the tag, in source order.
+	Elements []Node
+}
+
+// Position implements [Node].
+func (f Form) Position() Pos { return f.Pos }
+
+func (Form) node() {}
+
+// Symbol is a bare name: a tag's argument, a record name, a member of a closed
+// value set.
+type Symbol struct {
+	Pos   Pos
+	Value string
+}
+
+// Position implements [Node].
+func (s Symbol) Position() Pos { return s.Pos }
+
+func (Symbol) node() {}
+
+// Text is a string literal. docs/layout/SPEC.md calls the sort `text`, and this
+// type is named for the sort rather than for the token so that a position's
+// declared sort and the node standing in it read as the same word.
+type Text struct {
+	Pos   Pos
+	Value string
+}
+
+// Position implements [Node].
+func (t Text) Position() Pos { return t.Pos }
+
+func (Text) node() {}
+
+// Int is an integer literal. The sorts `number` and `positive-number` are both
+// written as one.
+type Int struct {
+	Pos   Pos
+	Value int64
+}
+
+// Position implements [Node].
+func (i Int) Position() Pos { return i.Pos }
+
+func (Int) node() {}
+
+// Float is a non-integer number literal.
+//
+// No position in the format is declared to take one today, and the sort
+// `number` admits it: a layout that writes `4096.5` where a count belongs is
+// held to the sort by the schema, with a diagnostic naming the position, rather
+// than being rejected here as something the AST cannot hold. That is the
+// division this package keeps to — the reader builds what was written, and what
+// may stand where is the schema's.
+type Float struct {
+	Pos   Pos
+	Value float64
+}
+
+// Position implements [Node].
+func (f Float) Position() Pos { return f.Pos }
+
+func (Float) node() {}
+
+// File is a parsed layout: the top-level forms, in the order the source states
+// them.
+//
+// The order is kept because a diagnostic reads better in source order, not
+// because anything in the format depends on it. A layout is a set of statements
+// that refer to one another by name, and docs/layout/SPEC.md's "The layers stay
+// separable" is explicit that nothing orders them.
+type File struct {
+	// Name is what the layout was read under, and what every [Pos] in it
+	// carries.
+	Name string
+
+	// Forms are the layout's top-level forms.
+	Forms []Form
+}
+
+// Start is the position a diagnostic about the file as a whole carries.
+//
+// A form a layout is missing has no position of its own, and the start of the
+// file is where the reader has to add one.
+func (f File) Start() Pos {
+	return Pos{File: f.Name, Line: 1, Column: 1}
+}
+
+// Walk calls fn on n and then, unless fn returned false, on each of its
+// elements in source order.
+//
+// It is here because every layer above this one walks the same tree, and a walk
+// written once against the closed set of node kinds is one that cannot miss a
+// kind added later.
+func Walk(n Node, fn func(Node) bool) {
+	if !fn(n) {
+		return
+	}
+
+	form, ok := n.(Form)
+	if !ok {
+		return
+	}
+
+	for _, element := range form.Elements {
+		Walk(element, fn)
+	}
+}

--- a/internal/layout/doc.go
+++ b/internal/layout/doc.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Package layout reads a layout file into a positioned AST.
+//
+// A layout is a set of tagged forms written as S-expressions, specified by
+// docs/layout/SPEC.md's "The surface syntax". This package is the step between
+// the bytes an adopter wrote and everything that reasons about them: it hands
+// back [File], a set of [Form]s in the order the source states them, with a
+// [Pos] on every node naming the file, the line and the column it was written
+// at.
+//
+// # Why the AST is not sexpr-go's
+//
+// [github.com/z5labs/sexpr-go] already parses the source, and this package does
+// not re-parse it — SPEC.md's "What this document delegates" hands the lexis and
+// the grammar to that package, and there is one reading of it in this
+// repository. What is added here is the two things a layout needs and a generic
+// S-expression tree cannot have.
+//
+// A layout node carries the file it came from. sexpr-go parses an [io.Reader]
+// and so has no name to attach; its [github.com/z5labs/sexpr-go.Pos] is a line
+// and a column. A diagnostic an adopter can act on names the file too, and #31's
+// cross-file spans put a layout position and a copybook position side by side —
+// so a position that cannot say which file it is in is a position that stops
+// being usable exactly when there are two.
+//
+// And a layout node is a form. Every list in a layout opens with a symbol naming
+// the relation it states, so the AST has [Form] where the grammar has a list,
+// with the tag lifted out of the elements and carrying a position of its own.
+// That is what lets a diagnostic point at the tag that is misspelled rather than
+// at the form containing it, which SPEC.md's "Every diagnostic carries a span"
+// requires of every diagnostic this project emits.
+//
+// Uniform positions are the other half of it. Every [Node] answers
+// [Node.Position], so a walker asking where something is never needs a type
+// switch to find out.
+//
+// # What it rejects
+//
+// Several constructs are legal S-expressions and have no meaning in a layout:
+// improper lists, quote shorthands, nil, the empty list and booleans. SPEC.md
+// excludes each by name, for the reason it gives — "a construct with no meaning
+// that nevertheless parses is a construct two generators will emit
+// differently, and there is nothing for a diagnostic to say about it".
+//
+// This package rejects them rather than dropping them, and rejects them as
+// [ConstructError], naming the construct and where it was written. There is no
+// node in this AST for any of them, so accepting one would mean either
+// inventing a node nothing downstream can read or silently discarding something
+// an adopter wrote. Two further shapes are rejected the same way: a top-level
+// node that is not a form ([NotAFormError]) and a form that does not open with
+// a symbol ([UntaggedFormError]).
+//
+// [Parse] reports every fault it finds rather than the first, joined with
+// [errors.Join], for the reason
+// [github.com/Zaba505/cpybkc/internal/layoutschema] returns a slice of
+// diagnostics: a generated layout is generated wrong in the same way in many
+// places at once, and a reader that reports one fault per run is a reader run
+// once per fault. Each is still assertable with [errors.As], because that is
+// what errors.Join is traversed by.
+//
+// # What it does not check
+//
+// Everything that needs to know what a tag means. Whether `encoding` is a form
+// a layout may carry, whether `recfm` admits `VBS`, whether a `record` name is
+// defined, how many `framing` forms a layout takes: those are the published
+// schema's, and [github.com/Zaba505/cpybkc/internal/layoutschema] is what holds
+// a layout to it. The rules relating two forms, the conditional arities and
+// everything needing a copybook are the layers above this one — SPEC.md's
+// "Validation and diagnostics" is the split and the reasoning.
+//
+// So an AST this package returns is well-formed S-expression-wise and says
+// nothing about whether it is a layout anything can resolve. Keeping the two
+// apart is what makes a misspelled tag reportable as a misspelled tag: the
+// reader has already built the form carrying it, with a position on it, by the
+// time anybody asks what the tag means.
+package layout

--- a/internal/layout/errors.go
+++ b/internal/layout/errors.go
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layout
+
+import (
+	"errors"
+	"fmt"
+
+	sexpr "github.com/z5labs/sexpr-go"
+)
+
+// SyntaxError is source the S-expression grammar rejected.
+//
+// It is the one failure that leaves no layout at all, so [Parse] returns it
+// alone: there are no forms to have found anything else wrong with. The
+// grammar's own error is kept and reachable with [errors.As], because it says
+// which token was unexpected and what was expected instead, and this repository
+// does not restate the grammar.
+type SyntaxError struct {
+	// Pos is where the grammar stopped. Its file is always set; its line and
+	// column are the grammar's own, and are zero for the errors it raises
+	// without one.
+	Pos Pos
+
+	// Err is the error [github.com/z5labs/sexpr-go] returned.
+	Err error
+}
+
+// Error implements the error interface.
+func (e *SyntaxError) Error() string {
+	return fmt.Sprintf("%s: %v", e.Pos, e.Err)
+}
+
+// Unwrap gives up the grammar's error.
+func (e *SyntaxError) Unwrap() error { return e.Err }
+
+// Construct names an S-expression construct that has no meaning in a layout.
+//
+// The set is docs/layout/SPEC.md's "What this document delegates": legal
+// S-expressions the layout format excludes by name. It is closed, because the
+// document's list is.
+type Construct int
+
+// The constructs a layout may not contain.
+const (
+	// ConstructImproperList is a dotted pair — `(a b . c)`.
+	ConstructImproperList Construct = iota
+
+	// ConstructQuoteShorthand is `'x`, `` `x ``, `,x` or `,@x`.
+	ConstructQuoteShorthand
+
+	// ConstructNil is `nil`.
+	ConstructNil
+
+	// ConstructEmptyList is `()`.
+	ConstructEmptyList
+
+	// ConstructBoolean is `#t`, `#true`, `#f` or `#false`.
+	ConstructBoolean
+)
+
+// String names the construct.
+func (c Construct) String() string {
+	switch c {
+	case ConstructImproperList:
+		return "an improper list"
+	case ConstructQuoteShorthand:
+		return "a quote shorthand"
+	case ConstructNil:
+		return "nil"
+	case ConstructEmptyList:
+		return "the empty list"
+	case ConstructBoolean:
+		return "a boolean"
+	default:
+		return fmt.Sprintf("Construct(%d)", int(c))
+	}
+}
+
+// reason is what the message says after naming the construct: why the format
+// has no place for it, where docs/layout/SPEC.md gives one.
+func (c Construct) reason() string {
+	switch c {
+	case ConstructNil:
+		return "; absence is expressed by omitting a child"
+	case ConstructEmptyList:
+		return "; every form has a tag"
+	default:
+		return ""
+	}
+}
+
+// ConstructError is a legal S-expression with no meaning in a layout.
+//
+// It names the construct rather than reporting that something did not match,
+// which is docs/layout/SPEC.md's requirement on it: each of these is "a
+// diagnostic naming the construct and its position".
+type ConstructError struct {
+	Pos       Pos
+	Construct Construct
+}
+
+// Error implements the error interface.
+func (e *ConstructError) Error() string {
+	return fmt.Sprintf("%s: %s has no meaning in a layout%s", e.Pos, e.Construct, e.Construct.reason())
+}
+
+// NotAFormError is a node written where the format admits only a form.
+//
+// A layout is its top-level forms and nothing else, so a bare symbol, a string
+// or a number written at the top level is this rather than a form with a tag
+// nobody declared.
+type NotAFormError struct {
+	Pos Pos
+
+	// Found names what was written instead, so that the message says what it
+	// found and not only what it wanted.
+	Found string
+}
+
+// Error implements the error interface.
+func (e *NotAFormError) Error() string {
+	return fmt.Sprintf("%s: a layout is a set of forms, and this is %s", e.Pos, e.Found)
+}
+
+// UntaggedFormError is a form that does not open with a symbol naming it.
+//
+// Every statement a layout makes is a tag and the things it relates, so
+// `("record" ORDER-HEADER)` is not a form whose tag happens to be text: it is a
+// form with no tag, and there is nothing to look the rest of it up under.
+type UntaggedFormError struct {
+	// Pos is the element standing where the tag belongs, rather than the form
+	// opened by it — the sub-form that is wrong is what a span points at.
+	Pos Pos
+
+	// Found names what was written where the tag belongs.
+	Found string
+}
+
+// Error implements the error interface.
+func (e *UntaggedFormError) Error() string {
+	return fmt.Sprintf("%s: a form opens with a symbol naming it, and this one opens with %s", e.Pos, e.Found)
+}
+
+// describe names a grammar node the way a message refers to it.
+func describe(node sexpr.Node) string {
+	switch node.(type) {
+	case sexpr.Symbol:
+		return "a symbol"
+	case sexpr.String:
+		return "text"
+	case sexpr.Int, sexpr.Float:
+		return "a number"
+	case sexpr.List:
+		return "a form"
+	default:
+		return "something else"
+	}
+}
+
+// positionOf is where the grammar's error happened, under the file it was
+// reading.
+//
+// Every error [github.com/z5labs/sexpr-go] returns carries a position and none
+// of them share an interface that exposes it, so this is a switch over the set
+// rather than an assertion against one type. An error it does not know yields
+// the file and no line, which is worse than a full position and better than
+// dropping the file too.
+func positionOf(name string, err error) Pos {
+	pos := Pos{File: name}
+
+	var (
+		depth      sexpr.MaxDepthExceededError
+		endOfInput sexpr.UnexpectedEndOfTokensError
+		token      sexpr.UnexpectedTokenError
+		number     sexpr.NumberRangeError
+		character  sexpr.UnexpectedCharacterError
+		comment    sexpr.UnterminatedCommentError
+		text       sexpr.UnterminatedStringError
+		numeral    sexpr.InvalidNumberError
+		escape     sexpr.InvalidEscapeError
+	)
+
+	switch {
+	case errors.As(err, &depth):
+		pos.Line, pos.Column = depth.Pos.Line, depth.Pos.Column
+	case errors.As(err, &endOfInput):
+		pos.Line, pos.Column = endOfInput.Pos.Line, endOfInput.Pos.Column
+	case errors.As(err, &token):
+		pos.Line, pos.Column = token.Actual.Pos.Line, token.Actual.Pos.Column
+	case errors.As(err, &number):
+		pos.Line, pos.Column = number.Pos.Line, number.Pos.Column
+	case errors.As(err, &character):
+		pos.Line, pos.Column = character.Pos.Line, character.Pos.Column
+	case errors.As(err, &comment):
+		pos.Line, pos.Column = comment.Pos.Line, comment.Pos.Column
+	case errors.As(err, &text):
+		pos.Line, pos.Column = text.Pos.Line, text.Pos.Column
+	case errors.As(err, &numeral):
+		pos.Line, pos.Column = numeral.Pos.Line, numeral.Pos.Column
+	case errors.As(err, &escape):
+		pos.Line, pos.Column = escape.Pos.Line, escape.Pos.Column
+	}
+
+	return pos
+}

--- a/internal/layout/parse.go
+++ b/internal/layout/parse.go
@@ -107,6 +107,15 @@ func (r *reader) form(list sexpr.List) (Form, bool) {
 	// admissible has already refused an empty list and an improper one, so
 	// there is an element zero and everything after it is an element rather
 	// than a tail.
+	//
+	// The tag position is held to the excluded constructs first, and for the
+	// same reason every other position is: `('record ORDER-HEADER)` is a quote
+	// shorthand, and reporting it as a form that opens with something odd names
+	// the symptom rather than the construct SPEC.md excludes by name.
+	if !r.admissible(list.Elements[0]) {
+		return Form{}, false
+	}
+
 	tag, ok := list.Elements[0].(sexpr.Symbol)
 	if !ok {
 		r.fail(&UntaggedFormError{

--- a/internal/layout/parse.go
+++ b/internal/layout/parse.go
@@ -1,0 +1,235 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layout
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	sexpr "github.com/z5labs/sexpr-go"
+)
+
+// ParseFile reads the layout at path.
+//
+// The path is what every position in the returned [File] carries, so a
+// diagnostic names the file an adopter has to open rather than describing where
+// in an unnamed stream something went wrong.
+func ParseFile(path string) (*File, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open the layout: %w", err)
+	}
+
+	// Nothing is written, so a failure to close says nothing about whether the
+	// bytes were read correctly; the parse below is what decides that.
+	defer func() { _ = f.Close() }()
+
+	return Parse(path, f)
+}
+
+// Parse reads a layout from r under the name name.
+//
+// It returns every fault it found, joined, rather than the first — a generated
+// layout is generated wrong in the same way in many places at once, and each is
+// still assertable with [errors.As]. The one exception is source the grammar
+// itself rejects: that leaves no forms to have found anything else wrong with,
+// so a [SyntaxError] is returned alone.
+func Parse(name string, r io.Reader) (*File, error) {
+	parsed, err := sexpr.Parse(r)
+	if err != nil {
+		return nil, &SyntaxError{Pos: positionOf(name, err), Err: err}
+	}
+
+	read := &reader{name: name}
+	file := &File{Name: name}
+
+	for _, node := range parsed.Nodes {
+		form, ok := read.topLevel(node)
+		if !ok {
+			continue
+		}
+
+		file.Forms = append(file.Forms, form)
+	}
+
+	if len(read.errs) > 0 {
+		// The half-built file is dropped rather than returned beside the
+		// errors. A layout that was rejected has no AST anything downstream
+		// should be reading, and handing one back invites a caller to read it.
+		return nil, errors.Join(read.errs...)
+	}
+
+	return file, nil
+}
+
+// reader holds the state one parse accumulates: the name every position carries
+// and the faults found so far.
+type reader struct {
+	name string
+	errs []error
+}
+
+// pos lifts a grammar position into a layout one by naming the file it is in.
+func (r *reader) pos(pos sexpr.Pos) Pos {
+	return Pos{File: r.name, Line: pos.Line, Column: pos.Column}
+}
+
+// fail records a fault. Parsing continues after one, because the point of
+// collecting them is to report the second.
+func (r *reader) fail(err error) {
+	r.errs = append(r.errs, err)
+}
+
+// topLevel converts one of the layout's top-level nodes, which may only be a
+// form.
+func (r *reader) topLevel(node sexpr.Node) (Form, bool) {
+	if !r.admissible(node) {
+		return Form{}, false
+	}
+
+	list, ok := node.(sexpr.List)
+	if !ok {
+		r.fail(&NotAFormError{Pos: r.pos(positionOfNode(node)), Found: describe(node)})
+
+		return Form{}, false
+	}
+
+	return r.form(list)
+}
+
+// form converts a list into the tagged form a layout writes as one.
+func (r *reader) form(list sexpr.List) (Form, bool) {
+	// admissible has already refused an empty list and an improper one, so
+	// there is an element zero and everything after it is an element rather
+	// than a tail.
+	tag, ok := list.Elements[0].(sexpr.Symbol)
+	if !ok {
+		r.fail(&UntaggedFormError{
+			Pos:   r.pos(positionOfNode(list.Elements[0])),
+			Found: describe(list.Elements[0]),
+		})
+
+		return Form{}, false
+	}
+
+	form := Form{
+		Pos:    r.pos(list.Pos),
+		Tag:    tag.Value,
+		TagPos: r.pos(tag.Pos),
+	}
+
+	for _, element := range list.Elements[1:] {
+		node, ok := r.node(element)
+		if !ok {
+			continue
+		}
+
+		form.Elements = append(form.Elements, node)
+	}
+
+	return form, true
+}
+
+// node converts one element of a form: a value, or a nested form.
+func (r *reader) node(node sexpr.Node) (Node, bool) {
+	if !r.admissible(node) {
+		return nil, false
+	}
+
+	switch node := node.(type) {
+	case sexpr.Symbol:
+		return Symbol{Pos: r.pos(node.Pos), Value: node.Value}, true
+	case sexpr.String:
+		return Text{Pos: r.pos(node.Pos), Value: node.Value}, true
+	case sexpr.Int:
+		return Int{Pos: r.pos(node.Pos), Value: node.Value}, true
+	case sexpr.Float:
+		return Float{Pos: r.pos(node.Pos), Value: node.Value}, true
+	case sexpr.List:
+		form, ok := r.form(node)
+		if !ok {
+			return nil, false
+		}
+
+		return form, true
+	default:
+		// Unreachable while sexpr-go's node set is the one admissible knows,
+		// and reported rather than dropped if that ever stops being true: a
+		// node kind nobody has heard of is exactly what this package must not
+		// pass over in silence.
+		r.fail(&NotAFormError{Pos: r.pos(positionOfNode(node)), Found: describe(node)})
+
+		return nil, false
+	}
+}
+
+// admissible reports whether a node is one the layout format admits at all,
+// recording a fault when it is not.
+//
+// These are the constructs docs/layout/SPEC.md's "What this document delegates"
+// excludes: legal S-expressions with no meaning in a layout. Each is rejected by
+// name rather than by failing to fit somewhere, because a construct with no
+// meaning that nevertheless parses is a construct two generators will emit
+// differently.
+func (r *reader) admissible(node sexpr.Node) bool {
+	switch node := node.(type) {
+	case sexpr.Quote:
+		r.fail(&ConstructError{Pos: r.pos(node.Pos), Construct: ConstructQuoteShorthand})
+	case sexpr.Nil:
+		r.fail(&ConstructError{Pos: r.pos(node.Pos), Construct: ConstructNil})
+	case sexpr.Bool:
+		r.fail(&ConstructError{Pos: r.pos(node.Pos), Construct: ConstructBoolean})
+	case sexpr.List:
+		if len(node.Elements) == 0 {
+			r.fail(&ConstructError{Pos: r.pos(node.Pos), Construct: ConstructEmptyList})
+
+			return false
+		}
+
+		if node.Tail != nil {
+			r.fail(&ConstructError{Pos: r.pos(node.Pos), Construct: ConstructImproperList})
+
+			return false
+		}
+
+		return true
+	default:
+		return true
+	}
+
+	return false
+}
+
+// positionOfNode is where a grammar node was written.
+//
+// [github.com/z5labs/sexpr-go]'s nodes carry a position as a field rather than
+// behind a method, so asking one where it is means switching on its kind. The
+// AST this package builds does not — [Node.Position] is why — and this function
+// is the boundary between the two.
+func positionOfNode(node sexpr.Node) sexpr.Pos {
+	switch node := node.(type) {
+	case sexpr.Symbol:
+		return node.Pos
+	case sexpr.String:
+		return node.Pos
+	case sexpr.Int:
+		return node.Pos
+	case sexpr.Float:
+		return node.Pos
+	case sexpr.Bool:
+		return node.Pos
+	case sexpr.Nil:
+		return node.Pos
+	case sexpr.List:
+		return node.Pos
+	case sexpr.Quote:
+		return node.Pos
+	default:
+		return sexpr.Pos{}
+	}
+}

--- a/internal/layout/parse_test.go
+++ b/internal/layout/parse_test.go
@@ -30,7 +30,7 @@ func TestParseBuildsAPositionedAST(t *testing.T) {
 		want   string
 	}{
 		{
-			name:   "a form with one argument",
+			name:   "a form that is nothing but a tag",
 			source: "(framing)",
 			want:   "1:1 form framing",
 		},
@@ -229,6 +229,40 @@ func TestParseRejectsConstructsWithNoMeaningInALayout(t *testing.T) {
 			source:    "(record `ORDER-HEADER)",
 			construct: ConstructQuoteShorthand,
 			pos:       Pos{File: "layout.sexpr", Line: 1, Column: 9},
+		},
+		{
+			// The tag position is held to the same exclusions as every other,
+			// so an excluded construct written there is reported as the
+			// construct it is rather than as a form that opens with something
+			// odd.
+			name:      "a quote shorthand where the tag belongs",
+			source:    "('record ORDER-HEADER)",
+			construct: ConstructQuoteShorthand,
+			pos:       Pos{File: "layout.sexpr", Line: 1, Column: 2},
+		},
+		{
+			name:      "a boolean where the tag belongs",
+			source:    "(#t ORDER-HEADER)",
+			construct: ConstructBoolean,
+			pos:       Pos{File: "layout.sexpr", Line: 1, Column: 2},
+		},
+		{
+			name:      "the empty list where the tag belongs",
+			source:    "(() ORDER-HEADER)",
+			construct: ConstructEmptyList,
+			pos:       Pos{File: "layout.sexpr", Line: 1, Column: 2},
+		},
+		{
+			name:      "an improper list where the tag belongs",
+			source:    "((record . ORDER-HEADER) HEADER)",
+			construct: ConstructImproperList,
+			pos:       Pos{File: "layout.sexpr", Line: 1, Column: 2},
+		},
+		{
+			name:      "nil where the tag belongs",
+			source:    "(nil ORDER-HEADER)",
+			construct: ConstructNil,
+			pos:       Pos{File: "layout.sexpr", Line: 1, Column: 2},
 		},
 		{
 			name:      "nil where a child was omitted",

--- a/internal/layout/parse_test.go
+++ b/internal/layout/parse_test.go
@@ -1,0 +1,876 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layout
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	sexpr "github.com/z5labs/sexpr-go"
+)
+
+// TestParseBuildsAPositionedAST is the criterion this package exists for, and
+// it is asserted as a rendering rather than as a struct literal on purpose:
+// what has to be right is the shape *and* the position of every node, and a
+// rendering carrying both fails with the whole tree in the message rather than
+// with a diff of nested values.
+func TestParseBuildsAPositionedAST(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name:   "a form with one argument",
+			source: "(framing)",
+			want:   "1:1 form framing",
+		},
+		{
+			name:   "arguments and a child",
+			source: "(record ORDER-HEADER\n  (copybook \"cpy/orders.cpy\" ORDER-HEADER-REC))",
+			want: strings.Join([]string{
+				"1:1 form record",
+				"  1:9 symbol ORDER-HEADER",
+				"  2:3 form copybook",
+				"    2:13 text \"cpy/orders.cpy\"",
+				"    2:30 symbol ORDER-HEADER-REC",
+			}, "\n"),
+		},
+		{
+			name:   "numbers keep the spelling they were written in",
+			source: "(framing (lrecl 512) (drift -1.5))",
+			want: strings.Join([]string{
+				"1:1 form framing",
+				"  1:10 form lrecl",
+				"    1:17 int 512",
+				"  1:22 form drift",
+				"    1:29 float -1.5",
+			}, "\n"),
+		},
+		{
+			name:   "a form nested three deep",
+			source: "(discriminate ORDER-HEADER (equals (item ORDER-HEADER OH-REC-TYPE) \"10\"))",
+			want: strings.Join([]string{
+				"1:1 form discriminate",
+				"  1:15 symbol ORDER-HEADER",
+				"  1:28 form equals",
+				"    1:36 form item",
+				"      1:42 symbol ORDER-HEADER",
+				"      1:55 symbol OH-REC-TYPE",
+				"    1:68 text \"10\"",
+			}, "\n"),
+		},
+		{
+			name:   "the layers are separate top-level forms",
+			source: "(encoding (charset cp037))\n(framing (recfm VB))",
+			want: strings.Join([]string{
+				"1:1 form encoding",
+				"  1:11 form charset",
+				"    1:20 symbol cp037",
+				"2:1 form framing",
+				"  2:10 form recfm",
+				"    2:17 symbol VB",
+			}, "\n"),
+		},
+		{
+			name:   "comments and blank lines are not nodes, and do not move the ones that are",
+			source: ";; the record types.\n\n(record HEADER) ;; and its trailing note\n",
+			want:   "3:1 form record\n  3:9 symbol HEADER",
+		},
+		{
+			name:   "an empty layout has no forms",
+			source: ";; nothing here yet.\n",
+			want:   "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			file, err := Parse("layout.sexpr", strings.NewReader(testCase.source))
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+
+			if got := render(file); got != testCase.want {
+				t.Errorf("parsed as\n%s\nwant\n%s", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestEveryNodeCarriesTheFileItWasReadFrom is the half of the position that
+// sexpr-go cannot supply, and the half #31's cross-file spans are built on: a
+// position that cannot say which file it is in stops being usable exactly when
+// there are two.
+func TestEveryNodeCarriesTheFileItWasReadFrom(t *testing.T) {
+	t.Parallel()
+
+	file, err := Parse("orders.sexpr", strings.NewReader(specExample(t)))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	var nodes int
+
+	for _, form := range file.Forms {
+		Walk(form, func(node Node) bool {
+			nodes++
+
+			pos := node.Position()
+			if pos.File != "orders.sexpr" || pos.Line < 1 || pos.Column < 1 {
+				t.Errorf("%T at %+v carries no complete position", node, pos)
+			}
+
+			return true
+		})
+	}
+
+	if nodes == 0 {
+		t.Fatal("the walk visited no nodes, so the check above passed vacuously")
+	}
+}
+
+// TestTheSpecsWorkedExampleParses is the staleness gate over the notation.
+//
+// docs/layout/SPEC.md's "A layout, end to end" appendix is the layout the
+// document shows an adopter, and it is the one layout in this repository nobody
+// wrote against this reader. Reading it out of the document rather than copying
+// it here is the point: a change to the notation the appendix followed and the
+// reader did not would otherwise be invisible until an adopter pasted the
+// example into a file.
+func TestTheSpecsWorkedExampleParses(t *testing.T) {
+	t.Parallel()
+
+	file, err := Parse("orders.sexpr", strings.NewReader(specExample(t)))
+	if err != nil {
+		t.Fatalf("the reader rejects SPEC.md's own worked example: %v", err)
+	}
+
+	// Every statement in the appendix is a top-level form, and the count is
+	// stated here so that an example gaining or losing one is a failure rather
+	// than something the walk above absorbs.
+	if len(file.Forms) != 14 {
+		t.Errorf("read %d top-level forms out of the appendix, want 14: %s", len(file.Forms), strings.Join(tags(file), ", "))
+	}
+}
+
+// TestAFormsTagCarriesItsOwnPosition is what lets a diagnostic about a tag
+// point at the tag. A form's own position is its opening parenthesis, and a
+// reader sent there to find a misspelled word one column over has been sent to
+// the wrong place.
+func TestAFormsTagCarriesItsOwnPosition(t *testing.T) {
+	t.Parallel()
+
+	file, err := Parse("layout.sexpr", strings.NewReader("(framing\n  (recfm VB))"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	framing := file.Forms[0]
+	if framing.Pos.Column != 1 || framing.TagPos.Column != 2 {
+		t.Errorf("framing opens at column %d with its tag at column %d, want 1 and 2", framing.Pos.Column, framing.TagPos.Column)
+	}
+
+	recfm, ok := framing.Elements[0].(Form)
+	if !ok {
+		t.Fatalf("the child of framing is %T, want a Form", framing.Elements[0])
+	}
+
+	if recfm.Pos.Line != 2 || recfm.Pos.Column != 3 || recfm.TagPos.Column != 4 {
+		t.Errorf("recfm opens at %s with its tag at %s, want 2:3 and 2:4", recfm.Pos, recfm.TagPos)
+	}
+}
+
+// TestParseRejectsConstructsWithNoMeaningInALayout covers docs/layout/SPEC.md's
+// "What this document delegates" — the legal S-expressions the format excludes
+// by name. Each is rejected rather than dropped, and each names the construct:
+// a construct with no meaning that nevertheless parses is one two generators
+// will emit differently, and there is nothing for a diagnostic to say about it.
+func TestParseRejectsConstructsWithNoMeaningInALayout(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		source    string
+		construct Construct
+		pos       Pos
+	}{
+		{
+			name:      "an improper list at the top level",
+			source:    "(record . ORDER-HEADER)",
+			construct: ConstructImproperList,
+			pos:       Pos{File: "layout.sexpr", Line: 1, Column: 1},
+		},
+		{
+			name:      "an improper list inside a form",
+			source:    "(record ORDER-HEADER\n  (copybook . \"cpy/orders.cpy\"))",
+			construct: ConstructImproperList,
+			pos:       Pos{File: "layout.sexpr", Line: 2, Column: 3},
+		},
+		{
+			name:      "a quote shorthand where a value belongs",
+			source:    "(record 'ORDER-HEADER)",
+			construct: ConstructQuoteShorthand,
+			pos:       Pos{File: "layout.sexpr", Line: 1, Column: 9},
+		},
+		{
+			name:      "a quasiquote",
+			source:    "(record `ORDER-HEADER)",
+			construct: ConstructQuoteShorthand,
+			pos:       Pos{File: "layout.sexpr", Line: 1, Column: 9},
+		},
+		{
+			name:      "nil where a child was omitted",
+			source:    "(framing (recfm VB) nil)",
+			construct: ConstructNil,
+			pos:       Pos{File: "layout.sexpr", Line: 1, Column: 21},
+		},
+		{
+			name:      "the empty list",
+			source:    "(framing ())",
+			construct: ConstructEmptyList,
+			pos:       Pos{File: "layout.sexpr", Line: 1, Column: 10},
+		},
+		{
+			name:      "a boolean where a closed value set belongs",
+			source:    "(framing (blocks #t))",
+			construct: ConstructBoolean,
+			pos:       Pos{File: "layout.sexpr", Line: 1, Column: 18},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			file, err := Parse("layout.sexpr", strings.NewReader(testCase.source))
+			if err == nil {
+				t.Fatalf("the reader accepted %q, which carries %s", testCase.source, testCase.construct)
+			}
+
+			if file != nil {
+				t.Errorf("a rejected layout came back with an AST anyway")
+			}
+
+			var construct *ConstructError
+			if !errors.As(err, &construct) {
+				t.Fatalf("the error is %T (%v), want a *ConstructError", err, err)
+			}
+
+			if construct.Construct != testCase.construct {
+				t.Errorf("reported %s, want %s", construct.Construct, testCase.construct)
+			}
+
+			if construct.Pos != testCase.pos {
+				t.Errorf("reported at %s, want %s", construct.Pos, testCase.pos)
+			}
+		})
+	}
+}
+
+// TestParseRejectsWhatCannotBeAForm covers the two shapes that parse as
+// S-expressions and are not statements: a top-level node that is not a form,
+// and a form with nothing naming it. Neither has a node in this AST, so
+// accepting one would mean inventing a node nothing downstream can read.
+func TestParseRejectsWhatCannotBeAForm(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		source string
+		assert func(*testing.T, error)
+	}{
+		{
+			name:   "a bare symbol at the top level",
+			source: "(framing)\nORDER-HEADER",
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				assertNotAForm(t, err, "a symbol", Pos{File: "layout.sexpr", Line: 2, Column: 1})
+			},
+		},
+		{
+			name:   "text at the top level",
+			source: "\"cpy/orders.cpy\"",
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				assertNotAForm(t, err, "text", Pos{File: "layout.sexpr", Line: 1, Column: 1})
+			},
+		},
+		{
+			name:   "a number at the top level",
+			source: "512",
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				assertNotAForm(t, err, "a number", Pos{File: "layout.sexpr", Line: 1, Column: 1})
+			},
+		},
+		{
+			name:   "a form opening with a number",
+			source: "(1 2)",
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				assertUntagged(t, err, "a number", Pos{File: "layout.sexpr", Line: 1, Column: 2})
+			},
+		},
+		{
+			name:   "a form opening with text",
+			source: "(\"record\" ORDER-HEADER)",
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				assertUntagged(t, err, "text", Pos{File: "layout.sexpr", Line: 1, Column: 2})
+			},
+		},
+		{
+			name:   "a child form opening with a form",
+			source: "(framing ((recfm) VB))",
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+				assertUntagged(t, err, "a form", Pos{File: "layout.sexpr", Line: 1, Column: 11})
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			file, err := Parse("layout.sexpr", strings.NewReader(testCase.source))
+			if err == nil {
+				t.Fatalf("the reader accepted %q", testCase.source)
+			}
+
+			if file != nil {
+				t.Errorf("a rejected layout came back with an AST anyway")
+			}
+
+			testCase.assert(t, err)
+		})
+	}
+}
+
+// TestAnErrorSaysWhatItFoundAndWhere holds the messages themselves, because
+// they are what an adopter reads. docs/layout/SPEC.md requires that a
+// diagnostic name what it found and where and not merely report that a layout
+// is invalid, so the wording is under test rather than left to whatever the
+// fields happen to render as.
+func TestAnErrorSaysWhatItFoundAndWhere(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name:   "an improper list",
+			source: "(record . ORDER-HEADER)",
+			want:   "layout.sexpr:1:1: an improper list has no meaning in a layout",
+		},
+		{
+			name:   "a quote shorthand",
+			source: "(record 'ORDER-HEADER)",
+			want:   "layout.sexpr:1:9: a quote shorthand has no meaning in a layout",
+		},
+		{
+			name:   "nil",
+			source: "(framing (recfm VB) nil)",
+			want:   "layout.sexpr:1:21: nil has no meaning in a layout; absence is expressed by omitting a child",
+		},
+		{
+			name:   "the empty list",
+			source: "(framing ())",
+			want:   "layout.sexpr:1:10: the empty list has no meaning in a layout; every form has a tag",
+		},
+		{
+			name:   "a boolean",
+			source: "(framing (blocks #t))",
+			want:   "layout.sexpr:1:18: a boolean has no meaning in a layout",
+		},
+		{
+			name:   "a number at the top level",
+			source: "512",
+			want:   "layout.sexpr:1:1: a layout is a set of forms, and this is a number",
+		},
+		{
+			name:   "a form with nothing naming it",
+			source: "(\"record\" ORDER-HEADER)",
+			want:   "layout.sexpr:1:2: a form opens with a symbol naming it, and this one opens with text",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := Parse("layout.sexpr", strings.NewReader(testCase.source))
+			if err == nil {
+				t.Fatalf("the reader accepted %q", testCase.source)
+			}
+
+			if got := err.Error(); got != testCase.want {
+				t.Errorf("said\n%s\nwant\n%s", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestParseReportsEveryFaultRatherThanTheFirst is why the errors are joined. A
+// generated layout is generated wrong in the same way in many places at once,
+// and a reader reporting one fault per run is a reader run once per fault.
+func TestParseReportsEveryFaultRatherThanTheFirst(t *testing.T) {
+	t.Parallel()
+
+	const source = "(framing (blocks #t) ())\nORDER-HEADER\n(record 'HEADER)"
+
+	_, err := Parse("layout.sexpr", strings.NewReader(source))
+	if err == nil {
+		t.Fatal("the reader accepted a layout with four faults in it")
+	}
+
+	faults := faults(err)
+	if len(faults) != 4 {
+		t.Fatalf("reported %d faults, want 4:\n%v", len(faults), err)
+	}
+
+	// Every one of them is still assertable on its own, which is what
+	// errors.Join buys and what a single concatenated message would not.
+	for _, fault := range faults {
+		var (
+			construct *ConstructError
+			notAForm  *NotAFormError
+		)
+
+		if !errors.As(fault, &construct) && !errors.As(fault, &notAForm) {
+			t.Errorf("fault %v is neither a *ConstructError nor a *NotAFormError", fault)
+		}
+	}
+}
+
+// TestParseFailsOnSourceTheGrammarRejects keeps a grammatical failure the
+// grammar's. It is reported as one error rather than beside a list of forms,
+// because it leaves no forms — and the grammar's own error stays reachable,
+// since docs/layout/SPEC.md delegates what a symbol is and where one ends and
+// this repository does not restate it.
+func TestParseFailsOnSourceTheGrammarRejects(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		source string
+		pos    Pos
+	}{
+		{
+			// The position is the last token the grammar read, which is where
+			// it ran out rather than where the parenthesis is missing. It is
+			// the grammar's to say: docs/layout/SPEC.md delegates the parse and
+			// the positions on it, and this package carries them rather than
+			// improving on them.
+			name:   "a form nobody closed",
+			source: "(record ORDER-HEADER",
+			pos:    Pos{File: "layout.sexpr", Line: 1, Column: 9},
+		},
+		{
+			name:   "a string nobody closed",
+			source: "(copybook \"cpy/orders.cpy)",
+			pos:    Pos{File: "layout.sexpr", Line: 1, Column: 11},
+		},
+		{
+			name:   "a closing parenthesis with nothing open",
+			source: "(framing))",
+			pos:    Pos{File: "layout.sexpr", Line: 1, Column: 10},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			file, err := Parse("layout.sexpr", strings.NewReader(testCase.source))
+			if err == nil {
+				t.Fatalf("the reader accepted %q", testCase.source)
+			}
+
+			if file != nil {
+				t.Errorf("a rejected layout came back with an AST anyway")
+			}
+
+			var syntax *SyntaxError
+			if !errors.As(err, &syntax) {
+				t.Fatalf("the error is %T (%v), want a *SyntaxError", err, err)
+			}
+
+			if syntax.Pos != testCase.pos {
+				t.Errorf("reported at %s, want %s", syntax.Pos, testCase.pos)
+			}
+
+			if syntax.Unwrap() == nil {
+				t.Error("the grammar's own error was dropped")
+			}
+
+			if !strings.Contains(syntax.Error(), testCase.pos.String()) {
+				t.Errorf("the message %q does not open with the position", syntax.Error())
+			}
+		})
+	}
+}
+
+// TestASyntaxErrorKeepsTheGrammarsError asserts what the position on a
+// SyntaxError is a summary of: the error sexpr-go returned survives, so a
+// caller that wants to know which token was unexpected can ask.
+func TestASyntaxErrorKeepsTheGrammarsError(t *testing.T) {
+	t.Parallel()
+
+	_, err := Parse("layout.sexpr", strings.NewReader("(record ORDER-HEADER"))
+
+	var unexpected sexpr.UnexpectedEndOfTokensError
+	if !errors.As(err, &unexpected) {
+		t.Fatalf("the grammar's error did not survive: %v", err)
+	}
+
+	if unexpected.Pos.Line != 1 {
+		t.Errorf("the grammar reported line %d, want 1", unexpected.Pos.Line)
+	}
+}
+
+// TestParseFileNamesTheFileItRead is the one thing an in-memory reader cannot
+// cover, and the reason ParseFile exists rather than being left to every
+// caller: the name a position carries is the path the layout was opened at.
+func TestParseFileNamesTheFileItRead(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("testdata", "line-sequential.sexpr")
+
+	file, err := ParseFile(path)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	if file.Name != path {
+		t.Errorf("the file is named %q, want %q", file.Name, path)
+	}
+
+	if file.Start() != (Pos{File: path, Line: 1, Column: 1}) {
+		t.Errorf("the start of the file is %s, want %s:1:1", file.Start(), path)
+	}
+
+	for _, form := range file.Forms {
+		Walk(form, func(node Node) bool {
+			if node.Position().File != path {
+				t.Errorf("%T at %s does not name the file it was read from", node, node.Position())
+			}
+
+			return true
+		})
+	}
+}
+
+// TestParseFileFailsOnAFileThatIsNotThere reports the open failure rather than
+// an empty layout, which is the difference between a layout that says nothing
+// and a layout nobody found.
+func TestParseFileFailsOnAFileThatIsNotThere(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseFile(filepath.Join("testdata", "no-such-layout.sexpr"))
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("opening a layout that is not there failed with %v, want it to be an os.ErrNotExist", err)
+	}
+}
+
+// TestPosRenders covers the spelling a diagnostic is read in. A position with
+// no file renders as line and column alone rather than as a leading colon,
+// because a caller that named nothing is not naming a file called "".
+func TestPosRenders(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		pos  Pos
+		want string
+	}{
+		{name: "a named file", pos: Pos{File: "orders.sexpr", Line: 12, Column: 3}, want: "orders.sexpr:12:3"},
+		{name: "no file", pos: Pos{Line: 12, Column: 3}, want: "12:3"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := testCase.pos.String(); got != testCase.want {
+				t.Errorf("rendered as %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestWalkStopsWhereItIsTold keeps the walk usable for a search rather than
+// only for a census: a caller that has found what it came for should not pay
+// for the subtree under it.
+func TestWalkStopsWhereItIsTold(t *testing.T) {
+	t.Parallel()
+
+	file, err := Parse("layout.sexpr", strings.NewReader("(discriminate HEADER (equals (item HEADER H-TYPE) \"H\"))"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	var visited int
+
+	Walk(file.Forms[0], func(node Node) bool {
+		visited++
+
+		form, ok := node.(Form)
+
+		return !ok || form.Tag != "equals"
+	})
+
+	// discriminate, HEADER and equals — and nothing under equals.
+	if visited != 3 {
+		t.Errorf("visited %d nodes, want 3", visited)
+	}
+}
+
+// TestConstructsAreNamed keeps the enumeration's spelling under test, because
+// the names are what a message says it found rather than an internal label.
+func TestConstructsAreNamed(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		construct Construct
+		want      string
+	}{
+		{construct: ConstructImproperList, want: "an improper list"},
+		{construct: ConstructQuoteShorthand, want: "a quote shorthand"},
+		{construct: ConstructNil, want: "nil"},
+		{construct: ConstructEmptyList, want: "the empty list"},
+		{construct: ConstructBoolean, want: "a boolean"},
+		{construct: Construct(42), want: "Construct(42)"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.want, func(t *testing.T) {
+			t.Parallel()
+
+			if got := testCase.construct.String(); got != testCase.want {
+				t.Errorf("named %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+// assertNotAForm asserts that err reports a node written where only a form
+// belongs.
+func assertNotAForm(t *testing.T, err error, found string, pos Pos) {
+	t.Helper()
+
+	var notAForm *NotAFormError
+	if !errors.As(err, &notAForm) {
+		t.Fatalf("the error is %T (%v), want a *NotAFormError", err, err)
+	}
+
+	if notAForm.Found != found {
+		t.Errorf("reported %q, want %q", notAForm.Found, found)
+	}
+
+	if notAForm.Pos != pos {
+		t.Errorf("reported at %s, want %s", notAForm.Pos, pos)
+	}
+}
+
+// assertUntagged asserts that err reports a form with nothing naming it.
+func assertUntagged(t *testing.T, err error, found string, pos Pos) {
+	t.Helper()
+
+	var untagged *UntaggedFormError
+	if !errors.As(err, &untagged) {
+		t.Fatalf("the error is %T (%v), want an *UntaggedFormError", err, err)
+	}
+
+	if untagged.Found != found {
+		t.Errorf("reported %q, want %q", untagged.Found, found)
+	}
+
+	if untagged.Pos != pos {
+		t.Errorf("reported at %s, want %s", untagged.Pos, pos)
+	}
+}
+
+// faults splits a joined error back into the faults it was built from.
+func faults(err error) []error {
+	var joined interface{ Unwrap() []error }
+	if errors.As(err, &joined) {
+		return joined.Unwrap()
+	}
+
+	return []error{err}
+}
+
+// render draws an AST as one line per node, indented by depth, carrying the
+// position of every one.
+func render(file *File) string {
+	var lines []string
+
+	for _, form := range file.Forms {
+		lines = append(lines, renderNode(form, 0)...)
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// renderNode draws one node and everything under it.
+func renderNode(node Node, depth int) []string {
+	indent := strings.Repeat("  ", depth)
+	pos := fmt.Sprintf("%d:%d", node.Position().Line, node.Position().Column)
+
+	switch node := node.(type) {
+	case Form:
+		lines := []string{fmt.Sprintf("%s%s form %s", indent, pos, node.Tag)}
+		for _, element := range node.Elements {
+			lines = append(lines, renderNode(element, depth+1)...)
+		}
+
+		return lines
+	case Symbol:
+		return []string{fmt.Sprintf("%s%s symbol %s", indent, pos, node.Value)}
+	case Text:
+		return []string{fmt.Sprintf("%s%s text %q", indent, pos, node.Value)}
+	case Int:
+		return []string{fmt.Sprintf("%s%s int %d", indent, pos, node.Value)}
+	case Float:
+		return []string{fmt.Sprintf("%s%s float %v", indent, pos, node.Value)}
+	default:
+		return []string{fmt.Sprintf("%s%s %T", indent, pos, node)}
+	}
+}
+
+// tags names a layout's top-level forms, for a failure message about how many
+// of them there are.
+func tags(file *File) []string {
+	names := make([]string, 0, len(file.Forms))
+	for _, form := range file.Forms {
+		names = append(names, form.Tag)
+	}
+
+	return names
+}
+
+// specExample returns docs/layout/SPEC.md's worked example.
+func specExample(t *testing.T) string {
+	t.Helper()
+
+	return fencedBlock(t, section(t, "## Appendix: A layout, end to end"))
+}
+
+// fencedBlock returns the first fenced code block in body.
+func fencedBlock(t *testing.T, body string) string {
+	t.Helper()
+
+	var (
+		block []string
+		open  bool
+	)
+
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+			if open {
+				return strings.Join(block, "\n")
+			}
+
+			open = true
+
+			continue
+		}
+
+		if open {
+			block = append(block, line)
+		}
+	}
+
+	t.Fatal("no fenced code block found")
+
+	return ""
+}
+
+// section returns the text of SPEC.md under heading, up to the next heading at
+// the same level or above.
+func section(t *testing.T, heading string) string {
+	t.Helper()
+
+	level := strings.IndexFunc(heading, func(r rune) bool { return r != '#' })
+
+	var (
+		body  []string
+		found bool
+	)
+
+	for _, line := range strings.Split(specText(t), "\n") {
+		if line == heading {
+			found = true
+
+			continue
+		}
+
+		if !found {
+			continue
+		}
+
+		if strings.HasPrefix(line, "#") && strings.IndexFunc(line, func(r rune) bool { return r != '#' }) <= level {
+			break
+		}
+
+		body = append(body, line)
+	}
+
+	if !found {
+		t.Fatalf("the layout SPEC has no %q section", heading)
+	}
+
+	return strings.Join(body, "\n")
+}
+
+// specText reads docs/layout/SPEC.md.
+func specText(t *testing.T) string {
+	t.Helper()
+
+	b, err := os.ReadFile(filepath.Join(repoRoot(t), "docs", "layout", "SPEC.md"))
+	if err != nil {
+		t.Fatalf("read the layout SPEC: %v", err)
+	}
+
+	return string(b)
+}
+
+// repoRoot walks up from the test's working directory to the directory holding
+// go.mod, which for this module is the repository root and so the directory
+// docs/ sits in.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("working directory: %v", err)
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("no go.mod above the test's working directory")
+		}
+
+		dir = parent
+	}
+}

--- a/internal/layout/testdata/line-sequential.sexpr
+++ b/internal/layout/testdata/line-sequential.sexpr
@@ -1,0 +1,21 @@
+;; A layout on disk, for the one thing an in-memory reader cannot cover: that
+;; ParseFile names the file it read, on every position in it.
+(encoding
+  (charset ascii)
+  (sign-convention ascii-zone-37)
+  (byte-order little-endian)
+  (float-format ieee-754))
+
+(framing
+  (recfm line-sequential)
+  (delimiter (bytes "0A"))
+  (placement terminator))
+
+(record HEADER (copybook "cpy/export.cpy" HEADER-REC))
+(record DETAIL (copybook "cpy/export.cpy" DETAIL-REC))
+
+(discriminate HEADER (equals (item HEADER H-TYPE) "H"))
+(discriminate DETAIL (one-of (item DETAIL D-TYPE) "D" "E"))
+
+(sequence
+  (seq HEADER (+ DETAIL)))


### PR DESCRIPTION
Closes #24

Adds `internal/layout`, the reader between the bytes an adopter wrote and everything that reasons about them. `Parse` and `ParseFile` return a `File` of tagged `Form`s in source order, with a `Pos` naming the file, line and column on every node.

## What it adds over sexpr-go's parse

The grammar stays `sexpr-go`'s — `docs/layout/SPEC.md`'s "What this document delegates" hands it the lexis, the parse and the positions, and there is one reading of it in this repository. Two things are added:

- **The file on every position.** `sexpr-go` parses an `io.Reader` and so has no name to attach; its `Pos` is a line and a column. #31's cross-file spans put a layout position and a copybook position side by side, and a position that cannot say which file it is in stops being usable exactly when there are two.
- **A `Form` where the grammar has a list**, with the tag lifted out of the elements and carrying a position of its own — so a diagnostic can point at a misspelled tag rather than at the form it opened, which "Every diagnostic carries a span" requires.

Every node answers `Node.Position()`, so a walker asking where something is never needs a type switch. `internal/layoutschema` needs a `posOf` switch over `sexpr`'s nodes for exactly that reason.

## What it rejects

The constructs SPEC.md's "What this document delegates" excludes, each by name and with its position: improper lists, quote shorthands, `nil`, `()` and booleans (`*ConstructError`). Two further shapes that parse and are not statements: a top-level node that is not a form (`*NotAFormError`) and a form with nothing naming it (`*UntaggedFormError`). There is no node in this AST for any of them, so accepting one would mean inventing a node nothing downstream can read or silently discarding something an adopter wrote.

`Parse` reports every fault rather than the first, joined with `errors.Join` — a generated layout is generated wrong in the same way in many places at once — and each stays assertable with `errors.As`, which is what `errors.Join` is traversed by. Source the grammar itself rejects is a `*SyntaxError` returned alone, since it leaves no forms to have found anything else wrong with, and it keeps `sexpr-go`'s own error reachable.

## Judgment calls

- **Where the boundary sits.** "Unrecognised constructs" is read as SPEC.md's own list of excluded S-expression constructs, not as unknown tags. Whether `encoding` is a form a layout may carry, whether `recfm` admits `VBS`, whether a `record` name resolves — those are the published schema's, and `internal/layoutschema` (#23) is what holds a layout to it; the conditional arities and everything needing a copybook are the layers above (#25–#31). SPEC.md's "Validation and diagnostics" is that split. Keeping them apart is what makes a misspelled tag reportable *as* a misspelled tag: the form carrying it is already built, with a position on it, by the time anybody asks what the tag means.
- **`Form.Elements` is one slice, not arguments and children.** Which elements are a form's arguments and which are its children is stated per tag by the published schema, so splitting them here would be a second statement of that rule for the two to disagree about.
- **A rejected layout comes back with no AST.** Returning a half-built one beside the errors invites a caller to read it.
- **Positions on a grammar error are the grammar's**, not improved on: `(record ORDER-HEADER` reports where the parser ran out of tokens, not where the parenthesis is missing.
- **`Float` exists** even though no position is declared to take one today. The sort `number` admits it, so a layout writing `4096.5` where a count belongs is held to the sort by the schema with a diagnostic naming the position, rather than being rejected here as something the AST cannot hold.

## Acceptance criteria

- [x] **Layout files parse into an AST** — `Parse(name, r)` and `ParseFile(path)` return `*File`, a set of `Form`s in source order.
- [x] **Every node carries file, line, and column** — `Pos{File, Line, Column}` on every node, reachable uniformly through `Node.Position()`; asserted by walking the whole of SPEC.md's worked example.
- [x] **Unrecognised constructs are rejected rather than silently ignored** — `*ConstructError` for the five excluded constructs, `*NotAFormError` and `*UntaggedFormError` for the two shapes that are not statements, each naming what it found and where.
- [x] **Table-driven tests with `t.Parallel()`, including malformed input** — every test and subtest is parallel; the malformed tables cover each excluded construct, each not-a-form shape, and source the grammar rejects.
- [x] **Typed errors assertable with `errors.As`** — asserted for all four types, including through the joined multi-fault error and through to `sexpr-go`'s own error.

## Verified

- `dagger call ci` — green (fmt, vet, lint, `go test -race`, schema lint, the `irpb` module's own stages and the release artifacts).
- The suite includes a staleness gate that parses `docs/layout/SPEC.md`'s "A layout, end to end" appendix out of the document rather than a copy of it, so a change to the notation the example follows and the reader does not is a failing test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>