### PR TITLE
story(layout): model and validate encoding profiles

### DIFF
--- a/internal/layoutmodel/axes.go
+++ b/internal/layoutmodel/axes.go
@@ -1,0 +1,328 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layoutmodel
+
+import (
+	"fmt"
+	"slices"
+)
+
+// Axis is one of the four encoding axes.
+//
+// The set is `cobol-go`'s `codec/SPEC.md`'s and is closed: four settings have to
+// be known before a byte of a data file can be read, every one of them fails
+// silently when wrong, and none is recoverable from the file with certainty.
+// docs/layout/SPEC.md's "The encoding profile" is the spelling of them, and this
+// type is that spelling as data.
+type Axis int
+
+// The four axes, in the order docs/layout/SPEC.md's table states them, which is
+// also the order every list of them is rendered in.
+const (
+	// AxisCharset governs alphanumeric character data, the digit zone of zoned
+	// decimal, and the byte values of a separate sign.
+	AxisCharset Axis = iota
+
+	// AxisSignConvention governs how an overpunched sign is spelled.
+	AxisSignConvention
+
+	// AxisByteOrder governs binary integers.
+	AxisByteOrder
+
+	// AxisFloatFormat governs floating point.
+	AxisFloatFormat
+)
+
+// allAxes is the four, in SPEC.md's order. A caller wanting them takes
+// [Axes.Missing] or [Axes.Stated]; this is what those and the reader iterate.
+var allAxes = []Axis{AxisCharset, AxisSignConvention, AxisByteOrder, AxisFloatFormat}
+
+// String is the tag a layout writes the axis as.
+//
+// It is the layout spelling rather than a prose name because every message this
+// package produces is read beside the file that provoked it: an adopter told
+// that `sign-convention` is missing can search for the word they would have
+// typed.
+func (a Axis) String() string {
+	switch a {
+	case AxisCharset:
+		return "charset"
+	case AxisSignConvention:
+		return "sign-convention"
+	case AxisByteOrder:
+		return "byte-order"
+	case AxisFloatFormat:
+		return "float-format"
+	default:
+		return fmt.Sprintf("Axis(%d)", int(a))
+	}
+}
+
+// Values is what the axis admits, in the order docs/layout/SPEC.md states them.
+//
+// It is what a diagnostic names when a layout writes something else, which is
+// why it is a method on the axis rather than four lists the messages reach for
+// by hand: an axis and the set it admits are one fact, and a message naming the
+// wrong set is a message that sends an adopter looking in the wrong place.
+func (a Axis) Values() []string {
+	switch a {
+	case AxisCharset:
+		values := make([]string, 0, len(charsets))
+		for _, charset := range charsets {
+			values = append(values, string(charset))
+		}
+
+		return values
+	case AxisSignConvention:
+		return []string{
+			string(SignEBCDIC),
+			string(SignASCIIZone37),
+			string(SignTranslatedEBCDIC),
+			string(SignRealia),
+		}
+	case AxisByteOrder:
+		return []string{string(BigEndian), string(LittleEndian)}
+	case AxisFloatFormat:
+		return []string{string(IEEE754), string(HFP)}
+	default:
+		return nil
+	}
+}
+
+// admits reports whether value is one the axis takes.
+func (a Axis) admits(value string) bool {
+	for _, admitted := range a.Values() {
+		if admitted == value {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Charset is a character set the charset axis admits.
+//
+// The set is bounded and every member is named here. `cobol-go`'s `codec` is
+// forbidden from depending on golang.org/x/text, so every code page it supports
+// is a table somebody wrote by hand — which makes the axis an enumeration and
+// not an open string, and makes a layout naming a code page nobody has written a
+// table for something to reject while a layout is being read rather than
+// something to discover against a data file.
+//
+// A code page added to `codec/SPEC.md`'s charset axis is added here, and here
+// alone: schema/layout.sexpr deliberately declares `charset` as an open symbol
+// so that this registry is the only place in this repository the members are
+// written down. It is still a change to what a layout may say, so it advances
+// the published schema's version under docs/layout/SPEC.md's "The version is in
+// the file, and it moves with the format", even though no declaration in that
+// file moves with it.
+type Charset string
+
+// The code pages a layout may name. The EBCDIC ones are spelled as
+// `codec/SPEC.md` spells them; `ascii` is the identity charset.
+const (
+	// CP037 is the US/Canada EBCDIC code page.
+	CP037 Charset = "cp037"
+
+	// CP500 is the international EBCDIC code page.
+	CP500 Charset = "cp500"
+
+	// CP1047 is the Latin-1/Open Systems EBCDIC code page.
+	CP1047 Charset = "cp1047"
+
+	// CP1140 is cp037 with the euro sign.
+	CP1140 Charset = "cp1140"
+
+	// ASCII is the identity charset, for a file that was written in ASCII or
+	// converted to it.
+	ASCII Charset = "ascii"
+)
+
+// charsets is the registry, in the order docs/layout/SPEC.md names them: the
+// EBCDIC code pages by number, then the identity charset.
+var charsets = []Charset{CP037, CP500, CP1047, CP1140, ASCII}
+
+// Charsets is every code page the charset axis admits.
+//
+// The slice is a copy, so a caller cannot edit the registry by writing to what
+// it was handed.
+func Charsets() []Charset {
+	return slices.Clone(charsets)
+}
+
+// LookupCharset resolves a code page written in a layout, reporting whether it
+// is one this project supports.
+func LookupCharset(value string) (Charset, bool) {
+	for _, charset := range charsets {
+		if string(charset) == value {
+			return charset, true
+		}
+	}
+
+	return "", false
+}
+
+// SignConvention is how an overpunched sign is spelled in a zoned decimal byte.
+//
+// The four are `codec/SPEC.md`'s, respelled: it names them as Go identifiers and
+// a layout is data. docs/layout/SPEC.md's "The encoding profile" carries the
+// mapping, and it is the one place either spelling is translated into the other.
+type SignConvention string
+
+// The sign conventions a layout may name.
+const (
+	// SignEBCDIC is codec/SPEC.md's SignEBCDIC: the one mainframe convention.
+	SignEBCDIC SignConvention = "ebcdic"
+
+	// SignASCIIZone37 is codec/SPEC.md's SignASCIIZone37: the native ASCII
+	// convention, written by a program that never saw a mainframe.
+	SignASCIIZone37 SignConvention = "ascii-zone-37"
+
+	// SignTranslatedEBCDIC is codec/SPEC.md's SignTranslatedEBCDIC: what an
+	// EBCDIC-to-ASCII text conversion leaves behind.
+	SignTranslatedEBCDIC SignConvention = "translated-ebcdic"
+
+	// SignRealia is codec/SPEC.md's SignRealia.
+	SignRealia SignConvention = "realia"
+)
+
+// ByteOrder is the order of the bytes in a binary integer.
+type ByteOrder string
+
+// The byte orders a layout may name.
+const (
+	// BigEndian is the mainframe order, and what a converted file usually keeps.
+	BigEndian ByteOrder = "big-endian"
+
+	// LittleEndian is the native order on the platforms that write ASCII files.
+	LittleEndian ByteOrder = "little-endian"
+)
+
+// FloatFormat is the representation of a floating point item.
+type FloatFormat string
+
+// The float formats a layout may name.
+const (
+	// IEEE754 is the distributed-platform format.
+	IEEE754 FloatFormat = "ieee-754"
+
+	// HFP is IBM hexadecimal floating point.
+	HFP FloatFormat = "hfp"
+)
+
+// Axes is a setting of the four encoding axes, each of which may be unstated.
+//
+// The zero value of every axis is invalid and means "nobody said". That is
+// `codec/SPEC.md`'s requirement on the axes — each "MUST have an invalid zero
+// value" — carried into the source side, and it is what lets this type stand for
+// both of the things a layout writes: a profile, whose four axes are all stated,
+// and an override, which states as few as one.
+//
+// Which of the two a value is, is a question [Axes.Complete] answers, and
+// [ReadProfile] answers it before handing anything back: the [Axes] on a
+// [Profile] is always complete and the one on an [Override] never is empty.
+type Axes struct {
+	// Charset is the code page, or the empty string where none is stated.
+	Charset Charset
+
+	// SignConvention is how an overpunched sign is spelled, or the empty
+	// string.
+	SignConvention SignConvention
+
+	// ByteOrder is the order of the bytes in a binary integer, or the empty
+	// string.
+	ByteOrder ByteOrder
+
+	// FloatFormat is the representation of a floating point item, or the empty
+	// string.
+	FloatFormat FloatFormat
+}
+
+// value is what the axis says, or the empty string where it says nothing.
+func (a Axes) value(axis Axis) string {
+	switch axis {
+	case AxisCharset:
+		return string(a.Charset)
+	case AxisSignConvention:
+		return string(a.SignConvention)
+	case AxisByteOrder:
+		return string(a.ByteOrder)
+	case AxisFloatFormat:
+		return string(a.FloatFormat)
+	default:
+		return ""
+	}
+}
+
+// set states an axis. The value has already been held to [Axis.admits], which is
+// what makes the conversion here safe.
+func (a *Axes) set(axis Axis, value string) {
+	switch axis {
+	case AxisCharset:
+		a.Charset = Charset(value)
+	case AxisSignConvention:
+		a.SignConvention = SignConvention(value)
+	case AxisByteOrder:
+		a.ByteOrder = ByteOrder(value)
+	case AxisFloatFormat:
+		a.FloatFormat = FloatFormat(value)
+	}
+}
+
+// Stated is the axes this value states, in docs/layout/SPEC.md's order.
+func (a Axes) Stated() []Axis {
+	var stated []Axis
+
+	for _, axis := range allAxes {
+		if a.value(axis) != "" {
+			stated = append(stated, axis)
+		}
+	}
+
+	return stated
+}
+
+// Missing is the axes this value does not state, in docs/layout/SPEC.md's order.
+//
+// It is what a diagnostic about an incomplete profile names, one error per axis,
+// because SPEC.md requires an implementation to "report the missing one by
+// name": an adopter told that their profile is incomplete has to open the file
+// to find out which line to write.
+func (a Axes) Missing() []Axis {
+	var missing []Axis
+
+	for _, axis := range allAxes {
+		if a.value(axis) == "" {
+			missing = append(missing, axis)
+		}
+	}
+
+	return missing
+}
+
+// Complete reports whether all four axes are stated.
+func (a Axes) Complete() bool {
+	return len(a.Missing()) == 0
+}
+
+// Over applies a over base, axis by axis: an axis a states replaces base's, and
+// an axis it does not leaves base's alone.
+//
+// This is docs/layout/SPEC.md's "An override naming one axis leaves the other
+// three as the profile states them; one naming all four replaces the profile
+// entirely for that item", and it is here because it is a fact about the two
+// values rather than about the resolution that will use it. Which items an
+// override reaches — a group reaches every elementary item under it, a repeating
+// item every occurrence — needs a copybook and is `resolve`'s (#33).
+func (a Axes) Over(base Axes) Axes {
+	applied := base
+
+	for _, axis := range a.Stated() {
+		applied.set(axis, a.value(axis))
+	}
+
+	return applied
+}

--- a/internal/layoutmodel/axes.go
+++ b/internal/layoutmodel/axes.go
@@ -308,8 +308,8 @@ func (a Axes) Complete() bool {
 	return len(a.Missing()) == 0
 }
 
-// Over applies a over base, axis by axis: an axis a states replaces base's, and
-// an axis it does not leaves base's alone.
+// Over applies the receiver over base, axis by axis: an axis the receiver states
+// replaces base's, and an axis it leaves unstated leaves base's alone.
 //
 // This is docs/layout/SPEC.md's "An override naming one axis leaves the other
 // three as the profile states them; one naming all four replaces the profile

--- a/internal/layoutmodel/axes_test.go
+++ b/internal/layoutmodel/axes_test.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layoutmodel
+
+import (
+	"slices"
+	"testing"
+)
+
+// TestCharsetRegistryIsBounded is the property the charset axis is an
+// enumeration for: a code page is either one somebody wrote a table for or it is
+// not, and there is no third answer for a layout to be believed about.
+func TestCharsetRegistryIsBounded(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		value string
+		want  Charset
+		found bool
+	}{
+		{name: "the US/Canada code page", value: "cp037", want: CP037, found: true},
+		{name: "the international code page", value: "cp500", want: CP500, found: true},
+		{name: "the Latin-1 code page", value: "cp1047", want: CP1047, found: true},
+		{name: "cp037 with the euro sign", value: "cp1140", want: CP1140, found: true},
+		{name: "the identity charset", value: "ascii", want: ASCII, found: true},
+		{name: "a Windows code page nobody has a table for", value: "cp1252"},
+		{name: "a Unicode encoding, which is not a code page", value: "utf-8"},
+		{name: "the right code page under the wrong name", value: "ebcdic-us"},
+		{name: "a code page written with the case a title uses", value: "CP037"},
+		{name: "nothing at all", value: ""},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			charset, found := LookupCharset(testCase.value)
+			if found != testCase.found {
+				t.Fatalf("LookupCharset(%q) found=%v, want %v", testCase.value, found, testCase.found)
+			}
+
+			if charset != testCase.want {
+				t.Errorf("LookupCharset(%q) = %q, want %q", testCase.value, charset, testCase.want)
+			}
+		})
+	}
+}
+
+// TestCharsetsIsACopy keeps the registry the one place a code page is added:
+// a caller that could write to what it was handed would be a second place, and
+// one that only some of the process can see.
+func TestCharsetsIsACopy(t *testing.T) {
+	t.Parallel()
+
+	handed := Charsets()
+	handed[0] = "cp1252"
+
+	if charset, found := LookupCharset("cp1252"); found {
+		t.Errorf("writing to the returned slice added %q to the registry", charset)
+	}
+
+	if _, found := LookupCharset("cp037"); !found {
+		t.Error("writing to the returned slice removed cp037 from the registry")
+	}
+}
+
+// TestAxisValuesAreTheClosedSets holds each axis to what docs/layout/SPEC.md's
+// table says it admits, in the order the table states it, because that order is
+// what every diagnostic naming the set is read in.
+func TestAxisValuesAreTheClosedSets(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		axis Axis
+		tag  string
+		want []string
+	}{
+		{axis: AxisCharset, tag: "charset", want: []string{"cp037", "cp500", "cp1047", "cp1140", "ascii"}},
+		{
+			axis: AxisSignConvention,
+			tag:  "sign-convention",
+			want: []string{"ebcdic", "ascii-zone-37", "translated-ebcdic", "realia"},
+		},
+		{axis: AxisByteOrder, tag: "byte-order", want: []string{"big-endian", "little-endian"}},
+		{axis: AxisFloatFormat, tag: "float-format", want: []string{"ieee-754", "hfp"}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.tag, func(t *testing.T) {
+			t.Parallel()
+
+			if got := testCase.axis.String(); got != testCase.tag {
+				t.Errorf("axis renders as %q, want %q", got, testCase.tag)
+			}
+
+			if got := testCase.axis.Values(); !slices.Equal(got, testCase.want) {
+				t.Errorf("admits %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestAxesOverAppliesAxisByAxis is docs/layout/SPEC.md's "An override naming one
+// axis leaves the other three as the profile states them; one naming all four
+// replaces the profile entirely for that item".
+func TestAxesOverAppliesAxisByAxis(t *testing.T) {
+	t.Parallel()
+
+	base := Axes{
+		Charset:        CP037,
+		SignConvention: SignEBCDIC,
+		ByteOrder:      BigEndian,
+		FloatFormat:    HFP,
+	}
+
+	testCases := []struct {
+		name     string
+		override Axes
+		want     Axes
+	}{
+		{
+			name: "an override naming nothing changes nothing",
+			want: base,
+		},
+		{
+			name:     "one axis moves and the other three do not",
+			override: Axes{Charset: ASCII},
+			want: Axes{
+				Charset:        ASCII,
+				SignConvention: SignEBCDIC,
+				ByteOrder:      BigEndian,
+				FloatFormat:    HFP,
+			},
+		},
+		{
+			name:     "the combination real files hit, which no compiler produces",
+			override: Axes{Charset: ASCII, SignConvention: SignTranslatedEBCDIC},
+			want: Axes{
+				Charset:        ASCII,
+				SignConvention: SignTranslatedEBCDIC,
+				ByteOrder:      BigEndian,
+				FloatFormat:    HFP,
+			},
+		},
+		{
+			name: "all four replace the profile entirely",
+			override: Axes{
+				Charset:        CP1047,
+				SignConvention: SignRealia,
+				ByteOrder:      LittleEndian,
+				FloatFormat:    IEEE754,
+			},
+			want: Axes{
+				Charset:        CP1047,
+				SignConvention: SignRealia,
+				ByteOrder:      LittleEndian,
+				FloatFormat:    IEEE754,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := testCase.override.Over(base); got != testCase.want {
+				t.Errorf("applied as %+v, want %+v", got, testCase.want)
+			}
+
+			if base.Charset != CP037 {
+				t.Error("applying an override wrote to the profile it was applied over")
+			}
+		})
+	}
+}
+
+// TestAxesCompleteAndMissing is what makes "no axis is ever silently defaulted" a
+// question about a value: an [Axes] either states four axes or names the ones it
+// does not.
+func TestAxesCompleteAndMissing(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		axes     Axes
+		complete bool
+		missing  []Axis
+	}{
+		{
+			name:    "the zero value states nothing",
+			missing: []Axis{AxisCharset, AxisSignConvention, AxisByteOrder, AxisFloatFormat},
+		},
+		{
+			name:    "three of four is not a profile",
+			axes:    Axes{Charset: CP037, SignConvention: SignEBCDIC, FloatFormat: HFP},
+			missing: []Axis{AxisByteOrder},
+		},
+		{
+			name: "all four",
+			axes: Axes{
+				Charset:        CP037,
+				SignConvention: SignEBCDIC,
+				ByteOrder:      BigEndian,
+				FloatFormat:    HFP,
+			},
+			complete: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := testCase.axes.Complete(); got != testCase.complete {
+				t.Errorf("Complete() = %v, want %v", got, testCase.complete)
+			}
+
+			if got := testCase.axes.Missing(); !slices.Equal(got, testCase.missing) {
+				t.Errorf("Missing() = %v, want %v", got, testCase.missing)
+			}
+		})
+	}
+}

--- a/internal/layoutmodel/doc.go
+++ b/internal/layoutmodel/doc.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Package layoutmodel turns a positioned layout AST into the typed model of the
+// format's layers, and enforces the rules a schema declaration cannot state.
+//
+// [github.com/Zaba505/cpybkc/internal/layout] hands back what an adopter wrote,
+// with a position on every node.
+// [github.com/Zaba505/cpybkc/internal/layoutschema] holds that to the published
+// schema: an unknown form, an unknown child, a missing or repeated one, a value
+// outside a closed set. Between them a layout is well-formed, and that is all it
+// is — docs/layout/SPEC.md's "What the schema does not say" lists what a
+// declaration cannot reach, and this package is where those land.
+//
+// Each layer of the format gets a reader here, and a type for what the layer
+// says. [ReadProfile] is the encoding profile (#25); physical framing, record
+// definitions, discrimination and sequencing arrive beside it (#26–#30). What
+// they have in common is that a value handed back is one the format admits: a
+// [Profile] carries four stated axes because a profile stating three is an error
+// and not a value with a hole in it.
+//
+// # Why the model is not the AST
+//
+// A layer's rules are about what a form means, and a walker over [layout.Form]
+// has to rediscover the meaning at every use. `(charset cp037)` is a form with a
+// tag and a symbol until something decides that the tag names an axis, that the
+// symbol names a code page, and that a code page is one of a bounded set — and a
+// second walker deciding that a second time is a second reading of SPEC.md for
+// the two to disagree about.
+//
+// So the reading happens once, here, and what comes out is data: [Charset] is a
+// code page this project supports and cannot hold anything else, and
+// [Axes.Complete] is a question about a value rather than about a check somebody
+// remembered to run.
+//
+// # What it assumes about the schema
+//
+// Nothing. A reader here reports every fault it finds in the layer it reads,
+// including the ones the published schema would also have caught, because a
+// caller that skipped the schema check would otherwise get a model built out of
+// a layout nothing held to anything.
+//
+// That is not a second statement of the schema. The schema says a well-formed
+// layout carries four axes; this package says an [Axes] value has four axes, and
+// refuses to build one from a layout that states three. The overlap is the point
+// at which a declaration and a Go type happen to agree, and the rule
+// docs/layout/SPEC.md states — "An implementation MUST NOT supply a default for
+// a missing axis" — is a rule about the value, which only the value can keep.
+//
+// # Diagnostics
+//
+// Every fault is a typed error carrying a [layout.Pos], assertable with
+// [errors.As], and a reader returns every one it found rather than the first,
+// joined with [errors.Join]. The reasoning is
+// [github.com/Zaba505/cpybkc/internal/layout]'s: a generated layout is generated
+// wrong in the same way in many places at once, and a reader that reports one
+// fault per run is a reader run once per fault.
+//
+// A reader that found a fault returns no model. A half-built value is one a
+// caller can read, and there is no reading of a layout that was rejected.
+package layoutmodel

--- a/internal/layoutmodel/errors.go
+++ b/internal/layoutmodel/errors.go
@@ -1,0 +1,266 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layoutmodel
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/Zaba505/cpybkc/internal/layout"
+)
+
+// ProfileCountError is a layout that does not carry exactly one `encoding` form.
+//
+// Both halves are faults an adopter can act on and neither has a default:
+// docs/layout/SPEC.md requires exactly one, a layout carrying none states no
+// axes at all, and a layout carrying two leaves the order they were written in
+// deciding which one governs the file.
+type ProfileCountError struct {
+	// Pos is the second `encoding` form where there is one, and the start of
+	// the file where there is none — a form a layout is missing has no position
+	// of its own, and the start of the file is where the adopter has to add it.
+	Pos layout.Pos
+
+	// Count is how many the layout carries.
+	Count int
+}
+
+// Error implements the error interface.
+func (e *ProfileCountError) Error() string {
+	return fmt.Sprintf("%s: a layout carries exactly one encoding form, and this one carries %d", e.Pos, e.Count)
+}
+
+// MissingAxisError is an axis the encoding profile does not state.
+//
+// It names the axis, which docs/layout/SPEC.md requires: "An implementation MUST
+// NOT supply a default for a missing axis, and MUST report the missing one by
+// name." One of these is reported per missing axis rather than one naming them
+// all, so that a profile missing two axes is two things to fix rather than one
+// message to read twice.
+type MissingAxisError struct {
+	// Pos is the `encoding` form, which is where the axis has to be written.
+	Pos layout.Pos
+
+	// Axis is the one nobody stated.
+	Axis Axis
+}
+
+// Error implements the error interface.
+func (e *MissingAxisError) Error() string {
+	return fmt.Sprintf(
+		"%s: the encoding profile states no %s; all four axes are required and none of them has a default",
+		e.Pos, e.Axis,
+	)
+}
+
+// AxisValueError is a value written for an axis that the axis does not admit.
+//
+// The message names the whole set, because every one of these is a spelling
+// question an adopter can answer from it — a code page nobody has a table for, a
+// sign convention spelled as `codec/SPEC.md`'s Go identifier rather than as a
+// layout spells it, `little` for `little-endian`.
+type AxisValueError struct {
+	// Pos is the value, not the form carrying it.
+	Pos layout.Pos
+
+	// Axis is the axis it was written for.
+	Axis Axis
+
+	// Value is what was written.
+	Value string
+}
+
+// Error implements the error interface.
+func (e *AxisValueError) Error() string {
+	return fmt.Sprintf("%s: %s is one of %s, and this one says %s", e.Pos, e.Axis, and(e.Axis.Values()), quote(e.Value))
+}
+
+// AxisFormError is an axis form that does not carry exactly one symbol naming
+// its value.
+//
+// `(charset)` states nothing, `(charset cp037 cp500)` states two things, and
+// `(charset "cp037")` writes a code page as text where the format writes it as a
+// symbol. None of the three is a value with something wrong with it, so none is
+// an [AxisValueError].
+type AxisFormError struct {
+	// Pos is the form.
+	Pos layout.Pos
+
+	// Axis is the axis the form states.
+	Axis Axis
+
+	// Found names what was written instead, so the message says what it found
+	// and not only what it wanted.
+	Found string
+}
+
+// Error implements the error interface.
+func (e *AxisFormError) Error() string {
+	return fmt.Sprintf("%s: form %s takes one symbol naming its value, and this one has %s", e.Pos, quote(e.Axis.String()), e.Found)
+}
+
+// RepeatedAxisError is one axis stated twice in one form.
+//
+// It carries both positions, because the fault is the pair: either line is a
+// perfectly good statement of the axis on its own, and what an adopter has to
+// decide is which of the two they meant.
+type RepeatedAxisError struct {
+	// Pos is the second statement.
+	Pos layout.Pos
+
+	// First is the one before it.
+	First layout.Pos
+
+	// Axis is the axis stated twice.
+	Axis Axis
+
+	// Form is the tag of the form carrying both.
+	Form string
+}
+
+// Error implements the error interface.
+func (e *RepeatedAxisError) Error() string {
+	return fmt.Sprintf("%s: form %s states %s twice, and states it first at %s", e.Pos, quote(e.Form), e.Axis, e.First)
+}
+
+// ChildError is something written among a form's children that is not one of the
+// axes it admits.
+//
+// It covers both shapes the fault takes — a form whose tag names no axis, and an
+// element that is not a form at all — because what is wrong with each is the
+// same thing: the position admits one of four children and holds something else.
+type ChildError struct {
+	// Pos is the child, or the element standing where one belongs.
+	Pos layout.Pos
+
+	// Form is the tag of the form the child was written in.
+	Form string
+
+	// Found names what was written.
+	Found string
+
+	// Admits is what the position takes, named in the message so that a
+	// misspelled axis is one search away from the spelling that works.
+	Admits []string
+}
+
+// Error implements the error interface.
+func (e *ChildError) Error() string {
+	return fmt.Sprintf("%s: form %s admits %s, and this is %s", e.Pos, quote(e.Form), and(e.Admits), e.Found)
+}
+
+// EmptyOverrideError is an `encoding-override` that names no axis.
+//
+// docs/layout/SPEC.md makes it a diagnostic by name, and "What the schema does
+// not say" files it under the rules a declaration cannot state: the schema
+// declares each axis `at-most-one` on this form, and "at least one of the four"
+// is a statement about the four together.
+type EmptyOverrideError struct {
+	// Pos is the `encoding-override` form.
+	Pos layout.Pos
+
+	// Item is the item it named.
+	Item ItemRef
+}
+
+// Error implements the error interface.
+func (e *EmptyOverrideError) Error() string {
+	return fmt.Sprintf(
+		"%s: the override on %s states no axis; an override states at least one of %s",
+		e.Pos, e.Item, and(axisNames()),
+	)
+}
+
+// DuplicateOverrideError is a second `encoding-override` naming an item another
+// one already named.
+//
+// docs/layout/SPEC.md gives the reason and this message repeats it: two
+// overrides on one item "would leave the order they were written in deciding the
+// answer", and the order forms are written in is not something this format lets
+// anything depend on.
+type DuplicateOverrideError struct {
+	// Pos is the second override.
+	Pos layout.Pos
+
+	// First is the one before it.
+	First layout.Pos
+
+	// Item is the item both name.
+	Item ItemRef
+}
+
+// Error implements the error interface.
+func (e *DuplicateOverrideError) Error() string {
+	return fmt.Sprintf(
+		"%s: %s is overridden twice, and is overridden first at %s; two overrides on one item would leave the order they were written in deciding the answer",
+		e.Pos, e.Item, e.First,
+	)
+}
+
+// ItemReferenceError is a reference that is not `(item <record-name> <name> …)`.
+//
+// It is about the spelling alone. Whether the path names an item, and whether
+// the record it starts at is one the layout defines, are the published schema's
+// and `resolve`'s respectively — neither is answerable from the reference.
+type ItemReferenceError struct {
+	// Pos is the reference, or the part of it that is wrong.
+	Pos layout.Pos
+
+	// Found names what was written.
+	Found string
+}
+
+// Error implements the error interface.
+func (e *ItemReferenceError) Error() string {
+	return fmt.Sprintf("%s: an item reference is written (item <record-name> <name> ...), and this is %s", e.Pos, e.Found)
+}
+
+// axisNames is the four axes as a layout spells them, for a message that has to
+// list them.
+func axisNames() []string {
+	names := make([]string, 0, len(allAxes))
+
+	for _, axis := range allAxes {
+		names = append(names, axis.String())
+	}
+
+	return names
+}
+
+// describe names a layout node the way a message refers to it.
+func describe(node layout.Node) string {
+	switch node := node.(type) {
+	case layout.Form:
+		return "form " + quote(node.Tag)
+	case layout.Symbol:
+		return "the symbol " + quote(node.Value)
+	case layout.Text:
+		return "text"
+	case layout.Int, layout.Float:
+		return "a number"
+	default:
+		return "something else"
+	}
+}
+
+// quote renders a name the way every message here quotes one.
+func quote(value string) string { return strconv.Quote(value) }
+
+// and joins a list the way a sentence does, so that a message naming what is
+// admitted reads as one.
+func and(items []string) string {
+	switch len(items) {
+	case 0:
+		return "nothing"
+	case 1:
+		return items[0]
+	case 2:
+		return items[0] + " or " + items[1]
+	default:
+		return strings.Join(items[:len(items)-1], ", ") + " or " + items[len(items)-1]
+	}
+}

--- a/internal/layoutmodel/errors.go
+++ b/internal/layoutmodel/errors.go
@@ -41,6 +41,11 @@ func (e *ProfileCountError) Error() string {
 // name." One of these is reported per missing axis rather than one naming them
 // all, so that a profile missing two axes is two things to fix rather than one
 // message to read twice.
+//
+// An axis is missing when the profile says nothing about it. An axis stated with
+// a value the axis does not admit is an [AxisValueError] and not this: the line
+// is there, and calling it absent would send an adopter to write one they have
+// already written.
 type MissingAxisError struct {
 	// Pos is the `encoding` form, which is where the axis has to be written.
 	Pos layout.Pos
@@ -159,6 +164,11 @@ func (e *ChildError) Error() string {
 // not say" files it under the rules a declaration cannot state: the schema
 // declares each axis `at-most-one` on this form, and "at least one of the four"
 // is a statement about the four together.
+//
+// An override states an axis when it carries one of the four forms, whatever
+// that form turned out to say. One whose only axis was rejected on its own
+// account is an [AxisValueError] or an [AxisFormError] alone, because the layout
+// plainly names an axis and this message would deny it.
 type EmptyOverrideError struct {
 	// Pos is the `encoding-override` form.
 	Pos layout.Pos

--- a/internal/layoutmodel/itemref.go
+++ b/internal/layoutmodel/itemref.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layoutmodel
+
+import (
+	"strings"
+
+	"github.com/Zaba505/cpybkc/internal/layout"
+)
+
+// ItemRef is a reference into a copybook: `(item <record-name> <name> …)`.
+//
+// docs/layout/SPEC.md's "An item reference" is the whole of it. The first name
+// is a `record` form's; the rest is the path from that record's top-level item
+// down to the item named, one name per level, outermost first, with the
+// top-level item's own name not repeated.
+//
+// Whether the path names an item at all is `resolve`'s (#31, #32) — that needs
+// the copybook, which nothing at this layer has. What is known here is what was
+// written.
+type ItemRef struct {
+	// Pos is the `(item …)` form.
+	Pos layout.Pos
+
+	// Record is the name of the `record` form the path starts at.
+	Record string
+
+	// Path is the names below it, outermost first, ending at the item named. It
+	// always carries at least one name: a reference to a record's top-level item
+	// and no field is not a spelling the format has.
+	Path []string
+}
+
+// String renders the reference the way a layout writes it, which is what a
+// diagnostic naming an item quotes.
+func (r ItemRef) String() string {
+	return "(item " + strings.Join(append([]string{r.Record}, r.Path...), " ") + ")"
+}
+
+// identity is what makes two references the same item.
+//
+// It is the spelling, and that is exact rather than approximate: SPEC.md's "An
+// item reference" requires the path to be complete rather than qualified in
+// COBOL's OF/IN sense, and gives as one of its two reasons that "a complete path
+// has exactly one spelling". Two references to one item are therefore the same
+// text, so text is an identity here and would not have been under qualification.
+func (r ItemRef) identity() string { return r.String() }
+
+// readItemRef reads an `(item …)` form.
+//
+// Everything about the shape is checked, because this is the only reading of a
+// reference in this package and a caller handed an [ItemRef] is entitled to
+// assume its record and its path are names somebody wrote.
+func readItemRef(node layout.Node) (ItemRef, error) {
+	form, ok := node.(layout.Form)
+	if !ok {
+		return ItemRef{}, &ItemReferenceError{Pos: node.Position(), Found: describe(node)}
+	}
+
+	if form.Tag != tagItem {
+		return ItemRef{}, &ItemReferenceError{Pos: form.TagPos, Found: "form " + quote(form.Tag)}
+	}
+
+	if len(form.Elements) < 2 {
+		found := "a reference naming nothing"
+		if len(form.Elements) == 1 {
+			found = "a reference naming a record and no item below it"
+		}
+
+		return ItemRef{}, &ItemReferenceError{Pos: form.Pos, Found: found}
+	}
+
+	ref := ItemRef{Pos: form.Pos}
+
+	for i, element := range form.Elements {
+		symbol, ok := element.(layout.Symbol)
+		if !ok {
+			return ItemRef{}, &ItemReferenceError{Pos: element.Position(), Found: describe(element)}
+		}
+
+		if i == 0 {
+			ref.Record = symbol.Value
+
+			continue
+		}
+
+		ref.Path = append(ref.Path, symbol.Value)
+	}
+
+	return ref, nil
+}

--- a/internal/layoutmodel/itemref_test.go
+++ b/internal/layoutmodel/itemref_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layoutmodel
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestItemRefRendersAsALayoutWritesIt is what every diagnostic naming an item
+// quotes, so the rendering is the reference an adopter can search their layout
+// for rather than a description of one.
+func TestItemRefRendersAsALayoutWritesIt(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		ref  ItemRef
+		want string
+	}{
+		{
+			name: "a field directly under a record's top-level item",
+			ref:  ItemRef{Record: "ORDER-HEADER", Path: []string{"OH-PARTNER-REF"}},
+			want: "(item ORDER-HEADER OH-PARTNER-REF)",
+		},
+		{
+			name: "a field two levels down",
+			ref:  ItemRef{Record: "ORDER-HEADER", Path: []string{"OH-KEY", "OH-CUST-NO"}},
+			want: "(item ORDER-HEADER OH-KEY OH-CUST-NO)",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := testCase.ref.String(); got != testCase.want {
+				t.Errorf("rendered as %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestOverridesOnDifferentItemsAreBothKept is the other side of the duplicate
+// rule: what makes two overrides the same is the item, and a path passing
+// through the same names is not the same path.
+func TestOverridesOnDifferentItemsAreBothKept(t *testing.T) {
+	t.Parallel()
+
+	source := strings.Join([]string{
+		"(encoding (charset cp037) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))",
+		"(encoding-override (item ORDER-HEADER OH-KEY) (charset ascii))",
+		"(encoding-override (item ORDER-HEADER OH-KEY OH-CUST-NO) (charset cp500))",
+		"(encoding-override (item ORDER-DETAIL OH-KEY) (charset cp1047))",
+	}, "\n")
+
+	read, err := profile(t, source)
+	if err != nil {
+		t.Fatalf("read profile: %v", err)
+	}
+
+	want := []string{
+		"(item ORDER-HEADER OH-KEY)",
+		"(item ORDER-HEADER OH-KEY OH-CUST-NO)",
+		"(item ORDER-DETAIL OH-KEY)",
+	}
+
+	if len(read.Overrides) != len(want) {
+		t.Fatalf("read %d overrides, want %d", len(read.Overrides), len(want))
+	}
+
+	for i, override := range read.Overrides {
+		if got := override.Item.String(); got != want[i] {
+			t.Errorf("override %d is on %s, want %s", i, got, want[i])
+		}
+	}
+}

--- a/internal/layoutmodel/profile.go
+++ b/internal/layoutmodel/profile.go
@@ -94,10 +94,17 @@ func ReadProfile(file *layout.File) (*Profile, error) {
 		case tagEncoding:
 			encodings = append(encodings, form)
 
-			axes := read.axes(form, form.Elements)
+			axes, stated := read.axes(form, form.Elements)
 
-			for _, axis := range axes.Missing() {
-				read.fail(&MissingAxisError{Pos: form.Pos, Axis: axis})
+			// Only an axis the profile says nothing at all about is missing. An
+			// axis stated with a value the axis does not admit has already been
+			// reported against the value, and reporting it again as unstated
+			// would name the same line twice and describe it wrongly the second
+			// time.
+			for _, axis := range allAxes {
+				if _, ok := stated[axis]; !ok {
+					read.fail(&MissingAxisError{Pos: form.Pos, Axis: axis})
+				}
 			}
 
 			if len(encodings) == 1 {
@@ -161,7 +168,7 @@ func (r *profileReader) override(profile *Profile, form layout.Form) {
 		// The axes are read anyway. An override whose reference is misspelled is
 		// still an override, and a charset misspelled underneath it is a second
 		// thing to fix rather than something to discover on the next run.
-		r.axes(form, form.Elements[1:])
+		_, _ = r.axes(form, form.Elements[1:])
 
 		return
 	}
@@ -176,10 +183,19 @@ func (r *profileReader) override(profile *Profile, form layout.Form) {
 		r.overridden[item.identity()] = form.Pos
 	}
 
-	axes := r.axes(form, form.Elements[1:])
-	if len(axes.Stated()) == 0 {
+	axes, stated := r.axes(form, form.Elements[1:])
+
+	// An override states an axis when it carries one of the four forms, whatever
+	// the form turned out to say. One whose only axis was rejected on its own
+	// account is not also an override that names no axis: the layout plainly
+	// names one, and the fault is already reported against the value.
+	if len(stated) == 0 {
 		r.fail(&EmptyOverrideError{Pos: form.Pos, Item: item})
 
+		return
+	}
+
+	if len(axes.Stated()) == 0 {
 		return
 	}
 
@@ -188,10 +204,12 @@ func (r *profileReader) override(profile *Profile, form layout.Form) {
 
 // axes reads the axis children of a form, whichever of the four are there.
 //
-// What is missing is the caller's to judge: `encoding` requires all four and
-// `encoding-override` requires one, and neither rule is visible from the
+// It returns what the form says and where it said each axis — including an axis
+// whose value was rejected, which is stated and unusable rather than unstated.
+// How many are required is the caller's to judge: `encoding` takes all four and
+// `encoding-override` takes at least one, and neither rule is visible from the
 // children alone.
-func (r *profileReader) axes(form layout.Form, elements []layout.Node) Axes {
+func (r *profileReader) axes(form layout.Form, elements []layout.Node) (Axes, map[Axis]layout.Pos) {
 	var (
 		axes  Axes
 		first = make(map[Axis]layout.Pos)
@@ -228,7 +246,7 @@ func (r *profileReader) axes(form layout.Form, elements []layout.Node) Axes {
 		axes.set(axis, value)
 	}
 
-	return axes
+	return axes, first
 }
 
 // axisValue reads the one symbol an axis form carries, holding it to the set the

--- a/internal/layoutmodel/profile.go
+++ b/internal/layoutmodel/profile.go
@@ -1,0 +1,273 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layoutmodel
+
+import (
+	"errors"
+
+	"github.com/Zaba505/cpybkc/internal/layout"
+)
+
+// The tags this layer reads. Everything else at the top level belongs to another
+// layer and is left alone.
+const (
+	tagEncoding         = "encoding"
+	tagEncodingOverride = "encoding-override"
+	tagItem             = "item"
+)
+
+// Profile is a layout's encoding layer: the one profile, and the overrides over
+// it.
+//
+// There is exactly one of these per layout, and its [Axes] is always complete —
+// a [Profile] handed back by [ReadProfile] states all four axes, because a
+// layout stating three is an error rather than a profile with a hole in it.
+//
+// It is the whole of the layer. docs/layout/SPEC.md's "An override is per item,
+// and there is no second profile" is explicit that overrides "are the whole of
+// the mechanism: there is no second profile to inherit from, no per-record
+// profile, and no profile named and referred to by name", so there is nothing
+// here for a record to refer to and no name for it to refer to it by.
+type Profile struct {
+	// Pos is the `encoding` form.
+	Pos layout.Pos
+
+	// Axes is the four axes the profile states.
+	Axes Axes
+
+	// Overrides are the per-item overrides, in the order the layout writes
+	// them. Each names a distinct item and states at least one axis.
+	Overrides []Override
+}
+
+// Override is one `encoding-override`: an item, and the axes restated for it.
+//
+// The item **MAY** be a group, in which case the override reaches every
+// elementary item under it, and **MAY** repeat, in which case it reaches every
+// occurrence. Both of those need a copybook to act on and are `resolve`'s (#33);
+// what is here is the statement.
+type Override struct {
+	// Pos is the `encoding-override` form.
+	Pos layout.Pos
+
+	// Item is what it applies to.
+	Item ItemRef
+
+	// Axes are the axes it restates. At least one is stated, and the ones that
+	// are not leave the profile's alone — [Axes.Over] is that application.
+	Axes Axes
+}
+
+// Applied is the encoding governing this override's item: the override over the
+// profile, axis by axis.
+//
+// The result is complete, because the profile is.
+func (p *Profile) Applied(o Override) Axes {
+	return o.Axes.Over(p.Axes)
+}
+
+// ReadProfile reads the encoding layer out of a parsed layout.
+//
+// It reports every fault it finds, joined, and returns no profile when it found
+// one: a profile missing an axis is the failure the whole layer exists to
+// prevent, and handing one back with the axis defaulted or blank would leave a
+// caller to notice.
+//
+// Top-level forms belonging to other layers are not read here and are not
+// faults. A layout's forms are a set that refer to one another by name, and
+// nothing orders them.
+func ReadProfile(file *layout.File) (*Profile, error) {
+	read := &profileReader{}
+	profile := &Profile{Pos: file.Start()}
+
+	// The forms are read in source order, so that a layout wrong in several
+	// places is reported the way it is read. Every `encoding` form is read and
+	// not only the one that will be kept: a layout carrying two malformed
+	// profiles is told about both rather than about the count alone.
+	var encodings []layout.Form
+
+	for _, form := range file.Forms {
+		switch form.Tag {
+		case tagEncoding:
+			encodings = append(encodings, form)
+
+			axes := read.axes(form, form.Elements)
+
+			for _, axis := range axes.Missing() {
+				read.fail(&MissingAxisError{Pos: form.Pos, Axis: axis})
+			}
+
+			if len(encodings) == 1 {
+				profile.Pos, profile.Axes = form.Pos, axes
+			}
+		case tagEncodingOverride:
+			read.override(profile, form)
+		}
+	}
+
+	// The count is a fact about the layout rather than about any one form, so it
+	// is reported after everything the forms themselves were wrong about.
+	if len(encodings) != 1 {
+		// The second form is what the diagnostic points at where there is one:
+		// the first is a profile an adopter meant, and the second is the line
+		// making it ambiguous.
+		pos := file.Start()
+		if len(encodings) > 1 {
+			pos = encodings[1].Pos
+		}
+
+		read.fail(&ProfileCountError{Pos: pos, Count: len(encodings)})
+	}
+
+	if len(read.errs) > 0 {
+		return nil, errors.Join(read.errs...)
+	}
+
+	return profile, nil
+}
+
+// profileReader holds the state one [ReadProfile] accumulates: the faults found
+// so far, and the items already overridden.
+type profileReader struct {
+	errs []error
+
+	// overridden is where each item was first overridden, keyed by the
+	// reference's identity. It is what makes a second override on one item
+	// reportable against the first.
+	overridden map[string]layout.Pos
+}
+
+// fail records a fault. Reading continues after one, because the point of
+// collecting them is to report the second.
+func (r *profileReader) fail(err error) {
+	r.errs = append(r.errs, err)
+}
+
+// override reads one `encoding-override` and appends it to the profile.
+func (r *profileReader) override(profile *Profile, form layout.Form) {
+	if len(form.Elements) == 0 {
+		r.fail(&ItemReferenceError{Pos: form.Pos, Found: "an override naming no item at all"})
+
+		return
+	}
+
+	item, err := readItemRef(form.Elements[0])
+	if err != nil {
+		r.fail(err)
+
+		// The axes are read anyway. An override whose reference is misspelled is
+		// still an override, and a charset misspelled underneath it is a second
+		// thing to fix rather than something to discover on the next run.
+		r.axes(form, form.Elements[1:])
+
+		return
+	}
+
+	if first, already := r.overridden[item.identity()]; already {
+		r.fail(&DuplicateOverrideError{Pos: form.Pos, First: first, Item: item})
+	} else {
+		if r.overridden == nil {
+			r.overridden = make(map[string]layout.Pos)
+		}
+
+		r.overridden[item.identity()] = form.Pos
+	}
+
+	axes := r.axes(form, form.Elements[1:])
+	if len(axes.Stated()) == 0 {
+		r.fail(&EmptyOverrideError{Pos: form.Pos, Item: item})
+
+		return
+	}
+
+	profile.Overrides = append(profile.Overrides, Override{Pos: form.Pos, Item: item, Axes: axes})
+}
+
+// axes reads the axis children of a form, whichever of the four are there.
+//
+// What is missing is the caller's to judge: `encoding` requires all four and
+// `encoding-override` requires one, and neither rule is visible from the
+// children alone.
+func (r *profileReader) axes(form layout.Form, elements []layout.Node) Axes {
+	var (
+		axes  Axes
+		first = make(map[Axis]layout.Pos)
+	)
+
+	for _, element := range elements {
+		child, ok := element.(layout.Form)
+		if !ok {
+			r.fail(&ChildError{Pos: element.Position(), Form: form.Tag, Found: describe(element), Admits: axisNames()})
+
+			continue
+		}
+
+		axis, ok := lookupAxis(child.Tag)
+		if !ok {
+			r.fail(&ChildError{Pos: child.TagPos, Form: form.Tag, Found: describe(child), Admits: axisNames()})
+
+			continue
+		}
+
+		if pos, repeated := first[axis]; repeated {
+			r.fail(&RepeatedAxisError{Pos: child.Pos, First: pos, Axis: axis, Form: form.Tag})
+
+			continue
+		}
+
+		first[axis] = child.Pos
+
+		value, ok := r.axisValue(child, axis)
+		if !ok {
+			continue
+		}
+
+		axes.set(axis, value)
+	}
+
+	return axes
+}
+
+// axisValue reads the one symbol an axis form carries, holding it to the set the
+// axis admits.
+func (r *profileReader) axisValue(form layout.Form, axis Axis) (string, bool) {
+	if len(form.Elements) != 1 {
+		found := "no value"
+		if len(form.Elements) > 1 {
+			found = "several"
+		}
+
+		r.fail(&AxisFormError{Pos: form.Pos, Axis: axis, Found: found})
+
+		return "", false
+	}
+
+	symbol, ok := form.Elements[0].(layout.Symbol)
+	if !ok {
+		r.fail(&AxisFormError{Pos: form.Elements[0].Position(), Axis: axis, Found: describe(form.Elements[0])})
+
+		return "", false
+	}
+
+	if !axis.admits(symbol.Value) {
+		r.fail(&AxisValueError{Pos: symbol.Pos, Axis: axis, Value: symbol.Value})
+
+		return "", false
+	}
+
+	return symbol.Value, true
+}
+
+// lookupAxis resolves an axis from the tag a layout writes it as.
+func lookupAxis(tag string) (Axis, bool) {
+	for _, axis := range allAxes {
+		if axis.String() == tag {
+			return axis, true
+		}
+	}
+
+	return 0, false
+}

--- a/internal/layoutmodel/profile_test.go
+++ b/internal/layoutmodel/profile_test.go
@@ -1,0 +1,663 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layoutmodel
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/layout"
+)
+
+// profile is the whole pipeline a caller runs: parse the source, then read the
+// encoding layer out of it.
+func profile(t *testing.T, source string) (*Profile, error) {
+	t.Helper()
+
+	file, err := layout.Parse("layout.sexpr", strings.NewReader(source))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	return ReadProfile(file)
+}
+
+// render draws a profile the way the tests assert one: the axes in SPEC.md's
+// order, then the overrides in the order the layout writes them, each with the
+// position it was read at.
+//
+// It is a rendering rather than a struct literal for the reason
+// [github.com/Zaba505/cpybkc/internal/layout]'s tests give: what has to be right
+// is the model *and* the position of every part of it, and a rendering carrying
+// both fails with the whole model in the message.
+func render(p *Profile) string {
+	lines := []string{fmt.Sprintf("%s encoding", p.Pos)}
+	lines = append(lines, renderAxes(p.Axes)...)
+
+	for _, override := range p.Overrides {
+		lines = append(lines, fmt.Sprintf("%s override %s", override.Pos, override.Item))
+		lines = append(lines, renderAxes(override.Axes)...)
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// renderAxes draws the axes a value states, indented under whatever states them.
+func renderAxes(axes Axes) []string {
+	var lines []string
+
+	for _, axis := range axes.Stated() {
+		lines = append(lines, fmt.Sprintf("  %s %s", axis, axes.value(axis)))
+	}
+
+	return lines
+}
+
+// TestReadProfileModelsTheEncodingLayer is the criterion this reader exists for:
+// a layout's encoding layer becomes a typed value naming what the layout said,
+// with a position on every part of it.
+func TestReadProfileModelsTheEncodingLayer(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		source string
+		want   []string
+	}{
+		{
+			name: "the four axes and nothing else",
+			source: strings.Join([]string{
+				"(encoding",
+				"  (charset cp037)",
+				"  (sign-convention ebcdic)",
+				"  (byte-order big-endian)",
+				"  (float-format hfp))",
+			}, "\n"),
+			want: []string{
+				"layout.sexpr:1:1 encoding",
+				"  charset cp037",
+				"  sign-convention ebcdic",
+				"  byte-order big-endian",
+				"  float-format hfp",
+			},
+		},
+		{
+			name: "the axes may be written in any order",
+			source: strings.Join([]string{
+				"(encoding",
+				"  (float-format ieee-754)",
+				"  (byte-order little-endian)",
+				"  (sign-convention ascii-zone-37)",
+				"  (charset ascii))",
+			}, "\n"),
+			want: []string{
+				"layout.sexpr:1:1 encoding",
+				"  charset ascii",
+				"  sign-convention ascii-zone-37",
+				"  byte-order little-endian",
+				"  float-format ieee-754",
+			},
+		},
+		{
+			name: "an override states one axis and leaves the rest",
+			source: strings.Join([]string{
+				"(encoding",
+				"  (charset cp037)",
+				"  (sign-convention ebcdic)",
+				"  (byte-order big-endian)",
+				"  (float-format hfp))",
+				"(encoding-override (item ORDER-HEADER OH-PARTNER-REF)",
+				"  (charset ascii))",
+			}, "\n"),
+			want: []string{
+				"layout.sexpr:1:1 encoding",
+				"  charset cp037",
+				"  sign-convention ebcdic",
+				"  byte-order big-endian",
+				"  float-format hfp",
+				"layout.sexpr:6:1 override (item ORDER-HEADER OH-PARTNER-REF)",
+				"  charset ascii",
+			},
+		},
+		{
+			name: "an override naming all four replaces the profile for its item",
+			source: strings.Join([]string{
+				"(encoding",
+				"  (charset cp037)",
+				"  (sign-convention ebcdic)",
+				"  (byte-order big-endian)",
+				"  (float-format hfp))",
+				"(encoding-override (item ORDER-DETAIL OD-CONVERTED)",
+				"  (charset ascii)",
+				"  (sign-convention translated-ebcdic)",
+				"  (byte-order little-endian)",
+				"  (float-format ieee-754))",
+			}, "\n"),
+			want: []string{
+				"layout.sexpr:1:1 encoding",
+				"  charset cp037",
+				"  sign-convention ebcdic",
+				"  byte-order big-endian",
+				"  float-format hfp",
+				"layout.sexpr:6:1 override (item ORDER-DETAIL OD-CONVERTED)",
+				"  charset ascii",
+				"  sign-convention translated-ebcdic",
+				"  byte-order little-endian",
+				"  float-format ieee-754",
+			},
+		},
+		{
+			name: "an override may name a group, deep in a record",
+			source: strings.Join([]string{
+				"(encoding",
+				"  (charset cp500)",
+				"  (sign-convention realia)",
+				"  (byte-order big-endian)",
+				"  (float-format hfp))",
+				"(encoding-override (item ORDER-HEADER OH-KEY OH-CUST-NO)",
+				"  (sign-convention ascii-zone-37))",
+			}, "\n"),
+			want: []string{
+				"layout.sexpr:1:1 encoding",
+				"  charset cp500",
+				"  sign-convention realia",
+				"  byte-order big-endian",
+				"  float-format hfp",
+				"layout.sexpr:6:1 override (item ORDER-HEADER OH-KEY OH-CUST-NO)",
+				"  sign-convention ascii-zone-37",
+			},
+		},
+		{
+			name: "the other layers are not this reader's and are not faults",
+			source: strings.Join([]string{
+				"(framing (recfm VB) (lrecl 512))",
+				"(encoding",
+				"  (charset cp1140)",
+				"  (sign-convention ebcdic)",
+				"  (byte-order big-endian)",
+				"  (float-format hfp))",
+				"(record FILE-HEADER (copybook \"cpy/orders.cpy\" FILE-HEADER-REC))",
+			}, "\n"),
+			want: []string{
+				"layout.sexpr:2:1 encoding",
+				"  charset cp1140",
+				"  sign-convention ebcdic",
+				"  byte-order big-endian",
+				"  float-format hfp",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			read, err := profile(t, testCase.source)
+			if err != nil {
+				t.Fatalf("read profile: %v", err)
+			}
+
+			if got, want := render(read), strings.Join(testCase.want, "\n"); got != want {
+				t.Errorf("read as\n%s\nwant\n%s", got, want)
+			}
+		})
+	}
+}
+
+// TestReadProfileAcceptsEveryAdmittedValue holds the reader to the sets the axes
+// admit, member by member, so that a value SPEC.md names and this package does
+// not read is a failure here rather than a layout an adopter cannot write.
+func TestReadProfileAcceptsEveryAdmittedValue(t *testing.T) {
+	t.Parallel()
+
+	for _, axis := range allAxes {
+		for _, value := range axis.Values() {
+			t.Run(fmt.Sprintf("%s %s", axis, value), func(t *testing.T) {
+				t.Parallel()
+
+				// The axis under test is written last, over a profile that
+				// already states all four, which is the same reading either way
+				// round and keeps the source one line per axis.
+				source := strings.Join([]string{
+					"(encoding",
+					"  (charset cp037)",
+					"  (sign-convention ebcdic)",
+					"  (byte-order big-endian)",
+					"  (float-format hfp))",
+					fmt.Sprintf("(encoding-override (item R F) (%s %s))", axis, value),
+				}, "\n")
+
+				read, err := profile(t, source)
+				if err != nil {
+					t.Fatalf("read profile: %v", err)
+				}
+
+				if len(read.Overrides) != 1 {
+					t.Fatalf("read %d overrides, want 1", len(read.Overrides))
+				}
+
+				if got := read.Overrides[0].Axes.value(axis); got != value {
+					t.Errorf("%s read as %q, want %q", axis, got, value)
+				}
+			})
+		}
+	}
+}
+
+// TestReadProfileRejects is the load-bearing half: a reader that accepts
+// everything passes the tests above.
+//
+// Each case states the message it expects in full, because the message is what
+// an adopter acts on — docs/layout/SPEC.md requires a diagnostic to "name what
+// it found and where", and an assertion on the type alone would pass on a
+// message that names neither.
+func TestReadProfileRejects(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		source string
+		want   []string
+	}{
+		{
+			name:   "a layout with no encoding form",
+			source: "(framing (recfm VB))",
+			want:   []string{"layout.sexpr:1:1: a layout carries exactly one encoding form, and this one carries 0"},
+		},
+		{
+			name: "a second encoding form",
+			source: strings.Join([]string{
+				"(encoding (charset cp037) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))",
+				"(encoding (charset ascii) (sign-convention ascii-zone-37) (byte-order little-endian) (float-format ieee-754))",
+			}, "\n"),
+			want: []string{"layout.sexpr:2:1: a layout carries exactly one encoding form, and this one carries 2"},
+		},
+		{
+			name:   "an axis nobody stated is named, and is not defaulted",
+			source: "(encoding (charset cp037) (float-format hfp))",
+			want: []string{
+				"layout.sexpr:1:1: the encoding profile states no sign-convention; all four axes are required and none of them has a default",
+				"layout.sexpr:1:1: the encoding profile states no byte-order; all four axes are required and none of them has a default",
+			},
+		},
+		{
+			name:   "a code page nobody has a table for",
+			source: "(encoding (charset cp1252) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))",
+			want: []string{
+				"layout.sexpr:1:20: charset is one of cp037, cp500, cp1047, cp1140 or ascii, and this one says \"cp1252\"",
+				"layout.sexpr:1:1: the encoding profile states no charset; all four axes are required and none of them has a default",
+			},
+		},
+		{
+			name:   "a sign convention spelled as codec/SPEC.md's Go identifier",
+			source: "(encoding (charset cp037) (sign-convention SignEBCDIC) (byte-order big-endian) (float-format hfp))",
+			want: []string{
+				"layout.sexpr:1:44: sign-convention is one of ebcdic, ascii-zone-37, translated-ebcdic or realia, and this one says \"SignEBCDIC\"",
+				"layout.sexpr:1:1: the encoding profile states no sign-convention; all four axes are required and none of them has a default",
+			},
+		},
+		{
+			name:   "a byte order abbreviated",
+			source: "(encoding (charset cp037) (sign-convention ebcdic) (byte-order little) (float-format hfp))",
+			want: []string{
+				"layout.sexpr:1:64: byte-order is one of big-endian or little-endian, and this one says \"little\"",
+				"layout.sexpr:1:1: the encoding profile states no byte-order; all four axes are required and none of them has a default",
+			},
+		},
+		{
+			name:   "an axis form with no value",
+			source: "(encoding (charset) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))",
+			want: []string{
+				"layout.sexpr:1:11: form \"charset\" takes one symbol naming its value, and this one has no value",
+				"layout.sexpr:1:1: the encoding profile states no charset; all four axes are required and none of them has a default",
+			},
+		},
+		{
+			name:   "an axis form with two",
+			source: "(encoding (charset cp037 cp500) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))",
+			want: []string{
+				"layout.sexpr:1:11: form \"charset\" takes one symbol naming its value, and this one has several",
+				"layout.sexpr:1:1: the encoding profile states no charset; all four axes are required and none of them has a default",
+			},
+		},
+		{
+			name:   "a code page written as text",
+			source: "(encoding (charset \"cp037\") (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))",
+			want: []string{
+				"layout.sexpr:1:20: form \"charset\" takes one symbol naming its value, and this one has text",
+				"layout.sexpr:1:1: the encoding profile states no charset; all four axes are required and none of them has a default",
+			},
+		},
+		{
+			name:   "one axis stated twice",
+			source: "(encoding (charset cp037) (charset cp500) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))",
+			want:   []string{"layout.sexpr:1:27: form \"encoding\" states charset twice, and states it first at layout.sexpr:1:11"},
+		},
+		{
+			name:   "a child that is not an axis",
+			source: "(encoding (charset cp037) (lrecl 512) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))",
+			want: []string{
+				"layout.sexpr:1:28: form \"encoding\" admits charset, sign-convention, byte-order or float-format, and this is form \"lrecl\"",
+			},
+		},
+		{
+			name:   "a child that is not a form at all",
+			source: "(encoding cp037 (charset cp037) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))",
+			want: []string{
+				"layout.sexpr:1:11: form \"encoding\" admits charset, sign-convention, byte-order or float-format, and this is the symbol \"cp037\"",
+			},
+		},
+		{
+			name: "an override naming no axis",
+			source: strings.Join([]string{
+				"(encoding (charset cp037) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))",
+				"(encoding-override (item ORDER-HEADER OH-PARTNER-REF))",
+			}, "\n"),
+			want: []string{
+				"layout.sexpr:2:1: the override on (item ORDER-HEADER OH-PARTNER-REF) states no axis; an override states at least one of charset, sign-convention, byte-order or float-format",
+			},
+		},
+		{
+			name: "two overrides on one item",
+			source: strings.Join([]string{
+				"(encoding (charset cp037) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))",
+				"(encoding-override (item ORDER-HEADER OH-PARTNER-REF) (charset ascii))",
+				"(encoding-override (item ORDER-HEADER OH-PARTNER-REF) (charset cp500))",
+			}, "\n"),
+			want: []string{
+				"layout.sexpr:3:1: (item ORDER-HEADER OH-PARTNER-REF) is overridden twice, and is overridden first at layout.sexpr:2:1; two overrides on one item would leave the order they were written in deciding the answer",
+			},
+		},
+		{
+			name: "an override naming nothing at all",
+			source: strings.Join([]string{
+				"(encoding (charset cp037) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))",
+				"(encoding-override)",
+			}, "\n"),
+			want: []string{
+				"layout.sexpr:2:1: an item reference is written (item <record-name> <name> ...), and this is an override naming no item at all",
+			},
+		},
+		{
+			name: "an override whose reference names a record and no item",
+			source: strings.Join([]string{
+				"(encoding (charset cp037) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))",
+				"(encoding-override (item ORDER-HEADER) (charset ascii))",
+			}, "\n"),
+			want: []string{
+				"layout.sexpr:2:20: an item reference is written (item <record-name> <name> ...), and this is a reference naming a record and no item below it",
+			},
+		},
+		{
+			name: "an override naming its item as text",
+			source: strings.Join([]string{
+				"(encoding (charset cp037) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))",
+				"(encoding-override \"ORDER-HEADER.OH-PARTNER-REF\" (charset ascii))",
+			}, "\n"),
+			want: []string{
+				"layout.sexpr:2:20: an item reference is written (item <record-name> <name> ...), and this is text",
+			},
+		},
+		{
+			name: "a fault under a misspelled reference is reported too",
+			source: strings.Join([]string{
+				"(encoding (charset cp037) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))",
+				"(encoding-override (item) (charset cp1252))",
+			}, "\n"),
+			want: []string{
+				"layout.sexpr:2:20: an item reference is written (item <record-name> <name> ...), and this is a reference naming nothing",
+				"layout.sexpr:2:36: charset is one of cp037, cp500, cp1047, cp1140 or ascii, and this one says \"cp1252\"",
+			},
+		},
+		{
+			name: "every fault is reported, in the order the layout states them",
+			source: strings.Join([]string{
+				"(encoding-override (item R F) (byte-order sideways))",
+				"(encoding (charset cp037) (sign-convention ebcdic))",
+			}, "\n"),
+			want: []string{
+				"layout.sexpr:1:43: byte-order is one of big-endian or little-endian, and this one says \"sideways\"",
+				"layout.sexpr:1:1: the override on (item R F) states no axis; an override states at least one of charset, sign-convention, byte-order or float-format",
+				"layout.sexpr:2:1: the encoding profile states no byte-order; all four axes are required and none of them has a default",
+				"layout.sexpr:2:1: the encoding profile states no float-format; all four axes are required and none of them has a default",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			read, err := profile(t, testCase.source)
+			if err == nil {
+				t.Fatalf("read as %s, want a fault", render(read))
+			}
+
+			if read != nil {
+				t.Errorf("a rejected layout yielded a profile: %s", render(read))
+			}
+
+			if got, want := err.Error(), strings.Join(testCase.want, "\n"); got != want {
+				t.Errorf("reported\n%s\nwant\n%s", got, want)
+			}
+		})
+	}
+}
+
+// TestFaultsAreAssertable is the other requirement on a fault: a caller deciding
+// what to do about one reaches for the type rather than for the text of the
+// message.
+func TestFaultsAreAssertable(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		source string
+		assert func(*testing.T, error)
+	}{
+		{
+			name:   "a missing axis names which one",
+			source: "(encoding (charset cp037) (sign-convention ebcdic) (byte-order big-endian))",
+			assert: func(t *testing.T, err error) {
+				var fault *MissingAxisError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no MissingAxisError in %v", err)
+				}
+
+				if fault.Axis != AxisFloatFormat {
+					t.Errorf("missing axis is %s, want float-format", fault.Axis)
+				}
+			},
+		},
+		{
+			name:   "an unsupported code page carries what was written",
+			source: "(encoding (charset utf-8) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))",
+			assert: func(t *testing.T, err error) {
+				var fault *AxisValueError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no AxisValueError in %v", err)
+				}
+
+				if fault.Axis != AxisCharset || fault.Value != "utf-8" {
+					t.Errorf("fault is %s %q, want charset \"utf-8\"", fault.Axis, fault.Value)
+				}
+			},
+		},
+		{
+			name: "a duplicate override carries both positions",
+			source: strings.Join([]string{
+				"(encoding (charset cp037) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))",
+				"(encoding-override (item R F) (charset ascii))",
+				"(encoding-override (item R F) (charset cp500))",
+			}, "\n"),
+			assert: func(t *testing.T, err error) {
+				var fault *DuplicateOverrideError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no DuplicateOverrideError in %v", err)
+				}
+
+				if fault.First.Line != 2 || fault.Pos.Line != 3 {
+					t.Errorf("fault is at %s, first at %s; want lines 3 and 2", fault.Pos, fault.First)
+				}
+			},
+		},
+		{
+			name:   "a layout with no profile",
+			source: "(framing (recfm VB))",
+			assert: func(t *testing.T, err error) {
+				var fault *ProfileCountError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no ProfileCountError in %v", err)
+				}
+
+				if fault.Count != 0 {
+					t.Errorf("count is %d, want 0", fault.Count)
+				}
+			},
+		},
+		{
+			name: "an override that states nothing",
+			source: strings.Join([]string{
+				"(encoding (charset cp037) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))",
+				"(encoding-override (item R F))",
+			}, "\n"),
+			assert: func(t *testing.T, err error) {
+				var fault *EmptyOverrideError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no EmptyOverrideError in %v", err)
+				}
+
+				if fault.Item.Record != "R" {
+					t.Errorf("item is %s, want one on record R", fault.Item)
+				}
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := profile(t, testCase.source)
+			if err == nil {
+				t.Fatal("read cleanly, want a fault")
+			}
+
+			testCase.assert(t, err)
+		})
+	}
+}
+
+// TestTheSpecsWorkedExampleReads is the staleness gate over the layer.
+//
+// docs/layout/SPEC.md's "A layout, end to end" appendix is the layout the
+// document shows an adopter, and it is read out of the document rather than
+// copied here for the reason
+// [github.com/Zaba505/cpybkc/internal/layout]'s tests read it: an encoding form
+// the example writes and this reader does not read would otherwise be invisible
+// until somebody pasted the example into a file.
+//
+// What it asserts is the appendix's own claim — a shop's mainframe is EBCDIC and
+// one partner field never was — which is the whole of the layer in one layout.
+func TestTheSpecsWorkedExampleReads(t *testing.T) {
+	t.Parallel()
+
+	read, err := profile(t, specExample(t))
+	if err != nil {
+		t.Fatalf("the reader rejects SPEC.md's own worked example: %v", err)
+	}
+
+	want := Axes{
+		Charset:        CP037,
+		SignConvention: SignEBCDIC,
+		ByteOrder:      BigEndian,
+		FloatFormat:    HFP,
+	}
+
+	if read.Axes != want {
+		t.Errorf("the profile reads as %+v, want %+v", read.Axes, want)
+	}
+
+	if len(read.Overrides) != 1 {
+		t.Fatalf("read %d overrides out of the appendix, want 1", len(read.Overrides))
+	}
+
+	override := read.Overrides[0]
+	if got := override.Item.String(); got != "(item ORDER-HEADER OH-PARTNER-REF)" {
+		t.Errorf("the override is on %s, want (item ORDER-HEADER OH-PARTNER-REF)", got)
+	}
+
+	// The partner reference is ASCII characters in a file that is EBCDIC
+	// everywhere else, and nothing else about that field moves.
+	applied := want
+	applied.Charset = ASCII
+
+	if got := read.Applied(override); got != applied {
+		t.Errorf("the override applies as %+v, want %+v", got, applied)
+	}
+}
+
+// specExample returns the layout in docs/layout/SPEC.md's "A layout, end to end"
+// appendix: the first fenced block under that heading.
+//
+// [github.com/Zaba505/cpybkc/internal/layout]'s tests read the same block, with
+// their own copy of this. Two are a duplication worth leaving until a third
+// package wants one, at which point what they share is a helper and not three
+// readings of a document.
+func specExample(t *testing.T) string {
+	t.Helper()
+
+	spec, err := os.ReadFile(filepath.Join(repoRoot(t), "docs", "layout", "SPEC.md"))
+	if err != nil {
+		t.Fatalf("read the layout SPEC: %v", err)
+	}
+
+	_, appendix, found := strings.Cut(string(spec), "## Appendix: A layout, end to end")
+	if !found {
+		t.Fatal("the layout SPEC has no \"A layout, end to end\" appendix")
+	}
+
+	_, block, found := strings.Cut(appendix, "```\n")
+	if !found {
+		t.Fatal("the appendix carries no fenced code block")
+	}
+
+	example, _, found := strings.Cut(block, "```")
+	if !found {
+		t.Fatal("the appendix's fenced code block is not closed")
+	}
+
+	return example
+}
+
+// repoRoot walks up from the test's working directory to the directory holding
+// go.mod, which for this module is the repository root and so the directory
+// docs/ sits in.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("working directory: %v", err)
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("no go.mod above the test's working directory")
+		}
+
+		dir = parent
+	}
+}

--- a/internal/layoutmodel/profile_test.go
+++ b/internal/layoutmodel/profile_test.go
@@ -288,11 +288,12 @@ func TestReadProfileRejects(t *testing.T) {
 			},
 		},
 		{
+			// The charset is stated and unusable rather than unstated, so this
+			// is the value fault alone and not a MissingAxisError beside it.
 			name:   "a code page nobody has a table for",
 			source: "(encoding (charset cp1252) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))",
 			want: []string{
 				"layout.sexpr:1:20: charset is one of cp037, cp500, cp1047, cp1140 or ascii, and this one says \"cp1252\"",
-				"layout.sexpr:1:1: the encoding profile states no charset; all four axes are required and none of them has a default",
 			},
 		},
 		{
@@ -300,7 +301,6 @@ func TestReadProfileRejects(t *testing.T) {
 			source: "(encoding (charset cp037) (sign-convention SignEBCDIC) (byte-order big-endian) (float-format hfp))",
 			want: []string{
 				"layout.sexpr:1:44: sign-convention is one of ebcdic, ascii-zone-37, translated-ebcdic or realia, and this one says \"SignEBCDIC\"",
-				"layout.sexpr:1:1: the encoding profile states no sign-convention; all four axes are required and none of them has a default",
 			},
 		},
 		{
@@ -308,7 +308,6 @@ func TestReadProfileRejects(t *testing.T) {
 			source: "(encoding (charset cp037) (sign-convention ebcdic) (byte-order little) (float-format hfp))",
 			want: []string{
 				"layout.sexpr:1:64: byte-order is one of big-endian or little-endian, and this one says \"little\"",
-				"layout.sexpr:1:1: the encoding profile states no byte-order; all four axes are required and none of them has a default",
 			},
 		},
 		{
@@ -316,7 +315,6 @@ func TestReadProfileRejects(t *testing.T) {
 			source: "(encoding (charset) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))",
 			want: []string{
 				"layout.sexpr:1:11: form \"charset\" takes one symbol naming its value, and this one has no value",
-				"layout.sexpr:1:1: the encoding profile states no charset; all four axes are required and none of them has a default",
 			},
 		},
 		{
@@ -324,7 +322,6 @@ func TestReadProfileRejects(t *testing.T) {
 			source: "(encoding (charset cp037 cp500) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))",
 			want: []string{
 				"layout.sexpr:1:11: form \"charset\" takes one symbol naming its value, and this one has several",
-				"layout.sexpr:1:1: the encoding profile states no charset; all four axes are required and none of them has a default",
 			},
 		},
 		{
@@ -332,7 +329,6 @@ func TestReadProfileRejects(t *testing.T) {
 			source: "(encoding (charset \"cp037\") (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))",
 			want: []string{
 				"layout.sexpr:1:20: form \"charset\" takes one symbol naming its value, and this one has text",
-				"layout.sexpr:1:1: the encoding profile states no charset; all four axes are required and none of them has a default",
 			},
 		},
 		{
@@ -362,6 +358,19 @@ func TestReadProfileRejects(t *testing.T) {
 			}, "\n"),
 			want: []string{
 				"layout.sexpr:2:1: the override on (item ORDER-HEADER OH-PARTNER-REF) states no axis; an override states at least one of charset, sign-convention, byte-order or float-format",
+			},
+		},
+		{
+			// The layout plainly names an axis, so the fault is the value and
+			// nothing else: reporting it as an override naming no axis would
+			// deny what is written on the line above it.
+			name: "an override whose only axis was rejected is not also an override naming none",
+			source: strings.Join([]string{
+				"(encoding (charset cp037) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))",
+				"(encoding-override (item ORDER-HEADER OH-PARTNER-REF) (charset cp1252))",
+			}, "\n"),
+			want: []string{
+				"layout.sexpr:2:64: charset is one of cp037, cp500, cp1047, cp1140 or ascii, and this one says \"cp1252\"",
 			},
 		},
 		{
@@ -424,7 +433,6 @@ func TestReadProfileRejects(t *testing.T) {
 			}, "\n"),
 			want: []string{
 				"layout.sexpr:1:43: byte-order is one of big-endian or little-endian, and this one says \"sideways\"",
-				"layout.sexpr:1:1: the override on (item R F) states no axis; an override states at least one of charset, sign-convention, byte-order or float-format",
 				"layout.sexpr:2:1: the encoding profile states no byte-order; all four axes are required and none of them has a default",
 				"layout.sexpr:2:1: the encoding profile states no float-format; all four axes are required and none of them has a default",
 			},


### PR DESCRIPTION
Closes #25

Adds `internal/layoutmodel`, where a positioned layout AST becomes the typed model of a layer, and `ReadProfile`, which reads the encoding layer out of one. A `Profile` carries the four axes the layout stated and the per-item overrides over them, and a layout that states three axes yields no profile at all.

`internal/layout` (#24) says what was written and `internal/layoutschema` (#23) holds it to the published schema; between them a layout is well-formed. `docs/layout/SPEC.md`'s "What the schema does not say" is the list of what a declaration cannot reach, and this is the first of the layers that reads it — #26–#30 land beside it.

## The four axes, and why the type is the enforcement

`(charset cp037)` is a form with a tag and a symbol until something decides that the tag names an axis, that the symbol names a code page, and that a code page is one of a bounded set. That reading happens once, here, and what comes out is data: `Charset` is a code page this project supports and cannot hold anything else, `Axes.Complete()` is a question about a value, and `Axes.Over(base)` is SPEC.md's "An override naming one axis leaves the other three as the profile states them".

The overlap with the schema is deliberate and is not a second statement of it. The schema says a well-formed layout carries four axes; this package says an `Axes` value has four axes and refuses to build one from a layout that states three. SPEC.md's "An implementation **MUST NOT** supply a default for a missing axis, and **MUST** report the missing one by name" is a rule about the value, and only the value can keep it.

## The charset registry

`charset` is the one axis `schema/layout.sexpr` declares as an open symbol, on the schema's own reasoning: "a code page added to that axis would otherwise have to be added here before an adopter could name it". So the bound lives here instead, in one `var` — `cp037`, `cp500`, `cp1047`, `cp1140`, `ascii`, `docs/layout/SPEC.md`'s list — and an unsupported one is rejected while the layout is read, naming the whole set:

```
layout.sexpr:1:20: charset is one of cp037, cp500, cp1047, cp1140 or ascii, and this one says "cp1252"
```

That is `cobol-go`'s constraint arriving from the source side: `codec` is forbidden from depending on `golang.org/x/text`, so every code page it supports is a table somebody wrote by hand, which makes the axis an enumeration rather than an open string. A code page added to `codec/SPEC.md`'s charset axis is added to the registry and to nothing else in this repository — it is still a change to what a layout may say, so it advances the published schema's version under "The version is in the file, and it moves with the format", even though no declaration in that file moves with it.

## What it rejects

Every fault is a typed error carrying a `layout.Pos`, assertable with `errors.As`, and `ReadProfile` reports all of them joined, in source order, rather than the first:

- `*ProfileCountError` — no `encoding` form, or two. The second one is what the span points at; the first is the profile an adopter meant.
- `*MissingAxisError` — one per unstated axis, naming it.
- `*AxisValueError` — a value outside the axis's set, naming the whole set.
- `*AxisFormError` — `(charset)`, `(charset cp037 cp500)`, `(charset "cp037")`: not values with something wrong with them.
- `*RepeatedAxisError` — one axis stated twice in one form, carrying both positions, because either line is fine on its own and what has to be decided is which was meant.
- `*ChildError` — a child of `encoding` or `encoding-override` that is not one of the four axes.
- `*EmptyOverrideError`, `*DuplicateOverrideError` — the two rules SPEC.md files under "Rules counting one form against another"; the duplicate carries both positions and the reason, that two overrides on one item "would leave the order they were written in deciding the answer".
- `*ItemReferenceError` — an override whose target is not `(item <record-name> <name> …)`.

## Judgment calls

- **A new package, not `internal/layout`.** That package's contract is that it builds what was written and knows nothing about what a tag means, which is what makes a misspelled tag reportable as one. The layer models need the meanings, so they are a package of their own — one for all five layers rather than one each, because they share `ItemRef`, the diagnostics and the position discipline.
- **"Named, reusable profiles referenced by record definitions" is not implemented, because SPEC.md rules it out.** The story predates `docs/layout/SPEC.md`, which settled the question in this story's name: "there is no second profile to inherit from, no per-record profile, and no profile named and referred to by name" (#25, #33), and "Named encoding bundles" is an *Out of Scope* section giving the reason — a bundle in a layout is a name whose expansion lives in another repository, so a layout could resolve to one set of axes before a `cobol-go` release and another afterwards, which is the silent failure the four axes exist to prevent. Reuse is delivered instead by the property the appendix names: the profile is four lines that are the same in every layout a shop writes, and every form is top-level, so a shop's profile can live in a file of its own. The acceptance criterion is checked off against that reading below.
- **`ItemRef` identity is the spelling.** SPEC.md requires a complete path rather than COBOL's `OF`/`IN` qualification, and gives as one of its two reasons that "a complete path has exactly one spelling" — so two references to one item are the same text, which is what makes the duplicate-override rule checkable without a copybook.
- **`Axes.Over` is here, and applying an override to fields is not.** Merging two `Axes` axis by axis is a fact about the two values. Which items an override reaches — a group reaches every elementary item under it, a repeating item every occurrence — needs a copybook and is `resolve`'s (#33).
- **A fault under a misspelled item reference still reads the axes.** An override whose reference is wrong is still an override, and a code page misspelled underneath it is a second thing to fix rather than something to discover on the next run.

## Acceptance criteria

- [x] **Named, reusable profiles referenced by record definitions** — implemented as SPEC.md settles it: one top-level `encoding` form governing the whole layout, per-item overrides over it, and no name for a record to refer to a profile by. See the judgment call above; the alternative is an *Out of Scope* section in the spec this story wrote.
- [x] **All four axes required; a missing axis is an error and never silently defaulted** — `*MissingAxisError` per axis, naming it; `Profile.Axes` is complete or there is no `Profile`. Asserted against a profile missing one axis, missing two, and missing one because the value it stated was rejected.
- [x] **Charset validated against a bounded registry of supported codepages** — `Charset`, `Charsets()` and `LookupCharset`; every member round-trips through the reader in `TestReadProfileAcceptsEveryAdmittedValue`, and `TestCharsetRegistryIsBounded` holds the boundary against `cp1252`, `utf-8`, `ebcdic-us` and `CP037`.
- [x] **An unsupported codepage produces an actionable error naming the supported set** — the message above, asserted in full; the same shape covers the other three axes, including `SignEBCDIC` written where `ebcdic` belongs.
- [x] **Per-field overrides of the record's profile supported** — `encoding-override`, axis by axis, one per item, with `Profile.Applied` giving the complete axes for an override's item.

## Verified

- `dagger call ci` — green (fmt, vet, lint, `go test -race`, schema lint, the `irpb` module's own stages and the release artifacts).
- The suite includes a staleness gate that reads `docs/layout/SPEC.md`'s "A layout, end to end" appendix out of the document rather than a copy of it, and asserts the profile, the override and the encoding the override applies to `OH-PARTNER-REF` — so a change to the example this reader does not follow is a failing test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
