### PR TITLE
story(layout): model and validate physical framing

### DIFF
--- a/internal/layoutmodel/bytestring.go
+++ b/internal/layoutmodel/bytestring.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layoutmodel
+
+import (
+	"encoding/hex"
+	"errors"
+	"strings"
+
+	"github.com/Zaba505/cpybkc/internal/layout"
+)
+
+// The tag a byte string is written with, wherever one appears.
+const tagBytes = "bytes"
+
+// ByteString is a run of bytes given literally: `(bytes "0D0A")`.
+//
+// docs/layout/SPEC.md's "Literals" is the whole of it — hexadecimal digits in
+// pairs, taken as they are written, "with no charset and no padding". It is the
+// one spelling in the format that says exactly what is in the file, which is why
+// a framing's delimiter is written as one and never as a named character
+// (docs/layout/SPEC.md's "A delimiter is bytes, and it has a placement").
+//
+// The zero value states nothing, which is what [ByteString.Stated] reports. A
+// byte string of no bytes is a diagnostic rather than a stated empty one, so a
+// value that was written always carries at least one byte.
+type ByteString struct {
+	// Pos is the `(bytes …)` form.
+	Pos layout.Pos
+
+	// Bytes is what the hexadecimal decoded to.
+	Bytes []byte
+}
+
+// Stated reports whether a byte string was written at all.
+func (b ByteString) Stated() bool { return len(b.Bytes) > 0 }
+
+// String renders the byte string the way a layout writes it, which is what a
+// diagnostic naming one quotes.
+//
+// The digits are upper case because that is how a dump prints them and how
+// docs/layout/SPEC.md writes every example of one.
+func (b ByteString) String() string {
+	return `(bytes "` + strings.ToUpper(hex.EncodeToString(b.Bytes)) + `")`
+}
+
+// readByteString reads a `(bytes "…")` form.
+//
+// That the text is hexadecimal, and that a byte string of no bytes is a fault,
+// are checked here because they are the two things schema/layout.sexpr says it
+// leaves to the reader: the schema can declare the argument to be text and
+// nothing more.
+func readByteString(node layout.Node) (ByteString, error) {
+	form, ok := node.(layout.Form)
+	if !ok {
+		return ByteString{}, &ByteStringError{Pos: node.Position(), Found: describe(node)}
+	}
+
+	if form.Tag != tagBytes {
+		return ByteString{}, &ByteStringError{Pos: form.TagPos, Found: "form " + quote(form.Tag)}
+	}
+
+	if len(form.Elements) != 1 {
+		found := "a byte string carrying nothing"
+		if len(form.Elements) > 1 {
+			found = "a byte string carrying several"
+		}
+
+		return ByteString{}, &ByteStringError{Pos: form.Pos, Found: found}
+	}
+
+	text, ok := form.Elements[0].(layout.Text)
+	if !ok {
+		return ByteString{}, &ByteStringError{Pos: form.Elements[0].Position(), Found: describe(form.Elements[0])}
+	}
+
+	if text.Value == "" {
+		return ByteString{}, &ByteStringError{Pos: text.Pos, Found: "a byte string of no bytes"}
+	}
+
+	decoded, err := hex.DecodeString(text.Value)
+	if err != nil {
+		found := quote(text.Value) + ", which is not hexadecimal"
+		if errors.Is(err, hex.ErrLength) {
+			found = quote(text.Value) + ", which is an odd number of digits"
+		}
+
+		return ByteString{}, &ByteStringError{Pos: text.Pos, Found: found}
+	}
+
+	return ByteString{Pos: form.Pos, Bytes: decoded}, nil
+}

--- a/internal/layoutmodel/doc.go
+++ b/internal/layoutmodel/doc.go
@@ -15,11 +15,13 @@
 // declaration cannot reach, and this package is where those land.
 //
 // Each layer of the format gets a reader here, and a type for what the layer
-// says. [ReadProfile] is the encoding profile (#25); physical framing, record
-// definitions, discrimination and sequencing arrive beside it (#26–#30). What
-// they have in common is that a value handed back is one the format admits: a
-// [Profile] carries four stated axes because a profile stating three is an error
-// and not a value with a hole in it.
+// says. [ReadProfile] is the encoding profile (#25) and [ReadFraming] is the
+// physical framing (#26); record definitions, discrimination and sequencing
+// arrive beside them (#27–#30). What they have in common is that a value handed
+// back is one the format admits: a [Profile] carries four stated axes because a
+// profile stating three is an error and not a value with a hole in it, and a
+// [Framing] resolves to one of the IR's four framings because the one record
+// format that resolves to none is rejected while the layout is read.
 //
 // # Why the model is not the AST
 //

--- a/internal/layoutmodel/errors.go
+++ b/internal/layoutmodel/errors.go
@@ -13,6 +13,24 @@ import (
 	"github.com/Zaba505/cpybkc/internal/layout"
 )
 
+// faults is the fault list a layer reader accumulates.
+//
+// Every reader here collects rather than returning the first, for the reason
+// [github.com/Zaba505/cpybkc/internal/layout]'s parser gives: a generated layout
+// is generated wrong in the same way in many places at once, and a reader that
+// reports one fault per run is a reader run once per fault. It is one type
+// rather than a field on each reader so that "keep reading after a fault" is
+// decided once.
+type faults struct {
+	errs []error
+}
+
+// fail records a fault. Reading continues after one, because the point of
+// collecting them is to report the second.
+func (f *faults) fail(err error) {
+	f.errs = append(f.errs, err)
+}
+
 // ProfileCountError is a layout that does not carry exactly one `encoding` form.
 //
 // Both halves are faults an adopter can act on and neither has a default:
