### PR TITLE
story(layout): parse the record sequencing grammar

### DIFF
--- a/internal/layoutmodel/discriminate.go
+++ b/internal/layoutmodel/discriminate.go
@@ -636,8 +636,10 @@ func (r *discriminationReader) strategy(node layout.Node, subject string) (Strat
 	strategy := Strategy{Pos: form.Pos, Kind: kind, Item: item}
 
 	for _, element := range form.Elements[1:] {
-		literal, ok := r.literal(element)
-		if !ok {
+		literal, err := readLiteral(element)
+		if err != nil {
+			r.fail(err)
+
 			return Strategy{}, false
 		}
 
@@ -647,32 +649,33 @@ func (r *discriminationReader) strategy(node layout.Node, subject string) (Strat
 	return strategy, true
 }
 
-// literal reads one of the three spellings a literal takes.
-func (r *discriminationReader) literal(node layout.Node) (Literal, bool) {
+// readLiteral reads one of the three spellings a literal takes.
+//
+// It is a free function rather than a reader's method for [readItemRef]'s
+// reason: sequencing's `when` compares a value against literals too
+// (docs/layout/SPEC.md's "Two operators read a value"), and one reading of a
+// literal is what keeps the two layers spelling them alike.
+func readLiteral(node layout.Node) (Literal, error) {
 	switch value := node.(type) {
 	case layout.Text:
-		return Literal{Pos: value.Pos, Kind: TextLiteral, Text: value.Value}, true
+		return Literal{Pos: value.Pos, Kind: TextLiteral, Text: value.Value}, nil
 	case layout.Int:
-		return Literal{Pos: value.Pos, Kind: NumberLiteral, Number: strconv.FormatInt(value.Value, 10)}, true
+		return Literal{Pos: value.Pos, Kind: NumberLiteral, Number: strconv.FormatInt(value.Value, 10)}, nil
 	case layout.Float:
 		return Literal{
 			Pos:    value.Pos,
 			Kind:   NumberLiteral,
 			Number: strconv.FormatFloat(value.Value, 'f', -1, 64),
-		}, true
+		}, nil
 	case layout.Form:
 		bytes, err := readByteString(value)
 		if err != nil {
-			r.fail(err)
-
-			return Literal{}, false
+			return Literal{}, err
 		}
 
-		return Literal{Pos: bytes.Pos, Kind: BytesLiteral, Bytes: bytes}, true
+		return Literal{Pos: bytes.Pos, Kind: BytesLiteral, Bytes: bytes}, nil
 	default:
-		r.fail(&LiteralError{Pos: node.Position(), Found: describe(node)})
-
-		return Literal{}, false
+		return Literal{}, &LiteralError{Pos: node.Position(), Found: describe(node)}
 	}
 }
 

--- a/internal/layoutmodel/doc.go
+++ b/internal/layoutmodel/doc.go
@@ -16,14 +16,26 @@
 //
 // Each layer of the format gets a reader here, and a type for what the layer
 // says. [ReadProfile] is the encoding profile (#25), [ReadFraming] is the
-// physical framing (#26) and [ReadDiscrimination] is discrimination (#28);
-// record definitions and sequencing arrive beside them (#27, #29, #30). What
-// they have in common is that a value handed back is one the format admits: a
-// [Profile] carries four stated axes because a profile stating three is an error
-// and not a value with a hole in it, a [Framing] resolves to one of the IR's
-// four framings because the one record format that resolves to none is rejected
-// while the layout is read, and every `record` in a [Discrimination] carries
-// exactly one strategy out of a closed set.
+// physical framing (#26), [ReadDiscrimination] is discrimination (#28) and
+// [ReadSequence] is sequencing (#29); record definitions arrive beside them
+// (#27, #30). What they have in common is that a value handed back is one the
+// format admits: a [Profile] carries four stated axes because a profile stating
+// three is an error and not a value with a hole in it, a [Framing] resolves to
+// one of the IR's four framings because the one record format that resolves to
+// none is rejected while the layout is read, every `record` in a
+// [Discrimination] carries exactly one strategy out of a closed set, and every
+// node of a [Sequence]'s expression is one of the eight terms the algebra is
+// made of, carrying what that term takes.
+//
+// # The one layer that prints as well as reads
+//
+// Sequencing is the only layer whose value is a term rather than a record of
+// settings, and [Expression.String] renders one back into the notation a layout
+// writes it in. It exists because a term is the one thing here that a diagnostic
+// has to quote a *part* of — the subexpression a rule was broken under, not the
+// form it was written in — and because printing then reading yields the same
+// expression, which is a property the reader can be tested against and the other
+// layers have no shape to state.
 //
 // # Why the model is not the AST
 //

--- a/internal/layoutmodel/errors.go
+++ b/internal/layoutmodel/errors.go
@@ -991,6 +991,157 @@ func (e *ArmOverlapError) Error() string {
 	)
 }
 
+// SequenceCountError is a layout that does not carry exactly one `sequence`
+// form.
+//
+// docs/layout/SPEC.md requires exactly one, and it is the whole of what the
+// layout says about the order records may appear in. A layout carrying none says
+// nothing about that order, and one carrying two leaves the order they were
+// written in deciding which orders the file admits.
+type SequenceCountError struct {
+	// Pos is the second `sequence` form where there is one, and the start of the
+	// file where there is none.
+	Pos layout.Pos
+
+	// Count is how many the layout carries.
+	Count int
+}
+
+// Error implements the error interface.
+func (e *SequenceCountError) Error() string {
+	return fmt.Sprintf("%s: a layout carries exactly one sequence form, and this one carries %d", e.Pos, e.Count)
+}
+
+// SequenceFormError is a `sequence` that does not carry exactly one expression.
+//
+// `(sequence)` states no order at all, and `(sequence HEADER TRAILER)` is two
+// expressions where one belongs — which is `seq`, spelled by leaving it out.
+type SequenceFormError struct {
+	// Pos is the form.
+	Pos layout.Pos
+
+	// Found names what was written.
+	Found string
+}
+
+// Error implements the error interface.
+func (e *SequenceFormError) Error() string {
+	return fmt.Sprintf(
+		"%s: a sequence is written (sequence <expression>), one expression, and this one has %s",
+		e.Pos, e.Found,
+	)
+}
+
+// ExpressionError is something written where a sequencing expression belongs
+// that is neither a record name nor one of the seven operators.
+//
+// The message names the operators and not the record name, because a position
+// naming a record is the one shape nobody gets wrong by reaching for a form that
+// does not exist: every one of these is a layout that wrote `(one-of …)`, `(*)`
+// spelled `(star …)`, or a literal where a term belongs.
+type ExpressionError struct {
+	// Pos is what was written, or the tag of the form that was.
+	Pos layout.Pos
+
+	// Found names it.
+	Found string
+
+	// Admits is the set of operators, named in the message so that a misspelled
+	// one is one search away from the spelling that works.
+	Admits []string
+}
+
+// Error implements the error interface.
+func (e *ExpressionError) Error() string {
+	return fmt.Sprintf(
+		"%s: a sequencing expression is a record name or one of %s, and this is %s",
+		e.Pos, and(e.Admits), e.Found,
+	)
+}
+
+// ExpressionFormError is an operator that does not carry what it takes.
+//
+// `(seq HEADER)` is a concatenation of one, which is the subexpression itself;
+// `(* A B)` is two subexpressions under an operator that repeats one, which is
+// `(* (seq A B))` or `(seq (* A) B)` and not something to guess between; and a
+// `times` or a `when` missing its reference is an operator that reads a value
+// out of nothing.
+type ExpressionFormError struct {
+	// Pos is the form.
+	Pos layout.Pos
+
+	// Kind is the operator it states.
+	Kind ExpressionKind
+
+	// Found names what was written.
+	Found string
+}
+
+// Error implements the error interface.
+func (e *ExpressionFormError) Error() string {
+	return fmt.Sprintf("%s: form %s takes %s, and this one has %s", e.Pos, quote(string(e.Kind)), expressionTakes(e.Kind), e.Found)
+}
+
+// expressionTakes names what an operator carries, for the message above.
+func expressionTakes(kind ExpressionKind) string {
+	switch kind {
+	case Seq, Alt:
+		return "two or more subexpressions"
+	case Times:
+		return "one subexpression and the item counting it"
+	case When:
+		return "an item reference, a value and one subexpression"
+	default:
+		return "one subexpression"
+	}
+}
+
+// MatchFormError is a `(one-of …)` in a `when` that names no literal.
+//
+// A `when` selecting on nothing at all admits its subexpression under no value
+// and refuses it under every one, which is the subexpression left out.
+type MatchFormError struct {
+	// Pos is the form.
+	Pos layout.Pos
+
+	// Found names what was written.
+	Found string
+}
+
+// Error implements the error interface.
+func (e *MatchFormError) Error() string {
+	return fmt.Sprintf(
+		"%s: a when tests a value against a literal or (one-of <literal> ...), and this has %s",
+		e.Pos, e.Found,
+	)
+}
+
+// UnsequencedRecordError is a `record` the sequencing expression never names.
+//
+// docs/layout/SPEC.md requires every record to appear in the expression, and
+// gives the reason this message repeats: a record type nothing can ever admit is
+// one a file reader will never produce, and saying so is cheaper than leaving an
+// adopter to find that out. It is [MissingDiscriminatorError]'s counterpart in
+// this layer — the completeness rule counting one form against another, from the
+// other end.
+type UnsequencedRecordError struct {
+	// Pos is the `record` form, which is the record an adopter has to sequence.
+	// A record missing from an expression has no position inside it.
+	Pos layout.Pos
+
+	// Record is its name.
+	Record string
+}
+
+// Error implements the error interface.
+func (e *UnsequencedRecordError) Error() string {
+	return fmt.Sprintf(
+		"%s: record %s appears nowhere in the sequencing expression, and a record type nothing can ever "+
+			"admit is one nothing will ever produce",
+		e.Pos, quote(e.Record),
+	)
+}
+
 // axisNames is the four axes as a layout spells them, for a message that has to
 // list them.
 func axisNames() []string {

--- a/internal/layoutmodel/sequence.go
+++ b/internal/layoutmodel/sequence.go
@@ -442,6 +442,13 @@ func (r *sequenceReader) times(form layout.Form) (Expression, bool) {
 	if len(form.Elements) != 2 {
 		r.fail(&ExpressionFormError{Pos: form.Pos, Kind: Times, Found: timesShortfall(form.Elements)})
 
+		// What was written is read anyway, for the reason a `sequence` carrying
+		// two expressions has both read: an operator with the wrong number of
+		// arguments may also have something wrong inside one of them, and the
+		// second is a thing to fix rather than something to discover on the next
+		// run.
+		r.timesParts(form)
+
 		return Expression{}, false
 	}
 
@@ -471,6 +478,10 @@ func (r *sequenceReader) when(form layout.Form) (Expression, bool) {
 	if len(form.Elements) != 3 {
 		r.fail(&ExpressionFormError{Pos: form.Pos, Kind: When, Found: whenShortfall(form.Elements)})
 
+		// As in [sequenceReader.times]: the arity is one fault and what stands
+		// inside the operator may be another.
+		r.whenParts(form)
+
 		return Expression{}, false
 	}
 
@@ -491,6 +502,72 @@ func (r *sequenceReader) when(form layout.Form) (Expression, bool) {
 	}
 
 	return Expression{Pos: form.Pos, Kind: When, Item: item, Match: match, Sub: []Expression{sub}}, true
+}
+
+// timesParts reads whatever a malformed `times` carries, so that a fault inside
+// one of its arguments is reported beside the arity rather than after it.
+//
+// Each element is read in the position the operator declares for it, with one
+// exception: where a `times` carries a single element, which position that
+// element stands in is what the element itself says. An item reference is the
+// count and anything else is the subexpression, because reading a count as a
+// term would name the same line twice and describe it wrongly the second time.
+func (r *sequenceReader) timesParts(form layout.Form) {
+	for i, element := range form.Elements {
+		if i > 1 {
+			return
+		}
+
+		if i == 1 || (len(form.Elements) == 1 && isItemRef(element)) {
+			r.count(element, form.Tag)
+
+			continue
+		}
+
+		_, _ = r.expression(element, form.Tag)
+	}
+}
+
+// whenParts is the same for a malformed `when`.
+//
+// It needs no exception: a `when` names the item it reads first, so the position
+// an element stands in is what it is, however few of the three were written.
+func (r *sequenceReader) whenParts(form layout.Form) {
+	for i, element := range form.Elements {
+		switch i {
+		case 0:
+			r.count(element, form.Tag)
+		case 1:
+			_, _ = r.match(element)
+		case 2:
+			_, _ = r.expression(element, form.Tag)
+		default:
+			return
+		}
+	}
+}
+
+// count reads the item reference a value-reading operator stands on, and holds
+// the record it is rooted at to the records the layout defines.
+func (r *sequenceReader) count(node layout.Node, within string) {
+	item, err := readItemRef(node)
+	if err != nil {
+		r.fail(err)
+
+		return
+	}
+
+	r.itemRecord(item, within)
+}
+
+// isItemRef reports whether a node is written as an item reference.
+//
+// It is what tells "a count and no subexpression" from "a subexpression and no
+// count": the two are one arity and two different mistakes.
+func isItemRef(node layout.Node) bool {
+	form, ok := node.(layout.Form)
+
+	return ok && form.Tag == tagItem
 }
 
 // match reads what a `when` tests a value against: one literal, or `(one-of
@@ -594,14 +671,20 @@ func subexpressions(read int) string {
 
 // timesShortfall names what a `times` carries where a subexpression and a count
 // belong.
+//
+// One element is two different mistakes, and which one it is is what the element
+// says: a message telling an adopter they wrote a subexpression when they wrote
+// a count sends them to add the wrong half back.
 func timesShortfall(elements []layout.Node) string {
-	switch len(elements) {
-	case 0:
+	switch {
+	case len(elements) == 0:
 		return "neither"
-	case 1:
-		return "a subexpression and no count"
-	default:
+	case len(elements) > 1:
 		return "several"
+	case isItemRef(elements[0]):
+		return "a count and no subexpression"
+	default:
+		return "a subexpression and no count"
 	}
 }
 

--- a/internal/layoutmodel/sequence.go
+++ b/internal/layoutmodel/sequence.go
@@ -1,0 +1,621 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layoutmodel
+
+import (
+	"errors"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/Zaba505/cpybkc/internal/layout"
+)
+
+// The tags this layer reads. `sequence` is the top-level form; the seven below
+// it are the operators, and each is a tag in the `expression` sort rather than a
+// form a layout writes anywhere else.
+const (
+	tagSequence   = "sequence"
+	tagSeq        = "seq"
+	tagAlt        = "alt"
+	tagZeroOrMore = "*"
+	tagOneOrMore  = "+"
+	tagOptional   = "?"
+	tagTimes      = "times"
+	tagWhen       = "when"
+)
+
+// ExpressionKind is one member of the closed set a sequencing expression is
+// built out of: a record name, or one of the seven operators.
+//
+// The set is docs/layout/SPEC.md's "The operators" and this type is that set as
+// data. It is closed for the reason [StrategyKind] is: an eighth operator is a
+// fourth guard test in docs/ir/SPEC.md's "The automaton remembers in registers",
+// which is breaking there, and a change to what a layout may say besides.
+//
+// The zero value is not a kind. An [Expression] handed back by [ReadSequence]
+// always names one.
+type ExpressionKind string
+
+// The eight, in docs/layout/SPEC.md's order. Every operator's constant is the
+// tag a layout writes it as, which is what lets [Expression.String] print one
+// without a second table saying how each is spelled.
+const (
+	// RecordName is a bare record name: one record of that type. It is the only
+	// member that is not a form, and so the only one whose constant is a name
+	// for the position rather than a tag — it is the published schema's
+	// `record-name` sort, which is where the name comes from.
+	RecordName ExpressionKind = "record-name"
+
+	// Seq is `(seq <e> …)`: each in turn, left to right.
+	Seq ExpressionKind = tagSeq
+
+	// Alt is `(alt <e> …)`: exactly one of them.
+	Alt ExpressionKind = tagAlt
+
+	// ZeroOrMore is `(* <e>)`. An empty file is one of these accepting, which is
+	// the whole of the difference between it and [OneOrMore].
+	ZeroOrMore ExpressionKind = tagZeroOrMore
+
+	// OneOrMore is `(+ <e>)`.
+	OneOrMore ExpressionKind = tagOneOrMore
+
+	// Optional is `(? <e>)`: zero or one.
+	Optional ExpressionKind = tagOptional
+
+	// Times is `(times <e> <item-ref>)`: exactly as many as the named item
+	// holds. It lowers into a register holding an integer and a guard reading it
+	// (docs/ir/SPEC.md's "The automaton remembers in registers", #77).
+	Times ExpressionKind = tagTimes
+
+	// When is `(when <item-ref> <match> <e>)`: the subexpression only where the
+	// item holds that value. It lowers into a register and one of the two guard
+	// tests a [Match] names.
+	When ExpressionKind = tagWhen
+)
+
+// operators is the set an expression admits as a form, in the order every
+// message listing them renders them. A record name is not among them because it
+// is not a form: what a message about a form names is the seven.
+var operators = []ExpressionKind{Seq, Alt, ZeroOrMore, OneOrMore, Optional, Times, When}
+
+// branches is the subset taking two or more subexpressions.
+var branches = []ExpressionKind{Seq, Alt}
+
+// repetitions is the subset taking exactly one subexpression and nothing else.
+var repetitions = []ExpressionKind{ZeroOrMore, OneOrMore, Optional}
+
+// Match is what a `when` tests an item's value against: one literal, or one of
+// several.
+//
+// [Match.Kind] is the guard test it lowers into, and it is a [StrategyKind]
+// rather than a set of its own because there is no third: docs/layout/SPEC.md's
+// "Two operators read a value" closes the tests at the register test `times`
+// carries and the two an ordinary predicate carries, and those two are [Equals]
+// and [OneOf] already. A bare literal is [Equals] and `(one-of …)` is [OneOf],
+// whichever way round the layout happens to have written a single value.
+type Match struct {
+	// Pos is what was written: the literal itself, or the `(one-of …)` form
+	// around several.
+	Pos layout.Pos
+
+	// Kind is the test it lowers into, and is [Equals] or [OneOf].
+	Kind StrategyKind
+
+	// Literals are what the item's value is compared against, in the order the
+	// layout writes them. It holds exactly one under [Equals] and at least one
+	// under [OneOf].
+	Literals []Literal
+}
+
+// String renders a match the way a layout writes it, which is what a diagnostic
+// naming one quotes and what [Expression.String] prints inside a `when`.
+func (m Match) String() string {
+	literals := make([]string, 0, len(m.Literals))
+	for _, literal := range m.Literals {
+		literals = append(literals, literal.String())
+	}
+
+	if m.Kind == OneOf {
+		return "(" + tagOneOf + " " + strings.Join(literals, " ") + ")"
+	}
+
+	if len(literals) == 0 {
+		return "nothing"
+	}
+
+	return literals[0]
+}
+
+// Expression is one node of a sequencing expression.
+//
+// One type carries all eight kinds, and [Expression.Kind] says which, for the
+// reason [Strategy] carries three: the set is closed, so a switch over it is
+// exhaustive and stays exhaustive, and a caller compiling one reaches for the
+// same fields whatever it turns out to be.
+//
+// Which fields a value carries follows from its kind, and a value handed back by
+// [ReadSequence] always carries exactly those: [RecordName] carries a record and
+// nothing else; [Seq] and [Alt] carry two or more subexpressions; [ZeroOrMore],
+// [OneOrMore] and [Optional] carry one; [Times] carries one and the item
+// counting it; [When] carries one, the item it reads and the [Match] against it.
+type Expression struct {
+	// Pos is where it was written: the form, or the record name itself.
+	Pos layout.Pos
+
+	// Kind is which member of the closed set it is.
+	Kind ExpressionKind
+
+	// Record is the record named, under [RecordName] alone.
+	Record string
+
+	// Item is what [Times] counts by and what [When] reads, and is the zero
+	// [ItemRef] under every other kind.
+	Item ItemRef
+
+	// Match is what [When] compares that item against, and is the zero [Match]
+	// under every other kind.
+	Match Match
+
+	// Sub are the subexpressions, in the order the layout writes them.
+	Sub []Expression
+}
+
+// String renders an expression the way a layout writes it.
+//
+// It is the printer half of this layer, and it is total over the model rather
+// than over the source: what comes back is one line, whatever the layout's own
+// line breaks were, because an expression is a term and the line it was broken
+// across says nothing about it. Reading that line back yields the same
+// expression with new positions on it, which is what
+// [github.com/Zaba505/cpybkc/internal/layoutmodel]'s round-trip test asserts.
+func (e Expression) String() string {
+	switch {
+	case e.Kind == RecordName:
+		return e.Record
+	case slices.Contains(branches, e.Kind), slices.Contains(repetitions, e.Kind):
+		parts := make([]string, 0, len(e.Sub)+1)
+		parts = append(parts, string(e.Kind))
+
+		for _, sub := range e.Sub {
+			parts = append(parts, sub.String())
+		}
+
+		return "(" + strings.Join(parts, " ") + ")"
+	case e.Kind == Times:
+		return "(" + tagTimes + " " + e.subexpression() + " " + e.Item.String() + ")"
+	case e.Kind == When:
+		return "(" + tagWhen + " " + e.Item.String() + " " + e.Match.String() + " " + e.subexpression() + ")"
+	default:
+		return "nothing"
+	}
+}
+
+// subexpression renders the one subexpression an operator taking exactly one
+// carries.
+//
+// A value handed back by [ReadSequence] always carries it. The guard is for a
+// value somebody built by hand, which is [Literal.String]'s reason for having a
+// default case: a printer that panics is one nothing can use in a diagnostic.
+func (e Expression) subexpression() string {
+	if len(e.Sub) == 0 {
+		return "nothing"
+	}
+
+	return e.Sub[0].String()
+}
+
+// Sequence is a layout's sequencing layer: the one `sequence` form, and the
+// expression under it.
+//
+// It is the whole of what a layout says about the order records may appear in.
+// What that order *means* — the automaton, its start state, the registers the
+// value-reading operators compile into — is docs/ir/SPEC.md's and `resolve`'s
+// (#36).
+type Sequence struct {
+	// Pos is the `sequence` form.
+	Pos layout.Pos
+
+	// Expression is the expression it carries.
+	Expression Expression
+}
+
+// String renders the layer the way a layout writes it.
+func (s *Sequence) String() string {
+	return "(" + tagSequence + " " + s.Expression.String() + ")"
+}
+
+// ReadSequence reads the sequencing layer out of a parsed layout.
+//
+// It reports every fault it finds, joined, and returns nothing when it found
+// one, for [ReadProfile]'s reason: a sequence an adopter cannot act on is worse
+// than none.
+//
+// What it enforces is what a declaration cannot state and a copybook is not
+// needed for: that the layout carries exactly one `sequence`, that every node of
+// the expression is a member of the closed set carrying what that member takes,
+// that every record name is one the layout defines, and that every record the
+// layout defines is named somewhere in the expression. The last is
+// docs/layout/SPEC.md's in as many words — "a record defined and never sequenced
+// is a record type nothing can ever admit" — and it counts one form against
+// another, which is why the published schema cannot state it.
+//
+// What it does not enforce is the pair of rules on `times` and `when` that need
+// more than the layout: that the item is admitted strictly earlier on every path,
+// that it does not repeat, and that a counted item decodes to an integer. Each
+// needs the copybook or the compiled graph, and docs/layout/SPEC.md's "Validation
+// and diagnostics" files all three under `resolve` (#36, #37, #88). The half
+// checkable here is the reference's own spelling, which [readItemRef] holds it
+// to, and the record it is rooted at.
+//
+// Top-level forms belonging to other layers are not read here and are not
+// faults. `record` forms are read for their names alone, because "every record
+// is sequenced" counts one form against another and there is nowhere else to
+// count it.
+func ReadSequence(file *layout.File) (*Sequence, error) {
+	read := &sequenceReader{records: recordNames(file)}
+	sequence := &Sequence{Pos: file.Start()}
+
+	// Every `sequence` form is read and not only the one that will be kept, so
+	// that a layout carrying two malformed sequences is told about both rather
+	// than about the count alone.
+	var forms []layout.Form
+
+	for _, form := range file.Forms {
+		if form.Tag != tagSequence {
+			continue
+		}
+
+		forms = append(forms, form)
+
+		one, ok := read.sequence(form)
+		if ok && len(forms) == 1 {
+			sequence = one
+		}
+	}
+
+	if len(forms) != 1 {
+		// The second form is what the diagnostic points at where there is one:
+		// the first is a sequence an adopter meant, and the second is the line
+		// making it ambiguous.
+		pos := file.Start()
+		if len(forms) > 1 {
+			pos = forms[1].Pos
+		}
+
+		read.fail(&SequenceCountError{Pos: pos, Count: len(forms)})
+	}
+
+	// A record the expression never names is a fact about the layout rather than
+	// about any one form, so it is reported after everything the forms
+	// themselves were wrong about, and in source order for the same reason they
+	// are read in it.
+	//
+	// It is reported only where the layout states a sequence at all. A layout
+	// carrying none names no record anywhere, and saying so once per record
+	// would describe the missing form as many times as the layout has record
+	// types.
+	if len(forms) > 0 {
+		for _, record := range read.records {
+			if _, sequenced := read.sequenced[record.name]; !sequenced {
+				read.fail(&UnsequencedRecordError{Pos: record.pos, Record: record.name})
+			}
+		}
+	}
+
+	if len(read.errs) > 0 {
+		return nil, errors.Join(read.errs...)
+	}
+
+	return sequence, nil
+}
+
+// sequenceReader holds the state one [ReadSequence] accumulates.
+type sequenceReader struct {
+	faults
+
+	// records are the records the layout defines, which is what makes "a record
+	// name the layout defines" and "a record the expression never names"
+	// answerable.
+	records []recordDefinition
+
+	// sequenced is where each record name was first written in an expression,
+	// which is the other half of the completeness rule.
+	sequenced map[string]layout.Pos
+}
+
+// sequence reads one `sequence` form.
+func (r *sequenceReader) sequence(form layout.Form) (*Sequence, bool) {
+	if len(form.Elements) != 1 {
+		r.fail(&SequenceFormError{Pos: form.Pos, Found: count(len(form.Elements))})
+
+		// Every element is read anyway, for the reason a discriminator's
+		// strategy is read after a misspelled record name: a `sequence` carrying
+		// two expressions is one expression too many *and* possibly two
+		// expressions with something wrong inside them, and the second is a
+		// thing to fix rather than something to discover on the next run.
+		for _, element := range form.Elements {
+			_, _ = r.expression(element, form.Tag)
+		}
+
+		return nil, false
+	}
+
+	expression, ok := r.expression(form.Elements[0], form.Tag)
+	if !ok {
+		return nil, false
+	}
+
+	return &Sequence{Pos: form.Pos, Expression: expression}, true
+}
+
+// expression reads one node of the expression: a record name, or an operator.
+//
+// within is the tag of the form the node stands in, so that a diagnostic about a
+// record name names the operator it was written under rather than the layer.
+func (r *sequenceReader) expression(node layout.Node, within string) (Expression, bool) {
+	switch node := node.(type) {
+	case layout.Symbol:
+		r.name(node, within)
+
+		return Expression{Pos: node.Pos, Kind: RecordName, Record: node.Value}, true
+	case layout.Form:
+		return r.operator(node)
+	default:
+		r.fail(&ExpressionError{Pos: node.Position(), Found: describe(node), Admits: operatorNames()})
+
+		return Expression{}, false
+	}
+}
+
+// operator reads one of the seven forms an expression admits.
+func (r *sequenceReader) operator(form layout.Form) (Expression, bool) {
+	kind := ExpressionKind(form.Tag)
+
+	switch {
+	case slices.Contains(branches, kind):
+		return r.branch(form, kind)
+	case slices.Contains(repetitions, kind):
+		return r.repetition(form, kind)
+	case kind == Times:
+		return r.times(form)
+	case kind == When:
+		return r.when(form)
+	default:
+		r.fail(&ExpressionError{Pos: form.TagPos, Found: describe(form), Admits: operatorNames()})
+
+		return Expression{}, false
+	}
+}
+
+// branch reads a `seq` or an `alt`, which take two or more subexpressions.
+func (r *sequenceReader) branch(form layout.Form, kind ExpressionKind) (Expression, bool) {
+	expression := Expression{Pos: form.Pos, Kind: kind}
+
+	for _, element := range form.Elements {
+		sub, ok := r.expression(element, form.Tag)
+		if !ok {
+			continue
+		}
+
+		expression.Sub = append(expression.Sub, sub)
+	}
+
+	// The count is checked against the subexpressions that were read rather than
+	// against the elements written, for [VariantArmCountError]'s reason: a `seq`
+	// of two one of which is malformed is reported against that subexpression
+	// and against this rule, and not twice against this one.
+	if len(expression.Sub) < 2 {
+		r.fail(&ExpressionFormError{Pos: form.Pos, Kind: kind, Found: subexpressions(len(expression.Sub))})
+
+		return Expression{}, false
+	}
+
+	return expression, true
+}
+
+// repetition reads a `*`, a `+` or a `?`, which take exactly one subexpression.
+func (r *sequenceReader) repetition(form layout.Form, kind ExpressionKind) (Expression, bool) {
+	if len(form.Elements) != 1 {
+		r.fail(&ExpressionFormError{Pos: form.Pos, Kind: kind, Found: subexpressions(len(form.Elements))})
+
+		for _, element := range form.Elements {
+			_, _ = r.expression(element, form.Tag)
+		}
+
+		return Expression{}, false
+	}
+
+	sub, ok := r.expression(form.Elements[0], form.Tag)
+	if !ok {
+		return Expression{}, false
+	}
+
+	return Expression{Pos: form.Pos, Kind: kind, Sub: []Expression{sub}}, true
+}
+
+// times reads `(times <e> <item-ref>)`.
+func (r *sequenceReader) times(form layout.Form) (Expression, bool) {
+	if len(form.Elements) != 2 {
+		r.fail(&ExpressionFormError{Pos: form.Pos, Kind: Times, Found: timesShortfall(form.Elements)})
+
+		return Expression{}, false
+	}
+
+	sub, ok := r.expression(form.Elements[0], form.Tag)
+
+	// The count is read whatever was wrong with the subexpression, because the
+	// two are independent halves of the operator and an adopter fixing one
+	// should not have to run again to be told about the other.
+	item, err := readItemRef(form.Elements[1])
+	if err != nil {
+		r.fail(err)
+
+		return Expression{}, false
+	}
+
+	r.itemRecord(item, form.Tag)
+
+	if !ok {
+		return Expression{}, false
+	}
+
+	return Expression{Pos: form.Pos, Kind: Times, Item: item, Sub: []Expression{sub}}, true
+}
+
+// when reads `(when <item-ref> <match> <e>)`.
+func (r *sequenceReader) when(form layout.Form) (Expression, bool) {
+	if len(form.Elements) != 3 {
+		r.fail(&ExpressionFormError{Pos: form.Pos, Kind: When, Found: whenShortfall(form.Elements)})
+
+		return Expression{}, false
+	}
+
+	item, err := readItemRef(form.Elements[0])
+	if err != nil {
+		r.fail(err)
+
+		return Expression{}, false
+	}
+
+	r.itemRecord(item, form.Tag)
+
+	match, matched := r.match(form.Elements[1])
+
+	sub, ok := r.expression(form.Elements[2], form.Tag)
+	if !matched || !ok {
+		return Expression{}, false
+	}
+
+	return Expression{Pos: form.Pos, Kind: When, Item: item, Match: match, Sub: []Expression{sub}}, true
+}
+
+// match reads what a `when` tests a value against: one literal, or `(one-of
+// <literal> …)`.
+func (r *sequenceReader) match(node layout.Node) (Match, bool) {
+	form, ok := node.(layout.Form)
+	if ok && form.Tag == tagOneOf {
+		if len(form.Elements) == 0 {
+			r.fail(&MatchFormError{Pos: form.Pos, Found: "no literal"})
+
+			return Match{}, false
+		}
+
+		match := Match{Pos: form.Pos, Kind: OneOf}
+
+		for _, element := range form.Elements {
+			literal, err := readLiteral(element)
+			if err != nil {
+				r.fail(err)
+
+				return Match{}, false
+			}
+
+			match.Literals = append(match.Literals, literal)
+		}
+
+		return match, true
+	}
+
+	// Everything else is read as a literal, including a form: `(bytes "F0")` is
+	// one of the three spellings, and a form that is neither that nor `one-of`
+	// is a [LiteralError] naming what was written.
+	literal, err := readLiteral(node)
+	if err != nil {
+		r.fail(err)
+
+		return Match{}, false
+	}
+
+	return Match{Pos: literal.Pos, Kind: Equals, Literals: []Literal{literal}}, true
+}
+
+// name holds a record name written in the expression to the records the layout
+// defines, and records that the name was written at all.
+func (r *sequenceReader) name(symbol layout.Symbol, within string) {
+	if r.sequenced == nil {
+		r.sequenced = make(map[string]layout.Pos)
+	}
+
+	if _, already := r.sequenced[symbol.Value]; !already {
+		r.sequenced[symbol.Value] = symbol.Pos
+	}
+
+	if !r.defines(symbol.Value) {
+		r.fail(&UnknownRecordError{Pos: symbol.Pos, Record: symbol.Value, Form: within})
+	}
+}
+
+// itemRecord holds the record an operator's item reference is rooted at to the
+// records the layout defines.
+//
+// It does not count as the record being sequenced. A `times` reads a value out
+// of a record the expression has already admitted somewhere else; naming it here
+// admits nothing, and treating it as an appearance would let a record be
+// referred to by an operator and never actually sequenced.
+func (r *sequenceReader) itemRecord(item ItemRef, within string) {
+	if !r.defines(item.Record) {
+		r.fail(&UnknownRecordError{Pos: item.Pos, Record: item.Record, Form: within})
+	}
+}
+
+// defines reports whether the layout defines a record of that name.
+func (r *sequenceReader) defines(name string) bool {
+	return slices.ContainsFunc(r.records, func(record recordDefinition) bool { return record.name == name })
+}
+
+// operatorNames is the operators as a layout spells them, for a message that has
+// to list them.
+func operatorNames() []string {
+	names := make([]string, 0, len(operators))
+
+	for _, operator := range operators {
+		names = append(names, string(operator))
+	}
+
+	return names
+}
+
+// subexpressions names how many subexpressions stood where a fixed number
+// belongs.
+func subexpressions(read int) string {
+	switch read {
+	case 0:
+		return "none"
+	case 1:
+		return "one"
+	default:
+		return strconv.Itoa(read)
+	}
+}
+
+// timesShortfall names what a `times` carries where a subexpression and a count
+// belong.
+func timesShortfall(elements []layout.Node) string {
+	switch len(elements) {
+	case 0:
+		return "neither"
+	case 1:
+		return "a subexpression and no count"
+	default:
+		return "several"
+	}
+}
+
+// whenShortfall is the same for a `when`, which takes three things rather than
+// two.
+func whenShortfall(elements []layout.Node) string {
+	switch len(elements) {
+	case 0:
+		return "none of the three"
+	case 1:
+		return "an item and nothing to test it against"
+	case 2:
+		return "an item and a value and no subexpression"
+	default:
+		return "several"
+	}
+}

--- a/internal/layoutmodel/sequence_test.go
+++ b/internal/layoutmodel/sequence_test.go
@@ -1,0 +1,710 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layoutmodel
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/layout"
+)
+
+// sequenceOf is the whole pipeline a caller runs: parse the source, then read
+// the sequencing layer out of it.
+func sequenceOf(t *testing.T, source string) (*Sequence, error) {
+	t.Helper()
+
+	file, err := layout.Parse("layout.sexpr", strings.NewReader(source))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	return ReadSequence(file)
+}
+
+// sequenced wraps an expression in the least a layout has to say for the layer
+// to be readable: one `record` form per record it names.
+//
+// The records come first and one to a line, so that the `sequence` form always
+// starts at line len(records)+1 and every position in the expression is the
+// column it was written at.
+func sequenced(expression string, records ...string) string {
+	lines := make([]string, 0, len(records)+1)
+
+	for _, record := range records {
+		lines = append(lines, fmt.Sprintf("(record %s (copybook \"cpy/x.cpy\" %s-REC))", record, record))
+	}
+
+	return strings.Join(append(lines, expression), "\n")
+}
+
+// renderSequence draws the layer the way the tests assert one: the `sequence`
+// form, then its expression as a tree with a position, a kind and whatever the
+// kind carries on every node.
+//
+// It is a rendering rather than a struct literal for [renderDiscrimination]'s
+// reason: what has to be right is the model *and* the position of every part of
+// it, and a rendering carrying both fails with the whole model in the message.
+func renderSequence(s *Sequence) string {
+	return strings.Join(append([]string{fmt.Sprintf("%s sequence", s.Pos)}, renderExpression(s.Expression, 1)...), "\n")
+}
+
+// renderExpression draws one node and everything under it, indented by depth.
+func renderExpression(e Expression, depth int) []string {
+	head := fmt.Sprintf("%s%s %s", strings.Repeat("  ", depth), e.Pos, e.Kind)
+
+	switch e.Kind {
+	case RecordName:
+		head += " " + e.Record
+	case Times:
+		head += " " + e.Item.String()
+	case When:
+		head += " " + e.Item.String() + " " + e.Match.String()
+	}
+
+	lines := []string{head}
+	for _, sub := range e.Sub {
+		lines = append(lines, renderExpression(sub, depth+1)...)
+	}
+
+	return lines
+}
+
+// withoutPositions is the same expression with every position dropped, which is
+// what makes two readings of one term comparable.
+//
+// Everything else is kept, including which of the two spellings a `when`'s value
+// was written in and which of the three spellings each literal was: those are
+// the parts of the model a printer could silently normalise away, and they are
+// the parts a round trip is worth asserting over.
+func withoutPositions(e Expression) Expression {
+	e.Pos = layout.Pos{}
+	e.Item.Pos = layout.Pos{}
+	e.Match.Pos = layout.Pos{}
+
+	literals := make([]Literal, 0, len(e.Match.Literals))
+
+	for _, literal := range e.Match.Literals {
+		literal.Pos = layout.Pos{}
+		literal.Bytes.Pos = layout.Pos{}
+		literals = append(literals, literal)
+	}
+
+	e.Match.Literals = literals
+
+	sub := make([]Expression, 0, len(e.Sub))
+	for _, one := range e.Sub {
+		sub = append(sub, withoutPositions(one))
+	}
+
+	e.Sub = sub
+
+	return e
+}
+
+// TestReadSequenceModelsTheLayer is the criterion this reader exists for: a
+// layout's sequencing expression becomes a typed term over the closed set of
+// operators, with a position on every node of it.
+func TestReadSequenceModelsTheLayer(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		source string
+		want   []string
+	}{
+		{
+			name:   "a file of one record type",
+			source: sequenced("(sequence (* DETAIL))", "DETAIL"),
+			want: []string{
+				"layout.sexpr:2:1 sequence",
+				"  layout.sexpr:2:11 *",
+				"    layout.sexpr:2:14 record-name DETAIL",
+			},
+		},
+		{
+			name:   "a header, a body and a trailer",
+			source: sequenced("(sequence (seq HEADER (+ DETAIL) TRAILER))", "HEADER", "DETAIL", "TRAILER"),
+			want: []string{
+				"layout.sexpr:4:1 sequence",
+				"  layout.sexpr:4:11 seq",
+				"    layout.sexpr:4:16 record-name HEADER",
+				"    layout.sexpr:4:23 +",
+				"      layout.sexpr:4:26 record-name DETAIL",
+				"    layout.sexpr:4:34 record-name TRAILER",
+			},
+		},
+		{
+			// Grouping is the notation's own: a subexpression standing where a
+			// record name may stand is a group, and nothing is written to say so.
+			name:   "a repeated group of two record types",
+			source: sequenced("(sequence (* (seq ORDER OPTION)))", "ORDER", "OPTION"),
+			want: []string{
+				"layout.sexpr:3:1 sequence",
+				"  layout.sexpr:3:11 *",
+				"    layout.sexpr:3:14 seq",
+				"      layout.sexpr:3:19 record-name ORDER",
+				"      layout.sexpr:3:25 record-name OPTION",
+			},
+		},
+		{
+			name:   "either of two record types at one point",
+			source: sequenced("(sequence (alt DEBIT CREDIT))", "DEBIT", "CREDIT"),
+			want: []string{
+				"layout.sexpr:3:1 sequence",
+				"  layout.sexpr:3:11 alt",
+				"    layout.sexpr:3:16 record-name DEBIT",
+				"    layout.sexpr:3:22 record-name CREDIT",
+			},
+		},
+		{
+			name:   "an optional trailer",
+			source: sequenced("(sequence (seq DETAIL (? TRAILER)))", "DETAIL", "TRAILER"),
+			want: []string{
+				"layout.sexpr:3:1 sequence",
+				"  layout.sexpr:3:11 seq",
+				"    layout.sexpr:3:16 record-name DETAIL",
+				"    layout.sexpr:3:23 ?",
+				"      layout.sexpr:3:26 record-name TRAILER",
+			},
+		},
+		{
+			// The count is a field of a record the expression admits earlier,
+			// which is the whole of what makes this expressible at all: the
+			// register is read from the header and the details are counted
+			// against it.
+			name:   "as many details as the header counts",
+			source: sequenced("(sequence (seq HEADER (times DETAIL (item HEADER H-COUNT))))", "HEADER", "DETAIL"),
+			want: []string{
+				"layout.sexpr:3:1 sequence",
+				"  layout.sexpr:3:11 seq",
+				"    layout.sexpr:3:16 record-name HEADER",
+				"    layout.sexpr:3:23 times (item HEADER H-COUNT)",
+				"      layout.sexpr:3:30 record-name DETAIL",
+			},
+		},
+		{
+			name:   "a trailer the header says whether to expect",
+			source: sequenced("(sequence (seq HEADER (when (item HEADER H-FLAG) \"Y\" TRAILER)))", "HEADER", "TRAILER"),
+			want: []string{
+				"layout.sexpr:3:1 sequence",
+				"  layout.sexpr:3:11 seq",
+				"    layout.sexpr:3:16 record-name HEADER",
+				"    layout.sexpr:3:23 when (item HEADER H-FLAG) \"Y\"",
+				"      layout.sexpr:3:54 record-name TRAILER",
+			},
+		},
+		{
+			name:   "a trailer any of several flag values calls for",
+			source: sequenced("(sequence (seq HEADER (when (item HEADER H-FLAG) (one-of \"Y\" \"T\") TRAILER)))", "HEADER", "TRAILER"),
+			want: []string{
+				"layout.sexpr:3:1 sequence",
+				"  layout.sexpr:3:11 seq",
+				"    layout.sexpr:3:16 record-name HEADER",
+				"    layout.sexpr:3:23 when (item HEADER H-FLAG) (one-of \"Y\" \"T\")",
+				"      layout.sexpr:3:67 record-name TRAILER",
+			},
+		},
+		{
+			// A conjunction of two conditions is a nested `when`, which SPEC.md
+			// gives as the shape that already works in place of an operator
+			// taking two.
+			name: "two conditions on one subexpression",
+			source: sequenced(
+				"(sequence (seq HEADER (when (item HEADER H-FLAG) \"Y\" (when (item HEADER H-KIND) \"A\" TRAILER))))",
+				"HEADER", "TRAILER",
+			),
+			want: []string{
+				"layout.sexpr:3:1 sequence",
+				"  layout.sexpr:3:11 seq",
+				"    layout.sexpr:3:16 record-name HEADER",
+				"    layout.sexpr:3:23 when (item HEADER H-FLAG) \"Y\"",
+				"      layout.sexpr:3:54 when (item HEADER H-KIND) \"A\"",
+				"        layout.sexpr:3:85 record-name TRAILER",
+			},
+		},
+		{
+			// A record may stand at more than one point in the expression.
+			// Nothing in SPEC.md says otherwise, and a file whose trailer is the
+			// same record type as its header is an ordinary one.
+			name:   "one record type at two points",
+			source: sequenced("(sequence (seq MARKER DETAIL MARKER))", "MARKER", "DETAIL"),
+			want: []string{
+				"layout.sexpr:3:1 sequence",
+				"  layout.sexpr:3:11 seq",
+				"    layout.sexpr:3:16 record-name MARKER",
+				"    layout.sexpr:3:23 record-name DETAIL",
+				"    layout.sexpr:3:30 record-name MARKER",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			read, err := sequenceOf(t, testCase.source)
+			if err != nil {
+				t.Fatalf("read the sequence: %v", err)
+			}
+
+			if got, want := renderSequence(read), strings.Join(testCase.want, "\n"); got != want {
+				t.Errorf("the sequence reads as\n%s\nwant\n%s", got, want)
+			}
+		})
+	}
+}
+
+// TestEveryOperatorIsWritable is the closed set from the other side: every
+// member of it is something a layout can say, and the reader reads each as
+// itself.
+//
+// A member nothing can write is a member of a set nobody agreed on, and the set
+// is the one thing about this layer that #36 compiles against.
+func TestEveryOperatorIsWritable(t *testing.T) {
+	t.Parallel()
+
+	written := map[ExpressionKind]string{
+		RecordName: "(sequence DETAIL)",
+		Seq:        "(sequence (seq DETAIL DETAIL))",
+		Alt:        "(sequence (alt DETAIL DETAIL))",
+		ZeroOrMore: "(sequence (* DETAIL))",
+		OneOrMore:  "(sequence (+ DETAIL))",
+		Optional:   "(sequence (? DETAIL))",
+		Times:      "(sequence (times DETAIL (item DETAIL D-COUNT)))",
+		When:       "(sequence (when (item DETAIL D-FLAG) \"Y\" DETAIL))",
+	}
+
+	for _, kind := range append([]ExpressionKind{RecordName}, operators...) {
+		source, ok := written[kind]
+		if !ok {
+			t.Fatalf("%s is a member of the set with no layout in this test writing one", kind)
+		}
+
+		read, err := sequenceOf(t, sequenced(source, "DETAIL"))
+		if err != nil {
+			t.Fatalf("%s: %v", kind, err)
+		}
+
+		if read.Expression.Kind != kind {
+			t.Errorf("%s reads as %s", kind, read.Expression.Kind)
+		}
+	}
+}
+
+// TestSequenceRoundTrips is the printer's criterion: an expression printed and
+// read back is the expression that was printed.
+//
+// Positions are dropped before the comparison and nothing else is — the layout's
+// own line breaks are not part of the term, and the printer puts one on a line —
+// so what this asserts is that no part of the model is lost or normalised on the
+// way out and back.
+func TestSequenceRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		expression string
+		records    []string
+	}{
+		{
+			name:       "a record name alone",
+			expression: "(sequence DETAIL)",
+			records:    []string{"DETAIL"},
+		},
+		{
+			name:       "every operator at once",
+			expression: "(sequence (seq HEADER (* (alt (+ DETAIL) (? OPTION))) TRAILER))",
+			records:    []string{"HEADER", "DETAIL", "OPTION", "TRAILER"},
+		},
+		{
+			name:       "a count read out of an earlier record",
+			expression: "(sequence (seq HEADER (times DETAIL (item HEADER H-KEY H-COUNT))))",
+			records:    []string{"HEADER", "DETAIL"},
+		},
+		{
+			name:       "a presence test against one literal",
+			expression: "(sequence (seq HEADER (when (item HEADER H-FLAG) \"Y\" TRAILER)))",
+			records:    []string{"HEADER", "TRAILER"},
+		},
+		{
+			name:       "a presence test against several literals",
+			expression: "(sequence (seq HEADER (when (item HEADER H-FLAG) (one-of \"Y\" \"T\") TRAILER)))",
+			records:    []string{"HEADER", "TRAILER"},
+		},
+		{
+			// A single literal under `one-of` is not the same term as that
+			// literal on its own: they lower into the two different guard tests,
+			// so a printer that dropped the wrapper would change what the layout
+			// says.
+			name:       "one literal written as a set of one",
+			expression: "(sequence (seq HEADER (when (item HEADER H-FLAG) (one-of \"Y\") TRAILER)))",
+			records:    []string{"HEADER", "TRAILER"},
+		},
+		{
+			// The three literal spellings resolve differently, and which one was
+			// written is part of the term for the same reason.
+			name:       "the three spellings a literal takes",
+			expression: "(sequence (seq HEADER (when (item HEADER H-FLAG) (one-of \"Y\" 1 (bytes \"F0F1\")) TRAILER)))",
+			records:    []string{"HEADER", "TRAILER"},
+		},
+		{
+			name:       "a term the layout wrote across several lines",
+			expression: "(sequence\n  (seq HEADER\n       (* DETAIL)\n       TRAILER))",
+			records:    []string{"HEADER", "DETAIL", "TRAILER"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			first, err := sequenceOf(t, sequenced(testCase.expression, testCase.records...))
+			if err != nil {
+				t.Fatalf("read the sequence: %v", err)
+			}
+
+			printed := first.String()
+
+			second, err := sequenceOf(t, sequenced(printed, testCase.records...))
+			if err != nil {
+				t.Fatalf("read what the printer wrote — %s: %v", printed, err)
+			}
+
+			if got := second.String(); got != printed {
+				t.Errorf("printing twice gives\n%s\nand\n%s", printed, got)
+			}
+
+			want := withoutPositions(first.Expression)
+			if got := withoutPositions(second.Expression); !reflect.DeepEqual(got, want) {
+				t.Errorf("the expression read back is\n%+v\nwant\n%+v", got, want)
+			}
+		})
+	}
+}
+
+// TestReadSequenceRejects is the load-bearing half: a reader that accepts
+// everything passes every test above.
+//
+// Each case is a layout the format does not admit, and the whole joined message
+// is asserted rather than the first fault, because reporting every fault is the
+// reader's other requirement.
+func TestReadSequenceRejects(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		source string
+		want   []string
+	}{
+		{
+			name:   "a layout that sequences nothing",
+			source: sequenced("(record DETAIL (copybook \"cpy/x.cpy\" DETAIL-REC))"),
+			want: []string{
+				"layout.sexpr:1:1: a layout carries exactly one sequence form, and this one carries 0",
+			},
+		},
+		{
+			name:   "a layout that sequences twice",
+			source: sequenced("(sequence (* DETAIL))\n(sequence (+ DETAIL))", "DETAIL"),
+			want: []string{
+				"layout.sexpr:3:1: a layout carries exactly one sequence form, and this one carries 2",
+			},
+		},
+		{
+			name:   "a sequence carrying no expression",
+			source: sequenced("(sequence)", "DETAIL"),
+			want: []string{
+				"layout.sexpr:2:1: a sequence is written (sequence <expression>), one expression, and this one " +
+					"has no value",
+				"layout.sexpr:1:1: record \"DETAIL\" appears nowhere in the sequencing expression, and a record " +
+					"type nothing can ever admit is one nothing will ever produce",
+			},
+		},
+		{
+			name:   "a sequence carrying two expressions",
+			source: sequenced("(sequence HEADER DETAIL)", "HEADER", "DETAIL"),
+			want: []string{
+				"layout.sexpr:3:1: a sequence is written (sequence <expression>), one expression, and this one " +
+					"has several",
+			},
+		},
+		{
+			name:   "a record the expression never names",
+			source: sequenced("(sequence (* DETAIL))", "DETAIL", "TRAILER"),
+			want: []string{
+				"layout.sexpr:2:1: record \"TRAILER\" appears nowhere in the sequencing expression, and a record " +
+					"type nothing can ever admit is one nothing will ever produce",
+			},
+		},
+		{
+			name:   "an expression naming a record nobody defined",
+			source: sequenced("(sequence (seq DETAIL TRAILER))", "DETAIL"),
+			want: []string{
+				"layout.sexpr:2:23: form \"seq\" names record \"TRAILER\", and the layout defines no record of " +
+					"that name",
+			},
+		},
+		{
+			name:   "an operator outside the closed set",
+			source: sequenced("(sequence (repeat DETAIL 4))", "DETAIL"),
+			want: []string{
+				"layout.sexpr:2:12: a sequencing expression is a record name or one of seq, alt, *, +, ?, times " +
+					"or when, and this is form \"repeat\"",
+				"layout.sexpr:1:1: record \"DETAIL\" appears nowhere in the sequencing expression, and a record " +
+					"type nothing can ever admit is one nothing will ever produce",
+			},
+		},
+		{
+			name:   "a literal where a term belongs",
+			source: sequenced("(sequence (seq DETAIL \"TRAILER\"))", "DETAIL"),
+			want: []string{
+				"layout.sexpr:2:23: a sequencing expression is a record name or one of seq, alt, *, +, ?, times " +
+					"or when, and this is text",
+				"layout.sexpr:2:11: form \"seq\" takes two or more subexpressions, and this one has one",
+			},
+		},
+		{
+			name:   "a concatenation of one",
+			source: sequenced("(sequence (seq DETAIL))", "DETAIL"),
+			want: []string{
+				"layout.sexpr:2:11: form \"seq\" takes two or more subexpressions, and this one has one",
+			},
+		},
+		{
+			name:   "an alternation of none",
+			source: sequenced("(sequence (alt))", "DETAIL"),
+			want: []string{
+				"layout.sexpr:2:11: form \"alt\" takes two or more subexpressions, and this one has none",
+				"layout.sexpr:1:1: record \"DETAIL\" appears nowhere in the sequencing expression, and a record " +
+					"type nothing can ever admit is one nothing will ever produce",
+			},
+		},
+		{
+			name:   "a repetition of two subexpressions",
+			source: sequenced("(sequence (* DETAIL TRAILER))", "DETAIL", "TRAILER"),
+			want: []string{
+				"layout.sexpr:3:11: form \"*\" takes one subexpression, and this one has 2",
+			},
+		},
+		{
+			name:   "a count with no item counting it",
+			source: sequenced("(sequence (seq HEADER (times DETAIL)))", "HEADER", "DETAIL"),
+			want: []string{
+				"layout.sexpr:3:23: form \"times\" takes one subexpression and the item counting it, and this " +
+					"one has a subexpression and no count",
+				"layout.sexpr:3:11: form \"seq\" takes two or more subexpressions, and this one has one",
+				"layout.sexpr:2:1: record \"DETAIL\" appears nowhere in the sequencing expression, and a record " +
+					"type nothing can ever admit is one nothing will ever produce",
+			},
+		},
+		{
+			name:   "a count read out of a record nobody defined",
+			source: sequenced("(sequence (seq HEADER (times DETAIL (item ORDER O-COUNT))))", "HEADER", "DETAIL"),
+			want: []string{
+				"layout.sexpr:3:37: form \"times\" names record \"ORDER\", and the layout defines no record of " +
+					"that name",
+			},
+		},
+		{
+			// What the copybook says the record holds is `resolve`'s, and a
+			// reference naming a record and no item below it is not: there is no
+			// copybook in which that spells a field.
+			name:   "a count read out of no field at all",
+			source: sequenced("(sequence (seq HEADER (times DETAIL (item HEADER))))", "HEADER", "DETAIL"),
+			want: []string{
+				"layout.sexpr:3:37: an item reference is written (item <record-name> <name> ...), and this is a " +
+					"reference naming a record and no item below it",
+				"layout.sexpr:3:11: form \"seq\" takes two or more subexpressions, and this one has one",
+			},
+		},
+		{
+			name:   "a presence test with no subexpression",
+			source: sequenced("(sequence (seq HEADER (when (item HEADER H-FLAG) \"Y\")))", "HEADER", "TRAILER"),
+			want: []string{
+				"layout.sexpr:3:23: form \"when\" takes an item reference, a value and one subexpression, and " +
+					"this one has an item and a value and no subexpression",
+				"layout.sexpr:3:11: form \"seq\" takes two or more subexpressions, and this one has one",
+				"layout.sexpr:2:1: record \"TRAILER\" appears nowhere in the sequencing expression, and a record " +
+					"type nothing can ever admit is one nothing will ever produce",
+			},
+		},
+		{
+			name:   "a presence test against nothing",
+			source: sequenced("(sequence (seq HEADER (when (item HEADER H-FLAG) (one-of) TRAILER)))", "HEADER", "TRAILER"),
+			want: []string{
+				"layout.sexpr:3:50: a when tests a value against a literal or (one-of <literal> ...), and this " +
+					"has no literal",
+				"layout.sexpr:3:11: form \"seq\" takes two or more subexpressions, and this one has one",
+			},
+		},
+		{
+			name:   "a presence test against a record name",
+			source: sequenced("(sequence (seq HEADER (when (item HEADER H-FLAG) TRAILER TRAILER)))", "HEADER", "TRAILER"),
+			want: []string{
+				"layout.sexpr:3:50: a literal is text, a number or (bytes \"<hex>\"), and this is the symbol " +
+					"\"TRAILER\"",
+				"layout.sexpr:3:11: form \"seq\" takes two or more subexpressions, and this one has one",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			read, err := sequenceOf(t, testCase.source)
+			if err == nil {
+				t.Fatalf("the reader accepts %s", testCase.source)
+			}
+
+			if read != nil {
+				t.Errorf("the reader hands back a sequence beside the fault: %+v", read)
+			}
+
+			if got, want := err.Error(), strings.Join(testCase.want, "\n"); got != want {
+				t.Errorf("the reader reports\n%s\nwant\n%s", got, want)
+			}
+		})
+	}
+}
+
+// TestSequenceFaultsAreAssertable is the other requirement on a fault: a caller
+// deciding what to do about one reaches for the type rather than for the text of
+// the message.
+func TestSequenceFaultsAreAssertable(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		source string
+		assert func(*testing.T, error)
+	}{
+		{
+			name:   "a layout with no sequence counts none",
+			source: sequenced("(record DETAIL (copybook \"cpy/x.cpy\" DETAIL-REC))"),
+			assert: func(t *testing.T, err error) {
+				var fault *SequenceCountError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no SequenceCountError in %v", err)
+				}
+
+				if fault.Count != 0 {
+					t.Errorf("the fault counts %d sequences, want 0", fault.Count)
+				}
+			},
+		},
+		{
+			name:   "an unsequenced record names the record",
+			source: sequenced("(sequence (* DETAIL))", "DETAIL", "TRAILER"),
+			assert: func(t *testing.T, err error) {
+				var fault *UnsequencedRecordError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no UnsequencedRecordError in %v", err)
+				}
+
+				if fault.Record != "TRAILER" {
+					t.Errorf("the fault is about %q, want \"TRAILER\"", fault.Record)
+				}
+			},
+		},
+		{
+			name:   "an undefined record name names the operator it stands under",
+			source: sequenced("(sequence (seq DETAIL TRAILER))", "DETAIL"),
+			assert: func(t *testing.T, err error) {
+				var fault *UnknownRecordError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no UnknownRecordError in %v", err)
+				}
+
+				if fault.Record != "TRAILER" || fault.Form != tagSeq {
+					t.Errorf("the fault is %q under %q, want \"TRAILER\" under \"seq\"", fault.Record, fault.Form)
+				}
+			},
+		},
+		{
+			name:   "an operator outside the set names the set it is outside",
+			source: sequenced("(sequence (repeat DETAIL 4))", "DETAIL"),
+			assert: func(t *testing.T, err error) {
+				var fault *ExpressionError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no ExpressionError in %v", err)
+				}
+
+				if !reflect.DeepEqual(fault.Admits, operatorNames()) {
+					t.Errorf("the fault admits %v, want %v", fault.Admits, operatorNames())
+				}
+			},
+		},
+		{
+			name:   "a malformed operator names which one it is",
+			source: sequenced("(sequence (* DETAIL TRAILER))", "DETAIL", "TRAILER"),
+			assert: func(t *testing.T, err error) {
+				var fault *ExpressionFormError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no ExpressionFormError in %v", err)
+				}
+
+				if fault.Kind != ZeroOrMore {
+					t.Errorf("the fault is about %s, want %s", fault.Kind, ZeroOrMore)
+				}
+			},
+		},
+		{
+			name:   "a value set with nothing in it is a match fault",
+			source: sequenced("(sequence (seq HEADER (when (item HEADER H-FLAG) (one-of) TRAILER)))", "HEADER", "TRAILER"),
+			assert: func(t *testing.T, err error) {
+				var fault *MatchFormError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no MatchFormError in %v", err)
+				}
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := sequenceOf(t, testCase.source)
+			if err == nil {
+				t.Fatalf("the reader accepts %s", testCase.source)
+			}
+
+			testCase.assert(t, err)
+		})
+	}
+}
+
+// TestTheSpecsWorkedExampleSequences is the staleness gate over the layer.
+//
+// docs/layout/SPEC.md's "A layout, end to end" appendix is the layout the
+// document shows an adopter, and it is read out of the document rather than
+// copied here for [TestTheSpecsWorkedExampleDiscriminates]'s reason: an operator
+// the example writes and this reader does not read would otherwise be invisible
+// until somebody pasted the example into a file.
+//
+// It is also the one example in the document carrying both value-reading
+// operators, which is what #76 put in scope and the reason this layer has them.
+func TestTheSpecsWorkedExampleSequences(t *testing.T) {
+	t.Parallel()
+
+	read, err := sequenceOf(t, specExample(t))
+	if err != nil {
+		t.Fatalf("the reader rejects SPEC.md's own worked example: %v", err)
+	}
+
+	want := "(sequence (seq FILE-HEADER (* (seq ORDER-HEADER " +
+		"(times ORDER-DETAIL (item ORDER-HEADER OH-DETAIL-COUNT)))) " +
+		"(when (item FILE-HEADER FH-TRAILER-FLAG) \"Y\" FILE-TRAILER)))"
+
+	if got := read.String(); got != want {
+		t.Errorf("the example sequences as\n%s\nwant\n%s", got, want)
+	}
+}

