### PR TITLE
story(layout): implement the closed set of discriminator strategies

### DIFF
--- a/docs/ir/SPEC.md
+++ b/docs/ir/SPEC.md
@@ -1906,10 +1906,11 @@ consumer that decides differently in each language.
 
 Three tests, and no fourth. Conjunction is the list, disjunction is a second
 transition leaving the same state, and a state already *is* a disjunction — so
-the set needs neither. Its membership is settled here rather than deferred the
-way the predicate set's is (#22, #28), because a guard reads a value this
-document's own machinery put in a register: there is no layout-side strategy
-list for it to follow and nothing to wait for.
+the set needs neither. Its membership was settled here rather than with a
+layout-side strategy list, the way the [predicate
+set](#discriminator-predicates)'s was (#22, #28), because a guard reads a value
+this document's own machinery put in a register: there was no strategy list for
+it to follow and nothing to wait for.
 
 **A register is read only where it has been written.** A register is read in
 three places, and every one of them reads the register file as it stood on entry
@@ -2074,14 +2075,11 @@ constant offset removes both, and costs a discriminator nothing it was using:
 the position of a type code is a property of the record's shape, not of its
 data.
 
-Neither restriction is known to cost the strategies anything. The ones proposed
-for the layout format that name a field name a type code at a fixed offset, or
-one in a header copybook every alternative includes, and neither shape repeats
-or sits behind a variable item. The ones that name no field do not lower into a
-predicate at all, which is [A predicate always names a
-field](#a-predicate-always-names-a-field)'s (#80). That set is #28's to settle
-and is not settled here, so this is a check against the strategies as proposed
-rather than a claim about a closed set (#22, #28).
+Neither restriction costs the strategies anything. The two that name a field
+name a type code at a fixed offset, or one in a header copybook every
+alternative includes, and neither shape repeats or sits behind a variable item.
+The ones that name no field do not lower into a predicate at all, which is [A
+predicate always names a field](#a-predicate-always-names-a-field)'s (#80).
 
 A predicate and a guard divide the two things a transition can be selected on,
 and neither reaches into the other's half. A predicate **MUST NOT** name a
@@ -2108,22 +2106,55 @@ ordinary layout rather than a special case.
 The set is closed for the reason `layout/SPEC.md` gives when it closes the
 strategies that lower into it — a closed set can be checked for overlap and for
 exhaustiveness, and it is what lets the IR stay data instead of carrying source
-that only one language could run. Its membership is settled when those
-strategies are (#22, #28) and lands in this section in that change, the way the
-layout format's grammar joins its governing sources when its syntax is chosen.
-It is settled before the first release rather than grown afterwards, because
-under [Versioning and compatibility](#versioning-and-compatibility) a new member
-is a breaking change. What may land is bounded from two sides while it waits: by
-[A writer evaluates a predicate, it never inverts
-one](#a-writer-evaluates-a-predicate-it-never-inverts-one), which requires a
-member to be decidable by a writer, and by the subsection below, which requires
-one to name a field.
+that only one language could run. Its membership is settled here, with those
+strategies (#22, #28), and it is **two** tests:
+
+| Test | Satisfied when |
+|---|---|
+| **bytes equal** | the target's bytes are the carried literal |
+| **bytes one of** | the target's bytes are one of the carried literals |
+
+Both carry their literals as bytes, already padded by the producer to the
+target's width, so that a consumer compares the whole of the target rather than
+a prefix of it and never applies a COBOL comparison rule of its own. A test
+carrying no literal at all does not exist, and a test carrying the same literal
+twice is a producer emitting one member's work as another's; neither is a member
+here.
+
+**bytes one of** is a member rather than a shorthand a producer expands. A
+transition carries at most one predicate and an arm carries exactly one, so a
+strategy admitting three type codes has nowhere to put three predicates — and
+splitting it into three transitions to the same state would make a set of values
+into a set of edges, which the overlap rule would then have to be taught to
+forgive. One member with a list is decidable by exactly the same test as one
+member with a literal: two of them overlap when their literal sets intersect,
+which is a question about bytes and stays a question about bytes.
+
+Three tests were proposed and refused, and each is refused where its reason is:
+a record's length and where a record sits in the stream by [A predicate always
+names a field](#a-predicate-always-names-a-field), and selecting on nothing at
+all by [A transition may carry no
+predicate](#a-transition-may-carry-no-predicate), which makes it the absence of
+a predicate rather than a member. `layout/SPEC.md`'s `single-record-type` is
+that absence and is not spelled here.
+
+Both members meet the two bounds a member has to meet. Each names a field, which
+the subsection below requires. And each is decidable by a writer against the
+record it is about to emit ([A writer evaluates a predicate, it never inverts
+one](#a-writer-evaluates-a-predicate-it-never-inverts-one), #79): the target is
+a field of the record in the writer's hands, and comparing its bytes to a
+literal — or to a list of them — asks nothing of what the writer will be handed
+next.
+
+A third member is a breaking change under [Versioning and
+compatibility](#versioning-and-compatibility), which is why the set is settled
+before the first release rather than grown afterwards.
 
 ### A predicate always names a field
 
-A predicate names a field node and tests its bytes. Every member of the closed
-set does, whatever the set turns out to contain (#22, #28), and there is no
-other thing about a record a transition can be selected on (#80).
+A predicate names a field node and tests its bytes. Both members of the closed
+set do (#22, #28), and there is no other thing about a record a transition can
+be selected on (#80).
 
 Three of the strategies proposed for the layout format test something else, and
 each is refused on its own terms rather than by an appeal to tidiness.
@@ -2666,9 +2697,10 @@ places: a record no transition matched is a record type the layout is missing,
 while an occurrence no arm matched is a record the layout does describe carrying
 an entry it does not. An adopter sent to the first for the second spends the day
 on a record type they already have. One whose entries carry a code the
-alternatives do not cover writes an arm for the residue, and whether the closed
-set can spell one is that set's membership question rather than this
-subsection's (#22, #28).
+alternatives do not cover writes an arm for the residue, spelled as the test
+over the codes it covers — the set carries no member matching whatever is left,
+and [Discriminator predicates](#discriminator-predicates) is where that is
+settled (#22, #28).
 
 ## Writing a file
 
@@ -2836,12 +2868,14 @@ change, and the bytes emitted are still the ones the caller holds. Ergonomics
 over the contract are the generator's, the way [Names](#names) leaves identifier
 munging to it.
 
-The set's membership lands with the strategies that lower into it (#22, #28),
-and this is the requirement it lands against. Every member **MUST** be decidable
-by a writer against the record it is about to emit, from that record's bytes and
-the writer's own position in the automaton, at the moment it emits it. Weaker
-than invertibility, stricter than nothing, and it is what a writer can actually
-meet.
+The set's membership landed with the strategies that lower into it (#22, #28),
+and this is the requirement it landed against. Every member **MUST** be
+decidable by a writer against the record it is about to emit, from that record's
+bytes and the writer's own position in the automaton, at the moment it emits it.
+Weaker than invertibility, stricter than nothing, and it is what a writer can
+actually meet. Both members meet it by comparing the target's bytes against
+literals the descriptor carries, which asks the writer for nothing it does not
+already hold — and the shape below is the one that would not have.
 
 One shape fails it, and it is worth naming because it is the shape a
 discriminator by position takes: a test for the *last* record in a stream. A

--- a/docs/layout/SPEC.md
+++ b/docs/layout/SPEC.md
@@ -298,6 +298,7 @@ diagnostic naming the tag and its position.
 | `copybook-reading` | 0..1 | record definitions |
 | `rename` | 0..n | record definitions |
 | `discriminate` | one per `record` | discrimination |
+| `discriminate-variant` | one per variant | discrimination |
 | `sequence` | 1 | sequencing |
 
 ### An item reference
@@ -842,6 +843,15 @@ record with none is a diagnostic, and so is a second one naming the same record.
 Requiring it of every record is what makes "this record carries nothing to test"
 a statement an adopter made rather than a gap in the file.
 
+Discrimination is stated in **two** scopes and the strategies are one closed set
+lowering into both. A `discriminate` chooses a record; a
+[`discriminate-variant`](#a-discriminator-for-a-redefine-inside-a-table) chooses
+an alternative inside one occurrence of a table, where a copybook redefines an
+item inside a repeating group (#90). The strategies below are the set for both,
+minus the one member the second scope has no use for; what differs between the
+scopes is what the item reference **MUST** satisfy, and that difference is
+stated where each scope is.
+
 ### Three strategies, and the set is closed for v1
 
 | Strategy | Written | What it says |
@@ -850,11 +860,29 @@ a statement an adopter made rather than a gap in the file.
 | `one-of` | `(one-of <item-ref> <literal> …)` | the item's value is one of the literals |
 | `single-record-type` | `single-record-type` | the record carries nothing a predicate may test |
 
-The set is closed. A fourth strategy is a fourth member of the IR's predicate
-set, which is a breaking change under
-[`ir/SPEC.md`](../ir/SPEC.md#versioning-and-compatibility), so the set is
-settled before the first release rather than grown afterwards; the corresponding
-IR membership lands with the implementation (#28).
+The set is closed. `equals` and `one-of` lower into the two members of the IR's
+predicate set — `bytes-equal` and `bytes-one-of`, settled in
+[`ir/SPEC.md`](../ir/SPEC.md#discriminator-predicates) with these strategies
+(#28) — and `single-record-type` lowers into the absence of a predicate. A
+fourth strategy is therefore a fourth member of a closed set in the IR, which is
+a breaking change under
+[`ir/SPEC.md`](../ir/SPEC.md#versioning-and-compatibility), *and* a change to
+what a layout may say, which advances [the schema
+version](#the-version-is-in-the-file-and-it-moves-with-the-format). Both prices
+are paid at once, by everything that reads either interface, which is why the
+set is settled before the first release rather than grown afterwards.
+
+Both members are decidable by a writer, which is the other bound on what may
+join them. A generator emitting records walks the same automaton a reader does
+and evaluates a predicate against the record it is about to emit, from that
+record's bytes and its own position in the automaton, rather than inverting one
+into a value to fill in
+([`ir/SPEC.md`](../ir/SPEC.md#a-writer-evaluates-a-predicate-it-never-inverts-one),
+#79). Testing a field's bytes against one literal, or against a set of them, is
+answerable from bytes the writer already holds. A strategy testing anything the
+writer learns *after* the record is written is not, and [the strategies that are
+not in the set](#the-strategies-that-are-not-in-the-set-and-where-each-one-went)
+is where the one that fails on exactly that is refused.
 
 Closed because a closed set can be *checked*. Overlap between two records that
 may appear at the same point, exhaustiveness, and whether the item named exists
@@ -889,14 +917,77 @@ miss, and the IR refuses the reading in as many words, because a state offering
 two transitions that can both apply is a layout that was rejected before a
 consumer saw it.
 
+### The strategies that are not in the set, and where each one went
+
+Five ways of telling record types apart were proposed for this format (#28).
+Three of them are above, and the two shapes that name a field — a type code at a
+fixed offset, and a type code in a header copybook every alternative includes —
+are one strategy for the reason the paragraph above gives. The other two are not
+in the set, and neither is an omission to be closed later.
+
+**A record's length is not something a strategy may test**, and there is nowhere
+in this format to write one. It is refused in the IR rather than here
+([`ir/SPEC.md`](../ir/SPEC.md#a-predicate-always-names-a-field), #80): under
+**descriptor-word** and **segmented** a length is in hand when discrimination
+runs and it is a framing byte's value, which no predicate ever sees, and under
+**unframed** and **delimited** there is no length to see at all, because a
+record's end is its extent and the extent follows from the record type a
+discriminator has not chosen yet. What refusing costs an adopter is a file whose
+record types agree on every byte and differ only in how long they are, and
+[`ir/SPEC.md`](../ir/SPEC.md#a-record-told-apart-only-by-its-length) states that
+as an exclusion rather than leaving it to be found.
+
+**Position is the sequencing expression's, not a strategy's.** A record type
+that is a file's first is written as the first thing
+[`sequence`](#sequencing)'s expression admits, and `resolve` compiles a start
+state no transition re-enters
+([`ir/SPEC.md`](../ir/SPEC.md#a-predicate-always-names-a-field), #36). Nothing
+is written to say so and nothing needs to be: a record's position is which state
+the automaton is in, which is what an automaton is for, and a strategy spelling
+it would be a second statement of what the expression already said.
+
+**Positional *last* is refused outright**, and the reason is the writer's rather
+than the reader's. A writer walks the same automaton and evaluates a predicate
+against the record it is about to emit
+([`ir/SPEC.md`](../ir/SPEC.md#a-writer-evaluates-a-predicate-it-never-inverts-one),
+#79) — and *last* is not a property of that record's bytes or of the writer's
+position in the automaton. It becomes true only when the caller says there are
+no more records, which is after the record has been written; the only way to
+decide it at the moment of writing is to hold the record back until the next
+call arrives, and buffering a record is exactly the streaming property a
+file-level writer is required to keep (#52). A reader could decide it and a
+writer could not, so the two would disagree about a file neither of them is
+wrong about, and
+[`ir/SPEC.md`](../ir/SPEC.md#the-last-record-of-a-stream) refuses the whole
+notion at the layer where both are specified. An adopter whose trailer is
+distinguishable by content writes `equals` on it; one whose trailer is not is
+describing a file whose last record is knowable only by running out of input.
+
 ### What the item reference must satisfy
 
 The item **MUST** be contained in the record the strategy is written on, at any
-depth. It **MUST NOT** repeat and **MUST NOT** sit inside a group that repeats
-(#84). And no item ahead of it in the record **MAY** carry a repetition whose
-count is a reference: its position **MUST** be constant within the record, and
-`resolve` rejects a layout whose discriminator sits behind a variable item,
-naming the record, the item and the variable item in front of it (#37, #84).
+depth. Its reference is therefore rooted at that record's own name, which is the
+half of the rule the layout reader checks: a `discriminate` on `ORDER-DETAIL`
+whose item reference opens with `ORDER-HEADER` is a diagnostic naming both,
+reported without a copybook because nothing in a copybook could make it true.
+The other half — that the path names an item of that record at all — needs one
+and is `resolve`'s (#31).
+
+It **MUST NOT** repeat and **MUST NOT** sit inside a group that repeats (#84).
+And no item ahead of it in the record **MAY** carry a repetition whose count is
+a reference: its position **MUST** be constant within the record, and `resolve`
+rejects a layout whose discriminator sits behind a variable item, naming the
+record, the item and the variable item in front of it (#37, #84). A target must
+also lie inside the shortest record its point in the sequence can put in front
+of a consumer, which is `resolve`'s too and is
+[`ir/SPEC.md`](../ir/SPEC.md#a-predicate-never-reads-past-the-record-in-front-of-it)'s
+(#94).
+
+Every rule in this subsection binds a strategy chosen for a *record*, which is
+what lowers into a transition's predicate. A strategy chosen for an arm is
+bounded differently and in one case oppositely, and [A discriminator for a
+redefine inside a table](#a-discriminator-for-a-redefine-inside-a-table) states
+which rules it keeps.
 
 The reason is the read loop's order and it is
 [`ir/SPEC.md`](../ir/SPEC.md#discriminator-predicates)'s: a discriminator is
@@ -904,6 +995,111 @@ evaluated *before* its record has been admitted, so a target whose position
 depends on a count obliges a consumer to decode that count out of bytes it has
 not identified. It costs a discriminator nothing it was using — the position of
 a type code is a property of a record's shape rather than of its data.
+
+### A discriminator for a redefine inside a table
+
+```
+(discriminate-variant <item-ref>
+  (arm <name> <predicate>)
+  (arm <name> <predicate>)
+  …)
+```
+
+A `REDEFINES` is ordinarily resolved away: each alternative a discriminator can
+select becomes its own record type, chosen by its own `discriminate`
+([`ir/SPEC.md`](../ir/SPEC.md#members-never-overlap-and-redefines-is-resolved-away)).
+That resolution cannot reach a redefine **inside a repeating group**, because
+the alternative is chosen once per occurrence rather than once per record, and
+ten entries choosing between two alternatives are not two record types
+([`ir/SPEC.md`](../ir/SPEC.md#a-variant-is-chosen-once-per-occurrence), #90).
+This form is where that choice is stated, and it is the only place a layout says
+anything about a redefine at all.
+
+The argument names the **variant**: an item reference to the item the copybook
+redefines — the first alternative, the one every `REDEFINES` of it names. Each
+`arm` names one alternative, by the name the copybook gives it, and the strategy
+that selects it. Which names are alternatives at that position, and that the
+group containing them repeats, are the copybook's and are `resolve`'s (#31,
+#35); what is written here is the choice.
+
+| Position | Sort | Arity | What it says |
+|---|---|---|---|
+| variant | item reference | 1 | the redefined item, inside a repeating group |
+| `arm` | `(arm <name> <predicate>)` | 2..n | an alternative, and what selects it |
+
+A `<predicate>` is `equals` or `one-of` — the same two strategies, testing the
+same [literals](#literals), and no third. `single-record-type` is not among
+them and there is no arm carrying nothing: an arm selected by nothing at all is
+a default arm, and
+[`ir/SPEC.md`](../ir/SPEC.md#a-predicate-on-an-arm-reads-one-occurrence) refuses
+one in as many words. An occurrence matching no arm is reported by the
+consumer, with a diagnostic distinguishable from a record no transition matched,
+and an adopter whose entries carry a code the alternatives do not cover writes
+an arm for it.
+
+**An arm's target sits inside the occurrence, which is the mirror of the rule
+above and not an exception to it.** The target **MUST** be contained, at any
+depth, in the innermost repeating group containing the variant — the entry the
+arm is being chosen for — and **MUST NOT** sit inside an arm that does not also
+contain the variant, which rules out the variant's own alternatives and a
+sibling variant's while admitting an enclosing one, where a copybook redefines a
+redefinition. `resolve` rejects either, naming the record, the repeating group,
+the variant and the target (#37, #90).
+
+Two of the record-scope restrictions do **not** bind it, and both for their own
+reasons. The target **MAY** repeat and **MAY** sit inside a group that repeats:
+[`ir/SPEC.md`](../ir/SPEC.md#a-reference-names-a-field-not-an-occurrence-of-one)
+refuses a reference carrying no occurrence to be read in, and an arm's predicate
+is evaluated in the occurrence being walked, so it carries one (#84, #90). And
+its position need not be constant: an arm runs against a record already
+admitted, so a target behind an item whose extent moves with a count the record
+carries is a target a consumer can already locate.
+
+The layout reader checks the halves that need no copybook, and they are the ones
+an adopter gets wrong while holding the copybook open. The variant reference and
+every arm's target **MUST** be rooted at the same `record`. Every target
+**MUST** stand under the same outermost group as the variant, which is what
+"outside the occurrence" looks like from here — a target reaching into a header
+elsewhere in the record shares no group with the variant and would select the
+same arm in every occurrence, a choice made once per record and so a record's to
+make. No target **MAY** descend through the variant or through any of its arms.
+No two arms **MAY** name one alternative. And no two arms of one variant **MAY**
+name one target and one literal, which is the smallest overlap and the one
+decidable from the layout alone. Everything else about overlap is `resolve`'s,
+because `"01"` and `(bytes "F0F1")` are the same bytes only once a charset and a
+width have been applied.
+
+**Two arms that can both match are refused, and nothing exempts a pair.** Arms
+are checked against each other, over the alternatives of one variant, rather
+than against the transitions of a state
+([`ir/SPEC.md`](../ir/SPEC.md#a-predicate-on-an-arm-reads-one-occurrence)): they
+are the choices at one position inside one occurrence, and no record type is
+involved. There is no guard on an arm and no way to write one — a guard reads a
+register, a register holds one value for the whole of a record's read, and a
+value that is the same in every occurrence selects a record rather than an arm —
+so the exemption a counted run of records relies on has no counterpart here, and
+two overlapping arms are always a diagnostic.
+
+One `discriminate-variant` **MUST** name each variant, and two naming one item
+is a diagnostic like a second `discriminate` on one record. A variant that
+nothing names is a diagnostic too, and it is `resolve`'s: a redefine inside a
+repeating group is a fact about a copybook, and nothing in the layout says one
+is there.
+
+```
+;; Each entry of a policy carries its own kind and a body redefined two ways.
+;; The alternative is chosen once per occurrence, so it is not two record types.
+(discriminate-variant (item POLICY PL-ENTRIES PL-BODY-MOTOR)
+  (arm PL-BODY-MOTOR    (equals (item POLICY PL-ENTRIES PL-KIND) "M"))
+  (arm PL-BODY-PROPERTY (one-of (item POLICY PL-ENTRIES PL-KIND) "P" "H")))
+```
+
+It is a form of its own rather than a second spelling of `discriminate` because
+the two say different things about different subjects: one names a record and
+carries one strategy, this names an item and carries an ordered list of them. A
+single form taking either would make the arity rule — one per `record` — a rule
+about which of two shapes was written, and the schema could not state even the
+half of it that it states today.
 
 ### Literals
 
@@ -1104,6 +1300,15 @@ first release rather than grown afterwards. An edit changing no declaration — 
 comment, a reordering — leaves the version alone, because nothing a generator or
 a reader can observe has changed.
 
+Version 1 is the format as it first ships, and it stands at 1 while that version
+is being assembled. There is nothing to advance *from*: the number exists so
+that a consumer holding a schema can refuse one it does not understand, and no
+consumer holds a schema that was never released. A change to what a layout may
+say, made before the first release, is the settling this section asks for rather
+than an exception to it, and it is the standing
+[`ir/SPEC.md`](../ir/SPEC.md#the-version-field) gives its own closed sets under
+`IR_VERSION_1` (#28).
+
 The version is not this document's. A spec carries no version number
 ([CONVENTIONS.md](../CONVENTIONS.md)); what is versioned is the interface, and
 the schema is where that number lives for this one.
@@ -1125,8 +1330,10 @@ describing their file as something else. What rejects them, with the diagnostic
 each is owed, is the reader.
 
 **Rules counting one form against another.** Exactly one `discriminate` per
-`record`, every `record` appearing somewhere in the sequencing expression, an
-`encoding-override` naming at least one axis. A declaration is about one form
+`record`, one `discriminate-variant` per variant, two arms of one variant that
+do not name one alternative, every `record` appearing somewhere in the
+sequencing expression, an `encoding-override` naming at least one axis. A
+declaration is about one form
 and its positions, so a rule relating two of them is the reader's. The one
 cross-form statement the schema does make is the reference, and it is the
 important one: a position declared to name a `record` **MUST** name one the
@@ -1153,7 +1360,12 @@ lexical or grammatical error, from `sexpr-go`; an unknown top-level tag, an
 unknown child, a repeated child whose arity forbids it, a missing required child
 or form; a value outside a closed set — a `recfm`, a `placement`, a strategy,
 an axis value; a duplicate record name; a record with no `discriminate` form or
-two; a record name in the sequencing expression that no `record` form defines,
+two; a discriminator whose item reference is rooted at a record other than the
+one it discriminates; a second `discriminate-variant` naming one variant; two
+arms of one variant naming one alternative, or naming one target and one
+literal; an arm whose target is rooted at another record, stands under another
+outermost group than the variant, or descends through the variant or one of its
+arms; a record name in the sequencing expression that no `record` form defines,
 and a `record` the expression never names; a `blksize`, `lrecl`, `max-segment`
 or `delimiter` under a spelling that does not admit it; and the framing
 spellings rejected by name — `U`, a carriage-control suffix,
@@ -1169,8 +1381,12 @@ compared against; a `times` or `when` whose item is not admitted strictly
 earlier on every path; a record type whose extent does not account for `lrecl`
 under `F` or `FB`, or exceeds it under the others; a variable-extent record type
 on a fixed-length dataset; a copybook carrying an `OCCURS DEPENDING ON` with no
-`copybook-reading` form to read it under; and two records at one point in the
-sequence whose discriminators can both match.
+`copybook-reading` form to read it under; two records at one point in the
+sequence whose discriminators can both match; an arm's target outside the
+innermost repeating group containing the variant, or inside an arm that does not
+also contain it; two arms of one variant whose predicates can both match one
+occurrence; and a redefine inside a repeating group that no
+`discriminate-variant` names.
 
 The split is not a policy. A check that needs a copybook cannot run before one
 has been read, and a check that does not **SHOULD** run in the reader, so that a
@@ -1239,6 +1455,14 @@ disagree about, which is the outcome depending on `cobol-go` exists to prevent.
 per-type body; [Composition is the
 copybook's](#composition-is-the-copybooks-and-copy-is-where-it-is-written) is
 why the joining is not a layout form.
+
+`REDEFINES` is part of it too, and the one thing a layout says about a redefine
+is which alternative to read — never what a redefine is, where its bytes are, or
+which items overlay which. A redefine whose alternatives are whole record types
+is told apart by an ordinary `discriminate`; one inside a repeating group is
+told apart by
+[`discriminate-variant`](#a-discriminator-for-a-redefine-inside-a-table), and
+both name items the copybook declared and nothing the copybook did not.
 
 ### The S-expression grammar
 

--- a/internal/layoutmodel/discriminate.go
+++ b/internal/layoutmodel/discriminate.go
@@ -360,6 +360,13 @@ func (r *discriminationReader) discriminate(into *Discrimination, form layout.Fo
 	if !ok {
 		r.fail(&DiscriminateFormError{Pos: form.Elements[0].Position(), Found: describe(form.Elements[0])})
 
+		// The strategy is read anyway, for the reason an override's axes are
+		// read after a misspelled item reference: a discriminator whose record
+		// is written as text is still a discriminator, and a literal misspelled
+		// underneath it is a second thing to fix rather than something to
+		// discover on the next run.
+		_, _ = r.strategy(form.Elements[1], subjectRecord)
+
 		return
 	}
 

--- a/internal/layoutmodel/discriminate.go
+++ b/internal/layoutmodel/discriminate.go
@@ -1,0 +1,752 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layoutmodel
+
+import (
+	"errors"
+	"slices"
+	"strconv"
+
+	"github.com/Zaba505/cpybkc/internal/layout"
+)
+
+// The tags this layer reads. `discriminate` and `discriminate-variant` are the
+// top-level forms; the rest stand inside them. `record` is read for its name
+// alone, because a rule counting one form against another needs both.
+const (
+	tagDiscriminate        = "discriminate"
+	tagDiscriminateVariant = "discriminate-variant"
+	tagArm                 = "arm"
+	tagEquals              = "equals"
+	tagOneOf               = "one-of"
+	tagRecord              = "record"
+)
+
+// StrategyKind is one member of the closed set of discrimination strategies.
+//
+// The set is docs/layout/SPEC.md's "Three strategies, and the set is closed for
+// v1" and this type is that set as data. Nothing here adds a member: a fourth
+// strategy is a fourth member of the IR's predicate set, which is breaking under
+// docs/ir/SPEC.md's "Versioning and compatibility", and a change to what a
+// layout may say besides.
+//
+// The zero value is not a strategy. A [Strategy] handed back by
+// [ReadDiscrimination] always names one.
+type StrategyKind string
+
+// The three strategies, in docs/layout/SPEC.md's order.
+const (
+	// Equals is `(equals <item-ref> <literal>)`: the item's value is the
+	// literal. It lowers into the IR's **bytes equal** predicate.
+	Equals StrategyKind = "equals"
+
+	// OneOf is `(one-of <item-ref> <literal> …)`: the item's value is one of
+	// the literals. It lowers into the IR's **bytes one of** predicate, which is
+	// a member of that set rather than a shorthand for several **bytes equal**
+	// ones — a transition carries at most one predicate and an arm exactly one,
+	// so there is nowhere to put the others.
+	OneOf StrategyKind = "one-of"
+
+	// SingleRecordType is the record that carries nothing a predicate may test.
+	// It lowers into the *absence* of a predicate
+	// (docs/ir/SPEC.md's "A transition may carry no predicate") and not into a
+	// member of the set testing nothing, which is why [Strategy.Predicate]
+	// reports whether a strategy lowers into one at all.
+	//
+	// It is not a default arm: it is not tried last and it does not catch what
+	// the others miss. Where two records carrying it may appear at the same
+	// point and nothing separates them, `resolve` rejects the layout.
+	SingleRecordType StrategyKind = "single-record-type"
+)
+
+// strategies is the set a record's discriminator admits, in the order every
+// message listing them renders them.
+var strategies = []StrategyKind{Equals, OneOf, SingleRecordType}
+
+// predicates is the set an arm admits: the strategies that lower into a
+// predicate, and no third.
+//
+// An arm carries exactly one predicate. An arm selected by nothing at all would
+// be the default arm docs/ir/SPEC.md's "A predicate on an arm reads one
+// occurrence" refuses in as many words, so [SingleRecordType] is not among them.
+var predicates = []StrategyKind{Equals, OneOf}
+
+// LiteralKind is which of the three spellings a literal was written in.
+//
+// Which one it is decides what the literal is compared against, and all three
+// resolutions are `resolve`'s: a layout says which *value* tells a record apart
+// and the IR carries the *bytes* a consumer compares
+// (docs/layout/SPEC.md's "Literals").
+type LiteralKind string
+
+// The three spellings, in docs/layout/SPEC.md's order.
+const (
+	// TextLiteral is `"01"`: resolved to bytes through the item's own charset
+	// and padded to the item's width.
+	TextLiteral LiteralKind = "text"
+
+	// NumberLiteral is `12`: resolved to bytes through the item's `PICTURE`,
+	// `USAGE` and axes.
+	NumberLiteral LiteralKind = "number"
+
+	// BytesLiteral is `(bytes "F0F1")`: taken literally, with no charset and no
+	// padding. It is the one spelling that says exactly what is in the file, and
+	// the one that is wrong if the file is converted.
+	BytesLiteral LiteralKind = "bytes"
+)
+
+// Literal is one value a strategy compares an item against.
+//
+// Exactly one of the three fields below carries the value, and [Literal.Kind]
+// says which. What the bytes are is `resolve`'s under every spelling.
+type Literal struct {
+	// Pos is the literal itself, which is what a diagnostic about its value
+	// points at.
+	Pos layout.Pos
+
+	// Kind is the spelling it was written in.
+	Kind LiteralKind
+
+	// Text is what a [TextLiteral] said, with the grammar's escapes already
+	// applied.
+	Text string
+
+	// Number is what a [NumberLiteral] said, rendered back from the value the
+	// grammar read. Two spellings of one number — `12` and `12.0` — render the
+	// same, which is what makes two of them one literal for [Literal.identity].
+	Number string
+
+	// Bytes is what a [BytesLiteral] said.
+	Bytes ByteString
+}
+
+// String renders a literal the way a layout writes it, which is what a
+// diagnostic naming one quotes.
+func (l Literal) String() string {
+	switch l.Kind {
+	case TextLiteral:
+		return strconv.Quote(l.Text)
+	case NumberLiteral:
+		return l.Number
+	case BytesLiteral:
+		return l.Bytes.String()
+	default:
+		return "nothing"
+	}
+}
+
+// identity is what makes two literals the same one.
+//
+// The spelling *and* the sort, because the sort decides the resolution: `"01"`
+// is text through the item's charset and `01` is a number through its `PICTURE`,
+// and whether the two end up as the same bytes is a question only `resolve` can
+// answer. Two literals that are the same here are the same under every charset,
+// which is what makes an overlap decided on this identity one decidable from the
+// layout alone.
+func (l Literal) identity() string { return string(l.Kind) + " " + l.String() }
+
+// Strategy is one discrimination strategy, read.
+//
+// A value handed back by [ReadDiscrimination] names a member of the closed set,
+// and carries what that member needs: [SingleRecordType] carries neither an item
+// nor a literal, [Equals] carries an item and one literal, and [OneOf] carries
+// an item and at least one.
+type Strategy struct {
+	// Pos is the strategy — the `(equals …)` or `(one-of …)` form, or the
+	// `single-record-type` symbol.
+	Pos layout.Pos
+
+	// Kind is which strategy it is.
+	Kind StrategyKind
+
+	// Item is what it tests, and is the zero [ItemRef] under
+	// [SingleRecordType].
+	Item ItemRef
+
+	// Literals are what the item's value is compared against, in the order the
+	// layout writes them. It is empty under [SingleRecordType] and holds exactly
+	// one literal under [Equals].
+	Literals []Literal
+}
+
+// Predicate reports whether this strategy lowers into an IR predicate, which
+// every one but [SingleRecordType] does.
+//
+// It is a question about the value rather than a switch a caller writes for
+// itself, because the answer is the whole of the difference between the two
+// halves of the set: docs/ir/SPEC.md's "A transition may carry no predicate"
+// makes selecting on nothing the *absence* of a predicate rather than a member
+// testing nothing, so a caller compiling one has to ask before it reaches for
+// [Strategy.Item].
+func (s Strategy) Predicate() bool { return slices.Contains(predicates, s.Kind) }
+
+// RecordDiscriminator is one `discriminate` form: a record, and what tells it
+// apart.
+type RecordDiscriminator struct {
+	// Pos is the `discriminate` form.
+	Pos layout.Pos
+
+	// Record is the name of the `record` form it discriminates.
+	Record string
+
+	// RecordPos is the record name inside the form, which is what a diagnostic
+	// about the name rather than about the strategy points at.
+	RecordPos layout.Pos
+
+	// Strategy is what tells the record apart.
+	Strategy Strategy
+}
+
+// VariantDiscriminator is one `discriminate-variant` form: a redefine inside a
+// repeating group, and the arms it may take.
+//
+// docs/layout/SPEC.md's "A discriminator for a redefine inside a table" is the
+// whole of it. The alternative is chosen once per occurrence rather than once
+// per record, which is why it is not a set of record types
+// (docs/ir/SPEC.md's "A variant is chosen once per occurrence").
+type VariantDiscriminator struct {
+	// Pos is the `discriminate-variant` form.
+	Pos layout.Pos
+
+	// Variant is the item the copybook redefines — the first alternative, the
+	// one every `REDEFINES` of it names.
+	Variant ItemRef
+
+	// Arms are the alternatives, in the order the layout writes them. There are
+	// always at least two on a value handed back, and no two name one
+	// alternative.
+	Arms []Arm
+}
+
+// Arm is one alternative of a variant, and the predicate selecting it.
+type Arm struct {
+	// Pos is the `arm` form.
+	Pos layout.Pos
+
+	// Alternative is the name the copybook gives this alternative. That the
+	// name is one the copybook declares at the variant's position is `resolve`'s
+	// (#31, #35).
+	Alternative string
+
+	// Predicate is what selects it. Its [Strategy.Predicate] is always true: an
+	// arm selected by nothing at all is a default arm, and there is none.
+	Predicate Strategy
+}
+
+// Discrimination is a layout's discrimination layer: every `discriminate` form,
+// and every `discriminate-variant` beside them.
+//
+// The two are the two scopes a discriminator is written in — a record, and an
+// alternative inside one occurrence of a table — and the strategies are one
+// closed set lowering into both.
+type Discrimination struct {
+	// Records are the record discriminators, in the order the layout writes
+	// them. On a value handed back there is exactly one per `record` form the
+	// layout defines.
+	Records []RecordDiscriminator
+
+	// Variants are the variant discriminators, in the order the layout writes
+	// them, and no two of them name one item.
+	Variants []VariantDiscriminator
+}
+
+// ReadDiscrimination reads the discrimination layer out of a parsed layout.
+//
+// It reports every fault it finds, joined, and returns nothing when it found
+// one, for [ReadProfile]'s reason: a discriminator an adopter cannot act on is
+// worse than none.
+//
+// What it enforces is what a declaration cannot state and a copybook is not
+// needed for: that every `record` is named by exactly one `discriminate`, that a
+// discriminator tests an item of the record it discriminates, that an arm's
+// target stands where an arm's target may stand, and that two arms of one
+// variant do not name one alternative or one literal. Everything else about
+// containment and overlap needs a copybook and is `resolve`'s
+// (docs/layout/SPEC.md's "Validation and diagnostics").
+//
+// Top-level forms belonging to other layers are not read here and are not
+// faults. `record` forms are read for their names alone, because "exactly one
+// per record" counts one form against another and there is nowhere else to count
+// it.
+func ReadDiscrimination(file *layout.File) (*Discrimination, error) {
+	read := &discriminationReader{records: recordNames(file)}
+	discrimination := &Discrimination{}
+
+	for _, form := range file.Forms {
+		switch form.Tag {
+		case tagDiscriminate:
+			read.discriminate(discrimination, form)
+		case tagDiscriminateVariant:
+			read.variant(discrimination, form)
+		}
+	}
+
+	// A record nobody discriminated is a fact about the layout rather than about
+	// any one form, so it is reported after everything the forms themselves were
+	// wrong about. The records are walked in source order for the same reason
+	// the forms are.
+	for _, record := range read.records {
+		if _, discriminated := read.discriminated[record.name]; !discriminated {
+			read.fail(&MissingDiscriminatorError{Pos: record.pos, Record: record.name})
+		}
+	}
+
+	if len(read.errs) > 0 {
+		return nil, errors.Join(read.errs...)
+	}
+
+	return discrimination, nil
+}
+
+// recordDefinition is a `record` form as this layer sees one: the name it
+// defines, and where.
+type recordDefinition struct {
+	name string
+	pos  layout.Pos
+}
+
+// recordNames gathers the records a layout defines, in source order.
+//
+// Only the name is read. What a record is bound to is the record-definitions
+// layer's (#27, #30), and a `record` form this cannot read a name out of is that
+// layer's fault to report: a second message about it here would name the same
+// line twice.
+func recordNames(file *layout.File) []recordDefinition {
+	var records []recordDefinition
+
+	for _, form := range file.Forms {
+		if form.Tag != tagRecord || len(form.Elements) == 0 {
+			continue
+		}
+
+		if symbol, ok := form.Elements[0].(layout.Symbol); ok {
+			records = append(records, recordDefinition{name: symbol.Value, pos: form.Pos})
+		}
+	}
+
+	return records
+}
+
+// discriminationReader holds the state one [ReadDiscrimination] accumulates.
+type discriminationReader struct {
+	faults
+
+	// records are the records the layout defines, which is what makes "one
+	// discriminator per record" and "a discriminator on a record nobody defined"
+	// answerable.
+	records []recordDefinition
+
+	// discriminated is where each record was first discriminated, which makes a
+	// second `discriminate` on one record reportable against the first.
+	discriminated map[string]layout.Pos
+
+	// variants is the same for `discriminate-variant`, keyed by the variant
+	// reference's identity.
+	variants map[string]layout.Pos
+}
+
+// discriminate reads one `discriminate` form.
+func (r *discriminationReader) discriminate(into *Discrimination, form layout.Form) {
+	if len(form.Elements) != 2 {
+		r.fail(&DiscriminateFormError{Pos: form.Pos, Found: count(len(form.Elements))})
+
+		return
+	}
+
+	name, ok := form.Elements[0].(layout.Symbol)
+	if !ok {
+		r.fail(&DiscriminateFormError{Pos: form.Elements[0].Position(), Found: describe(form.Elements[0])})
+
+		return
+	}
+
+	if !slices.ContainsFunc(r.records, func(record recordDefinition) bool { return record.name == name.Value }) {
+		r.fail(&UnknownRecordError{Pos: name.Pos, Record: name.Value, Form: form.Tag})
+	} else if first, already := r.discriminated[name.Value]; already {
+		r.fail(&DuplicateDiscriminatorError{Pos: form.Pos, First: first, Record: name.Value})
+	} else {
+		if r.discriminated == nil {
+			r.discriminated = make(map[string]layout.Pos)
+		}
+
+		r.discriminated[name.Value] = form.Pos
+	}
+
+	// The strategy is read whatever was wrong with the name: a misspelled record
+	// with a misspelled charset in its literal is two things to fix rather than
+	// one to discover on the next run.
+	strategy, ok := r.strategy(form.Elements[1], subjectRecord)
+	if !ok {
+		return
+	}
+
+	// A discriminator tests an item of the record it discriminates. The half of
+	// that rule needing a copybook — that the path names an item of it at all —
+	// is `resolve`'s; this half is the reference's own spelling and is checkable
+	// here (#84).
+	if strategy.Predicate() && strategy.Item.Record != name.Value {
+		r.fail(&ForeignTargetError{Pos: strategy.Item.Pos, Item: strategy.Item, Record: name.Value})
+
+		return
+	}
+
+	into.Records = append(into.Records, RecordDiscriminator{
+		Pos:       form.Pos,
+		Record:    name.Value,
+		RecordPos: name.Pos,
+		Strategy:  strategy,
+	})
+}
+
+// variant reads one `discriminate-variant` form.
+func (r *discriminationReader) variant(into *Discrimination, form layout.Form) {
+	if len(form.Elements) == 0 {
+		r.fail(&VariantFormError{Pos: form.Pos, Found: "a variant discriminator naming no item at all"})
+
+		return
+	}
+
+	item, err := readItemRef(form.Elements[0])
+	if err != nil {
+		r.fail(err)
+
+		return
+	}
+
+	discriminator := VariantDiscriminator{Pos: form.Pos, Variant: item}
+
+	r.variantItem(form, item)
+
+	for _, element := range form.Elements[1:] {
+		arm, ok := r.arm(element, item)
+		if !ok {
+			continue
+		}
+
+		if first, already := armNamed(discriminator.Arms, arm.Alternative); already {
+			r.fail(&DuplicateArmError{Pos: arm.Pos, First: first, Variant: item, Alternative: arm.Alternative})
+
+			continue
+		}
+
+		r.overlap(discriminator.Arms, arm, item)
+
+		discriminator.Arms = append(discriminator.Arms, arm)
+	}
+
+	// The count is checked against the arms that were read rather than against
+	// the elements written, so a variant carrying two arms one of which is
+	// malformed is not also reported as a variant carrying one.
+	if len(discriminator.Arms) < 2 {
+		r.fail(&VariantArmCountError{Pos: form.Pos, Variant: item, Count: len(discriminator.Arms)})
+
+		return
+	}
+
+	into.Variants = append(into.Variants, discriminator)
+}
+
+// variantItem holds the item a `discriminate-variant` names to what a variant
+// reference can be checked against without a copybook.
+func (r *discriminationReader) variantItem(form layout.Form, item ItemRef) {
+	if !slices.ContainsFunc(r.records, func(record recordDefinition) bool { return record.name == item.Record }) {
+		r.fail(&UnknownRecordError{Pos: item.Pos, Record: item.Record, Form: form.Tag})
+	}
+
+	if first, already := r.variants[item.identity()]; already {
+		r.fail(&DuplicateVariantError{Pos: form.Pos, First: first, Variant: item})
+	} else {
+		if r.variants == nil {
+			r.variants = make(map[string]layout.Pos)
+		}
+
+		r.variants[item.identity()] = form.Pos
+	}
+
+	// A variant sits inside a group that repeats. A reference carrying one name
+	// names an item directly under the record's top-level item, whose only
+	// ancestor is that item — and a record does not repeat, so no copybook can
+	// make such a reference name a variant.
+	if len(item.Path) < 2 {
+		r.fail(&VariantDepthError{Pos: item.Pos, Variant: item})
+	}
+}
+
+// arm reads one `(arm <name> <predicate>)`.
+func (r *discriminationReader) arm(node layout.Node, variant ItemRef) (Arm, bool) {
+	form, ok := node.(layout.Form)
+	if !ok {
+		r.fail(&ArmFormError{Pos: node.Position(), Found: describe(node)})
+
+		return Arm{}, false
+	}
+
+	if form.Tag != tagArm {
+		r.fail(&ArmFormError{Pos: form.TagPos, Found: "form " + quote(form.Tag)})
+
+		return Arm{}, false
+	}
+
+	if len(form.Elements) != 2 {
+		r.fail(&ArmFormError{Pos: form.Pos, Found: count(len(form.Elements))})
+
+		return Arm{}, false
+	}
+
+	name, ok := form.Elements[0].(layout.Symbol)
+	if !ok {
+		r.fail(&ArmFormError{Pos: form.Elements[0].Position(), Found: describe(form.Elements[0])})
+
+		return Arm{}, false
+	}
+
+	predicate, ok := r.strategy(form.Elements[1], subjectArm)
+	if !ok {
+		return Arm{}, false
+	}
+
+	if !predicate.Predicate() {
+		r.fail(&StrategyError{
+			Pos:     predicate.Pos,
+			Subject: subjectArm,
+			Found:   "the symbol " + quote(string(predicate.Kind)),
+			Admits:  predicateNames(),
+		})
+
+		return Arm{}, false
+	}
+
+	if found, ok := armTargetFault(predicate.Item, variant, name.Value); ok {
+		r.fail(&ArmTargetError{
+			Pos:         predicate.Item.Pos,
+			Alternative: name.Value,
+			Item:        predicate.Item,
+			Variant:     variant,
+			Found:       found,
+		})
+
+		return Arm{}, false
+	}
+
+	return Arm{Pos: form.Pos, Alternative: name.Value, Predicate: predicate}, true
+}
+
+// overlap reports two arms of one variant that name one target and one literal.
+//
+// It is the smallest overlap and the only one decidable from the layout alone:
+// two arms testing one item for one value both match every occurrence the other
+// does, whatever the copybook says the item is. Everything else — one literal
+// written as text and another as bytes, two literals that resolve to the same
+// bytes under the item's charset and width — needs the copybook and is
+// `resolve`'s.
+func (r *discriminationReader) overlap(read []Arm, arm Arm, variant ItemRef) {
+	for _, earlier := range read {
+		if earlier.Predicate.Item.identity() != arm.Predicate.Item.identity() {
+			continue
+		}
+
+		for _, literal := range arm.Predicate.Literals {
+			index := slices.IndexFunc(earlier.Predicate.Literals, func(other Literal) bool {
+				return other.identity() == literal.identity()
+			})
+			if index < 0 {
+				continue
+			}
+
+			r.fail(&ArmOverlapError{
+				Pos:     literal.Pos,
+				First:   earlier.Predicate.Literals[index].Pos,
+				Variant: variant,
+				Arms:    [2]string{earlier.Alternative, arm.Alternative},
+				Item:    arm.Predicate.Item,
+				Literal: literal,
+			})
+
+			return
+		}
+	}
+}
+
+// strategy reads a strategy: the `single-record-type` symbol, or one of the two
+// forms that lower into a predicate.
+//
+// subject names what the strategy was written for, so that a diagnostic about
+// one says whether a record or an arm was being selected — the sets differ, and
+// a message naming the wrong one sends an adopter to write a strategy the
+// position does not take.
+func (r *discriminationReader) strategy(node layout.Node, subject string) (Strategy, bool) {
+	admits := strategyNames()
+	if subject == subjectArm {
+		admits = predicateNames()
+	}
+
+	if symbol, ok := node.(layout.Symbol); ok {
+		if StrategyKind(symbol.Value) == SingleRecordType {
+			return Strategy{Pos: symbol.Pos, Kind: SingleRecordType}, true
+		}
+
+		r.fail(&StrategyError{Pos: symbol.Pos, Subject: subject, Found: describe(symbol), Admits: admits})
+
+		return Strategy{}, false
+	}
+
+	form, ok := node.(layout.Form)
+	if !ok {
+		r.fail(&StrategyError{Pos: node.Position(), Subject: subject, Found: describe(node), Admits: admits})
+
+		return Strategy{}, false
+	}
+
+	kind := StrategyKind(form.Tag)
+	if !slices.Contains(predicates, kind) {
+		r.fail(&StrategyError{Pos: form.TagPos, Subject: subject, Found: describe(form), Admits: admits})
+
+		return Strategy{}, false
+	}
+
+	if len(form.Elements) < 2 {
+		r.fail(&StrategyFormError{Pos: form.Pos, Kind: kind, Found: strategyShortfall(form.Elements)})
+
+		return Strategy{}, false
+	}
+
+	if kind == Equals && len(form.Elements) > 2 {
+		r.fail(&StrategyFormError{Pos: form.Elements[2].Position(), Kind: kind, Found: "several"})
+
+		return Strategy{}, false
+	}
+
+	item, err := readItemRef(form.Elements[0])
+	if err != nil {
+		r.fail(err)
+
+		return Strategy{}, false
+	}
+
+	strategy := Strategy{Pos: form.Pos, Kind: kind, Item: item}
+
+	for _, element := range form.Elements[1:] {
+		literal, ok := r.literal(element)
+		if !ok {
+			return Strategy{}, false
+		}
+
+		strategy.Literals = append(strategy.Literals, literal)
+	}
+
+	return strategy, true
+}
+
+// literal reads one of the three spellings a literal takes.
+func (r *discriminationReader) literal(node layout.Node) (Literal, bool) {
+	switch value := node.(type) {
+	case layout.Text:
+		return Literal{Pos: value.Pos, Kind: TextLiteral, Text: value.Value}, true
+	case layout.Int:
+		return Literal{Pos: value.Pos, Kind: NumberLiteral, Number: strconv.FormatInt(value.Value, 10)}, true
+	case layout.Float:
+		return Literal{
+			Pos:    value.Pos,
+			Kind:   NumberLiteral,
+			Number: strconv.FormatFloat(value.Value, 'f', -1, 64),
+		}, true
+	case layout.Form:
+		bytes, err := readByteString(value)
+		if err != nil {
+			r.fail(err)
+
+			return Literal{}, false
+		}
+
+		return Literal{Pos: bytes.Pos, Kind: BytesLiteral, Bytes: bytes}, true
+	default:
+		r.fail(&LiteralError{Pos: node.Position(), Found: describe(node)})
+
+		return Literal{}, false
+	}
+}
+
+// armTargetFault reports what is wrong with an arm's target, where anything is.
+//
+// The three it answers are the halves of docs/layout/SPEC.md's rule that need no
+// copybook, and they are the three an adopter gets wrong while holding one open.
+// That the group the target shares with the variant is the *innermost repeating*
+// one, and that the names exist at all, are `resolve`'s.
+func armTargetFault(item ItemRef, variant ItemRef, alternative string) (string, bool) {
+	if item.Record != variant.Record {
+		return "rooted at record " + quote(item.Record) + ", and the variant is rooted at " + quote(variant.Record), true
+	}
+
+	if len(variant.Path) < 2 {
+		// The variant reference is already a fault of its own, and every answer
+		// this could give about a target under it would be about a variant that
+		// cannot exist.
+		return "", false
+	}
+
+	if len(item.Path) == 0 || item.Path[0] != variant.Path[0] {
+		return "outside " + quote(variant.Path[0]) + ", which is the outermost group the variant sits in", true
+	}
+
+	if slices.Equal(item.Path[:min(len(item.Path), len(variant.Path))], variant.Path) {
+		return "inside the variant itself", true
+	}
+
+	// An arm's own name stands where the variant's does, since every alternative
+	// redefines the same bytes. A target descending through one is a target
+	// inside an alternative, which has bytes only where that alternative was
+	// selected.
+	inside := variant.Path[:len(variant.Path)-1]
+	if len(item.Path) > len(inside) && slices.Equal(item.Path[:len(inside)], inside) && item.Path[len(inside)] == alternative {
+		return "inside the arm it selects", true
+	}
+
+	return "", false
+}
+
+// armNamed reports where an alternative was first named, among the arms already
+// read.
+func armNamed(read []Arm, alternative string) (layout.Pos, bool) {
+	index := slices.IndexFunc(read, func(arm Arm) bool { return arm.Alternative == alternative })
+	if index < 0 {
+		return layout.Pos{}, false
+	}
+
+	return read[index].Pos, true
+}
+
+// strategyShortfall names what a strategy form carries where an item and a
+// literal belong.
+func strategyShortfall(elements []layout.Node) string {
+	if len(elements) == 1 {
+		return "an item and no literal"
+	}
+
+	return "no value"
+}
+
+// strategyNames is the strategies as a layout spells them, for a message that
+// has to list them.
+func strategyNames() []string {
+	names := make([]string, 0, len(strategies))
+
+	for _, strategy := range strategies {
+		names = append(names, string(strategy))
+	}
+
+	return names
+}
+
+// predicateNames is the same for the strategies an arm admits.
+func predicateNames() []string {
+	names := make([]string, 0, len(predicates))
+
+	for _, predicate := range predicates {
+		names = append(names, string(predicate))
+	}
+
+	return names
+}

--- a/internal/layoutmodel/discriminate_test.go
+++ b/internal/layoutmodel/discriminate_test.go
@@ -371,6 +371,20 @@ func TestReadDiscriminationRejects(t *testing.T) {
 			},
 		},
 		{
+			// A discriminator whose record is written as text is still a
+			// discriminator, so the strategy under it is read and what is wrong
+			// with the literal is reported in the same run.
+			name:   "every fault is reported: the record, then the strategy under it",
+			source: oneRecord("DETAIL", "(discriminate \"DETAIL\" (equals (item DETAIL D-REC-TYPE) TWENTY))"),
+			want: []string{
+				"layout.sexpr:2:15: a discriminator is written (discriminate <record-name> <strategy>), " +
+					"and this has text",
+				"layout.sexpr:2:57: a literal is text, a number or (bytes \"<hex>\"), and this is the symbol \"TWENTY\"",
+				"layout.sexpr:1:1: record \"DETAIL\" carries no discriminator; a record that carries nothing to " +
+					"test says so, with \"single-record-type\"",
+			},
+		},
+		{
 			name: "an arm selected by nothing at all",
 			source: oneRecord("POLICY", "(discriminate POLICY single-record-type)", strings.Join([]string{
 				"(discriminate-variant (item POLICY PL-ENTRIES PL-BODY-MOTOR)",
@@ -407,10 +421,10 @@ func TestReadDiscriminationRejects(t *testing.T) {
 				"  (arm PL-BODY-PROPERTY (one-of (item POLICY PL-ENTRIES PL-KIND) \"P\" \"M\")))",
 			}, "\n")),
 			want: []string{
-				"layout.sexpr:5:70: arms \"PL-BODY-MOTOR\" and \"PL-BODY-PROPERTY\" of the variant at " +
-					"(item POLICY PL-ENTRIES PL-BODY-MOTOR) both admit \"M\" on (item POLICY PL-ENTRIES PL-KIND), " +
-					"and is admitted first at layout.sexpr:4:66; two arms that can both match one occurrence have " +
-					"nothing to tell them apart",
+				"layout.sexpr:5:70: \"M\" on (item POLICY PL-ENTRIES PL-KIND) is admitted by arms " +
+					"\"PL-BODY-MOTOR\" and \"PL-BODY-PROPERTY\" of the variant at " +
+					"(item POLICY PL-ENTRIES PL-BODY-MOTOR), and is admitted first at layout.sexpr:4:66; " +
+					"two arms that can both match one occurrence have nothing to tell them apart",
 			},
 		},
 		{

--- a/internal/layoutmodel/discriminate_test.go
+++ b/internal/layoutmodel/discriminate_test.go
@@ -1,0 +1,703 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layoutmodel
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/layout"
+)
+
+// discriminationOf is the whole pipeline a caller runs: parse the source, then
+// read the discrimination layer out of it.
+func discriminationOf(t *testing.T, source string) (*Discrimination, error) {
+	t.Helper()
+
+	file, err := layout.Parse("layout.sexpr", strings.NewReader(source))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	return ReadDiscrimination(file)
+}
+
+// renderDiscrimination draws the layer the way the tests assert one: every
+// discriminator in source order, the record or variant it is about, and the
+// strategy under it with a position on each part.
+//
+// It is a rendering rather than a struct literal for [renderFraming]'s reason:
+// what has to be right is the model *and* the position of every part of it, and
+// a rendering carrying both fails with the whole model in the message.
+func renderDiscrimination(d *Discrimination) string {
+	var lines []string
+
+	for _, record := range d.Records {
+		lines = append(lines,
+			fmt.Sprintf("%s discriminate %s", record.Pos, record.Record),
+			"  "+renderStrategy(record.Strategy),
+		)
+	}
+
+	for _, variant := range d.Variants {
+		lines = append(lines, fmt.Sprintf("%s discriminate-variant %s", variant.Pos, variant.Variant))
+
+		for _, arm := range variant.Arms {
+			lines = append(lines, fmt.Sprintf("  %s arm %s: %s", arm.Pos, arm.Alternative, renderStrategy(arm.Predicate)))
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// renderStrategy draws one strategy: where it was written, which member of the
+// closed set it is, and — where it lowers into a predicate — what it tests
+// against what.
+func renderStrategy(s Strategy) string {
+	if !s.Predicate() {
+		return fmt.Sprintf("%s %s, which lowers into no predicate", s.Pos, s.Kind)
+	}
+
+	literals := make([]string, 0, len(s.Literals))
+	for _, literal := range s.Literals {
+		literals = append(literals, literal.String())
+	}
+
+	return fmt.Sprintf("%s %s %s %s", s.Pos, s.Kind, s.Item, strings.Join(literals, " "))
+}
+
+// oneRecord wraps a discrimination layer in the least a layout has to say for
+// the layer to be readable: the `record` form the discriminator names.
+//
+// The record definitions layer is somebody else's (#27, #30) and this reader
+// takes nothing from a `record` form but its name — which it needs, because
+// "one discriminator per record" counts one form against another.
+func oneRecord(name string, forms ...string) string {
+	return strings.Join(append([]string{
+		fmt.Sprintf("(record %s (copybook \"cpy/x.cpy\" %s-REC))", name, name),
+	}, forms...), "\n")
+}
+
+// TestReadDiscriminationModelsTheLayer is the criterion this reader exists for:
+// a layout's discrimination layer becomes a typed value naming what tells each
+// record apart, out of a closed set, with a position on every part of it.
+func TestReadDiscriminationModelsTheLayer(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		source string
+		want   []string
+	}{
+		{
+			name:   "a type code at a fixed offset",
+			source: oneRecord("DETAIL", "(discriminate DETAIL (equals (item DETAIL D-REC-TYPE) \"20\"))"),
+			want: []string{
+				"layout.sexpr:2:1 discriminate DETAIL",
+				"  layout.sexpr:2:22 equals (item DETAIL D-REC-TYPE) \"20\"",
+			},
+		},
+		{
+			// The shared header is a group inside each record type rather than
+			// something standing outside them, so a type code in one is an
+			// ordinary item reference and not a second strategy.
+			name:   "a type code in a shared header copybook",
+			source: oneRecord("DETAIL", "(discriminate DETAIL (equals (item DETAIL STD-HDR HDR-TYPE) \"20\"))"),
+			want: []string{
+				"layout.sexpr:2:1 discriminate DETAIL",
+				"  layout.sexpr:2:22 equals (item DETAIL STD-HDR HDR-TYPE) \"20\"",
+			},
+		},
+		{
+			name:   "several type codes for one record",
+			source: oneRecord("DETAIL", "(discriminate DETAIL (one-of (item DETAIL D-REC-TYPE) \"20\" \"21\"))"),
+			want: []string{
+				"layout.sexpr:2:1 discriminate DETAIL",
+				"  layout.sexpr:2:22 one-of (item DETAIL D-REC-TYPE) \"20\" \"21\"",
+			},
+		},
+		{
+			name:   "a record carrying nothing to test",
+			source: oneRecord("DETAIL", "(discriminate DETAIL single-record-type)"),
+			want: []string{
+				"layout.sexpr:2:1 discriminate DETAIL",
+				"  layout.sexpr:2:22 single-record-type, which lowers into no predicate",
+			},
+		},
+		{
+			name:   "all three literal spellings",
+			source: oneRecord("DETAIL", "(discriminate DETAIL (one-of (item DETAIL D-FLAG) \"Y\" 12 (bytes \"F0F1\")))"),
+			want: []string{
+				"layout.sexpr:2:1 discriminate DETAIL",
+				"  layout.sexpr:2:22 one-of (item DETAIL D-FLAG) \"Y\" 12 (bytes \"F0F1\")",
+			},
+		},
+		{
+			name: "a redefine inside a repeating group",
+			source: oneRecord("POLICY", strings.Join([]string{
+				"(discriminate POLICY single-record-type)",
+				"(discriminate-variant (item POLICY PL-ENTRIES PL-BODY-MOTOR)",
+				"  (arm PL-BODY-MOTOR    (equals (item POLICY PL-ENTRIES PL-KIND) \"M\"))",
+				"  (arm PL-BODY-PROPERTY (one-of (item POLICY PL-ENTRIES PL-KIND) \"P\" \"H\")))",
+			}, "\n")),
+			want: []string{
+				"layout.sexpr:2:1 discriminate POLICY",
+				"  layout.sexpr:2:22 single-record-type, which lowers into no predicate",
+				"layout.sexpr:3:1 discriminate-variant (item POLICY PL-ENTRIES PL-BODY-MOTOR)",
+				"  layout.sexpr:4:3 arm PL-BODY-MOTOR: layout.sexpr:4:25 equals (item POLICY PL-ENTRIES PL-KIND) \"M\"",
+				"  layout.sexpr:5:3 arm PL-BODY-PROPERTY: layout.sexpr:5:25 one-of (item POLICY PL-ENTRIES PL-KIND) \"P\" \"H\"",
+			},
+		},
+		{
+			// An arm's target may sit behind the variant and inside the group
+			// that repeats, which is what a record's discriminator may not do.
+			// The rules are mirrors rather than exceptions: an arm is evaluated
+			// in the occurrence being walked, so it carries one.
+			name: "an arm's target may sit where a record's may not",
+			source: oneRecord("POLICY", strings.Join([]string{
+				"(discriminate POLICY single-record-type)",
+				"(discriminate-variant (item POLICY PL-ENTRIES PL-BODY-MOTOR)",
+				"  (arm PL-BODY-MOTOR    (equals (item POLICY PL-ENTRIES PL-TRAILER PL-KIND) \"M\"))",
+				"  (arm PL-BODY-PROPERTY (equals (item POLICY PL-ENTRIES PL-TRAILER PL-KIND) \"P\")))",
+			}, "\n")),
+			want: []string{
+				"layout.sexpr:2:1 discriminate POLICY",
+				"  layout.sexpr:2:22 single-record-type, which lowers into no predicate",
+				"layout.sexpr:3:1 discriminate-variant (item POLICY PL-ENTRIES PL-BODY-MOTOR)",
+				"  layout.sexpr:4:3 arm PL-BODY-MOTOR: layout.sexpr:4:25 equals " +
+					"(item POLICY PL-ENTRIES PL-TRAILER PL-KIND) \"M\"",
+				"  layout.sexpr:5:3 arm PL-BODY-PROPERTY: layout.sexpr:5:25 equals " +
+					"(item POLICY PL-ENTRIES PL-TRAILER PL-KIND) \"P\"",
+			},
+		},
+		{
+			// Nothing orders a layout's forms, so a discriminator written above
+			// the record it names is the same statement as one written below it.
+			name: "forms in any order",
+			source: strings.Join([]string{
+				"(discriminate DETAIL (equals (item DETAIL D-REC-TYPE) \"20\"))",
+				"(record DETAIL (copybook \"cpy/x.cpy\" DETAIL-REC))",
+			}, "\n"),
+			want: []string{
+				"layout.sexpr:1:1 discriminate DETAIL",
+				"  layout.sexpr:1:22 equals (item DETAIL D-REC-TYPE) \"20\"",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			read, err := discriminationOf(t, testCase.source)
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+
+			if got, want := renderDiscrimination(read), strings.Join(testCase.want, "\n"); got != want {
+				t.Errorf("read as\n%s\nwant\n%s", got, want)
+			}
+		})
+	}
+}
+
+// TestEveryStrategyIsWritable walks the whole closed set, so that a strategy
+// this reader cannot read is a failure here rather than a layout an adopter
+// writes from the document and cannot use.
+//
+// It is the set docs/layout/SPEC.md closes, and the set the IR's predicate
+// membership was settled against (#28): two strategies lower into a predicate
+// and one lowers into the absence of one.
+func TestEveryStrategyIsWritable(t *testing.T) {
+	t.Parallel()
+
+	written := map[StrategyKind]string{
+		Equals:           "(equals (item DETAIL D-REC-TYPE) \"20\")",
+		OneOf:            "(one-of (item DETAIL D-REC-TYPE) \"20\" \"21\")",
+		SingleRecordType: "single-record-type",
+	}
+
+	for _, kind := range strategies {
+		t.Run(string(kind), func(t *testing.T) {
+			t.Parallel()
+
+			source, ok := written[kind]
+			if !ok {
+				t.Fatalf("the set carries %s and this test does not write one", kind)
+			}
+
+			read, err := discriminationOf(t, oneRecord("DETAIL", "(discriminate DETAIL "+source+")"))
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+
+			if got := read.Records[0].Strategy.Kind; got != kind {
+				t.Fatalf("%s read as %s", source, got)
+			}
+		})
+	}
+}
+
+// TestSingleRecordTypeLowersIntoNoPredicate is docs/ir/SPEC.md's "A transition
+// may carry no predicate", read from the layout side.
+//
+// Selecting on nothing at all is the *absence* of a predicate and not a member
+// of the predicate set testing nothing, so the question a caller compiling a
+// discriminator asks is about the strategy rather than about whether an item
+// reference happens to be set.
+func TestSingleRecordTypeLowersIntoNoPredicate(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]bool{
+		"(equals (item DETAIL D-REC-TYPE) \"20\")":        true,
+		"(one-of (item DETAIL D-REC-TYPE) \"20\" \"21\")": true,
+		"single-record-type":                              false,
+	}
+
+	for source, want := range testCases {
+		t.Run(source, func(t *testing.T) {
+			t.Parallel()
+
+			read, err := discriminationOf(t, oneRecord("DETAIL", "(discriminate DETAIL "+source+")"))
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+
+			strategy := read.Records[0].Strategy
+			if got := strategy.Predicate(); got != want {
+				t.Errorf("%s lowers into a predicate: %t, want %t", source, got, want)
+			}
+
+			if !want && (strategy.Item.Record != "" || len(strategy.Literals) != 0) {
+				t.Errorf("%s carries %s and %v, want neither", source, strategy.Item, strategy.Literals)
+			}
+		})
+	}
+}
+
+// TestReadDiscriminationRejects is the load-bearing half: a reader that accepts
+// everything passes every test above.
+//
+// Each case is a layout the format does not admit, and the whole joined message
+// is asserted rather than the first fault, because reporting every fault is the
+// reader's other requirement.
+func TestReadDiscriminationRejects(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		source string
+		want   []string
+	}{
+		{
+			name:   "a record nobody discriminated",
+			source: oneRecord("DETAIL"),
+			want: []string{
+				"layout.sexpr:1:1: record \"DETAIL\" carries no discriminator; a record that carries nothing " +
+					"to test says so, with \"single-record-type\"",
+			},
+		},
+		{
+			name: "a record discriminated twice",
+			source: oneRecord("DETAIL",
+				"(discriminate DETAIL (equals (item DETAIL D-REC-TYPE) \"20\"))",
+				"(discriminate DETAIL (equals (item DETAIL D-REC-TYPE) \"21\"))",
+			),
+			want: []string{
+				"layout.sexpr:3:1: record \"DETAIL\" is discriminated twice, and is discriminated first at " +
+					"layout.sexpr:2:1; a record carries exactly one discriminator",
+			},
+		},
+		{
+			name:   "a discriminator on a record nobody defined",
+			source: oneRecord("DETAIL", "(discriminate DETAIL single-record-type)", "(discriminate HEADER single-record-type)"),
+			want: []string{
+				"layout.sexpr:3:15: form \"discriminate\" names record \"HEADER\", and the layout defines no " +
+					"record of that name",
+			},
+		},
+		{
+			name:   "a discriminator testing another record's item",
+			source: oneRecord("DETAIL", "(discriminate DETAIL (equals (item HEADER H-REC-TYPE) \"20\"))"),
+			want: []string{
+				"layout.sexpr:2:30: the discriminator on record \"DETAIL\" tests (item HEADER H-REC-TYPE), " +
+					"and a discriminator tests an item of the record it discriminates",
+			},
+		},
+		{
+			name:   "a strategy outside the closed set",
+			source: oneRecord("DETAIL", "(discriminate DETAIL (record-length 80))"),
+			want: []string{
+				"layout.sexpr:2:23: a record is selected by equals, one-of or single-record-type, and this is " +
+					"form \"record-length\"",
+			},
+		},
+		{
+			name:   "a strategy naming no literal",
+			source: oneRecord("DETAIL", "(discriminate DETAIL (equals (item DETAIL D-REC-TYPE)))"),
+			want: []string{
+				"layout.sexpr:2:22: form \"equals\" takes one item reference and one literal, and this one has " +
+					"an item and no literal",
+			},
+		},
+		{
+			name:   "two literals where equals takes one",
+			source: oneRecord("DETAIL", "(discriminate DETAIL (equals (item DETAIL D-REC-TYPE) \"20\" \"21\"))"),
+			want: []string{
+				"layout.sexpr:2:60: form \"equals\" takes one item reference and one literal, and this one has several",
+			},
+		},
+		{
+			name:   "a literal that is none of the three spellings",
+			source: oneRecord("DETAIL", "(discriminate DETAIL (equals (item DETAIL D-REC-TYPE) TWENTY))"),
+			want: []string{
+				"layout.sexpr:2:55: a literal is text, a number or (bytes \"<hex>\"), and this is the symbol \"TWENTY\"",
+			},
+		},
+		{
+			name:   "a discriminator that is not a discriminator",
+			source: oneRecord("DETAIL", "(discriminate DETAIL)"),
+			want: []string{
+				"layout.sexpr:2:1: a discriminator is written (discriminate <record-name> <strategy>), and this has no value",
+				"layout.sexpr:1:1: record \"DETAIL\" carries no discriminator; a record that carries nothing to " +
+					"test says so, with \"single-record-type\"",
+			},
+		},
+		{
+			name: "an arm selected by nothing at all",
+			source: oneRecord("POLICY", "(discriminate POLICY single-record-type)", strings.Join([]string{
+				"(discriminate-variant (item POLICY PL-ENTRIES PL-BODY-MOTOR)",
+				"  (arm PL-BODY-MOTOR    (equals (item POLICY PL-ENTRIES PL-KIND) \"M\"))",
+				"  (arm PL-BODY-PROPERTY single-record-type))",
+			}, "\n")),
+			want: []string{
+				"layout.sexpr:5:25: an arm is selected by equals or one-of, and this is the symbol \"single-record-type\"",
+				"layout.sexpr:3:1: the variant at (item POLICY PL-ENTRIES PL-BODY-MOTOR) carries 1 arms, and a " +
+					"variant carries at least two; a redefine every occurrence of which takes one alternative is " +
+					"not a variant",
+			},
+		},
+		{
+			name: "two arms naming one alternative",
+			source: oneRecord("POLICY", "(discriminate POLICY single-record-type)", strings.Join([]string{
+				"(discriminate-variant (item POLICY PL-ENTRIES PL-BODY-MOTOR)",
+				"  (arm PL-BODY-MOTOR (equals (item POLICY PL-ENTRIES PL-KIND) \"M\"))",
+				"  (arm PL-BODY-MOTOR (equals (item POLICY PL-ENTRIES PL-KIND) \"P\")))",
+			}, "\n")),
+			want: []string{
+				"layout.sexpr:5:3: the variant at (item POLICY PL-ENTRIES PL-BODY-MOTOR) names alternative " +
+					"\"PL-BODY-MOTOR\" twice, and names it first at layout.sexpr:4:3",
+				"layout.sexpr:3:1: the variant at (item POLICY PL-ENTRIES PL-BODY-MOTOR) carries 1 arms, and a " +
+					"variant carries at least two; a redefine every occurrence of which takes one alternative is " +
+					"not a variant",
+			},
+		},
+		{
+			name: "two arms admitting one literal on one item",
+			source: oneRecord("POLICY", "(discriminate POLICY single-record-type)", strings.Join([]string{
+				"(discriminate-variant (item POLICY PL-ENTRIES PL-BODY-MOTOR)",
+				"  (arm PL-BODY-MOTOR    (equals (item POLICY PL-ENTRIES PL-KIND) \"M\"))",
+				"  (arm PL-BODY-PROPERTY (one-of (item POLICY PL-ENTRIES PL-KIND) \"P\" \"M\")))",
+			}, "\n")),
+			want: []string{
+				"layout.sexpr:5:70: arms \"PL-BODY-MOTOR\" and \"PL-BODY-PROPERTY\" of the variant at " +
+					"(item POLICY PL-ENTRIES PL-BODY-MOTOR) both admit \"M\" on (item POLICY PL-ENTRIES PL-KIND), " +
+					"and is admitted first at layout.sexpr:4:66; two arms that can both match one occurrence have " +
+					"nothing to tell them apart",
+			},
+		},
+		{
+			name: "an arm testing an item outside the occurrence",
+			source: oneRecord("POLICY", "(discriminate POLICY single-record-type)", strings.Join([]string{
+				"(discriminate-variant (item POLICY PL-ENTRIES PL-BODY-MOTOR)",
+				"  (arm PL-BODY-MOTOR    (equals (item POLICY PL-HEADER PL-KIND) \"M\"))",
+				"  (arm PL-BODY-PROPERTY (equals (item POLICY PL-ENTRIES PL-KIND) \"P\")))",
+			}, "\n")),
+			want: []string{
+				"layout.sexpr:4:33: the arm on \"PL-BODY-MOTOR\" tests (item POLICY PL-HEADER PL-KIND), which is " +
+					"outside \"PL-ENTRIES\", which is the outermost group the variant sits in; an arm's target sits " +
+					"inside the occurrence it is chosen for",
+				"layout.sexpr:3:1: the variant at (item POLICY PL-ENTRIES PL-BODY-MOTOR) carries 1 arms, and a " +
+					"variant carries at least two; a redefine every occurrence of which takes one alternative is " +
+					"not a variant",
+			},
+		},
+		{
+			name: "an arm testing an item inside the arm it selects",
+			source: oneRecord("POLICY", "(discriminate POLICY single-record-type)", strings.Join([]string{
+				"(discriminate-variant (item POLICY PL-ENTRIES PL-BODY-MOTOR)",
+				"  (arm PL-BODY-MOTOR    (equals (item POLICY PL-ENTRIES PL-BODY-MOTOR PL-KIND) \"M\"))",
+				"  (arm PL-BODY-PROPERTY (equals (item POLICY PL-ENTRIES PL-BODY-PROPERTY PL-KIND) \"P\")))",
+			}, "\n")),
+			want: []string{
+				"layout.sexpr:4:33: the arm on \"PL-BODY-MOTOR\" tests " +
+					"(item POLICY PL-ENTRIES PL-BODY-MOTOR PL-KIND), which is inside the variant itself; " +
+					"an arm's target sits inside the occurrence it is chosen for",
+				"layout.sexpr:5:33: the arm on \"PL-BODY-PROPERTY\" tests " +
+					"(item POLICY PL-ENTRIES PL-BODY-PROPERTY PL-KIND), which is inside the arm it selects; " +
+					"an arm's target sits inside the occurrence it is chosen for",
+				"layout.sexpr:3:1: the variant at (item POLICY PL-ENTRIES PL-BODY-MOTOR) carries 0 arms, and a " +
+					"variant carries at least two; a redefine every occurrence of which takes one alternative is " +
+					"not a variant",
+			},
+		},
+		{
+			name: "a variant that cannot be inside a group that repeats",
+			source: oneRecord("POLICY", "(discriminate POLICY single-record-type)", strings.Join([]string{
+				"(discriminate-variant (item POLICY PL-BODY-MOTOR)",
+				"  (arm PL-BODY-MOTOR    (equals (item POLICY PL-KIND) \"M\"))",
+				"  (arm PL-BODY-PROPERTY (equals (item POLICY PL-KIND) \"P\")))",
+			}, "\n")),
+			want: []string{
+				"layout.sexpr:3:23: (item POLICY PL-BODY-MOTOR) names an item directly under record \"POLICY\"'s " +
+					"top-level item, and a variant sits inside a group that repeats; a redefine whose alternatives " +
+					"are whole record types is told apart by discriminate",
+			},
+		},
+		{
+			name: "a variant discriminated twice",
+			source: oneRecord("POLICY", "(discriminate POLICY single-record-type)", strings.Join([]string{
+				"(discriminate-variant (item POLICY PL-ENTRIES PL-BODY-MOTOR)",
+				"  (arm PL-BODY-MOTOR    (equals (item POLICY PL-ENTRIES PL-KIND) \"M\"))",
+				"  (arm PL-BODY-PROPERTY (equals (item POLICY PL-ENTRIES PL-KIND) \"P\")))",
+				"(discriminate-variant (item POLICY PL-ENTRIES PL-BODY-MOTOR)",
+				"  (arm PL-BODY-MOTOR    (equals (item POLICY PL-ENTRIES PL-KIND) \"1\"))",
+				"  (arm PL-BODY-PROPERTY (equals (item POLICY PL-ENTRIES PL-KIND) \"2\")))",
+			}, "\n")),
+			want: []string{
+				"layout.sexpr:6:1: (item POLICY PL-ENTRIES PL-BODY-MOTOR) is discriminated twice, and is " +
+					"discriminated first at layout.sexpr:3:1; a variant carries exactly one discriminator",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			read, err := discriminationOf(t, testCase.source)
+			if err == nil {
+				t.Fatalf("read as %s, want a fault", renderDiscrimination(read))
+			}
+
+			if read != nil {
+				t.Errorf("a rejected layout yielded a discrimination layer: %s", renderDiscrimination(read))
+			}
+
+			if got, want := err.Error(), strings.Join(testCase.want, "\n"); got != want {
+				t.Errorf("reported\n%s\nwant\n%s", got, want)
+			}
+		})
+	}
+}
+
+// TestDiscriminationFaultsAreAssertable is the other requirement on a fault: a
+// caller deciding what to do about one reaches for the type rather than for the
+// text of the message.
+func TestDiscriminationFaultsAreAssertable(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		source string
+		assert func(*testing.T, error)
+	}{
+		{
+			name:   "a record with no discriminator names the record",
+			source: oneRecord("DETAIL"),
+			assert: func(t *testing.T, err error) {
+				var fault *MissingDiscriminatorError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no MissingDiscriminatorError in %v", err)
+				}
+
+				if fault.Record != "DETAIL" {
+					t.Errorf("the fault is about %q, want \"DETAIL\"", fault.Record)
+				}
+			},
+		},
+		{
+			name:   "a foreign target names both records",
+			source: oneRecord("DETAIL", "(discriminate DETAIL (equals (item HEADER H-REC-TYPE) \"20\"))"),
+			assert: func(t *testing.T, err error) {
+				var fault *ForeignTargetError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no ForeignTargetError in %v", err)
+				}
+
+				if fault.Record != "DETAIL" || fault.Item.Record != "HEADER" {
+					t.Errorf("the fault is on %q testing %q, want \"DETAIL\" testing \"HEADER\"", fault.Record, fault.Item.Record)
+				}
+			},
+		},
+		{
+			name:   "a strategy outside the set names the set it is outside",
+			source: oneRecord("DETAIL", "(discriminate DETAIL (record-length 80))"),
+			assert: func(t *testing.T, err error) {
+				var fault *StrategyError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no StrategyError in %v", err)
+				}
+
+				if fault.Subject != subjectRecord || len(fault.Admits) != len(strategies) {
+					t.Errorf("the fault is on %q admitting %v, want %q admitting all three", fault.Subject, fault.Admits, subjectRecord)
+				}
+			},
+		},
+		{
+			name: "an overlap names both arms and the literal they share",
+			source: oneRecord("POLICY", "(discriminate POLICY single-record-type)", strings.Join([]string{
+				"(discriminate-variant (item POLICY PL-ENTRIES PL-BODY-MOTOR)",
+				"  (arm PL-BODY-MOTOR    (equals (item POLICY PL-ENTRIES PL-KIND) \"M\"))",
+				"  (arm PL-BODY-PROPERTY (equals (item POLICY PL-ENTRIES PL-KIND) \"M\")))",
+			}, "\n")),
+			assert: func(t *testing.T, err error) {
+				var fault *ArmOverlapError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no ArmOverlapError in %v", err)
+				}
+
+				if fault.Arms != [2]string{"PL-BODY-MOTOR", "PL-BODY-PROPERTY"} || fault.Literal.Text != "M" {
+					t.Errorf("the fault is on %v over %s, want both arms over \"M\"", fault.Arms, fault.Literal)
+				}
+			},
+		},
+		{
+			name: "an arm's target names where it stands instead",
+			source: oneRecord("POLICY", "(discriminate POLICY single-record-type)", strings.Join([]string{
+				"(discriminate-variant (item POLICY PL-ENTRIES PL-BODY-MOTOR)",
+				"  (arm PL-BODY-MOTOR    (equals (item OTHER PL-ENTRIES PL-KIND) \"M\"))",
+				"  (arm PL-BODY-PROPERTY (equals (item POLICY PL-ENTRIES PL-KIND) \"P\")))",
+			}, "\n")),
+			assert: func(t *testing.T, err error) {
+				var fault *ArmTargetError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no ArmTargetError in %v", err)
+				}
+
+				if fault.Alternative != "PL-BODY-MOTOR" || !strings.Contains(fault.Found, "rooted at record") {
+					t.Errorf("the fault is on %q, %s", fault.Alternative, fault.Found)
+				}
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := discriminationOf(t, testCase.source)
+			if err == nil {
+				t.Fatal("read without a fault, want one")
+			}
+
+			testCase.assert(t, err)
+		})
+	}
+}
+
+// TestTheSpecsWorkedExampleDiscriminates is the staleness gate over the layer.
+//
+// docs/layout/SPEC.md's "A layout, end to end" appendix is the layout the
+// document shows an adopter, and it is read out of the document rather than
+// copied here for [TestTheSpecsWorkedExampleFrames]'s reason: a strategy the
+// example writes and this reader does not read would otherwise be invisible
+// until somebody pasted the example into a file.
+func TestTheSpecsWorkedExampleDiscriminates(t *testing.T) {
+	t.Parallel()
+
+	read, err := discriminationOf(t, specExample(t))
+	if err != nil {
+		t.Fatalf("the reader rejects SPEC.md's own worked example: %v", err)
+	}
+
+	want := map[string]StrategyKind{
+		"FILE-HEADER":  Equals,
+		"ORDER-HEADER": Equals,
+		"ORDER-DETAIL": OneOf,
+		"FILE-TRAILER": Equals,
+	}
+
+	if len(read.Records) != len(want) {
+		t.Fatalf("the example discriminates %d records, want %d", len(read.Records), len(want))
+	}
+
+	for _, record := range read.Records {
+		if got := record.Strategy.Kind; got != want[record.Record] {
+			t.Errorf("%s is told apart by %s, want %s", record.Record, got, want[record.Record])
+		}
+	}
+}
+
+// TestTheSpecsVariantExampleDiscriminates is the same gate over the second scope
+// a discriminator is written in.
+//
+// The example under "A discriminator for a redefine inside a table" is the only
+// place the document shows an adopter what a variant discriminator looks like,
+// and it names a record the snippet does not define — so the record is supplied
+// here and nothing else is.
+func TestTheSpecsVariantExampleDiscriminates(t *testing.T) {
+	t.Parallel()
+
+	example := specVariantExample(t)
+
+	read, err := discriminationOf(t, oneRecord("POLICY", "(discriminate POLICY single-record-type)", example))
+	if err != nil {
+		t.Fatalf("the reader rejects SPEC.md's own variant example: %v", err)
+	}
+
+	if len(read.Variants) != 1 {
+		t.Fatalf("the example states %d variants, want 1", len(read.Variants))
+	}
+
+	variant := read.Variants[0]
+	if len(variant.Arms) != 2 {
+		t.Fatalf("the variant carries %d arms, want 2", len(variant.Arms))
+	}
+
+	for _, arm := range variant.Arms {
+		if !arm.Predicate.Predicate() {
+			t.Errorf("arm %s is selected by %s, which lowers into no predicate", arm.Alternative, arm.Predicate.Kind)
+		}
+	}
+}
+
+// specVariantExample is the fenced example under SPEC.md's "A discriminator for
+// a redefine inside a table", which is the last one in that subsection: the
+// first is the form's skeleton, and a skeleton is placeholders rather than a
+// layout.
+func specVariantExample(t *testing.T) string {
+	t.Helper()
+
+	const heading = "### A discriminator for a redefine inside a table"
+
+	spec, err := os.ReadFile(filepath.Join(repoRoot(t), "docs", "layout", "SPEC.md"))
+	if err != nil {
+		t.Fatalf("read the layout SPEC: %v", err)
+	}
+
+	_, subsection, found := strings.Cut(string(spec), heading+"\n")
+	if !found {
+		t.Fatalf("the layout SPEC has no %q subsection", heading)
+	}
+
+	if next := strings.Index(subsection, "\n### "); next >= 0 {
+		subsection = subsection[:next]
+	}
+
+	blocks := strings.Split(subsection, "```")
+	if len(blocks) < 5 {
+		t.Fatalf("the %q subsection carries fewer than two fenced blocks", heading)
+	}
+
+	// The fences split the text into alternating prose and blocks, so the last
+	// block is the second-to-last field.
+	return blocks[len(blocks)-2]
+}

--- a/internal/layoutmodel/doc.go
+++ b/internal/layoutmodel/doc.go
@@ -15,13 +15,15 @@
 // declaration cannot reach, and this package is where those land.
 //
 // Each layer of the format gets a reader here, and a type for what the layer
-// says. [ReadProfile] is the encoding profile (#25) and [ReadFraming] is the
-// physical framing (#26); record definitions, discrimination and sequencing
-// arrive beside them (#27–#30). What they have in common is that a value handed
-// back is one the format admits: a [Profile] carries four stated axes because a
-// profile stating three is an error and not a value with a hole in it, and a
-// [Framing] resolves to one of the IR's four framings because the one record
-// format that resolves to none is rejected while the layout is read.
+// says. [ReadProfile] is the encoding profile (#25), [ReadFraming] is the
+// physical framing (#26) and [ReadDiscrimination] is discrimination (#28);
+// record definitions and sequencing arrive beside them (#27, #29, #30). What
+// they have in common is that a value handed back is one the format admits: a
+// [Profile] carries four stated axes because a profile stating three is an error
+// and not a value with a hole in it, a [Framing] resolves to one of the IR's
+// four framings because the one record format that resolves to none is rejected
+// while the layout is read, and every `record` in a [Discrimination] carries
+// exactly one strategy out of a closed set.
 //
 // # Why the model is not the AST
 //

--- a/internal/layoutmodel/errors.go
+++ b/internal/layoutmodel/errors.go
@@ -578,6 +578,419 @@ func (e *ByteStringError) Error() string {
 	)
 }
 
+// What a strategy was written for, which is the half of a diagnostic about one
+// that says which set the position takes.
+const (
+	subjectRecord = "a record"
+	subjectArm    = "an arm"
+)
+
+// DiscriminateFormError is a `discriminate` that is not
+// `(discriminate <record-name> <strategy>)`.
+//
+// It is about the shape alone. Whether the record is one the layout defines is
+// an [UnknownRecordError], and whether the strategy is one of the three is a
+// [StrategyError]: both need the form to have been read first.
+type DiscriminateFormError struct {
+	// Pos is the form, or the part of it that is wrong.
+	Pos layout.Pos
+
+	// Found names what was written.
+	Found string
+}
+
+// Error implements the error interface.
+func (e *DiscriminateFormError) Error() string {
+	return fmt.Sprintf(
+		"%s: a discriminator is written (discriminate <record-name> <strategy>), and this has %s",
+		e.Pos, e.Found,
+	)
+}
+
+// UnknownRecordError is a form naming a record no `record` form defines.
+//
+// docs/layout/SPEC.md files it under the rules relating one form to another: the
+// published schema states it as a reference, and this package states it again
+// because it assumes nothing about the schema. A discriminator on a record
+// nobody defined tells nothing apart — it is the unreachable half of the layer's
+// completeness rule, the other half being a record nobody discriminated.
+type UnknownRecordError struct {
+	// Pos is the name, not the form carrying it.
+	Pos layout.Pos
+
+	// Record is what was named.
+	Record string
+
+	// Form is the tag it was named under, so that the message says which
+	// statement is about a record that is not there.
+	Form string
+}
+
+// Error implements the error interface.
+func (e *UnknownRecordError) Error() string {
+	return fmt.Sprintf(
+		"%s: form %s names record %s, and the layout defines no record of that name",
+		e.Pos, quote(e.Form), quote(e.Record),
+	)
+}
+
+// DuplicateDiscriminatorError is a second `discriminate` naming a record another
+// one already named.
+//
+// It carries both positions for [DuplicateOverrideError]'s reason: either form
+// is a perfectly good discriminator on its own, and what an adopter has to
+// decide is which of the two they meant. Nothing orders a layout's forms, so
+// there is no first one to prefer.
+type DuplicateDiscriminatorError struct {
+	// Pos is the second discriminator.
+	Pos layout.Pos
+
+	// First is the one before it.
+	First layout.Pos
+
+	// Record is the record both name.
+	Record string
+}
+
+// Error implements the error interface.
+func (e *DuplicateDiscriminatorError) Error() string {
+	return fmt.Sprintf(
+		"%s: record %s is discriminated twice, and is discriminated first at %s; "+
+			"a record carries exactly one discriminator",
+		e.Pos, quote(e.Record), e.First,
+	)
+}
+
+// MissingDiscriminatorError is a `record` no `discriminate` names.
+//
+// docs/layout/SPEC.md requires one of every record, and the reason is what the
+// requirement buys: it makes "this record carries nothing to test" a statement
+// an adopter made — `single-record-type`, written out — rather than a gap in the
+// file that reads the same way.
+type MissingDiscriminatorError struct {
+	// Pos is the `record` form, which is the record an adopter has to write a
+	// discriminator for. A form a layout is missing has no position of its own.
+	Pos layout.Pos
+
+	// Record is its name.
+	Record string
+}
+
+// Error implements the error interface.
+func (e *MissingDiscriminatorError) Error() string {
+	return fmt.Sprintf(
+		"%s: record %s carries no discriminator; a record that carries nothing to test says so, "+
+			"with %s",
+		e.Pos, quote(e.Record), quote(string(SingleRecordType)),
+	)
+}
+
+// ForeignTargetError is a record's discriminator testing an item of another
+// record.
+//
+// It is the half of docs/layout/SPEC.md's "The item MUST be contained in the
+// record the strategy is written on" that needs no copybook: an item reference
+// is rooted at a record name, and a reference rooted at another record names
+// bytes this discriminator will never be evaluated against, whatever the
+// copybooks turn out to hold.
+type ForeignTargetError struct {
+	// Pos is the item reference.
+	Pos layout.Pos
+
+	// Item is the reference.
+	Item ItemRef
+
+	// Record is the record being discriminated.
+	Record string
+}
+
+// Error implements the error interface.
+func (e *ForeignTargetError) Error() string {
+	return fmt.Sprintf(
+		"%s: the discriminator on record %s tests %s, and a discriminator tests an item of the record it discriminates",
+		e.Pos, quote(e.Record), e.Item,
+	)
+}
+
+// StrategyError is something written where a strategy belongs that is not one of
+// the set that position admits.
+//
+// The two sets differ by one member and the message names the one that applies:
+// a record admits `single-record-type` and an arm does not, because an arm
+// selected by nothing at all is the default arm docs/ir/SPEC.md refuses.
+type StrategyError struct {
+	// Pos is what was written, or the tag of the form that was.
+	Pos layout.Pos
+
+	// Subject is what the strategy would have selected.
+	Subject string
+
+	// Found names what was written.
+	Found string
+
+	// Admits is the set the position takes.
+	Admits []string
+}
+
+// Error implements the error interface.
+func (e *StrategyError) Error() string {
+	return fmt.Sprintf("%s: %s is selected by %s, and this is %s", e.Pos, e.Subject, and(e.Admits), e.Found)
+}
+
+// StrategyFormError is a strategy form that does not carry an item and the
+// literals it takes.
+//
+// `(equals)` states nothing, `(equals (item R F))` names an item and no value to
+// compare it against, and `(equals (item R F) "1" "2")` is two literals in the
+// position that takes one — which is `one-of`, spelled as `equals`.
+type StrategyFormError struct {
+	// Pos is the form, or the element standing where nothing belongs.
+	Pos layout.Pos
+
+	// Kind is the strategy it states.
+	Kind StrategyKind
+
+	// Found names what was written.
+	Found string
+}
+
+// Error implements the error interface.
+func (e *StrategyFormError) Error() string {
+	takes := "one item reference and one literal"
+	if e.Kind == OneOf {
+		takes = "one item reference and at least one literal"
+	}
+
+	return fmt.Sprintf("%s: form %s takes %s, and this one has %s", e.Pos, quote(string(e.Kind)), takes, e.Found)
+}
+
+// LiteralError is something written where a literal belongs that is none of the
+// three spellings.
+//
+// A byte string with something wrong inside it is a [ByteStringError] instead:
+// the position plainly holds a literal, and the fault is what it says.
+type LiteralError struct {
+	// Pos is what was written.
+	Pos layout.Pos
+
+	// Found names it.
+	Found string
+}
+
+// Error implements the error interface.
+func (e *LiteralError) Error() string {
+	return fmt.Sprintf(
+		"%s: a literal is text, a number or (bytes \"<hex>\"), and this is %s",
+		e.Pos, e.Found,
+	)
+}
+
+// VariantFormError is a `discriminate-variant` that names no item at all.
+//
+// A reference that is written and wrong is an [ItemReferenceError]; this is the
+// form carrying nothing where the variant belongs.
+type VariantFormError struct {
+	// Pos is the form.
+	Pos layout.Pos
+
+	// Found names what was written.
+	Found string
+}
+
+// Error implements the error interface.
+func (e *VariantFormError) Error() string {
+	return fmt.Sprintf(
+		"%s: a variant discriminator is written (discriminate-variant <item-ref> (arm <name> <predicate>) ...), "+
+			"and this is %s",
+		e.Pos, e.Found,
+	)
+}
+
+// VariantDepthError is a variant reference that cannot name one.
+//
+// A variant sits inside a group that repeats. A reference carrying a single name
+// names an item directly under the record's top-level item, whose only ancestor
+// is that item — and a record does not repeat, so no copybook can make such a
+// reference name a variant. A redefine at that depth is told apart by an
+// ordinary `discriminate`, because its alternatives are whole record types.
+type VariantDepthError struct {
+	// Pos is the reference.
+	Pos layout.Pos
+
+	// Variant is what was written.
+	Variant ItemRef
+}
+
+// Error implements the error interface.
+func (e *VariantDepthError) Error() string {
+	return fmt.Sprintf(
+		"%s: %s names an item directly under record %s's top-level item, and a variant sits inside a group "+
+			"that repeats; a redefine whose alternatives are whole record types is told apart by discriminate",
+		e.Pos, e.Variant, quote(e.Variant.Record),
+	)
+}
+
+// DuplicateVariantError is a second `discriminate-variant` naming an item
+// another one already named.
+//
+// It is [DuplicateDiscriminatorError] at the other scope and for the same
+// reason: two statements of which arm an occurrence takes would leave the order
+// they were written in deciding the answer.
+type DuplicateVariantError struct {
+	// Pos is the second variant discriminator.
+	Pos layout.Pos
+
+	// First is the one before it.
+	First layout.Pos
+
+	// Variant is the item both name.
+	Variant ItemRef
+}
+
+// Error implements the error interface.
+func (e *DuplicateVariantError) Error() string {
+	return fmt.Sprintf(
+		"%s: %s is discriminated twice, and is discriminated first at %s; a variant carries exactly one discriminator",
+		e.Pos, e.Variant, e.First,
+	)
+}
+
+// VariantArmCountError is a variant discriminator carrying fewer than two arms.
+//
+// A variant is an alternation, and an alternation with one arm is the redefine
+// every occurrence of which takes one alternative — which docs/ir/SPEC.md
+// resolves to that alternative's items with no variant at all.
+type VariantArmCountError struct {
+	// Pos is the `discriminate-variant` form.
+	Pos layout.Pos
+
+	// Variant is the item it names.
+	Variant ItemRef
+
+	// Count is how many arms it carries. It counts the arms that were read, so
+	// a variant whose second arm is malformed is reported against that arm and
+	// against this rule, and not twice against this one.
+	Count int
+}
+
+// Error implements the error interface.
+func (e *VariantArmCountError) Error() string {
+	return fmt.Sprintf(
+		"%s: the variant at %s carries %d arms, and a variant carries at least two; "+
+			"a redefine every occurrence of which takes one alternative is not a variant",
+		e.Pos, e.Variant, e.Count,
+	)
+}
+
+// ArmFormError is an arm that is not `(arm <name> <predicate>)`.
+type ArmFormError struct {
+	// Pos is the form, or the part of it that is wrong.
+	Pos layout.Pos
+
+	// Found names what was written.
+	Found string
+}
+
+// Error implements the error interface.
+func (e *ArmFormError) Error() string {
+	return fmt.Sprintf("%s: an arm is written (arm <name> <predicate>), and this has %s", e.Pos, e.Found)
+}
+
+// DuplicateArmError is two arms of one variant naming one alternative.
+//
+// Two arms over one alternative are two statements of when to read the same
+// bytes the same way, and which of them applies would be decided by the order
+// they were written in.
+type DuplicateArmError struct {
+	// Pos is the second arm.
+	Pos layout.Pos
+
+	// First is the one before it.
+	First layout.Pos
+
+	// Variant is the variant both are arms of.
+	Variant ItemRef
+
+	// Alternative is the name both give.
+	Alternative string
+}
+
+// Error implements the error interface.
+func (e *DuplicateArmError) Error() string {
+	return fmt.Sprintf(
+		"%s: the variant at %s names alternative %s twice, and names it first at %s",
+		e.Pos, e.Variant, quote(e.Alternative), e.First,
+	)
+}
+
+// ArmTargetError is an arm's target standing where an arm's target may not.
+//
+// docs/layout/SPEC.md's rule is that the target sits inside the innermost
+// repeating group containing the variant, and not inside an arm that does not
+// also contain it. The halves needing a copybook are `resolve`'s; the ones this
+// reports are the ones an adopter gets wrong while holding the copybook open — a
+// target in another record, a target in a header elsewhere in this one, and a
+// target inside the alternatives themselves.
+type ArmTargetError struct {
+	// Pos is the item reference.
+	Pos layout.Pos
+
+	// Alternative is the arm it selects.
+	Alternative string
+
+	// Item is the target.
+	Item ItemRef
+
+	// Variant is the variant the arm belongs to.
+	Variant ItemRef
+
+	// Found says where the target stands instead.
+	Found string
+}
+
+// Error implements the error interface.
+func (e *ArmTargetError) Error() string {
+	return fmt.Sprintf(
+		"%s: the arm on %s tests %s, which is %s; an arm's target sits inside the occurrence it is chosen for",
+		e.Pos, quote(e.Alternative), e.Item, e.Found,
+	)
+}
+
+// ArmOverlapError is two arms of one variant testing one item for one literal.
+//
+// It is the smallest overlap and the only one decidable from the layout alone.
+// Two arms that can both match one occurrence are refused because there is
+// nothing to break the tie: an arm carries no guard, the order arms are written
+// in decides nothing, and there is no default arm to fall through to.
+type ArmOverlapError struct {
+	// Pos is the literal on the second arm.
+	Pos layout.Pos
+
+	// First is the same literal on the first.
+	First layout.Pos
+
+	// Variant is the variant both are arms of.
+	Variant ItemRef
+
+	// Arms are the two alternatives, in the order the layout writes them.
+	Arms [2]string
+
+	// Item is the target both test.
+	Item ItemRef
+
+	// Literal is the value both admit.
+	Literal Literal
+}
+
+// Error implements the error interface.
+func (e *ArmOverlapError) Error() string {
+	return fmt.Sprintf(
+		"%s: arms %s and %s of the variant at %s both admit %s on %s, and is admitted first at %s; "+
+			"two arms that can both match one occurrence have nothing to tell them apart",
+		e.Pos, quote(e.Arms[0]), quote(e.Arms[1]), e.Variant, e.Literal, e.Item, e.First,
+	)
+}
+
 // axisNames is the four axes as a layout spells them, for a message that has to
 // list them.
 func axisNames() []string {

--- a/internal/layoutmodel/errors.go
+++ b/internal/layoutmodel/errors.go
@@ -985,9 +985,9 @@ type ArmOverlapError struct {
 // Error implements the error interface.
 func (e *ArmOverlapError) Error() string {
 	return fmt.Sprintf(
-		"%s: arms %s and %s of the variant at %s both admit %s on %s, and is admitted first at %s; "+
+		"%s: %s on %s is admitted by arms %s and %s of the variant at %s, and is admitted first at %s; "+
 			"two arms that can both match one occurrence have nothing to tell them apart",
-		e.Pos, quote(e.Arms[0]), quote(e.Arms[1]), e.Variant, e.Literal, e.Item, e.First,
+		e.Pos, e.Literal, e.Item, quote(e.Arms[0]), quote(e.Arms[1]), e.Variant, e.First,
 	)
 }
 

--- a/internal/layoutschema/testdata/invalid/strategy-in-an-arm.sexpr
+++ b/internal/layoutschema/testdata/invalid/strategy-in-an-arm.sexpr
@@ -1,0 +1,24 @@
+;; want: predicate of form "arm" is
+;;
+;; `single-record-type` is a strategy and not a predicate: it lowers into the
+;; absence of a predicate, and an arm selected by nothing at all would be the
+;; default arm neither this format nor the IR has.
+(encoding
+  (charset cp037)
+  (sign-convention ebcdic)
+  (byte-order big-endian)
+  (float-format hfp))
+
+(framing
+  (recfm VB)
+  (lrecl 1024))
+
+(record POLICY (copybook "cpy/policy.cpy" POLICY-REC))
+
+(discriminate POLICY single-record-type)
+
+(discriminate-variant (item POLICY PL-ENTRIES PL-BODY-MOTOR)
+  (arm PL-BODY-MOTOR    (equals (item POLICY PL-ENTRIES PL-KIND) "M"))
+  (arm PL-BODY-PROPERTY single-record-type))
+
+(sequence (+ POLICY))

--- a/internal/layoutschema/testdata/valid/variant-arms.sexpr
+++ b/internal/layoutschema/testdata/valid/variant-arms.sexpr
@@ -1,0 +1,38 @@
+;; A redefine inside a repeating group: each entry of a policy carries its own
+;; kind and a body redefined two ways, so the alternative is chosen once per
+;; occurrence rather than once per record. The record-level discriminators are
+;; ordinary; what this file is for is the second scope a discriminator is
+;; written in.
+(encoding
+  (charset cp037)
+  (sign-convention ebcdic)
+  (byte-order big-endian)
+  (float-format hfp))
+
+(framing
+  (recfm VB)
+  (lrecl 1024)
+  (blksize 27998))
+
+(record POLICY-HEADER (copybook "cpy/policy.cpy" POLICY-HEADER-REC))
+(record POLICY        (copybook "cpy/policy.cpy" POLICY-REC))
+
+(discriminate POLICY-HEADER (equals (item POLICY-HEADER PH-REC-TYPE) "00"))
+(discriminate POLICY        (one-of (item POLICY P-REC-TYPE) "10" "11"))
+
+;; The variant is the item the copybook redefines. Each arm names one
+;; alternative and the predicate selecting it, and both targets sit inside the
+;; entry the arm is being chosen for — a position a record-level discriminator
+;; may not name, and the only position an arm's may.
+(discriminate-variant (item POLICY PL-ENTRIES PL-BODY-MOTOR)
+  (arm PL-BODY-MOTOR    (equals (item POLICY PL-ENTRIES PL-KIND) "M"))
+  (arm PL-BODY-PROPERTY (one-of (item POLICY PL-ENTRIES PL-KIND) "P" "H")))
+
+;; A second variant in the same record, told apart by a byte string rather than
+;; by text: the flag byte carries a bit pattern and no PICTURE anybody trusts.
+(discriminate-variant (item POLICY PL-ENTRIES PL-EXTRA-CASH)
+  (arm PL-EXTRA-CASH  (equals (item POLICY PL-ENTRIES PL-EXTRA-FLAG) (bytes "40")))
+  (arm PL-EXTRA-CHECK (equals (item POLICY PL-ENTRIES PL-EXTRA-FLAG) (bytes "5C"))))
+
+(sequence
+  (seq POLICY-HEADER (+ POLICY)))

--- a/internal/layoutschema/validate_test.go
+++ b/internal/layoutschema/validate_test.go
@@ -28,6 +28,13 @@ import (
 // records over one `01`-level, and a record bound to a copybook that composes a
 // shared header with a body. It fails if the schema ever grows a uniqueness
 // rule over `copybook` that the document does not state.
+//
+// Nor is the fifth. It carries the second scope a discriminator is written in —
+// SPEC.md's "A discriminator for a redefine inside a table" — which is the one
+// top-level form the three framings do not reach: two variants in one record,
+// arms selected by both predicates, and a target inside the repeating group the
+// arm is being chosen for, which is a position a record-level discriminator may
+// not name.
 func TestValidLayoutsValidate(t *testing.T) {
 	schema := publishedSchema(t)
 

--- a/irpb/ir.pb.go
+++ b/irpb/ir.pb.go
@@ -2397,19 +2397,20 @@ type Predicate struct {
 	//
 	// The set is closed so that it can be checked for overlap and for
 	// exhaustiveness, and so that the IR stays data rather than carrying source
-	// only one language could run. Its membership lands with the layout
-	// format's discriminator strategies (#22, #28), which are what lower into it;
-	// until then it holds the one test those strategies all reduce to. Every
-	// member that lands MUST be decidable by a writer against the record it is
-	// about to emit, from that record's bytes and its own position in the
-	// automaton, at the moment it emits it — see docs/ir/SPEC.md, "A writer
-	// evaluates a predicate, it never inverts one". Adding one advances
-	// IrVersion, which is why the set is settled before the first release rather
-	// than grown afterwards.
+	// only one language could run. Its membership is these two, settled with the
+	// layout format's discriminator strategies (#22, #28), which are what lower
+	// into it: `equals` becomes BytesEqual and `one-of` becomes BytesOneOf, while
+	// `single-record-type` becomes no predicate at all. Every member MUST be
+	// decidable by a writer against the record it is about to emit, from that
+	// record's bytes and its own position in the automaton, at the moment it
+	// emits it — see docs/ir/SPEC.md, "A writer evaluates a predicate, it never
+	// inverts one". Adding one advances IrVersion, which is why the set is
+	// settled before the first release rather than grown afterwards.
 	//
 	// Types that are valid to be assigned to Test:
 	//
 	//	*Predicate_BytesEqual
+	//	*Predicate_BytesOneOf
 	Test          isPredicate_Test `protobuf_oneof:"test"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -2468,6 +2469,15 @@ func (x *Predicate) GetBytesEqual() *BytesEqual {
 	return nil
 }
 
+func (x *Predicate) GetBytesOneOf() *BytesOneOf {
+	if x != nil {
+		if x, ok := x.Test.(*Predicate_BytesOneOf); ok {
+			return x.BytesOneOf
+		}
+	}
+	return nil
+}
+
 type isPredicate_Test interface {
 	isPredicate_Test()
 }
@@ -2476,7 +2486,13 @@ type Predicate_BytesEqual struct {
 	BytesEqual *BytesEqual `protobuf:"bytes,2,opt,name=bytes_equal,json=bytesEqual,proto3,oneof"`
 }
 
+type Predicate_BytesOneOf struct {
+	BytesOneOf *BytesOneOf `protobuf:"bytes,3,opt,name=bytes_one_of,json=bytesOneOf,proto3,oneof"`
+}
+
 func (*Predicate_BytesEqual) isPredicate_Test() {}
+
+func (*Predicate_BytesOneOf) isPredicate_Test() {}
 
 // BytesEqual is satisfied when the target field's bytes are the carried
 // literal.
@@ -2530,6 +2546,71 @@ func (x *BytesEqual) GetValue() []byte {
 	return nil
 }
 
+// BytesOneOf is satisfied when the target field's bytes are one of the carried
+// literals.
+//
+// A member of its own rather than a shorthand a producer expands into several
+// BytesEqual predicates: a transition carries at most one predicate and an arm
+// carries exactly one, so a strategy admitting three type codes has nowhere to
+// put three of them, and splitting it into three transitions to one state would
+// turn a set of values into a set of edges for the overlap rule to forgive. Two
+// of these overlap when their literal sets intersect, which is the same
+// question about bytes that BytesEqual asks.
+type BytesOneOf struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The literals, each padded by the producer to the target field's width, in
+	// the order the layout wrote them. A producer MUST carry at least two and
+	// MUST NOT carry the same literal twice: one literal is BytesEqual's work,
+	// and a repeated one is a value tested twice and a producer that did not
+	// check its own overlap.
+	//
+	// The order decides nothing — a consumer stopping at the first that matches
+	// and one comparing them all report the same thing, because the literals are
+	// distinct. It is preserved so that two producers handed one layout emit one
+	// descriptor, which is what "identical inputs produce byte-identical IR"
+	// requires of every repeated field here.
+	Values        [][]byte `protobuf:"bytes,1,rep,name=values,proto3" json:"values,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BytesOneOf) Reset() {
+	*x = BytesOneOf{}
+	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BytesOneOf) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BytesOneOf) ProtoMessage() {}
+
+func (x *BytesOneOf) ProtoReflect() protoreflect.Message {
+	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BytesOneOf.ProtoReflect.Descriptor instead.
+func (*BytesOneOf) Descriptor() ([]byte, []int) {
+	return file_cpybkc_ir_v1_ir_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *BytesOneOf) GetValues() [][]byte {
+	if x != nil {
+		return x.Values
+	}
+	return nil
+}
+
 // State is a state of the record automaton. Sequencing reaches a generator
 // compiled: no consumer parses a grammar and no generator author implements
 // one. See docs/ir/SPEC.md, "The sequencing automaton".
@@ -2554,7 +2635,7 @@ type State struct {
 
 func (x *State) Reset() {
 	*x = State{}
-	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[20]
+	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2566,7 +2647,7 @@ func (x *State) String() string {
 func (*State) ProtoMessage() {}
 
 func (x *State) ProtoReflect() protoreflect.Message {
-	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[20]
+	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2579,7 +2660,7 @@ func (x *State) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use State.ProtoReflect.Descriptor instead.
 func (*State) Descriptor() ([]byte, []int) {
-	return file_cpybkc_ir_v1_ir_proto_rawDescGZIP(), []int{20}
+	return file_cpybkc_ir_v1_ir_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *State) GetAccepts() bool {
@@ -2647,7 +2728,7 @@ type Transition struct {
 
 func (x *Transition) Reset() {
 	*x = Transition{}
-	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[21]
+	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2659,7 +2740,7 @@ func (x *Transition) String() string {
 func (*Transition) ProtoMessage() {}
 
 func (x *Transition) ProtoReflect() protoreflect.Message {
-	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[21]
+	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2672,7 +2753,7 @@ func (x *Transition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Transition.ProtoReflect.Descriptor instead.
 func (*Transition) Descriptor() ([]byte, []int) {
-	return file_cpybkc_ir_v1_ir_proto_rawDescGZIP(), []int{21}
+	return file_cpybkc_ir_v1_ir_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *Transition) GetRecordId() uint64 {
@@ -2727,7 +2808,7 @@ type Register struct {
 
 func (x *Register) Reset() {
 	*x = Register{}
-	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[22]
+	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2739,7 +2820,7 @@ func (x *Register) String() string {
 func (*Register) ProtoMessage() {}
 
 func (x *Register) ProtoReflect() protoreflect.Message {
-	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[22]
+	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2752,7 +2833,7 @@ func (x *Register) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Register.ProtoReflect.Descriptor instead.
 func (*Register) Descriptor() ([]byte, []int) {
-	return file_cpybkc_ir_v1_ir_proto_rawDescGZIP(), []int{22}
+	return file_cpybkc_ir_v1_ir_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *Register) GetKind() RegisterKind {
@@ -2785,7 +2866,7 @@ type Binding struct {
 
 func (x *Binding) Reset() {
 	*x = Binding{}
-	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[23]
+	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2797,7 +2878,7 @@ func (x *Binding) String() string {
 func (*Binding) ProtoMessage() {}
 
 func (x *Binding) ProtoReflect() protoreflect.Message {
-	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[23]
+	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2810,7 +2891,7 @@ func (x *Binding) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Binding.ProtoReflect.Descriptor instead.
 func (*Binding) Descriptor() ([]byte, []int) {
-	return file_cpybkc_ir_v1_ir_proto_rawDescGZIP(), []int{23}
+	return file_cpybkc_ir_v1_ir_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *Binding) GetRegisterId() uint64 {
@@ -2882,7 +2963,7 @@ type Decrement struct {
 
 func (x *Decrement) Reset() {
 	*x = Decrement{}
-	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[24]
+	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2894,7 +2975,7 @@ func (x *Decrement) String() string {
 func (*Decrement) ProtoMessage() {}
 
 func (x *Decrement) ProtoReflect() protoreflect.Message {
-	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[24]
+	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2907,7 +2988,7 @@ func (x *Decrement) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Decrement.ProtoReflect.Descriptor instead.
 func (*Decrement) Descriptor() ([]byte, []int) {
-	return file_cpybkc_ir_v1_ir_proto_rawDescGZIP(), []int{24}
+	return file_cpybkc_ir_v1_ir_proto_rawDescGZIP(), []int{25}
 }
 
 // Guard reads a register and decides whether the transition carrying it is
@@ -2939,7 +3020,7 @@ type Guard struct {
 
 func (x *Guard) Reset() {
 	*x = Guard{}
-	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[25]
+	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2951,7 +3032,7 @@ func (x *Guard) String() string {
 func (*Guard) ProtoMessage() {}
 
 func (x *Guard) ProtoReflect() protoreflect.Message {
-	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[25]
+	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2964,7 +3045,7 @@ func (x *Guard) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Guard.ProtoReflect.Descriptor instead.
 func (*Guard) Descriptor() ([]byte, []int) {
-	return file_cpybkc_ir_v1_ir_proto_rawDescGZIP(), []int{25}
+	return file_cpybkc_ir_v1_ir_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *Guard) GetRegisterId() uint64 {
@@ -3049,7 +3130,7 @@ type Literal struct {
 
 func (x *Literal) Reset() {
 	*x = Literal{}
-	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[26]
+	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3061,7 +3142,7 @@ func (x *Literal) String() string {
 func (*Literal) ProtoMessage() {}
 
 func (x *Literal) ProtoReflect() protoreflect.Message {
-	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[26]
+	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3074,7 +3155,7 @@ func (x *Literal) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Literal.ProtoReflect.Descriptor instead.
 func (*Literal) Descriptor() ([]byte, []int) {
-	return file_cpybkc_ir_v1_ir_proto_rawDescGZIP(), []int{26}
+	return file_cpybkc_ir_v1_ir_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *Literal) GetValue() isLiteral_Value {
@@ -3132,7 +3213,7 @@ type LiteralSet struct {
 
 func (x *LiteralSet) Reset() {
 	*x = LiteralSet{}
-	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[27]
+	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3144,7 +3225,7 @@ func (x *LiteralSet) String() string {
 func (*LiteralSet) ProtoMessage() {}
 
 func (x *LiteralSet) ProtoReflect() protoreflect.Message {
-	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[27]
+	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3157,7 +3238,7 @@ func (x *LiteralSet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LiteralSet.ProtoReflect.Descriptor instead.
 func (*LiteralSet) Descriptor() ([]byte, []int) {
-	return file_cpybkc_ir_v1_ir_proto_rawDescGZIP(), []int{27}
+	return file_cpybkc_ir_v1_ir_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *LiteralSet) GetValues() []*Literal {
@@ -3177,7 +3258,7 @@ type GreaterThanZero struct {
 
 func (x *GreaterThanZero) Reset() {
 	*x = GreaterThanZero{}
-	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[28]
+	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3189,7 +3270,7 @@ func (x *GreaterThanZero) String() string {
 func (*GreaterThanZero) ProtoMessage() {}
 
 func (x *GreaterThanZero) ProtoReflect() protoreflect.Message {
-	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[28]
+	mi := &file_cpybkc_ir_v1_ir_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3202,7 +3283,7 @@ func (x *GreaterThanZero) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GreaterThanZero.ProtoReflect.Descriptor instead.
 func (*GreaterThanZero) Descriptor() ([]byte, []int) {
-	return file_cpybkc_ir_v1_ir_proto_rawDescGZIP(), []int{28}
+	return file_cpybkc_ir_v1_ir_proto_rawDescGZIP(), []int{29}
 }
 
 var File_cpybkc_ir_v1_ir_proto protoreflect.FileDescriptor
@@ -3302,15 +3383,20 @@ const file_cpybkc_ir_v1_ir_proto_rawDesc = "" +
 	"\x05Names\x12\x1a\n" +
 	"\boriginal\x18\x01 \x01(\tR\boriginal\x12(\n" +
 	"\roverride_name\x18\x02 \x01(\tH\x00R\foverrideName\x88\x01\x01B\x10\n" +
-	"\x0e_override_name\"k\n" +
+	"\x0e_override_name\"\xa9\x01\n" +
 	"\tPredicate\x12\x19\n" +
 	"\bfield_id\x18\x01 \x01(\x04R\afieldId\x12;\n" +
 	"\vbytes_equal\x18\x02 \x01(\v2\x18.cpybkc.ir.v1.BytesEqualH\x00R\n" +
-	"bytesEqualB\x06\n" +
+	"bytesEqual\x12<\n" +
+	"\fbytes_one_of\x18\x03 \x01(\v2\x18.cpybkc.ir.v1.BytesOneOfH\x00R\n" +
+	"bytesOneOfB\x06\n" +
 	"\x04test\"\"\n" +
 	"\n" +
 	"BytesEqual\x12\x14\n" +
-	"\x05value\x18\x01 \x01(\fR\x05value\"z\n" +
+	"\x05value\x18\x01 \x01(\fR\x05value\"$\n" +
+	"\n" +
+	"BytesOneOf\x12\x16\n" +
+	"\x06values\x18\x01 \x03(\fR\x06values\"z\n" +
 	"\x05State\x12\x18\n" +
 	"\aaccepts\x18\x01 \x01(\bR\aaccepts\x120\n" +
 	"\x14acceptance_guard_ids\x18\x02 \x03(\x04R\x12acceptanceGuardIds\x12%\n" +
@@ -3422,7 +3508,7 @@ func file_cpybkc_ir_v1_ir_proto_rawDescGZIP() []byte {
 }
 
 var file_cpybkc_ir_v1_ir_proto_enumTypes = make([]protoimpl.EnumInfo, 10)
-var file_cpybkc_ir_v1_ir_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
+var file_cpybkc_ir_v1_ir_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
 var file_cpybkc_ir_v1_ir_proto_goTypes = []any{
 	(IrVersion)(0),          // 0: cpybkc.ir.v1.IrVersion
 	(DelimiterPlacement)(0), // 1: cpybkc.ir.v1.DelimiterPlacement
@@ -3454,15 +3540,16 @@ var file_cpybkc_ir_v1_ir_proto_goTypes = []any{
 	(*Names)(nil),           // 27: cpybkc.ir.v1.Names
 	(*Predicate)(nil),       // 28: cpybkc.ir.v1.Predicate
 	(*BytesEqual)(nil),      // 29: cpybkc.ir.v1.BytesEqual
-	(*State)(nil),           // 30: cpybkc.ir.v1.State
-	(*Transition)(nil),      // 31: cpybkc.ir.v1.Transition
-	(*Register)(nil),        // 32: cpybkc.ir.v1.Register
-	(*Binding)(nil),         // 33: cpybkc.ir.v1.Binding
-	(*Decrement)(nil),       // 34: cpybkc.ir.v1.Decrement
-	(*Guard)(nil),           // 35: cpybkc.ir.v1.Guard
-	(*Literal)(nil),         // 36: cpybkc.ir.v1.Literal
-	(*LiteralSet)(nil),      // 37: cpybkc.ir.v1.LiteralSet
-	(*GreaterThanZero)(nil), // 38: cpybkc.ir.v1.GreaterThanZero
+	(*BytesOneOf)(nil),      // 30: cpybkc.ir.v1.BytesOneOf
+	(*State)(nil),           // 31: cpybkc.ir.v1.State
+	(*Transition)(nil),      // 32: cpybkc.ir.v1.Transition
+	(*Register)(nil),        // 33: cpybkc.ir.v1.Register
+	(*Binding)(nil),         // 34: cpybkc.ir.v1.Binding
+	(*Decrement)(nil),       // 35: cpybkc.ir.v1.Decrement
+	(*Guard)(nil),           // 36: cpybkc.ir.v1.Guard
+	(*Literal)(nil),         // 37: cpybkc.ir.v1.Literal
+	(*LiteralSet)(nil),      // 38: cpybkc.ir.v1.LiteralSet
+	(*GreaterThanZero)(nil), // 39: cpybkc.ir.v1.GreaterThanZero
 }
 var file_cpybkc_ir_v1_ir_proto_depIdxs = []int32{
 	0,  // 0: cpybkc.ir.v1.Descriptor.version:type_name -> cpybkc.ir.v1.IrVersion
@@ -3474,11 +3561,11 @@ var file_cpybkc_ir_v1_ir_proto_depIdxs = []int32{
 	21, // 6: cpybkc.ir.v1.Node.field:type_name -> cpybkc.ir.v1.Field
 	24, // 7: cpybkc.ir.v1.Node.slack:type_name -> cpybkc.ir.v1.Slack
 	28, // 8: cpybkc.ir.v1.Node.predicate:type_name -> cpybkc.ir.v1.Predicate
-	30, // 9: cpybkc.ir.v1.Node.state:type_name -> cpybkc.ir.v1.State
-	31, // 10: cpybkc.ir.v1.Node.transition:type_name -> cpybkc.ir.v1.Transition
-	32, // 11: cpybkc.ir.v1.Node.register:type_name -> cpybkc.ir.v1.Register
-	33, // 12: cpybkc.ir.v1.Node.binding:type_name -> cpybkc.ir.v1.Binding
-	35, // 13: cpybkc.ir.v1.Node.guard:type_name -> cpybkc.ir.v1.Guard
+	31, // 9: cpybkc.ir.v1.Node.state:type_name -> cpybkc.ir.v1.State
+	32, // 10: cpybkc.ir.v1.Node.transition:type_name -> cpybkc.ir.v1.Transition
+	33, // 11: cpybkc.ir.v1.Node.register:type_name -> cpybkc.ir.v1.Register
+	34, // 12: cpybkc.ir.v1.Node.binding:type_name -> cpybkc.ir.v1.Binding
+	36, // 13: cpybkc.ir.v1.Node.guard:type_name -> cpybkc.ir.v1.Guard
 	13, // 14: cpybkc.ir.v1.File.unframed:type_name -> cpybkc.ir.v1.Unframed
 	14, // 15: cpybkc.ir.v1.File.descriptor_word:type_name -> cpybkc.ir.v1.DescriptorWord
 	15, // 16: cpybkc.ir.v1.File.segmented:type_name -> cpybkc.ir.v1.Segmented
@@ -3501,17 +3588,18 @@ var file_cpybkc_ir_v1_ir_proto_depIdxs = []int32{
 	8,  // 33: cpybkc.ir.v1.Picture.sign_position:type_name -> cpybkc.ir.v1.SignPosition
 	26, // 34: cpybkc.ir.v1.Repetition.variable:type_name -> cpybkc.ir.v1.VariableCount
 	29, // 35: cpybkc.ir.v1.Predicate.bytes_equal:type_name -> cpybkc.ir.v1.BytesEqual
-	9,  // 36: cpybkc.ir.v1.Register.kind:type_name -> cpybkc.ir.v1.RegisterKind
-	34, // 37: cpybkc.ir.v1.Binding.decrement:type_name -> cpybkc.ir.v1.Decrement
-	36, // 38: cpybkc.ir.v1.Guard.equals:type_name -> cpybkc.ir.v1.Literal
-	37, // 39: cpybkc.ir.v1.Guard.one_of:type_name -> cpybkc.ir.v1.LiteralSet
-	38, // 40: cpybkc.ir.v1.Guard.greater_than_zero:type_name -> cpybkc.ir.v1.GreaterThanZero
-	36, // 41: cpybkc.ir.v1.LiteralSet.values:type_name -> cpybkc.ir.v1.Literal
-	42, // [42:42] is the sub-list for method output_type
-	42, // [42:42] is the sub-list for method input_type
-	42, // [42:42] is the sub-list for extension type_name
-	42, // [42:42] is the sub-list for extension extendee
-	0,  // [0:42] is the sub-list for field type_name
+	30, // 36: cpybkc.ir.v1.Predicate.bytes_one_of:type_name -> cpybkc.ir.v1.BytesOneOf
+	9,  // 37: cpybkc.ir.v1.Register.kind:type_name -> cpybkc.ir.v1.RegisterKind
+	35, // 38: cpybkc.ir.v1.Binding.decrement:type_name -> cpybkc.ir.v1.Decrement
+	37, // 39: cpybkc.ir.v1.Guard.equals:type_name -> cpybkc.ir.v1.Literal
+	38, // 40: cpybkc.ir.v1.Guard.one_of:type_name -> cpybkc.ir.v1.LiteralSet
+	39, // 41: cpybkc.ir.v1.Guard.greater_than_zero:type_name -> cpybkc.ir.v1.GreaterThanZero
+	37, // 42: cpybkc.ir.v1.LiteralSet.values:type_name -> cpybkc.ir.v1.Literal
+	43, // [43:43] is the sub-list for method output_type
+	43, // [43:43] is the sub-list for method input_type
+	43, // [43:43] is the sub-list for extension type_name
+	43, // [43:43] is the sub-list for extension extendee
+	0,  // [0:43] is the sub-list for field type_name
 }
 
 func init() { file_cpybkc_ir_v1_ir_proto_init() }
@@ -3554,18 +3642,19 @@ func file_cpybkc_ir_v1_ir_proto_init() {
 	file_cpybkc_ir_v1_ir_proto_msgTypes[17].OneofWrappers = []any{}
 	file_cpybkc_ir_v1_ir_proto_msgTypes[18].OneofWrappers = []any{
 		(*Predicate_BytesEqual)(nil),
+		(*Predicate_BytesOneOf)(nil),
 	}
-	file_cpybkc_ir_v1_ir_proto_msgTypes[21].OneofWrappers = []any{}
-	file_cpybkc_ir_v1_ir_proto_msgTypes[23].OneofWrappers = []any{
+	file_cpybkc_ir_v1_ir_proto_msgTypes[22].OneofWrappers = []any{}
+	file_cpybkc_ir_v1_ir_proto_msgTypes[24].OneofWrappers = []any{
 		(*Binding_FieldId)(nil),
 		(*Binding_Decrement)(nil),
 	}
-	file_cpybkc_ir_v1_ir_proto_msgTypes[25].OneofWrappers = []any{
+	file_cpybkc_ir_v1_ir_proto_msgTypes[26].OneofWrappers = []any{
 		(*Guard_Equals)(nil),
 		(*Guard_OneOf)(nil),
 		(*Guard_GreaterThanZero)(nil),
 	}
-	file_cpybkc_ir_v1_ir_proto_msgTypes[26].OneofWrappers = []any{
+	file_cpybkc_ir_v1_ir_proto_msgTypes[27].OneofWrappers = []any{
 		(*Literal_BytesValue)(nil),
 		(*Literal_Integer)(nil),
 	}
@@ -3575,7 +3664,7 @@ func file_cpybkc_ir_v1_ir_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cpybkc_ir_v1_ir_proto_rawDesc), len(file_cpybkc_ir_v1_ir_proto_rawDesc)),
 			NumEnums:      10,
-			NumMessages:   29,
+			NumMessages:   30,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/cpybkc/ir/v1/ir.proto
+++ b/proto/cpybkc/ir/v1/ir.proto
@@ -727,17 +727,18 @@ message Predicate {
   //
   // The set is closed so that it can be checked for overlap and for
   // exhaustiveness, and so that the IR stays data rather than carrying source
-  // only one language could run. Its membership lands with the layout
-  // format's discriminator strategies (#22, #28), which are what lower into it;
-  // until then it holds the one test those strategies all reduce to. Every
-  // member that lands MUST be decidable by a writer against the record it is
-  // about to emit, from that record's bytes and its own position in the
-  // automaton, at the moment it emits it — see docs/ir/SPEC.md, "A writer
-  // evaluates a predicate, it never inverts one". Adding one advances
-  // IrVersion, which is why the set is settled before the first release rather
-  // than grown afterwards.
+  // only one language could run. Its membership is these two, settled with the
+  // layout format's discriminator strategies (#22, #28), which are what lower
+  // into it: `equals` becomes BytesEqual and `one-of` becomes BytesOneOf, while
+  // `single-record-type` becomes no predicate at all. Every member MUST be
+  // decidable by a writer against the record it is about to emit, from that
+  // record's bytes and its own position in the automaton, at the moment it
+  // emits it — see docs/ir/SPEC.md, "A writer evaluates a predicate, it never
+  // inverts one". Adding one advances IrVersion, which is why the set is
+  // settled before the first release rather than grown afterwards.
   oneof test {
     BytesEqual bytes_equal = 2;
+    BytesOneOf bytes_one_of = 3;
   }
 }
 
@@ -751,6 +752,31 @@ message BytesEqual {
   // consumer left to decide whether "Y" matches "Y " is a consumer that decides
   // differently in each language.
   bytes value = 1;
+}
+
+// BytesOneOf is satisfied when the target field's bytes are one of the carried
+// literals.
+//
+// A member of its own rather than a shorthand a producer expands into several
+// BytesEqual predicates: a transition carries at most one predicate and an arm
+// carries exactly one, so a strategy admitting three type codes has nowhere to
+// put three of them, and splitting it into three transitions to one state would
+// turn a set of values into a set of edges for the overlap rule to forgive. Two
+// of these overlap when their literal sets intersect, which is the same
+// question about bytes that BytesEqual asks.
+message BytesOneOf {
+  // The literals, each padded by the producer to the target field's width, in
+  // the order the layout wrote them. A producer MUST carry at least two and
+  // MUST NOT carry the same literal twice: one literal is BytesEqual's work,
+  // and a repeated one is a value tested twice and a producer that did not
+  // check its own overlap.
+  //
+  // The order decides nothing — a consumer stopping at the first that matches
+  // and one comparing them all report the same thing, because the literals are
+  // distinct. It is preserved so that two producers handed one layout emit one
+  // descriptor, which is what "identical inputs produce byte-identical IR"
+  // requires of every repeated field here.
+  repeated bytes values = 1;
 }
 
 // State is a state of the record automaton. Sequencing reaches a generator

--- a/schema/layout.sexpr
+++ b/schema/layout.sexpr
@@ -65,8 +65,18 @@
 ;; What `when` tests a value against: one literal, or one of several.
 (sort match literal (form one-of))
 
-;; A discrimination strategy. The set is closed for v1.
-(sort strategy (form equals) (form one-of) (symbol single-record-type))
+;; What lowers into a predicate: a test on an item's bytes. The set is closed
+;; for v1, and it is the whole of what an arm may be selected by — an arm
+;; selected by nothing at all would be a default arm, and there is none.
+(sort predicate (form equals) (form one-of))
+
+;; A discrimination strategy: a predicate, or the record that carries nothing to
+;; test. `single-record-type` lowers into the absence of a predicate rather than
+;; into a member of the set above, which is why the two sorts are not one.
+(sort strategy predicate (symbol single-record-type))
+
+;; One alternative of a variant, and what selects it.
+(sort variant-arm (form arm))
 
 ;; A sequencing expression: a record name, or one of the seven operators. The
 ;; set is closed for the same reason the strategies are.
@@ -198,13 +208,29 @@
   (argument record record-name exactly-one)
   (argument strategy strategy exactly-one))
 
-(form equals (in strategy)
+(form equals (in predicate)
   (argument item item-ref exactly-one)
   (argument value literal exactly-one))
 
-(form one-of (in strategy)
+(form one-of (in predicate)
   (argument item item-ref exactly-one)
   (argument value literal one-or-more))
+
+;; A redefine inside a repeating group: the alternative is chosen once per
+;; occurrence, so it is a variant rather than a set of record types. The
+;; argument names the item the copybook redefines; each arm names one
+;; alternative and the predicate selecting it.
+;;
+;; That each arm names an alternative the copybook declares at that position,
+;; that the group containing it repeats, and where an arm's target may sit are
+;; all `resolve`'s: every one of them needs the copybook.
+(form discriminate-variant (in top-level) (arity zero-or-more) (layer discrimination)
+  (argument variant item-ref exactly-one)
+  (argument arm variant-arm two-or-more))
+
+(form arm (in variant-arm)
+  (argument alternative symbol exactly-one)
+  (argument predicate predicate exactly-one))
 
 ;;; Sequencing ----------------------------------------------------------------
 


### PR DESCRIPTION
Closes #28

Settles the closed set of discriminator strategies in both places it is stated —
`docs/layout/SPEC.md`'s **Discrimination** and `docs/ir/SPEC.md`'s **Discriminator
predicates** — adds the layout form for the second scope a discriminator is
written in, and implements the layer in `internal/layoutmodel`.

The set is three strategies at record scope (`equals`, `one-of`,
`single-record-type`) and two at arm scope, lowering into an IR predicate set of
exactly two members: `BytesEqual` and `BytesOneOf`. `single-record-type` lowers
into the *absence* of a predicate, which is why it is not a member.

## Acceptance criteria

- [x] **Strategies implemented.** A type code at a fixed offset and a type code
  in a shared header copybook are one strategy — the header is a group inside
  each record type — and both are `equals`/`one-of`, read and modelled here.
  `single-record-type` is read and reports `Strategy.Predicate() == false`.
  Record length and positional are **not** in the set; see below.
- [x] **Completeness and non-overlap at layout-validation time.** Every `record`
  is named by exactly one `discriminate` (missing, duplicated and naming an
  undefined record are three diagnostics); a variant carries at least two arms,
  no two naming one alternative; two arms of one variant naming one target and
  one literal are refused. The overlap that needs the copybook — two records at
  one point in the sequence, two literals that resolve to the same bytes — stays
  `resolve`'s and is listed there.
- [x] **Ambiguous or unreachable discriminators rejected with an explanatory
  error.** Fifteen typed faults, each carrying a span and assertable with
  `errors.As`, each naming what was found as well as what was wanted.
- [x] **Documented that adding a strategy requires an IR change and a version
  bump** — and a layout schema version besides, since it is also a change to
  what a layout may say. Both prices are named in one paragraph.
- [x] **Every predicate is writer-decidable** (#79). Both members compare a
  field's bytes against literals the descriptor carries, which asks a writer for
  nothing it does not already hold; stated in `layout/SPEC.md` and in the
  requirement's own subsection in `ir/SPEC.md`.
- [x] **Positional *last* resolved against #79** — refused, and the reason is the
  writer's: *last* becomes true only after the record has been written, and
  buffering until the caller says there are no more gives up #52's streaming
  property. Positional *first* is the automaton's start state and not a strategy.
- [x] **No transition predicate has a target that repeats or sits inside a group
  that repeats** (#84) — restated in *What the item reference must satisfy*, with
  the half needing no copybook (the reference is rooted at the record it
  discriminates) enforced by the reader.
- [x] **A discriminator can be stated for a `REDEFINES` inside a repeating
  group** (#90) — the new `discriminate-variant` top-level form, whose target is
  *required* to sit inside the repeating group holding the variant.
- [x] **An arm's target rejected where it sits outside the occurrence, or inside
  an arm that does not also contain the variant** — three of the four halves are
  decidable without a copybook and the reader reports each by name.
- [x] **Arms checked for overlap against each other**, with no guard available to
  exempt a pair and no default arm. `single-record-type` is not in the arm's
  sort, so an arm carrying nothing is a schema diagnostic as well as a reader
  one.
- [x] **No transition predicate sits behind an item whose count is a reference;
  an arm's carries no such restriction** (#84, #90) — both stated, the second
  with its reason (an arm runs against a record already admitted).

## Judgment calls

**`bytes one of` is a member of the IR set, not a shorthand a producer expands.**
A transition carries at most one predicate and an arm exactly one, so a strategy
admitting three type codes has nowhere to put three predicates. Splitting it into
three transitions to one state would turn a set of *values* into a set of *edges*
that the overlap rule would then have to be taught to forgive. Two `bytes one of`
predicates overlap when their literal sets intersect — the same question about
bytes that `bytes equal` asks — so the set stays checkable.

**A form of its own, `(discriminate-variant <item-ref> (arm <name> <predicate>)
…)`, rather than a second spelling of `discriminate`.** The two say different
things about different subjects: one names a record and carries one strategy, the
other names an item and carries an ordered list of them. A single form taking
either would make "one per `record`" a rule about which of two shapes was
written, and the published schema could not state even the half of it it states
today. The argument names the item the copybook *redefines* — the first
alternative, the one every `REDEFINES` of it names — and each arm names an
alternative by its copybook name.

**A new sort `predicate`, with `strategy` including it.** The arm position admits
`equals` and `one-of` and not `single-record-type`, because an arm selected by
nothing at all is the default arm `ir/SPEC.md` refuses in as many words. Two
sorts, one including the other, is how the schema says that without stating the
membership twice.

**The layout schema version stays at 1.** The rule *"the version advances for
every change to what a layout may say"* is about a released schema; there are no
releases, so there is nothing to advance from, and settling the vocabulary before
the first release is what that section asks for rather than an exception to it.
A sentence saying so is added, and it is the standing `IR_VERSION_1` already has
in `ir/SPEC.md`. `IrVersion` is unchanged for the same reason.

**Three arm-target rules are enforced without a copybook.** An item reference is
a complete path, so "rooted at another record", "under another outermost group
than the variant" and "descending through the variant or the arm it selects" are
decidable from the layout alone — and they are the three an adopter gets wrong
while holding the copybook open. That the shared group is the *innermost
repeating* one, and that the alternatives exist, remain `resolve`'s. A variant
reference carrying a single name is rejected outright: its only ancestor is the
record's top-level item, and a record does not repeat.

## Verification

- `dagger call ci` — green. `go vet` and `go test -race ./...` green in both
  modules.
- `irpb/ir.pb.go` regenerated with `dagger call proto-gen export --path=irpb`, in
  this commit with the `.proto` it comes from.
- New corpus fixtures: `valid/variant-arms.sexpr` (two variants in one record,
  both predicates, text and byte-string literals) and
  `invalid/strategy-in-an-arm.sexpr` (`single-record-type` in an arm).
- `internal/layoutmodel/discriminate_test.go` covers the model, every member of
  the closed set, every fault by message and by type, and two staleness gates
  reading SPEC.md's own examples — the end-to-end appendix and the variant
  example — out of the document rather than copying them.
- Every anchor added resolves from the file it is written in, and the new prose
  wraps at 80 columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