@@ -227,6 +245,337 @@ type ItemReferenceError struct {
 // Error implements the error interface.
 func (e *ItemReferenceError) Error() string {
 	return fmt.Sprintf("%s: an item reference is written (item <record-name> <name> ...), and this is %s", e.Pos, e.Found)
+}
+
+// FramingCountError is a layout that does not carry exactly one `framing` form.
+//
+// docs/layout/SPEC.md requires exactly one. A layout carrying none says nothing
+// about how the file is framed, and one carrying two leaves the order they were
+// written in deciding which dataset the copybooks are bound to.
+type FramingCountError struct {
+	// Pos is the second `framing` form where there is one, and the start of the
+	// file where there is none.
+	Pos layout.Pos
+
+	// Count is how many the layout carries.
+	Count int
+}
+
+// Error implements the error interface.
+func (e *FramingCountError) Error() string {
+	return fmt.Sprintf("%s: a layout carries exactly one framing form, and this one carries %d", e.Pos, e.Count)
+}
+
+// MissingRECFMError is a `framing` form that states no `recfm`.
+//
+// It is the one child no record format conditions, because it *is* the record
+// format: every other rule in the layer is keyed on it, and there is no default
+// for the same reason there is no default for an encoding axis.
+type MissingRECFMError struct {
+	// Pos is the `framing` form, which is where the record format has to be
+	// written.
+	Pos layout.Pos
+}
+
+// Error implements the error interface.
+func (e *MissingRECFMError) Error() string {
+	return fmt.Sprintf(
+		"%s: a framing states one recfm, and this one states none; the rest of the framing follows from it",
+		e.Pos,
+	)
+}
+
+// RequiredChildError is a `framing` child the record format requires and the
+// layout does not state.
+//
+// The three are docs/layout/SPEC.md's: `lrecl` under `F` and `FB`, because it is
+// the only thing standing between an adopter and a silent misalignment;
+// `max-segment` under `VBS`, because nothing a layout says implies it and a
+// writer cannot compute it; and `delimiter` and `placement` under
+// `line-sequential`, neither of which has a default.
+type RequiredChildError struct {
+	// Pos is the `framing` form, which is where the child has to be written.
+	Pos layout.Pos
+
+	// Child is the tag nobody wrote.
+	Child string
+
+	// RECFM is the record format requiring it, which is the other half of the
+	// fault: the same child is optional under another spelling.
+	RECFM RECFM
+}
+
+// Error implements the error interface.
+func (e *RequiredChildError) Error() string {
+	return fmt.Sprintf("%s: recfm %s requires %s, and this framing states none", e.Pos, e.RECFM, quote(e.Child))
+}
+
+// UnadmittedChildError is a `framing` child the record format does not admit.
+//
+// It names the record format, which docs/layout/SPEC.md requires of the case it
+// argues in full — an `lrecl` under `line-sequential`, "where the dataset has no
+// such number", is "a diagnostic naming the spelling". A child that says nothing
+// about the file the layout describes is a layout describing two files at once,
+// and which of them was meant is not something to guess at.
+type UnadmittedChildError struct {
+	// Pos is the child that should not be there.
+	Pos layout.Pos
+
+	// Child is its tag.
+	Child string
+
+	// RECFM is the record format that does not admit it.
+	RECFM RECFM
+}
+
+// Error implements the error interface.
+func (e *UnadmittedChildError) Error() string {
+	return fmt.Sprintf("%s: recfm %s admits no %s, and this framing states one", e.Pos, e.RECFM, quote(e.Child))
+}
+
+// RepeatedChildError is one `framing` child stated twice.
+//
+// Like [RepeatedAxisError] it carries both positions, because the fault is the
+// pair: either line is a perfectly good statement on its own, and what an
+// adopter has to decide is which of the two they meant.
+type RepeatedChildError struct {
+	// Pos is the second statement.
+	Pos layout.Pos
+
+	// First is the one before it.
+	First layout.Pos
+
+	// Child is the tag stated twice.
+	Child string
+
+	// Form is the tag of the form carrying both.
+	Form string
+}
+
+// Error implements the error interface.
+func (e *RepeatedChildError) Error() string {
+	return fmt.Sprintf("%s: form %s states %s twice, and states it first at %s", e.Pos, quote(e.Form), quote(e.Child), e.First)
+}
+
+// FramingValueError is a value written for a `framing` child that the child does
+// not admit.
+//
+// It is [AxisValueError]'s counterpart in this layer and names the whole set for
+// the same reason: every one of these is a spelling question an adopter can
+// answer from the message.
+type FramingValueError struct {
+	// Pos is the value, not the form carrying it.
+	Pos layout.Pos
+
+	// Child is the tag it was written under.
+	Child string
+
+	// Value is what was written.
+	Value string
+
+	// Admits is the set the child takes.
+	Admits []string
+}
+
+// Error implements the error interface.
+func (e *FramingValueError) Error() string {
+	return fmt.Sprintf("%s: %s is one of %s, and this one says %s", e.Pos, e.Child, and(e.Admits), quote(e.Value))
+}
+
+// FramingFormError is a `framing` child that does not carry exactly one value of
+// the sort it takes.
+//
+// `(lrecl)` states nothing, `(lrecl 80 80)` states two things, and
+// `(lrecl "80")` writes a byte count as text. None of the three is a value with
+// something wrong with it, so none is a [FramingValueError].
+type FramingFormError struct {
+	// Pos is the form, or the element standing where its value belongs.
+	Pos layout.Pos
+
+	// Child is the tag.
+	Child string
+
+	// Takes names what the position takes.
+	Takes string
+
+	// Found names what was written instead.
+	Found string
+}
+
+// Error implements the error interface.
+func (e *FramingFormError) Error() string {
+	return fmt.Sprintf("%s: form %s takes %s, and this one has %s", e.Pos, quote(e.Child), e.Takes, e.Found)
+}
+
+// SizeError is a byte count that is not positive.
+//
+// A framing's numbers are lengths of things that exist, so zero and negative are
+// not small sizes: they are a number nothing in the dataset could have.
+type SizeError struct {
+	// Pos is the number.
+	Pos layout.Pos
+
+	// Child is the tag it was written under.
+	Child string
+
+	// Value is what was written.
+	Value int64
+}
+
+// Error implements the error interface.
+func (e *SizeError) Error() string {
+	return fmt.Sprintf("%s: %s is a positive number of bytes, and this one says %d", e.Pos, e.Child, e.Value)
+}
+
+// UndefinedLengthError is RECFM U, which docs/ir/SPEC.md's "Undefined-length
+// records" excludes.
+//
+// It names the dataset rather than reporting a generic framing error, which both
+// specs require of it: an adopter who has one needs to know that the problem is
+// the record format they were given and not the layout they wrote.
+type UndefinedLengthError struct {
+	// Pos is the `recfm` value.
+	Pos layout.Pos
+}
+
+// Error implements the error interface.
+func (e *UndefinedLengthError) Error() string {
+	return fmt.Sprintf(
+		"%s: recfm U is a dataset whose record extents came from the physical blocks the access method read, "+
+			"and a byte stream on a filesystem has lost them; where every block was in fact the same size the file "+
+			"is a fixed-length one and the layout says F or FB, and where they were not the boundaries have to be "+
+			"put back by whatever writes the stream",
+		e.Pos,
+	)
+}
+
+// CarriageControlError is a record format carrying an ASA or machine carriage
+// control — `FBA`, `VBM`.
+//
+// docs/layout/SPEC.md requires the diagnostic to name the carriage control and
+// say where it belongs instead. The control character is a byte of the record:
+// it is positioned like every other byte, it counts toward LRECL, and something
+// may need to read it. A framing setting would make it a framing byte, and no
+// item covers one, no slack node accounts for one and no predicate ever sees
+// one.
+type CarriageControlError struct {
+	// Pos is the `recfm` value.
+	Pos layout.Pos
+
+	// Value is what was written, in full.
+	Value string
+
+	// Control names which carriage control it carries.
+	Control string
+
+	// RECFM is the record format underneath it, which is what the layout says
+	// once the control character is declared where it belongs.
+	RECFM RECFM
+}
+
+// Error implements the error interface.
+func (e *CarriageControlError) Error() string {
+	return fmt.Sprintf(
+		"%s: recfm %s carries %s carriage control, and a control character is a byte of the record rather than "+
+			"a byte of the framing; declare it as a leading item in the copybook and write recfm %s",
+		e.Pos, quote(e.Value), e.Control, e.RECFM,
+	)
+}
+
+// BlockedStreamError is `(blocks in-stream)`, which docs/ir/SPEC.md's "Block
+// descriptor words in the stream" excludes.
+//
+// A blocked *dataset* is ordinary — `FB` resolves to **unframed** and `VB` to
+// **descriptor-word** — because what blocking is on the mainframe is not what
+// arrives. What is refused is a stream that still carries the block descriptor
+// words, which is a dataset image rather than a record stream.
+type BlockedStreamError struct {
+	// Pos is the `blocks` value.
+	Pos layout.Pos
+}
+
+// Error implements the error interface.
+func (e *BlockedStreamError) Error() string {
+	return fmt.Sprintf(
+		"%s: blocks in-stream is a dataset image rather than a record stream, and the transfer has to deblock it; "+
+			"a blocked dataset is otherwise ordinary and needs nothing said about it",
+		e.Pos,
+	)
+}
+
+// BlockSizeNotAMultipleError is a `blksize` under `FB` that is not a whole
+// number of records.
+//
+// A fixed-length block holds whole records, so a block size that is not a
+// multiple of the record length describes a dataset nothing allocated: one of
+// the two numbers came from somewhere else.
+type BlockSizeNotAMultipleError struct {
+	// Pos is the `blksize` value.
+	Pos layout.Pos
+
+	// RECFM is the record format the rule is keyed on.
+	RECFM RECFM
+
+	// BlockSize and LRECL are the two numbers, so that the message names both.
+	BlockSize int64
+	LRECL     int64
+}
+
+// Error implements the error interface.
+func (e *BlockSizeNotAMultipleError) Error() string {
+	return fmt.Sprintf(
+		"%s: under recfm %s a blksize holds whole records and is a multiple of lrecl, and %d is not a multiple of %d",
+		e.Pos, e.RECFM, e.BlockSize, e.LRECL,
+	)
+}
+
+// BlockSizeTooSmallError is a `blksize` under `VB` or `VBS` that cannot hold one
+// record.
+//
+// A block carries a block descriptor word in front of the records in it, so a
+// block size below the record length plus that word describes a dataset in which
+// the longest record does not fit in a block.
+type BlockSizeTooSmallError struct {
+	// Pos is the `blksize` value.
+	Pos layout.Pos
+
+	// RECFM is the record format the rule is keyed on.
+	RECFM RECFM
+
+	// BlockSize and LRECL are the two numbers.
+	BlockSize int64
+	LRECL     int64
+}
+
+// Error implements the error interface.
+func (e *BlockSizeTooSmallError) Error() string {
+	return fmt.Sprintf(
+		"%s: under recfm %s a blksize is at least lrecl plus the %d bytes of a block descriptor word, "+
+			"and %d is less than %d",
+		e.Pos, e.RECFM, blockDescriptorWord, e.BlockSize, e.LRECL+blockDescriptorWord,
+	)
+}
+
+// ByteStringError is a literal that is not `(bytes "<hex>")`.
+//
+// It covers every shape the fault takes, including the two schema/layout.sexpr
+// names as the reader's: text that is not hexadecimal digits in pairs, and a
+// byte string of no bytes. A delimiter of no bytes would be a delimiter nothing
+// in the file could be found at.
+type ByteStringError struct {
+	// Pos is the literal, or the part of it that is wrong.
+	Pos layout.Pos
+
+	// Found names what was written.
+	Found string
+}
+
+// Error implements the error interface.
+func (e *ByteStringError) Error() string {
+	return fmt.Sprintf(
+		"%s: a byte string is written (bytes \"<hex>\"), hexadecimal digits in pairs, and this is %s",
+		e.Pos, e.Found,
+	)
 }
 
 // axisNames is the four axes as a layout spells them, for a message that has to

--- a/internal/layoutmodel/framing.go
+++ b/internal/layoutmodel/framing.go
@@ -1,0 +1,848 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layoutmodel
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/Zaba505/cpybkc/internal/layout"
+)
+
+// The tags this layer reads. `framing` is the top-level form; the rest are its
+// children and are not read anywhere else.
+const (
+	tagFraming    = "framing"
+	tagRECFM      = "recfm"
+	tagLRECL      = "lrecl"
+	tagBLKSIZE    = "blksize"
+	tagBlocks     = "blocks"
+	tagMaxSegment = "max-segment"
+	tagDelimiter  = "delimiter"
+	tagPlacement  = "placement"
+)
+
+// framingChildren is what a `framing` form admits, in the order
+// docs/layout/SPEC.md's table states them, which is also the order the
+// conditional rules are checked and reported in.
+var framingChildren = []string{
+	tagRECFM,
+	tagLRECL,
+	tagBLKSIZE,
+	tagBlocks,
+	tagMaxSegment,
+	tagDelimiter,
+	tagPlacement,
+}
+
+// blockDescriptorWord is the width in bytes of the block descriptor word a
+// blocked variable-length dataset carries.
+//
+// docs/layout/SPEC.md states the rule it is used in — a `blksize` under `VB` and
+// `VBS` "MUST be at least `lrecl` plus the width of a block descriptor word" —
+// and explicitly does not restate the width, "which DFSMS defines". DFSMS is a
+// governing source of both specs, the width comes with the definition, and this
+// is the one place in the repository it is written down.
+const blockDescriptorWord = 4
+
+// FramingKind is one of the four framings a file node carries: what a *consumer*
+// does, as against the RECFM letters an adopter writes in JCL.
+//
+// The set is closed and is docs/ir/SPEC.md's "Four framings, and none of them is
+// a RECFM" unchanged; this type is that set as data, and [RECFM.Framing] is the
+// mapping from the adopter's spelling onto it. Nothing here adds a member: a
+// framing added to the IR is a breaking change there, and a second reading of
+// the set here would be a second answer to what a consumer has to implement.
+//
+// The zero value is not a framing. A [Framing] handed back by [ReadFraming]
+// always resolves to one, because the one spelling that resolves to nothing —
+// RECFM U — never survives the read.
+type FramingKind string
+
+// The four framings, in docs/ir/SPEC.md's order.
+const (
+	// Unframed is a record at its extent, beginning at the byte after the
+	// record before it. It is what RECFM F and FB resolve to and what nothing
+	// else does, which is why a rule about a fixed-length dataset is keyed on
+	// it — see [Framing.LRECLBound].
+	Unframed FramingKind = "unframed"
+
+	// DescriptorWord is a record at its extent, preceded by a record descriptor
+	// word. RECFM V and VB resolve to it.
+	DescriptorWord FramingKind = "descriptor-word"
+
+	// Segmented is a record split across segments, each preceded by a segment
+	// descriptor word. RECFM VBS resolves to it, and it is the one framing that
+	// carries a number: the largest segment a writer may emit, which is
+	// [Framing.MaxSegment].
+	Segmented FramingKind = "segmented"
+
+	// Delimited is a record at its extent with the delimiter around it, as the
+	// placement says. A line-sequential file resolves to it.
+	//
+	// A delimited file whose records stop *before* their extent — the trailing
+	// spaces GnuCOBOL's and Micro Focus's line-sequential organisations drop on
+	// the way out — is not describable, and there is deliberately no spelling
+	// for one in a layout. docs/ir/SPEC.md's "A record shorter than its extent"
+	// puts that diagnostic on the consumer, which reports a delimiter found
+	// before the record's extent as malformed data and must not accept the
+	// short record by filling in the bytes it never reached (#52). There is
+	// nothing for this layer to reject, because there is nothing an adopter can
+	// write here that claims it.
+	Delimited FramingKind = "delimited"
+)
+
+// RECFM is a dataset's record format in the adopter's own spelling — the letters
+// out of the JCL that allocated the file, plus the one name for the file that
+// has no RECFM at all.
+//
+// docs/layout/SPEC.md's "The adopter's spelling, and what each one resolves to"
+// is why the format keeps these rather than the framings: they are what an
+// adopter can look up. [RECFM.Framing] is the other half of that sentence.
+type RECFM string
+
+// The record formats a `recfm` admits, in docs/layout/SPEC.md's order.
+const (
+	// RECFMF is fixed-length, unblocked.
+	RECFMF RECFM = "F"
+
+	// RECFMFB is fixed-length, blocked.
+	RECFMFB RECFM = "FB"
+
+	// RECFMV is variable-length, unblocked.
+	RECFMV RECFM = "V"
+
+	// RECFMVB is variable-length, blocked.
+	RECFMVB RECFM = "VB"
+
+	// RECFMVBS is variable-length, blocked and spanned.
+	RECFMVBS RECFM = "VBS"
+
+	// RECFMU is undefined-length, and is admitted as a spelling in order to be
+	// rejected by name: an [UndefinedLengthError] rather than a value nobody
+	// recognises. A format with no spelling for U would leave the adopter who
+	// has one describing their file as something else, and finding out at the
+	// first record.
+	RECFMU RECFM = "U"
+
+	// LineSequential is the file that has no RECFM: a delimiter behind each
+	// record and nothing in front, which is what GnuCOBOL and Micro Focus write
+	// and what their documentation confusingly also calls RECFM=V. A layout
+	// says which of the two it has by which spelling it writes, and neither
+	// vendor is the default.
+	LineSequential RECFM = "line-sequential"
+)
+
+// recfms is the set a `recfm` admits, in the order every message listing them
+// renders them.
+var recfms = []RECFM{RECFMF, RECFMFB, RECFMV, RECFMVB, RECFMVBS, RECFMU, LineSequential}
+
+// Framing resolves the record format onto the framing a consumer implements.
+//
+// The mapping is docs/ir/SPEC.md's, read from the layout side, and it is the one
+// statement of it here. RECFM U resolves to nothing, which is what the false
+// reports: it names a dataset whose record extents are not in the byte stream
+// at all.
+func (r RECFM) Framing() (FramingKind, bool) {
+	switch r {
+	case RECFMF, RECFMFB:
+		return Unframed, true
+	case RECFMV, RECFMVB:
+		return DescriptorWord, true
+	case RECFMVBS:
+		return Segmented, true
+	case LineSequential:
+		return Delimited, true
+	default:
+		return "", false
+	}
+}
+
+// Blocks says whether the byte stream still carries block descriptor words.
+type Blocks string
+
+// The two spellings `blocks` admits.
+const (
+	// Deblocked is a run of records with no block descriptor words, which is
+	// what a transfer that preserves record boundaries produces and what the
+	// absence of a `blocks` child means.
+	Deblocked Blocks = "deblocked"
+
+	// InStream is a dataset image rather than a record stream, and is admitted
+	// on the same terms as [RECFMU]: as a spelling to be rejected by name, so
+	// that an adopter whose transfer preserved the blocks is told what is wrong
+	// with their file rather than misreading it from the first byte.
+	InStream Blocks = "in-stream"
+)
+
+// blocksSpellings is the set `blocks` admits, in docs/layout/SPEC.md's order.
+var blocksSpellings = []Blocks{Deblocked, InStream}
+
+// Placement is where a delimited file's delimiter sits relative to its records.
+//
+// The three are docs/ir/SPEC.md's "Terminator, separator and the last record"
+// unchanged. None of them is a default: the distinction is what makes the end of
+// a file checkable, and an adopter who guesses gives up a diagnostic without
+// being told.
+type Placement string
+
+// The three placements a `placement` admits.
+const (
+	// Terminator is a delimiter after every record including the last.
+	Terminator Placement = "terminator"
+
+	// Separator is a delimiter between two records and none after the last.
+	Separator Placement = "separator"
+
+	// OptionalTerminator is a delimiter after every record except that the file
+	// may end without one.
+	OptionalTerminator Placement = "optional-terminator"
+)
+
+// placements is the set `placement` admits, in docs/layout/SPEC.md's order.
+var placements = []Placement{Terminator, Separator, OptionalTerminator}
+
+// Size is a number of bytes a framing states, or nothing.
+//
+// The zero value states nothing, which is what [Size.Stated] reports. Every
+// position in the format that takes one takes a *positive* number, so zero is
+// not a size an adopter can write and is free to mean "nobody said".
+type Size struct {
+	// Pos is the number itself, which is what a diagnostic about its value
+	// points at.
+	Pos layout.Pos
+
+	// Value is how many bytes.
+	Value int64
+}
+
+// Stated reports whether a size was written at all.
+func (s Size) Stated() bool { return s.Value != 0 }
+
+// LRECLBound is what a stated `lrecl` requires of a record type's extent.
+//
+// The two are not interchangeable and the difference is the whole reason this is
+// a type rather than a number beside one: under a fixed-length dataset the next
+// record begins at that distance whatever the record was, and under a
+// variable-length one the record's own descriptor word states its length.
+type LRECLBound int
+
+// The bounds, and the absence of one.
+const (
+	// LRECLUnstated is a framing that states no `lrecl`. There is nothing to
+	// check a record type against, which is a layout that is still readable
+	// everywhere `lrecl` is optional.
+	LRECLUnstated LRECLBound = iota
+
+	// LRECLExact is `lrecl` under **unframed**: every record type accounts for
+	// all of it. A record type whose items stop short carries the difference as
+	// slack (#34), and one that does not describes a file whose reader
+	// misaligns after the first record with nothing in the file to disagree
+	// with it.
+	LRECLExact
+
+	// LRECLMaximum is `lrecl` under **descriptor-word** and **segmented**: a
+	// record type's greatest extent is at most this. It is a maximum rather
+	// than a requirement because each record states its own length, and the
+	// check is worth having anyway, because a maximum the copybooks exceed is a
+	// copybook bound to the wrong dataset.
+	LRECLMaximum
+)
+
+// String names the bound the way a message about one does.
+func (b LRECLBound) String() string {
+	switch b {
+	case LRECLUnstated:
+		return "unstated"
+	case LRECLExact:
+		return "exact"
+	case LRECLMaximum:
+		return "maximum"
+	default:
+		return fmt.Sprintf("LRECLBound(%d)", int(b))
+	}
+}
+
+// Framing is a layout's physical framing layer: the one `framing` form, read.
+//
+// There is exactly one of these per layout. What it states is the half of
+// physical framing that stays on the adopter's side of `resolve` — the RECFM
+// spelling out of their JCL, the LRECL and BLKSIZE beside it, and the delimiter
+// and placement of a file that has no RECFM at all. What a consumer does with it
+// is the IR's four framings, and [Framing.Kind] is the mapping.
+//
+// A [Framing] handed back by [ReadFraming] is one the format admits: its
+// [Framing.Kind] is one of the four, every child its record format requires is
+// stated, and no child its record format refuses is. What is *not* answered here
+// is anything needing a copybook — the extents `lrecl` is checked against are
+// `resolve`'s, per docs/layout/SPEC.md's "`resolve` checks each record type's
+// extent against `lrecl` and reports the difference it cannot account for"
+// (#33–#35). [Framing.LRECLBound] is what that check is told.
+type Framing struct {
+	// Pos is the `framing` form.
+	Pos layout.Pos
+
+	// RECFM is the record format the layout writes.
+	RECFM RECFM
+
+	// LRECL is the dataset's logical record length, or the zero [Size] where
+	// the layout states none. What it requires is [Framing.LRECLBound].
+	LRECL Size
+
+	// BlockSize is the dataset's block size, or the zero [Size]. It is checked
+	// against [Framing.LRECL] and the record format here and then reaches no IR
+	// node, because the stream carries no blocks for a size to describe.
+	BlockSize Size
+
+	// Blocks is always [Deblocked] on a value handed back: [InStream] is
+	// rejected, and the absence of a `blocks` child means the same thing as
+	// writing `deblocked`.
+	Blocks Blocks
+
+	// MaxSegment is the largest segment a writer may emit. It is stated under
+	// RECFM VBS and nowhere else, and it is the one framing number that is not
+	// a check: it reaches the IR's **segmented** framing and a writer obeys it.
+	// A reader has no use for it, since every segment states its own length.
+	MaxSegment Size
+
+	// Delimiter is the bytes around a delimited file's records, or the zero
+	// [ByteString] under every other record format.
+	Delimiter ByteString
+
+	// Placement is where those bytes sit, or the empty string under every other
+	// record format.
+	Placement Placement
+}
+
+// Kind is the framing a consumer implements for this dataset.
+//
+// It is derived rather than stored so that the record format and the framing
+// cannot disagree, and it is total on a value [ReadFraming] handed back: the one
+// spelling that resolves to no framing is rejected while the layout is read.
+func (f *Framing) Kind() FramingKind {
+	kind, _ := f.RECFM.Framing()
+
+	return kind
+}
+
+// LRECLBound is what this framing's `lrecl` requires of a record type's extent,
+// and [LRECLUnstated] where the layout states none.
+//
+// It is the layout-side half of a check `resolve` performs, and the half that
+// can be answered without a copybook. The other half needs one and is not this
+// package's:
+//
+//   - Under [LRECLExact] every record type accounts for all of LRECL, with the
+//     difference carried as slack (#34).
+//   - A record type resolved under the non-sliding reading of `OCCURS DEPENDING
+//     ON` has a constant extent — its table resolves to a constant repetition
+//     of the copybook's declared maximum — so it meets [LRECLExact] exactly as
+//     a record type with no table does (#87). Which reading applies is the
+//     `copybook-reading` form's, a record-definitions statement rather than a
+//     framing one.
+//   - A record type whose extent really is data-dependent has no single number
+//     of bytes to pad and does not fit an [Unframed] dataset at all; `resolve`
+//     rejects it, naming the record and the repeating item (#92). It is not
+//     validated against a maximum extent, because under the sliding reading it
+//     has none — which is why [LRECLExact] and [LRECLMaximum] are different
+//     answers rather than one number with a comparison to pick.
+func (f *Framing) LRECLBound() LRECLBound {
+	if !f.LRECL.Stated() {
+		return LRECLUnstated
+	}
+
+	if f.Kind() == Unframed {
+		return LRECLExact
+	}
+
+	return LRECLMaximum
+}
+
+// ReadFraming reads the physical framing layer out of a parsed layout.
+//
+// It reports every fault it finds, joined, and returns no framing when it found
+// one, for [ReadProfile]'s reason: a framing an adopter cannot act on is worse
+// than none, and a half-built one would leave a caller to notice.
+//
+// Top-level forms belonging to other layers are not read here and are not
+// faults.
+func ReadFraming(file *layout.File) (*Framing, error) {
+	read := &framingReader{}
+	framing := &Framing{Pos: file.Start(), Blocks: Deblocked}
+
+	// Every `framing` form is read and not only the one that will be kept, so
+	// that a layout carrying two malformed framings is told about both rather
+	// than about the count alone.
+	var forms []layout.Form
+
+	for _, form := range file.Forms {
+		if form.Tag != tagFraming {
+			continue
+		}
+
+		forms = append(forms, form)
+
+		one := read.framing(form)
+		if len(forms) == 1 {
+			framing = one
+		}
+	}
+
+	// The count is a fact about the layout rather than about any one form, so it
+	// is reported after everything the forms themselves were wrong about.
+	if len(forms) != 1 {
+		// The second form is what the diagnostic points at where there is one:
+		// the first is a framing an adopter meant, and the second is the line
+		// making it ambiguous.
+		pos := file.Start()
+		if len(forms) > 1 {
+			pos = forms[1].Pos
+		}
+
+		read.fail(&FramingCountError{Pos: pos, Count: len(forms)})
+	}
+
+	if len(read.errs) > 0 {
+		return nil, errors.Join(read.errs...)
+	}
+
+	return framing, nil
+}
+
+// framingReader holds the state one [ReadFraming] accumulates.
+type framingReader struct {
+	faults
+}
+
+// framing reads one `framing` form.
+func (r *framingReader) framing(form layout.Form) *Framing {
+	framing := &Framing{Pos: form.Pos, Blocks: Deblocked}
+
+	var (
+		// stated is where each child was written, which makes a repeated one
+		// reportable against the first and a conditional rule answerable.
+		stated = make(map[string]layout.Pos)
+
+		// usable is the children whose value was read. A child written with a
+		// value nothing admits is stated and unusable, and a rule keyed on that
+		// value has nothing to say about it.
+		usable = make(map[string]bool)
+	)
+
+	for _, element := range form.Elements {
+		child, ok := element.(layout.Form)
+		if !ok {
+			r.fail(&ChildError{Pos: element.Position(), Form: form.Tag, Found: describe(element), Admits: framingChildren})
+
+			continue
+		}
+
+		if !slices.Contains(framingChildren, child.Tag) {
+			r.fail(&ChildError{Pos: child.TagPos, Form: form.Tag, Found: describe(child), Admits: framingChildren})
+
+			continue
+		}
+
+		if pos, repeated := stated[child.Tag]; repeated {
+			r.fail(&RepeatedChildError{Pos: child.Pos, First: pos, Child: child.Tag, Form: form.Tag})
+
+			continue
+		}
+
+		stated[child.Tag] = child.Pos
+
+		if r.value(framing, child) {
+			usable[child.Tag] = true
+		}
+	}
+
+	if _, ok := stated[tagRECFM]; !ok {
+		r.fail(&MissingRECFMError{Pos: form.Pos})
+	}
+
+	// Which children a framing requires and which it refuses follows from the
+	// record format, so a record format nothing could be made of leaves those
+	// rules with nothing to key on. The children have already been checked
+	// against their own sorts, which is everything that can be said about them
+	// without one.
+	if !usable[tagRECFM] {
+		return framing
+	}
+
+	r.children(form, framing.RECFM, stated)
+	r.blockSize(framing, usable)
+
+	return framing
+}
+
+// children holds the framing to the rules its record format states: what it
+// requires, and what it refuses.
+func (r *framingReader) children(form layout.Form, recfm RECFM, stated map[string]layout.Pos) {
+	for _, child := range framingChildren {
+		if child == tagRECFM {
+			continue
+		}
+
+		pos, present := stated[child]
+
+		switch admits(child, recfm) {
+		case arityRequired:
+			if !present {
+				r.fail(&RequiredChildError{Pos: form.Pos, Child: child, RECFM: recfm})
+			}
+		case arityRefused:
+			if present {
+				r.fail(&UnadmittedChildError{Pos: pos, Child: child, RECFM: recfm})
+			}
+		case arityAdmitted:
+		}
+	}
+}
+
+// blockSize checks a stated `blksize` against the `lrecl` and the record format
+// beside it.
+//
+// It runs only where both numbers were read, and only under the record formats
+// that admit a `blksize` at all: everywhere else the fault has already been
+// reported, and a second message about the same two lines would describe one of
+// them wrongly.
+func (r *framingReader) blockSize(framing *Framing, usable map[string]bool) {
+	if !usable[tagBLKSIZE] || !usable[tagLRECL] {
+		return
+	}
+
+	switch framing.RECFM {
+	case RECFMFB:
+		if framing.BlockSize.Value%framing.LRECL.Value != 0 {
+			r.fail(&BlockSizeNotAMultipleError{
+				Pos:       framing.BlockSize.Pos,
+				RECFM:     framing.RECFM,
+				BlockSize: framing.BlockSize.Value,
+				LRECL:     framing.LRECL.Value,
+			})
+		}
+	case RECFMVB, RECFMVBS:
+		if framing.BlockSize.Value < framing.LRECL.Value+blockDescriptorWord {
+			r.fail(&BlockSizeTooSmallError{
+				Pos:       framing.BlockSize.Pos,
+				RECFM:     framing.RECFM,
+				BlockSize: framing.BlockSize.Value,
+				LRECL:     framing.LRECL.Value,
+			})
+		}
+	}
+}
+
+// value reads one child's value into the framing, reporting whether it read one.
+func (r *framingReader) value(framing *Framing, child layout.Form) bool {
+	switch child.Tag {
+	case tagRECFM:
+		return r.recfm(framing, child)
+	case tagLRECL:
+		return r.size(&framing.LRECL, child)
+	case tagBLKSIZE:
+		return r.size(&framing.BlockSize, child)
+	case tagBlocks:
+		return r.blocks(framing, child)
+	case tagMaxSegment:
+		return r.size(&framing.MaxSegment, child)
+	case tagDelimiter:
+		return r.delimiter(framing, child)
+	case tagPlacement:
+		return r.placement(framing, child)
+	default:
+		return false
+	}
+}
+
+// recfm reads the record format, and rejects the two spellings that are admitted
+// in order to be rejected: RECFM U, and a record format carrying a carriage
+// control.
+func (r *framingReader) recfm(framing *Framing, child layout.Form) bool {
+	symbol, ok := r.symbol(child)
+	if !ok {
+		return false
+	}
+
+	value := RECFM(symbol.Value)
+
+	if slices.Contains(recfms, value) {
+		if value == RECFMU {
+			r.fail(&UndefinedLengthError{Pos: symbol.Pos})
+
+			return false
+		}
+
+		framing.RECFM = value
+
+		return true
+	}
+
+	if base, control, ok := carriageControl(symbol.Value); ok {
+		r.fail(&CarriageControlError{Pos: symbol.Pos, Value: symbol.Value, Control: control, RECFM: base})
+
+		return false
+	}
+
+	r.fail(&FramingValueError{Pos: symbol.Pos, Child: child.Tag, Value: symbol.Value, Admits: recfmNames()})
+
+	return false
+}
+
+// blocks reads whether the stream still carries block descriptor words.
+func (r *framingReader) blocks(framing *Framing, child layout.Form) bool {
+	symbol, ok := r.symbol(child)
+	if !ok {
+		return false
+	}
+
+	switch Blocks(symbol.Value) {
+	case Deblocked:
+		framing.Blocks = Deblocked
+
+		return true
+	case InStream:
+		r.fail(&BlockedStreamError{Pos: symbol.Pos})
+
+		return false
+	}
+
+	r.fail(&FramingValueError{Pos: symbol.Pos, Child: child.Tag, Value: symbol.Value, Admits: blocksNames()})
+
+	return false
+}
+
+// placement reads where a delimited file's delimiter sits.
+func (r *framingReader) placement(framing *Framing, child layout.Form) bool {
+	symbol, ok := r.symbol(child)
+	if !ok {
+		return false
+	}
+
+	value := Placement(symbol.Value)
+	if !slices.Contains(placements, value) {
+		r.fail(&FramingValueError{Pos: symbol.Pos, Child: child.Tag, Value: symbol.Value, Admits: placementNames()})
+
+		return false
+	}
+
+	framing.Placement = value
+
+	return true
+}
+
+// delimiter reads the bytes a delimited file's records are wrapped in.
+func (r *framingReader) delimiter(framing *Framing, child layout.Form) bool {
+	if len(child.Elements) != 1 {
+		r.fail(&FramingFormError{Pos: child.Pos, Child: child.Tag, Takes: "one byte string", Found: count(len(child.Elements))})
+
+		return false
+	}
+
+	value, err := readByteString(child.Elements[0])
+	if err != nil {
+		r.fail(err)
+
+		return false
+	}
+
+	framing.Delimiter = value
+
+	return true
+}
+
+// size reads a child carrying a positive number of bytes.
+func (r *framingReader) size(into *Size, child layout.Form) bool {
+	const takes = "one positive number of bytes"
+
+	if len(child.Elements) != 1 {
+		r.fail(&FramingFormError{Pos: child.Pos, Child: child.Tag, Takes: takes, Found: count(len(child.Elements))})
+
+		return false
+	}
+
+	switch value := child.Elements[0].(type) {
+	case layout.Int:
+		if value.Value <= 0 {
+			r.fail(&SizeError{Pos: value.Pos, Child: child.Tag, Value: value.Value})
+
+			return false
+		}
+
+		*into = Size{Pos: value.Pos, Value: value.Value}
+
+		return true
+	case layout.Float:
+		// A number with a fraction is not a number of bytes, and describe would
+		// call it "a number", which is what the position takes.
+		r.fail(&FramingFormError{Pos: value.Pos, Child: child.Tag, Takes: takes, Found: "a number with a fraction"})
+	default:
+		r.fail(&FramingFormError{
+			Pos:   child.Elements[0].Position(),
+			Child: child.Tag,
+			Takes: takes,
+			Found: describe(child.Elements[0]),
+		})
+	}
+
+	return false
+}
+
+// symbol reads the one symbol a child carrying a value out of a closed set is
+// written with.
+func (r *framingReader) symbol(child layout.Form) (layout.Symbol, bool) {
+	const takes = "one symbol naming its value"
+
+	if len(child.Elements) != 1 {
+		r.fail(&FramingFormError{Pos: child.Pos, Child: child.Tag, Takes: takes, Found: count(len(child.Elements))})
+
+		return layout.Symbol{}, false
+	}
+
+	symbol, ok := child.Elements[0].(layout.Symbol)
+	if !ok {
+		r.fail(&FramingFormError{
+			Pos:   child.Elements[0].Position(),
+			Child: child.Tag,
+			Takes: takes,
+			Found: describe(child.Elements[0]),
+		})
+
+		return layout.Symbol{}, false
+	}
+
+	return symbol, true
+}
+
+// arity is what a record format does with one of the `framing` children.
+type arity int
+
+const (
+	// arityAdmitted is a child the record format takes and does not require.
+	arityAdmitted arity = iota
+
+	// arityRequired is a child the record format cannot do without.
+	arityRequired
+
+	// arityRefused is a child that says nothing about this record format, and
+	// whose presence is a layout describing two different files at once.
+	arityRefused
+)
+
+// admits is docs/layout/SPEC.md's conditional arities, which the published
+// schema declares at their widest and leaves here: which children a `framing`
+// requires "follows from the `recfm` value", and an arity that depends on a
+// sibling's value is not something a declaration can state.
+func admits(child string, recfm RECFM) arity {
+	switch child {
+	case tagLRECL:
+		switch recfm {
+		case RECFMF, RECFMFB:
+			return arityRequired
+		case LineSequential:
+			return arityRefused
+		}
+
+		return arityAdmitted
+	case tagBLKSIZE:
+		switch recfm {
+		case RECFMFB, RECFMVB, RECFMVBS:
+			return arityAdmitted
+		}
+
+		return arityRefused
+	case tagMaxSegment:
+		if recfm == RECFMVBS {
+			return arityRequired
+		}
+
+		return arityRefused
+	case tagDelimiter, tagPlacement:
+		if recfm == LineSequential {
+			return arityRequired
+		}
+
+		return arityRefused
+	default:
+		// `blocks` is the one child no record format conditions: a stream either
+		// still carries block descriptor words or it does not, and that is a
+		// property of the transfer rather than of the dataset it came from.
+		return arityAdmitted
+	}
+}
+
+// carriageControl splits a record format carrying an ASA or machine carriage
+// control into the format underneath it and the control it carries.
+//
+// `FBA` and `VBM` are the shapes an adopter has in their JCL, and neither is a
+// record format this document admits: the control character is a byte of the
+// record, and docs/layout/SPEC.md's "The adopter's spelling" says where it
+// belongs instead. Recognising the suffix here is what turns "that is not a
+// record format" into a diagnostic naming what was written.
+func carriageControl(value string) (RECFM, string, bool) {
+	var control string
+
+	switch {
+	case strings.HasSuffix(value, "A"):
+		control = "an ASA"
+	case strings.HasSuffix(value, "M"):
+		control = "a machine"
+	default:
+		return "", "", false
+	}
+
+	base := RECFM(value[:len(value)-1])
+	if base == LineSequential || !slices.Contains(recfms, base) {
+		return "", "", false
+	}
+
+	return base, control, true
+}
+
+// count names how many things stood where one belongs.
+func count(elements int) string {
+	if elements > 1 {
+		return "several"
+	}
+
+	return "no value"
+}
+
+// recfmNames is the record formats as a layout spells them, for a message that
+// has to list them.
+func recfmNames() []string {
+	names := make([]string, 0, len(recfms))
+
+	for _, recfm := range recfms {
+		names = append(names, string(recfm))
+	}
+
+	return names
+}
+
+// blocksNames is the same for `blocks`.
+func blocksNames() []string {
+	names := make([]string, 0, len(blocksSpellings))
+
+	for _, blocks := range blocksSpellings {
+		names = append(names, string(blocks))
+	}
+
+	return names
+}
+
+// placementNames is the same for `placement`.
+func placementNames() []string {
+	names := make([]string, 0, len(placements))
+
+	for _, placement := range placements {
+		names = append(names, string(placement))
+	}
+
+	return names
+}