--- a/internal/layoutmodel/sequence_test.go
+++ b/internal/layoutmodel/sequence_test.go
@@ -500,8 +500,37 @@ func TestReadSequenceRejects(t *testing.T) {
 				"layout.sexpr:3:23: form \"times\" takes one subexpression and the item counting it, and this " +
 					"one has a subexpression and no count",
 				"layout.sexpr:3:11: form \"seq\" takes two or more subexpressions, and this one has one",
+			},
+		},
+		{
+			// The arity is one fault and what stands inside the operator is
+			// another, and both are reported: a `times` carrying an item
+			// reference alone is missing its subexpression, and the reference is
+			// still held to the records the layout defines.
+			name:   "a count and no subexpression",
+			source: sequenced("(sequence (seq HEADER (times (item ORDER O-COUNT))))", "HEADER", "DETAIL"),
+			want: []string{
+				"layout.sexpr:3:23: form \"times\" takes one subexpression and the item counting it, and this " +
+					"one has a count and no subexpression",
+				"layout.sexpr:3:30: form \"times\" names record \"ORDER\", and the layout defines no record of " +
+					"that name",
+				"layout.sexpr:3:11: form \"seq\" takes two or more subexpressions, and this one has one",
 				"layout.sexpr:2:1: record \"DETAIL\" appears nowhere in the sequencing expression, and a record " +
 					"type nothing can ever admit is one nothing will ever produce",
+			},
+		},
+		{
+			// The same, at the operator taking three things rather than two: the
+			// item is read in the position it stands in, so the record it names
+			// is checked even though the `when` is short a subexpression.
+			name:   "a presence test short a subexpression and rooted at no record",
+			source: sequenced("(sequence (seq HEADER (when (item ORDER O-FLAG) \"Y\")))", "HEADER"),
+			want: []string{
+				"layout.sexpr:2:23: form \"when\" takes an item reference, a value and one subexpression, and " +
+					"this one has an item and a value and no subexpression",
+				"layout.sexpr:2:29: form \"when\" names record \"ORDER\", and the layout defines no record of " +
+					"that name",
+				"layout.sexpr:2:11: form \"seq\" takes two or more subexpressions, and this one has one",
 			},
 		},
 		{


### PR DESCRIPTION
Closes #29

Reads a layout's `sequence` form into a typed term over the closed set of
operators, and prints one back into the notation a layout writes it in.
`ReadSequence` joins `ReadProfile`, `ReadFraming` and `ReadDiscrimination` as
this package's fourth layer reader.

## Acceptance criteria

- [x] **Grammar supports concatenation, alternation, `?`, `+`, `*`, and
  grouping over record names.** `seq`, `alt`, `?`, `+`, `*` and a bare record
  name are five of the eight members of `ExpressionKind`. Grouping is the
  notation's own — a subexpression standing where a record name may stand is a
  group, and nothing is written to say so.
- [x] **A repetition whose count is a field of another record.**
  `(times <e> <item-ref>)`, carrying the subexpression and the `ItemRef`
  counting it.
- [x] **An element whose presence is a field of another record, tested against
  a literal or a set of literals.** `(when <item-ref> <literal> <e>)` and
  `(when <item-ref> (one-of <literal> …) <e>)`. The two are kept apart in the
  model — `Match.Kind` is `Equals` or `OneOf` — because they lower into the two
  different guard tests, so `(one-of "Y")` is not the same term as `"Y"` and a
  printer that dropped the wrapper would change what the layout says.
- [x] **Tokenizer, parser and printer in the house style.** See the judgment
  call below: the tokenizer and the parser are `sexpr-go`'s and
  `internal/layout`'s by SPEC.md, and what this adds is the reading of the
  `expression` sort and `Expression.String` as the printer.
- [x] **Round-trip tests: parse, print, parse, comparing ASTs ignoring
  position.** `TestSequenceRoundTrips`, over eight terms including every
  operator at once, all three literal spellings, a set of one, and a term the
  layout broke across four lines. Positions are dropped before the comparison
  and nothing else is.
- [x] **References to undefined record names rejected**, both a bare record
  name in the expression (`UnknownRecordError`, naming the operator it stands
  under) and the record a `times` or `when` reference is rooted at. The
  completeness rule's other half is `UnsequencedRecordError`: a `record` the
  expression never names, which SPEC.md requires and the published schema
  cannot state because it counts one form against another.
- [x] **Positions preserved for diagnostics.** Every node of the term carries
  the `layout.Pos` it was written at, asserted node by node in
  `TestReadSequenceModelsTheLayer`.

## Judgment calls

**The tokenizer and parser are not new, and SPEC.md is why.** The issue was
written before #22 chose the surface syntax. A sequencing expression is now an
S-expression like every other form, and SPEC.md's "What this document
delegates" hands tokenising and parsing to `z5labs/sexpr-go` explicitly, so
that there is one reading of that grammar in the repository. A second
tokenizer here would be the second one. What the issue is really asking for —
a reading of the `expression` sort that is its own thing rather than a walk
somebody redoes at every use — is `ReadSequence`, and the printer half is
`Expression.String`. That is also what makes the round-trip criterion
meaningful: it asserts the printer against the reader rather than a hand-rolled
parser against itself.

**"A reference to a field the named record does not define" is only half
checkable here.** The layout does not carry the copybook, so what a record's
fields are is not knowable at this layer. SPEC.md's "Validation and
diagnostics" splits exactly this: an item reference "naming no item or more
than one" is `resolve`'s (#31, #32), and so are the three rules on `times` and
`when` that need the graph or the copybook — the item admitted strictly
earlier on every path, the item not repeating, and a counted item decoding to
an integer. The halves that need neither are enforced: the record the
reference is rooted at is one the layout defines, and the reference names at
least one field below it. `TestReadSequenceRejects` covers both.

**One expression node type rather than eight.** `Expression` carries a `Kind`
out of a closed set, mirroring `Strategy`, so a switch over it is exhaustive
and stays exhaustive and #36 reaches for the same fields whatever a node turns
out to be.

**`readLiteral` became a free function.** It was a method on
`discriminationReader`; sequencing's `when` reads literals too, and one reading
of a literal is what keeps the two layers spelling them alike. It now sits
beside `readItemRef` and `readByteString`, which are free functions for the
same reason. No behaviour changed.

## Verified

- `dagger call ci` — the repository's gate — passes.
- `go test ./...` green; `staticcheck ./internal/layoutmodel/` clean.
- `TestTheSpecsWorkedExampleSequences` reads the `sequence` form out of
  SPEC.md's own "A layout, end to end" appendix and asserts the printed term,
  so an operator the document shows an adopter and this reader cannot read
  fails the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)