--- a/internal/layoutmodel/framing_test.go
+++ b/internal/layoutmodel/framing_test.go
@@ -1,0 +1,866 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layoutmodel
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/layout"
+)
+
+// framingOf is the whole pipeline a caller runs: parse the source, then read the
+// physical framing layer out of it.
+func framingOf(t *testing.T, source string) (*Framing, error) {
+	t.Helper()
+
+	file, err := layout.Parse("layout.sexpr", strings.NewReader(source))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	return ReadFraming(file)
+}
+
+// renderFraming draws a framing the way the tests assert one: what the layout
+// said, in docs/layout/SPEC.md's order, with the framing it resolves to beside
+// the record format and a position on every part that carries one.
+//
+// It is a rendering rather than a struct literal for [render]'s reason: what has
+// to be right is the model *and* the position of every part of it, and a
+// rendering carrying both fails with the whole model in the message.
+func renderFraming(f *Framing) string {
+	lines := []string{
+		fmt.Sprintf("%s framing", f.Pos),
+		fmt.Sprintf("  recfm %s", f.RECFM),
+		fmt.Sprintf("  resolves to %s", f.Kind()),
+	}
+
+	if f.LRECL.Stated() {
+		lines = append(lines, fmt.Sprintf("  %s lrecl %d", f.LRECL.Pos, f.LRECL.Value))
+	}
+
+	if f.BlockSize.Stated() {
+		lines = append(lines, fmt.Sprintf("  %s blksize %d", f.BlockSize.Pos, f.BlockSize.Value))
+	}
+
+	lines = append(lines, fmt.Sprintf("  blocks %s", f.Blocks))
+
+	if f.MaxSegment.Stated() {
+		lines = append(lines, fmt.Sprintf("  %s max-segment %d", f.MaxSegment.Pos, f.MaxSegment.Value))
+	}
+
+	if f.Delimiter.Stated() {
+		lines = append(lines, fmt.Sprintf("  %s delimiter %s", f.Delimiter.Pos, f.Delimiter))
+	}
+
+	if f.Placement != "" {
+		lines = append(lines, fmt.Sprintf("  placement %s", f.Placement))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// minimalFraming is the least a layout may say under a record format: the
+// children that record format requires, and nothing it merely admits.
+func minimalFraming(recfm RECFM) string {
+	switch recfm {
+	case RECFMF, RECFMFB:
+		return fmt.Sprintf("(framing (recfm %s) (lrecl 80))", recfm)
+	case RECFMVBS:
+		return fmt.Sprintf("(framing (recfm %s) (max-segment 4096))", recfm)
+	case LineSequential:
+		return fmt.Sprintf("(framing (recfm %s) (delimiter (bytes \"0A\")) (placement terminator))", recfm)
+	default:
+		return fmt.Sprintf("(framing (recfm %s))", recfm)
+	}
+}
+
+// TestReadFramingModelsThePhysicalLayer is the criterion this reader exists for:
+// a layout's framing layer becomes a typed value naming what the layout said and
+// what it resolves to, with a position on every part of it.
+func TestReadFramingModelsThePhysicalLayer(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		source string
+		want   []string
+	}{
+		{
+			name: "a fixed-length blocked dataset",
+			source: strings.Join([]string{
+				"(framing",
+				"  (recfm FB)",
+				"  (lrecl 80)",
+				"  (blksize 800))",
+			}, "\n"),
+			want: []string{
+				"layout.sexpr:1:1 framing",
+				"  recfm FB",
+				"  resolves to unframed",
+				"  layout.sexpr:3:10 lrecl 80",
+				"  layout.sexpr:4:12 blksize 800",
+				"  blocks deblocked",
+			},
+		},
+		{
+			// The record descriptor word states each record's length, so a
+			// layout without an lrecl is still readable.
+			name:   "a variable-length dataset need not state an lrecl",
+			source: "(framing (recfm V))",
+			want: []string{
+				"layout.sexpr:1:1 framing",
+				"  recfm V",
+				"  resolves to descriptor-word",
+				"  blocks deblocked",
+			},
+		},
+		{
+			name: "a spanned dataset carries the largest segment a writer may emit",
+			source: strings.Join([]string{
+				"(framing",
+				"  (recfm VBS)",
+				"  (lrecl 27994)",
+				"  (blksize 27998)",
+				"  (blocks deblocked)",
+				"  (max-segment 4096))",
+			}, "\n"),
+			want: []string{
+				"layout.sexpr:1:1 framing",
+				"  recfm VBS",
+				"  resolves to segmented",
+				"  layout.sexpr:3:10 lrecl 27994",
+				"  layout.sexpr:4:12 blksize 27998",
+				"  blocks deblocked",
+				"  layout.sexpr:6:16 max-segment 4096",
+			},
+		},
+		{
+			name: "a line-sequential file carries its delimiter as bytes",
+			source: strings.Join([]string{
+				"(framing",
+				"  (recfm line-sequential)",
+				"  (delimiter (bytes \"0D0A\"))",
+				"  (placement optional-terminator))",
+			}, "\n"),
+			want: []string{
+				"layout.sexpr:1:1 framing",
+				"  recfm line-sequential",
+				"  resolves to delimited",
+				"  blocks deblocked",
+				"  layout.sexpr:3:14 delimiter (bytes \"0D0A\")",
+				"  placement optional-terminator",
+			},
+		},
+		{
+			name: "the other layers are not this reader's and are not faults",
+			source: strings.Join([]string{
+				"(encoding",
+				"  (charset cp037)",
+				"  (sign-convention ebcdic)",
+				"  (byte-order big-endian)",
+				"  (float-format hfp))",
+				"(framing (recfm VB) (lrecl 512))",
+				"(record FILE-HEADER (copybook \"cpy/orders.cpy\" FILE-HEADER-REC))",
+			}, "\n"),
+			want: []string{
+				"layout.sexpr:6:1 framing",
+				"  recfm VB",
+				"  resolves to descriptor-word",
+				"  layout.sexpr:6:28 lrecl 512",
+				"  blocks deblocked",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			read, err := framingOf(t, testCase.source)
+			if err != nil {
+				t.Fatalf("read framing: %v", err)
+			}
+
+			if got, want := renderFraming(read), strings.Join(testCase.want, "\n"); got != want {
+				t.Errorf("read as\n%s\nwant\n%s", got, want)
+			}
+		})
+	}
+}
+
+// TestEveryRECFMResolvesOntoAFraming walks the whole set a `recfm` admits, so
+// that a spelling docs/layout/SPEC.md names and this package does not map is a
+// failure here rather than a layout an adopter cannot write.
+//
+// RECFM U is the one member with no framing, and it is asserted as such rather
+// than skipped: that it resolves to nothing is the reason it is rejected.
+func TestEveryRECFMResolvesOntoAFraming(t *testing.T) {
+	t.Parallel()
+
+	want := map[RECFM]FramingKind{
+		RECFMF:         Unframed,
+		RECFMFB:        Unframed,
+		RECFMV:         DescriptorWord,
+		RECFMVB:        DescriptorWord,
+		RECFMVBS:       Segmented,
+		LineSequential: Delimited,
+	}
+
+	for _, recfm := range recfms {
+		t.Run(string(recfm), func(t *testing.T) {
+			t.Parallel()
+
+			kind, ok := recfm.Framing()
+
+			if recfm == RECFMU {
+				if ok {
+					t.Fatalf("recfm U resolves to %s, want nothing", kind)
+				}
+
+				return
+			}
+
+			if !ok {
+				t.Fatalf("recfm %s resolves to nothing", recfm)
+			}
+
+			if kind != want[recfm] {
+				t.Errorf("recfm %s resolves to %s, want %s", recfm, kind, want[recfm])
+			}
+
+			read, err := framingOf(t, minimalFraming(recfm))
+			if err != nil {
+				t.Fatalf("the least a layout may say under recfm %s is rejected: %v", recfm, err)
+			}
+
+			if read.Kind() != want[recfm] {
+				t.Errorf("the framing reads as %s, want %s", read.Kind(), want[recfm])
+			}
+		})
+	}
+}
+
+// TestLRECLBound is the layout-side half of the check `resolve` performs against
+// a record type's extent (#33–#35): the same number means "account for all of
+// it" on a fixed-length dataset and "no more than this" on a variable-length
+// one, and reading it as the wrong one is the misalignment the layer exists to
+// prevent.
+func TestLRECLBound(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		source string
+		want   LRECLBound
+	}{
+		{
+			name:   "under F every record type accounts for all of it",
+			source: "(framing (recfm F) (lrecl 80))",
+			want:   LRECLExact,
+		},
+		{
+			name:   "under FB too",
+			source: "(framing (recfm FB) (lrecl 80) (blksize 800))",
+			want:   LRECLExact,
+		},
+		{
+			name:   "under V it is a maximum",
+			source: "(framing (recfm V) (lrecl 512))",
+			want:   LRECLMaximum,
+		},
+		{
+			name:   "under VBS it is a maximum",
+			source: "(framing (recfm VBS) (lrecl 512) (max-segment 4096))",
+			want:   LRECLMaximum,
+		},
+		{
+			name:   "a variable-length dataset may state none",
+			source: "(framing (recfm VB))",
+			want:   LRECLUnstated,
+		},
+		{
+			name:   "a line-sequential file has none to state",
+			source: minimalFraming(LineSequential),
+			want:   LRECLUnstated,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			read, err := framingOf(t, testCase.source)
+			if err != nil {
+				t.Fatalf("read framing: %v", err)
+			}
+
+			if got := read.LRECLBound(); got != testCase.want {
+				t.Errorf("lrecl bound is %s, want %s", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestTheDelimiterIsTheBytesThatWereWritten is docs/layout/SPEC.md's "A
+// delimiter is bytes, and it has a placement": none of the four delimiters real
+// files carry is a default, and each one is the bytes the layout wrote and not a
+// character resolved through anything.
+func TestTheDelimiterIsTheBytesThatWereWritten(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		hex  string
+		want []byte
+	}{
+		{hex: "15", want: []byte{0x15}},
+		{hex: "25", want: []byte{0x25}},
+		{hex: "0A", want: []byte{0x0A}},
+		{hex: "0D0A", want: []byte{0x0D, 0x0A}},
+		{hex: "0d0a", want: []byte{0x0D, 0x0A}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.hex, func(t *testing.T) {
+			t.Parallel()
+
+			source := fmt.Sprintf(
+				"(framing (recfm line-sequential) (delimiter (bytes %q)) (placement separator))",
+				testCase.hex,
+			)
+
+			read, err := framingOf(t, source)
+			if err != nil {
+				t.Fatalf("read framing: %v", err)
+			}
+
+			if got := read.Delimiter.Bytes; string(got) != string(testCase.want) {
+				t.Errorf("delimiter reads as % X, want % X", got, testCase.want)
+			}
+
+			if read.Placement != Separator {
+				t.Errorf("placement reads as %q, want separator", read.Placement)
+			}
+		})
+	}
+}
+
+// TestEveryPlacementIsWritable holds the reader to the three placements, so that
+// one docs/layout/SPEC.md names and this package does not read is a failure here
+// rather than an adopter unable to say what their file does.
+func TestEveryPlacementIsWritable(t *testing.T) {
+	t.Parallel()
+
+	for _, placement := range placements {
+		t.Run(string(placement), func(t *testing.T) {
+			t.Parallel()
+
+			source := fmt.Sprintf(
+				"(framing (recfm line-sequential) (delimiter (bytes \"0A\")) (placement %s))",
+				placement,
+			)
+
+			read, err := framingOf(t, source)
+			if err != nil {
+				t.Fatalf("read framing: %v", err)
+			}
+
+			if read.Placement != placement {
+				t.Errorf("placement reads as %q, want %q", read.Placement, placement)
+			}
+		})
+	}
+}
+
+// TestReadFramingRejects is the load-bearing half: a reader that accepts
+// everything passes the tests above.
+//
+// Each case states the message it expects in full, because the message is what
+// an adopter acts on — docs/layout/SPEC.md requires a diagnostic to "name what
+// it found and where", and an assertion on the type alone would pass on a
+// message that names neither.
+func TestReadFramingRejects(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		source string
+		want   []string
+	}{
+		{
+			name:   "a layout with no framing form",
+			source: "(encoding (charset cp037))",
+			want:   []string{"layout.sexpr:1:1: a layout carries exactly one framing form, and this one carries 0"},
+		},
+		{
+			name: "a second framing form",
+			source: strings.Join([]string{
+				"(framing (recfm FB) (lrecl 80))",
+				"(framing (recfm V))",
+			}, "\n"),
+			want: []string{"layout.sexpr:2:1: a layout carries exactly one framing form, and this one carries 2"},
+		},
+		{
+			// Nothing below the recfm can be judged without it, so the missing
+			// record format is the whole diagnostic rather than the first of
+			// six about children whose rules have nothing to key on.
+			name:   "a framing that states no recfm",
+			source: "(framing (lrecl 80))",
+			want: []string{
+				"layout.sexpr:1:1: a framing states one recfm, and this one states none; the rest of the framing follows from it",
+			},
+		},
+		{
+			name:   "RECFM U names the dataset rather than reporting a generic framing error",
+			source: "(framing (recfm U) (lrecl 80))",
+			want: []string{
+				"layout.sexpr:1:17: recfm U is a dataset whose record extents came from the physical blocks the access " +
+					"method read, and a byte stream on a filesystem has lost them; where every block was in fact the same " +
+					"size the file is a fixed-length one and the layout says F or FB, and where they were not the " +
+					"boundaries have to be put back by whatever writes the stream",
+			},
+		},
+		{
+			name:   "an ASA carriage control is named, and so is where it belongs",
+			source: "(framing (recfm FBA) (lrecl 80))",
+			want: []string{
+				"layout.sexpr:1:17: recfm \"FBA\" carries an ASA carriage control, and a control character is a byte of " +
+					"the record rather than a byte of the framing; declare it as a leading item in the copybook and " +
+					"write recfm FB",
+			},
+		},
+		{
+			name:   "a machine carriage control is named the same way",
+			source: "(framing (recfm VBM))",
+			want: []string{
+				"layout.sexpr:1:17: recfm \"VBM\" carries a machine carriage control, and a control character is a byte " +
+					"of the record rather than a byte of the framing; declare it as a leading item in the copybook and " +
+					"write recfm VB",
+			},
+		},
+		{
+			name:   "a record format nobody has",
+			source: "(framing (recfm FIXED))",
+			want: []string{
+				"layout.sexpr:1:17: recfm is one of F, FB, V, VB, VBS, U or line-sequential, and this one says \"FIXED\"",
+			},
+		},
+		{
+			name:   "a fixed-length dataset that states no lrecl",
+			source: "(framing (recfm F))",
+			want:   []string{"layout.sexpr:1:1: recfm F requires \"lrecl\", and this framing states none"},
+		},
+		{
+			name: "an lrecl on a line-sequential file, where the dataset has no such number",
+			source: strings.Join([]string{
+				"(framing",
+				"  (recfm line-sequential)",
+				"  (lrecl 80)",
+				"  (delimiter (bytes \"0A\"))",
+				"  (placement terminator))",
+			}, "\n"),
+			want: []string{"layout.sexpr:3:3: recfm line-sequential admits no \"lrecl\", and this framing states one"},
+		},
+		{
+			name:   "a blksize on an unblocked dataset",
+			source: "(framing (recfm F) (lrecl 80) (blksize 800))",
+			want:   []string{"layout.sexpr:1:31: recfm F admits no \"blksize\", and this framing states one"},
+		},
+		{
+			name:   "a spanned dataset that states no max-segment",
+			source: "(framing (recfm VBS))",
+			want:   []string{"layout.sexpr:1:1: recfm VBS requires \"max-segment\", and this framing states none"},
+		},
+		{
+			name:   "a max-segment on a dataset that is not spanned",
+			source: "(framing (recfm VB) (max-segment 4096))",
+			want:   []string{"layout.sexpr:1:21: recfm VB admits no \"max-segment\", and this framing states one"},
+		},
+		{
+			name:   "a line-sequential file that says nothing about its delimiter",
+			source: "(framing (recfm line-sequential))",
+			want: []string{
+				"layout.sexpr:1:1: recfm line-sequential requires \"delimiter\", and this framing states none",
+				"layout.sexpr:1:1: recfm line-sequential requires \"placement\", and this framing states none",
+			},
+		},
+		{
+			name: "a delimiter and a placement on a dataset that has neither",
+			source: strings.Join([]string{
+				"(framing",
+				"  (recfm VB)",
+				"  (delimiter (bytes \"0A\"))",
+				"  (placement terminator))",
+			}, "\n"),
+			want: []string{
+				"layout.sexpr:3:3: recfm VB admits no \"delimiter\", and this framing states one",
+				"layout.sexpr:4:3: recfm VB admits no \"placement\", and this framing states one",
+			},
+		},
+		{
+			name:   "a blksize that is not a whole number of fixed-length records",
+			source: "(framing (recfm FB) (lrecl 80) (blksize 27998))",
+			want: []string{
+				"layout.sexpr:1:41: under recfm FB a blksize holds whole records and is a multiple of lrecl, " +
+					"and 27998 is not a multiple of 80",
+			},
+		},
+		{
+			name:   "a blksize with no room for a block descriptor word",
+			source: "(framing (recfm VB) (lrecl 512) (blksize 512))",
+			want: []string{
+				"layout.sexpr:1:42: under recfm VB a blksize is at least lrecl plus the 4 bytes of a block descriptor " +
+					"word, and 512 is less than 516",
+			},
+		},
+		{
+			name:   "a stream that still carries block descriptor words",
+			source: "(framing (recfm FB) (lrecl 80) (blocks in-stream))",
+			want: []string{
+				"layout.sexpr:1:40: blocks in-stream is a dataset image rather than a record stream, and the transfer " +
+					"has to deblock it; a blocked dataset is otherwise ordinary and needs nothing said about it",
+			},
+		},
+		{
+			name:   "a blocks value that is neither",
+			source: "(framing (recfm FB) (lrecl 80) (blocks blocked))",
+			want:   []string{"layout.sexpr:1:40: blocks is one of deblocked or in-stream, and this one says \"blocked\""},
+		},
+		{
+			name:   "a placement nobody has",
+			source: "(framing (recfm line-sequential) (delimiter (bytes \"0A\")) (placement trailing))",
+			want: []string{
+				"layout.sexpr:1:70: placement is one of terminator, separator or optional-terminator, " +
+					"and this one says \"trailing\"",
+			},
+		},
+		{
+			name: "a delimiter written as text rather than as bytes",
+			source: strings.Join([]string{
+				"(framing",
+				"  (recfm line-sequential)",
+				"  (delimiter \"0A\")",
+				"  (placement terminator))",
+			}, "\n"),
+			want: []string{
+				"layout.sexpr:3:14: a byte string is written (bytes \"<hex>\"), hexadecimal digits in pairs, " +
+					"and this is text",
+			},
+		},
+		{
+			name: "a delimiter of no bytes",
+			source: strings.Join([]string{
+				"(framing",
+				"  (recfm line-sequential)",
+				"  (delimiter (bytes \"\"))",
+				"  (placement terminator))",
+			}, "\n"),
+			want: []string{
+				"layout.sexpr:3:21: a byte string is written (bytes \"<hex>\"), hexadecimal digits in pairs, " +
+					"and this is a byte string of no bytes",
+			},
+		},
+		{
+			name: "a delimiter of half a byte",
+			source: strings.Join([]string{
+				"(framing",
+				"  (recfm line-sequential)",
+				"  (delimiter (bytes \"0\"))",
+				"  (placement terminator))",
+			}, "\n"),
+			want: []string{
+				"layout.sexpr:3:21: a byte string is written (bytes \"<hex>\"), hexadecimal digits in pairs, " +
+					"and this is \"0\", which is an odd number of digits",
+			},
+		},
+		{
+			name: "a delimiter that is not hexadecimal",
+			source: strings.Join([]string{
+				"(framing",
+				"  (recfm line-sequential)",
+				"  (delimiter (bytes \"0G\"))",
+				"  (placement terminator))",
+			}, "\n"),
+			want: []string{
+				"layout.sexpr:3:21: a byte string is written (bytes \"<hex>\"), hexadecimal digits in pairs, " +
+					"and this is \"0G\", which is not hexadecimal",
+			},
+		},
+		{
+			name:   "an lrecl of no bytes",
+			source: "(framing (recfm F) (lrecl 0))",
+			want:   []string{"layout.sexpr:1:27: lrecl is a positive number of bytes, and this one says 0"},
+		},
+		{
+			name:   "a byte count written as text",
+			source: "(framing (recfm F) (lrecl \"80\"))",
+			want: []string{
+				"layout.sexpr:1:27: form \"lrecl\" takes one positive number of bytes, and this one has text",
+			},
+		},
+		{
+			name:   "a byte count with no value",
+			source: "(framing (recfm F) (lrecl))",
+			want: []string{
+				"layout.sexpr:1:20: form \"lrecl\" takes one positive number of bytes, and this one has no value",
+			},
+		},
+		{
+			name:   "a byte count with a fraction",
+			source: "(framing (recfm F) (lrecl 80.5))",
+			want: []string{
+				"layout.sexpr:1:27: form \"lrecl\" takes one positive number of bytes, and this one has a number with a fraction",
+			},
+		},
+		{
+			name:   "a record format with no value",
+			source: "(framing (recfm) (lrecl 80))",
+			want: []string{
+				"layout.sexpr:1:10: form \"recfm\" takes one symbol naming its value, and this one has no value",
+			},
+		},
+		{
+			name:   "one child stated twice",
+			source: "(framing (recfm FB) (lrecl 80) (lrecl 100))",
+			want: []string{
+				"layout.sexpr:1:32: form \"framing\" states \"lrecl\" twice, and states it first at layout.sexpr:1:21",
+			},
+		},
+		{
+			name:   "a child belonging to another layer",
+			source: "(framing (recfm FB) (lrecl 80) (charset cp037))",
+			want: []string{
+				"layout.sexpr:1:33: form \"framing\" admits recfm, lrecl, blksize, blocks, max-segment, delimiter or " +
+					"placement, and this is form \"charset\"",
+			},
+		},
+		{
+			name:   "a child that is not a form at all",
+			source: "(framing FB (recfm FB) (lrecl 80))",
+			want: []string{
+				"layout.sexpr:1:10: form \"framing\" admits recfm, lrecl, blksize, blocks, max-segment, delimiter or " +
+					"placement, and this is the symbol \"FB\"",
+			},
+		},
+		{
+			// The delimiter is stated, so it is not also a delimiter nobody
+			// wrote: the layout plainly names one and the fault is what it says.
+			name: "every fault is reported: what the children say, then what the record format requires",
+			source: strings.Join([]string{
+				"(framing",
+				"  (recfm line-sequential)",
+				"  (lrecl 80)",
+				"  (delimiter (bytes \"\")))",
+			}, "\n"),
+			want: []string{
+				"layout.sexpr:4:21: a byte string is written (bytes \"<hex>\"), hexadecimal digits in pairs, " +
+					"and this is a byte string of no bytes",
+				"layout.sexpr:3:3: recfm line-sequential admits no \"lrecl\", and this framing states one",
+				"layout.sexpr:1:1: recfm line-sequential requires \"placement\", and this framing states none",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			read, err := framingOf(t, testCase.source)
+			if err == nil {
+				t.Fatalf("read as %s, want a fault", renderFraming(read))
+			}
+
+			if read != nil {
+				t.Errorf("a rejected layout yielded a framing: %s", renderFraming(read))
+			}
+
+			if got, want := err.Error(), strings.Join(testCase.want, "\n"); got != want {
+				t.Errorf("reported\n%s\nwant\n%s", got, want)
+			}
+		})
+	}
+}
+
+// TestFramingFaultsAreAssertable is the other requirement on a fault: a caller
+// deciding what to do about one reaches for the type rather than for the text of
+// the message.
+func TestFramingFaultsAreAssertable(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		source string
+		assert func(*testing.T, error)
+	}{
+		{
+			name:   "an undefined-length dataset is its own fault",
+			source: "(framing (recfm U))",
+			assert: func(t *testing.T, err error) {
+				var fault *UndefinedLengthError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no UndefinedLengthError in %v", err)
+				}
+			},
+		},
+		{
+			name:   "a carriage control carries what was written and what was meant",
+			source: "(framing (recfm FBA) (lrecl 80))",
+			assert: func(t *testing.T, err error) {
+				var fault *CarriageControlError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no CarriageControlError in %v", err)
+				}
+
+				if fault.Value != "FBA" || fault.RECFM != RECFMFB {
+					t.Errorf("fault is %q under recfm %s, want \"FBA\" under FB", fault.Value, fault.RECFM)
+				}
+			},
+		},
+		{
+			name:   "a blocked stream is its own fault",
+			source: "(framing (recfm FB) (lrecl 80) (blocks in-stream))",
+			assert: func(t *testing.T, err error) {
+				var fault *BlockedStreamError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no BlockedStreamError in %v", err)
+				}
+			},
+		},
+		{
+			name:   "a required child names itself and the record format requiring it",
+			source: "(framing (recfm VBS))",
+			assert: func(t *testing.T, err error) {
+				var fault *RequiredChildError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no RequiredChildError in %v", err)
+				}
+
+				if fault.Child != "max-segment" || fault.RECFM != RECFMVBS {
+					t.Errorf("fault is %q under recfm %s, want \"max-segment\" under VBS", fault.Child, fault.RECFM)
+				}
+			},
+		},
+		{
+			name:   "an unadmitted child does the same",
+			source: "(framing (recfm F) (lrecl 80) (blksize 800))",
+			assert: func(t *testing.T, err error) {
+				var fault *UnadmittedChildError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no UnadmittedChildError in %v", err)
+				}
+
+				if fault.Child != "blksize" || fault.RECFM != RECFMF {
+					t.Errorf("fault is %q under recfm %s, want \"blksize\" under F", fault.Child, fault.RECFM)
+				}
+			},
+		},
+		{
+			name:   "a block size that is not a multiple carries both numbers",
+			source: "(framing (recfm FB) (lrecl 80) (blksize 27998))",
+			assert: func(t *testing.T, err error) {
+				var fault *BlockSizeNotAMultipleError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no BlockSizeNotAMultipleError in %v", err)
+				}
+
+				if fault.BlockSize != 27998 || fault.LRECL != 80 {
+					t.Errorf("fault is blksize %d against lrecl %d, want 27998 against 80", fault.BlockSize, fault.LRECL)
+				}
+			},
+		},
+		{
+			name:   "a block size with no room for a descriptor word does too",
+			source: "(framing (recfm VBS) (lrecl 512) (blksize 512) (max-segment 512))",
+			assert: func(t *testing.T, err error) {
+				var fault *BlockSizeTooSmallError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no BlockSizeTooSmallError in %v", err)
+				}
+
+				if fault.BlockSize != 512 || fault.LRECL != 512 {
+					t.Errorf("fault is blksize %d against lrecl %d, want 512 against 512", fault.BlockSize, fault.LRECL)
+				}
+			},
+		},
+		{
+			name:   "a layout with no framing",
+			source: "(encoding (charset cp037))",
+			assert: func(t *testing.T, err error) {
+				var fault *FramingCountError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no FramingCountError in %v", err)
+				}
+
+				if fault.Count != 0 {
+					t.Errorf("count is %d, want 0", fault.Count)
+				}
+			},
+		},
+		{
+			name:   "a delimiter that is not a byte string",
+			source: "(framing (recfm line-sequential) (delimiter 10) (placement terminator))",
+			assert: func(t *testing.T, err error) {
+				var fault *ByteStringError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no ByteStringError in %v", err)
+				}
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := framingOf(t, testCase.source)
+			if err == nil {
+				t.Fatal("read cleanly, want a fault")
+			}
+
+			testCase.assert(t, err)
+		})
+	}
+}
+
+// TestTheSpecsWorkedExampleFrames is the staleness gate over the layer.
+//
+// docs/layout/SPEC.md's "A layout, end to end" appendix is the layout the
+// document shows an adopter, and it is read out of the document rather than
+// copied here for [TestTheSpecsWorkedExampleReads]'s reason: a framing child the
+// example writes and this reader does not read would otherwise be invisible
+// until somebody pasted the example into a file.
+//
+// What it asserts is the appendix's own claim — an order file on a
+// variable-length dataset, out of the JCL that allocated it.
+func TestTheSpecsWorkedExampleFrames(t *testing.T) {
+	t.Parallel()
+
+	read, err := framingOf(t, specExample(t))
+	if err != nil {
+		t.Fatalf("the reader rejects SPEC.md's own worked example: %v", err)
+	}
+
+	if read.RECFM != RECFMVB || read.Kind() != DescriptorWord {
+		t.Errorf("the framing reads as recfm %s resolving to %s, want VB resolving to descriptor-word", read.RECFM, read.Kind())
+	}
+
+	if read.LRECL.Value != 512 || read.BlockSize.Value != 27998 {
+		t.Errorf("the dataset reads as lrecl %d blksize %d, want 512 and 27998", read.LRECL.Value, read.BlockSize.Value)
+	}
+
+	// The record descriptor word states each record's length, so the appendix's
+	// lrecl is what the copybooks may not exceed rather than what they must be.
+	if got := read.LRECLBound(); got != LRECLMaximum {
+		t.Errorf("the lrecl binds as %s, want maximum", got)
+	}
+
+	if read.Blocks != Deblocked {
+		t.Errorf("the stream reads as %q, want deblocked", read.Blocks)
+	}
+}

--- a/internal/layoutmodel/profile.go
+++ b/internal/layoutmodel/profile.go
@@ -139,18 +139,12 @@ func ReadProfile(file *layout.File) (*Profile, error) {
 // profileReader holds the state one [ReadProfile] accumulates: the faults found
 // so far, and the items already overridden.
 type profileReader struct {
-	errs []error
+	faults
 
 	// overridden is where each item was first overridden, keyed by the
 	// reference's identity. It is what makes a second override on one item
 	// reportable against the first.
 	overridden map[string]layout.Pos
-}
-
-// fail records a fault. Reading continues after one, because the point of
-// collecting them is to report the second.
-func (r *profileReader) fail(err error) {
-	r.errs = append(r.errs, err)
 }
 
 // override reads one `encoding-override` and appends it to the profile.


### PR DESCRIPTION
Closes #26

`internal/layoutmodel` gains the physical framing layer beside the encoding
profile: `ReadFraming` turns a layout's one `framing` form into a typed
`Framing`, maps the adopter's RECFM spelling onto the IR's four framings, and
enforces the rules `schema/layout.sexpr` says it leaves to the reader — the
conditional arities, the spellings admitted in order to be rejected by name, and
the `blksize`/`lrecl` arithmetic.

## Acceptance criteria

- [x] **RECFM F, FB, V, VB and VBS in the adopter's spelling, each mapped to the
      framing `ir/SPEC.md` names.** `RECFM` is the closed set out of the JCL and
      `RECFM.Framing` is the one statement of the mapping; `FramingKind` is the
      IR's four. `TestEveryRECFMResolvesOntoAFraming` walks the whole set, so a
      spelling SPEC.md names and this package does not map fails here.
- [x] **A line-sequential file expressed as delimited, carrying the delimiter as
      literal bytes.** `ByteString` (new `bytestring.go`, shared with the
      discrimination literals of #28) decodes `(bytes "…")` and nothing else; the
      hexadecimal check and the empty-byte-string diagnostic are the two things
      the published schema explicitly leaves to the reader.
      `TestTheDelimiterIsTheBytesThatWereWritten` covers `0x15`, `0x25`, `0x0A`
      and `0x0D 0x0A`, and none of them is a default — the child is required
      under `line-sequential` and refused everywhere else.
- [x] **Placement expressible as terminator, separator or optional terminator,
      required rather than defaulted.** `Placement`, required under
      `line-sequential`; `Placement` is the empty string on nothing else.
- [x] **LRECL validated against the resolved record widths, with slack padding
      (#34).** The half that needs a copybook is `resolve`'s and is cited as such
      by both specs — *"`resolve` checks each record type's extent against
      `lrecl` and reports the difference it cannot account for"*. What lands here
      is the half that decides **what that check means**: `Framing.LRECLBound`
      returns `LRECLExact` under **unframed** (account for all of LRECL, the
      difference carried as slack) and `LRECLMaximum` under **descriptor-word**
      and **segmented** (a greatest extent, checked because a maximum the
      copybooks exceed is a copybook bound to the wrong dataset). Reading one as
      the other is the misalignment the layer exists to prevent, which is why it
      is a type rather than a number and a comparison chosen at the call site.
- [x] **A record type resolved under the non-sliding reading validated like any
      constant-extent record (#87).** It meets `LRECLExact` exactly as a record
      with no table does; nothing here special-cases it. Which reading applies is
      the `copybook-reading` form's, a record-definitions statement (#27, #30),
      and applying it needs the copybook. Documented on `Framing.LRECLBound`.
- [x] **A data-dependent extent handled as #92 lands, and not silently validated
      against its maximum.** Under **unframed** the bound is `LRECLExact`, so
      there is no maximum for such a record to be quietly measured against — the
      rejection is `resolve`'s, naming the record and the repeating item.
- [x] **BLKSIZE validated against LRECL and the record format, and not carried
      into the IR.** Admitted under `FB`, `VB` and `VBS` and a diagnostic
      elsewhere; a multiple of `lrecl` under `FB`
      (`BlockSizeNotAMultipleError`), at least `lrecl` plus a block descriptor
      word under `VB` and `VBS` (`BlockSizeTooSmallError`). It reaches no IR
      node.
- [x] **The largest segment a writer may emit expressible for VBS.**
      `max-segment`, required under `VBS` and refused elsewhere.
- [x] **RECFM=U rejected, naming the dataset.** `UndefinedLengthError` says the
      extents came from the physical blocks the access method read and what an
      adopter can do about it, rather than reporting a generic framing error.
- [x] **A stream declared to still carry block descriptor words rejected.**
      `BlockedStreamError` on `(blocks in-stream)`, saying the transfer has to
      deblock and that a blocked *dataset* is otherwise ordinary.
- [x] **A delimited record declared to stop before its extent rejected by name.**
      There is no spelling in the layout format by which one can be declared —
      `layout/SPEC.md`'s framing table and the published schema are both closed,
      and neither carries a child for it. `ir/SPEC.md`'s *A record shorter than
      its extent* puts the requirement on the **consumer**, which reports a
      delimiter found before the record's extent as malformed data and must not
      fill in the bytes it never reached (#52). Recorded where a reader will look
      for it, on the `Delimited` constant, rather than answered by inventing a
      spelling no spec has agreed.
- [x] **No carriage-control setting.** `FBA` and `VBM` are recognised and
      rejected by `CarriageControlError`, which names the control as ASA or
      machine and says to declare it as a leading item in the copybook. There is
      no framing child for it.
- [x] **Inconsistent combinations rejected with an error that explains the
      inconsistency.** `RequiredChildError` and `UnadmittedChildError` name both
      the child and the record format, which is the half of the fault a message
      naming one alone leaves out.

## Judgment calls that shaped the API

- **`Framing.Kind` is derived, not stored.** A record format and a framing that
  can disagree is a second answer to what a consumer implements; the mapping
  lives once, in `RECFM.Framing`.
- **`LRECLBound` is a type.** See the fourth criterion above — the difference
  between the two readings of one number is the whole point, and a `bool` beside
  an `int64` puts it in the caller's hands.
- **`blockDescriptorWord = 4` is written down once.** `layout/SPEC.md` states the
  rule and deliberately does not restate the width, "which DFSMS defines"; DFSMS
  is a governing source of both specs and the width comes with the definition.
- **`ByteString` got its own file.** `(bytes "…")` is a literal wherever one
  appears, not a framing detail, and #28's discriminators take the same sort.
- **`faults` was lifted out of `profileReader`.** "Keep reading after a fault" is
  now decided once for every layer reader rather than copied per reader.

**One thing worth a second look, deliberately not worked around:** SPEC.md
states the *at least `lrecl` plus a block descriptor word* rule for `VB` **and**
`VBS`, and this reader implements it as written. On a real spanned dataset LRECL
may exceed BLKSIZE — that is what spanning is for — and
`internal/layoutschema/testdata/valid/spanned.sexpr` (`lrecl 32760`,
`blksize 27998`) is exactly such a layout. That fixture is still correct on its
own terms, since "a layout this schema accepts is well-formed, not valid", but if
the rule is meant to hold for `VB` alone then SPEC.md is what changes, not this
check.

## Verified

- `dagger call ci` — clean.
- `go test ./...`, `go vet ./...`, `gofmt -l internal/` — clean.
