### PR TITLE
story(layout): resolve fully-qualified field renames

### DIFF
--- a/docs/layout/SPEC.md
+++ b/docs/layout/SPEC.md
@@ -792,7 +792,33 @@ identifier is a generator's work (#30, #50).
 At most one rename **MAY** name a given item; two would leave their order
 deciding. The reference **MAY** name a group, and **MAY** name an item that
 repeats, in which case the substitute is the name of the item and reaches every
-occurrence of it.
+occurrence of it. The substitute is a name and not an occurrence's, for the
+reason [an item reference](#an-item-reference) names an item and not an
+occurrence of one: a table of a hundred entries has one field there, named once.
+
+### A substitute is a name nothing beside it already answers to
+
+Two renames **MUST NOT** substitute one name for two items under one parent, and
+a rename **MUST NOT** substitute a name an item beside its target already
+carries. Each is a diagnostic carrying two spans — the substitute, and the
+statement it collides with — because either half is a perfectly good rename on
+its own, and what an adopter has to decide is which of the two items they meant
+to call the name (#30).
+
+The second holds even where that sibling is itself renamed. The original is
+carried beside the substitute rather than in place of it
+([`ir/SPEC.md`](../ir/SPEC.md#names)), so an item that has been renamed answers
+to the name the copybook gave it still, and two items under one parent answering
+to one name is the ambiguity a rename exists to remove. Swapping two names is
+spelled by renaming both to names nothing under that parent carries.
+
+Which items a target has beside it is the copybook's, so the rule divides where
+[Validation and diagnostics](#validation-and-diagnostics) divides everything
+else. The layout reader reports the halves the layout decides on its own — two
+renames under one parent substituting one name, and a substitute equal to the
+name of an item the layout itself references under that parent, an item the
+copybook therefore has — and `resolve` reports a substitute colliding with a
+name only the copybook knows about (#32).
 
 ### The `OCCURS DEPENDING ON` reading is one statement per layout
 
@@ -1332,9 +1358,10 @@ each is owed, is the reader.
 **Rules counting one form against another.** Exactly one `discriminate` per
 `record`, one `discriminate-variant` per variant, two arms of one variant that
 do not name one alternative, every `record` appearing somewhere in the
-sequencing expression, an `encoding-override` naming at least one axis. A
-declaration is about one form
-and its positions, so a rule relating two of them is the reader's. The one
+sequencing expression, an `encoding-override` naming at least one axis, at most
+one `rename` per item and no two of them substituting one name under one parent.
+A declaration is about one form and its positions, so a rule relating two of
+them is the reader's. The one
 cross-form statement the schema does make is the reference, and it is the
 important one: a position declared to name a `record` **MUST** name one the
 layout defines, which is what makes a reference checkable rather than
@@ -1366,9 +1393,11 @@ arms of one variant naming one alternative, or naming one target and one
 literal; an arm whose target is rooted at another record, stands under another
 outermost group than the variant, or descends through the variant or one of its
 arms; a record name in the sequencing expression that no `record` form defines,
-and a `record` the expression never names; a `blksize`, `lrecl`, `max-segment`
-or `delimiter` under a spelling that does not admit it; and the framing
-spellings rejected by name — `U`, a carriage-control suffix,
+and a `record` the expression never names; a second `rename` naming one item, a
+name substituted for two items under one parent, and a substitute equal to the
+name of an item the layout itself references under that parent; a `blksize`,
+`lrecl`, `max-segment` or `delimiter` under a spelling that does not admit it;
+and the framing spellings rejected by name — `U`, a carriage-control suffix,
 `(blocks in-stream)`.
 
 **`resolve`** (#32–#38) has the copybooks too, and reports everything that needs
@@ -1376,13 +1405,15 @@ them: a `copybook` child naming a file it cannot read, and one naming a
 top-level item the copybook it read does not declare (#27); an item reference
 naming no item or more than one; a reference that
 repeats or sits inside a repeating group where the position forbids it; a
-discriminator behind a variable item; a literal wider than the item it is
-compared against; a `times` or `when` whose item is not admitted strictly
-earlier on every path; a record type whose extent does not account for `lrecl`
-under `F` or `FB`, or exceeds it under the others; a variable-extent record type
-on a fixed-length dataset; a copybook carrying an `OCCURS DEPENDING ON` with no
-`copybook-reading` form to read it under; two records at one point in the
-sequence whose discriminators can both match; an arm's target outside the
+discriminator behind a variable item; a rename whose substitute is the name of
+an item beside its target that the layout itself never references; a literal
+wider than the item it is compared against; a `times` or `when` whose item is
+not admitted strictly earlier on every path; a record type whose extent does not
+account for `lrecl` under `F` or `FB`, or exceeds it under the others; a
+variable-extent record type on a fixed-length dataset; a copybook carrying an
+`OCCURS DEPENDING ON` with no `copybook-reading` form to read it under; two
+records at one point in the sequence whose discriminators can both match; an
+arm's target outside the
 innermost repeating group containing the variant, or inside an arm that does not
 also contain it; two arms of one variant whose predicates can both match one
 occurrence; and a redefine inside a repeating group that no

--- a/internal/layoutmodel/doc.go
+++ b/internal/layoutmodel/doc.go
@@ -16,16 +16,18 @@
 //
 // Each layer of the format gets a reader here, and a type for what the layer
 // says. [ReadProfile] is the encoding profile (#25), [ReadFraming] is the
-// physical framing (#26), [ReadDiscrimination] is discrimination (#28) and
-// [ReadSequence] is sequencing (#29); record definitions arrive beside them
-// (#27, #30). What they have in common is that a value handed back is one the
-// format admits: a [Profile] carries four stated axes because a profile stating
-// three is an error and not a value with a hole in it, a [Framing] resolves to
-// one of the IR's four framings because the one record format that resolves to
-// none is rejected while the layout is read, every `record` in a
-// [Discrimination] carries exactly one strategy out of a closed set, and every
-// node of a [Sequence]'s expression is one of the eight terms the algebra is
-// made of, carrying what that term takes.
+// physical framing (#26), [ReadDiscrimination] is discrimination (#28),
+// [ReadSequence] is sequencing (#29) and [ReadRenames] is the record
+// definitions layer's renames (#27, #30). What they have in common is that a
+// value handed back is one the format admits: a [Profile] carries four stated
+// axes because a profile stating three is an error and not a value with a hole
+// in it, a [Framing] resolves to one of the IR's four framings because the one
+// record format that resolves to none is rejected while the layout is read,
+// every `record` in a [Discrimination] carries exactly one strategy out of a
+// closed set, every node of a [Sequence]'s expression is one of the eight terms
+// the algebra is made of, carrying what that term takes, and every [Rename]
+// names its item in full and carries the substitute beside the original rather
+// than in place of it.
 //
 // # The one layer that prints as well as reads
 //

--- a/internal/layoutmodel/errors.go
+++ b/internal/layoutmodel/errors.go
@@ -991,6 +991,141 @@ func (e *ArmOverlapError) Error() string {
 	)
 }
 
+// RenameFormError is a `rename` that is not `(rename <item-ref> "<name>")`.
+//
+// It covers both shapes the fault takes — a form carrying something other than
+// an item and a name, and a name written as anything but text — because what is
+// wrong with each is the same thing: the form takes two things and holds
+// something else. A reference that is written and wrong is an
+// [ItemReferenceError] instead, which is also what a rename naming its target
+// with a bare name gets: a bare name is not a reference, and it is not one
+// because duplicate data names are legal COBOL and a name alone is not an
+// identity.
+type RenameFormError struct {
+	// Pos is the form, or the part of it that is wrong.
+	Pos layout.Pos
+
+	// Found names what was written.
+	Found string
+}
+
+// Error implements the error interface.
+func (e *RenameFormError) Error() string {
+	return fmt.Sprintf("%s: a rename is written (rename <item-ref> \"<name>\"), and this has %s", e.Pos, e.Found)
+}
+
+// EmptyRenameError is a rename substituting a name of no characters.
+//
+// It is [ByteStringError]'s empty case in this layer: the schema declares the
+// position to take text and cannot say that the text says something, and a name
+// nothing can be called is a rename that leaves an adopter's own name out.
+type EmptyRenameError struct {
+	// Pos is the string.
+	Pos layout.Pos
+
+	// Item is the item it was written for.
+	Item ItemRef
+}
+
+// Error implements the error interface.
+func (e *EmptyRenameError) Error() string {
+	return fmt.Sprintf(
+		"%s: the rename on %s substitutes a name of no characters, and a name is at least one",
+		e.Pos, e.Item,
+	)
+}
+
+// DuplicateRenameError is a second `rename` naming an item another one already
+// named.
+//
+// docs/layout/SPEC.md admits at most one per item and gives the reason this
+// message repeats: two "would leave their order deciding", and the order forms
+// are written in is not something this format lets anything depend on.
+type DuplicateRenameError struct {
+	// Pos is the second rename.
+	Pos layout.Pos
+
+	// First is the one before it.
+	First layout.Pos
+
+	// Item is the item both name.
+	Item ItemRef
+}
+
+// Error implements the error interface.
+func (e *DuplicateRenameError) Error() string {
+	return fmt.Sprintf(
+		"%s: %s is renamed twice, and is renamed first at %s; a rename names an item at most once",
+		e.Pos, e.Item, e.First,
+	)
+}
+
+// RenameCollisionError is one name substituted for two items under one parent.
+//
+// It carries both spans, because the fault is the pair: either rename is a
+// perfectly good one on its own, and what an adopter has to decide is which of
+// the two items they meant to call the name.
+type RenameCollisionError struct {
+	// Pos is the second substitute.
+	Pos layout.Pos
+
+	// First is the one before it.
+	First layout.Pos
+
+	// Items are the two items, in the order the layout renames them.
+	Items [2]ItemRef
+
+	// Name is what both are called.
+	Name string
+}
+
+// Error implements the error interface.
+func (e *RenameCollisionError) Error() string {
+	return fmt.Sprintf(
+		"%s: name %s is substituted for %s and for %s, which stand under one parent, and is substituted "+
+			"first at %s",
+		e.Pos, quote(e.Name), e.Items[0], e.Items[1], e.First,
+	)
+}
+
+// RenameShadowsSiblingError is a substitute equal to the name of an item
+// standing beside the one being renamed.
+//
+// It carries both spans for [RenameCollisionError]'s reason, and it holds even
+// where the sibling is itself renamed: docs/ir/SPEC.md's "Names" carries an
+// original beside a substitute rather than in place of it, so the sibling still
+// answers to the name the copybook gave it. Swapping two names is spelled by
+// renaming both to names nothing under that parent carries.
+//
+// It is the half of the rule the layout decides. Which siblings a target
+// actually has is the copybook's, and a substitute colliding with one the
+// layout never mentions is `resolve`'s to report.
+type RenameShadowsSiblingError struct {
+	// Pos is the substitute.
+	Pos layout.Pos
+
+	// First is where the layout names the sibling.
+	First layout.Pos
+
+	// Item is the item being renamed.
+	Item ItemRef
+
+	// Sibling is the item standing beside it that already carries the name.
+	Sibling ItemRef
+
+	// Name is the substitute.
+	Name string
+}
+
+// Error implements the error interface.
+func (e *RenameShadowsSiblingError) Error() string {
+	return fmt.Sprintf(
+		"%s: the rename on %s substitutes %s, which is the name of %s beside it at %s; an original is carried "+
+			"beside a substitute rather than in place of it, so the item there answers to that name still",
+		e.Pos, e.Item, quote(e.Name), e.Sibling, e.First,
+	)
+}
+
 // SequenceCountError is a layout that does not carry exactly one `sequence`
 // form.
 //

--- a/internal/layoutmodel/itemref.go
+++ b/internal/layoutmodel/itemref.go
@@ -34,6 +34,20 @@ type ItemRef struct {
 	Path []string
 }
 
+// Name is the item's own name, as the copybook spells it: the last name on the
+// path, which is the one the reference ends at.
+//
+// It is the name every other name in the reference qualifies, and so the one a
+// [Rename] substitutes for. The zero [ItemRef] has none — a reference always
+// carries at least one name, and a value that does not is one nobody read.
+func (r ItemRef) Name() string {
+	if len(r.Path) == 0 {
+		return ""
+	}
+
+	return r.Path[len(r.Path)-1]
+}
+
 // String renders the reference the way a layout writes it, which is what a
 // diagnostic naming an item quotes.
 func (r ItemRef) String() string {

--- a/internal/layoutmodel/rename.go
+++ b/internal/layoutmodel/rename.go
@@ -213,14 +213,20 @@ func (r *renameReader) target(form layout.Form, item ItemRef) bool {
 // the ambiguity a rename exists to remove. Swapping two names is spelled by
 // renaming both to names nothing under that parent carries.
 //
-// An item is not its own sibling, so a rename substituting the name its target
-// already has is admitted: it says the same thing twice and leaves every name
-// where it was.
+// An item is not its own sibling under either check. A rename substituting the
+// name its target already has is admitted — it says the same thing twice and
+// leaves every name where it was — and a second rename on one item is reported
+// as the duplicate it is and not as a collision between an item and itself.
 func (r *renameReader) collisions(read []Rename, rename Rename) bool {
 	sound := true
 
+	// An item is not its own sibling here either: two renames on one item are a
+	// [DuplicateRenameError] already, and a collision message about them would
+	// name that item twice and read as though two items were involved.
 	earlier := slices.IndexFunc(read, func(other Rename) bool {
-		return other.Substitute == rename.Substitute && siblings(other.Item, rename.Item)
+		return other.Substitute == rename.Substitute &&
+			other.Item.identity() != rename.Item.identity() &&
+			siblings(other.Item, rename.Item)
 	})
 	if earlier >= 0 {
 		r.fail(&RenameCollisionError{

--- a/internal/layoutmodel/rename.go
+++ b/internal/layoutmodel/rename.go
@@ -1,0 +1,322 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layoutmodel
+
+import (
+	"errors"
+	"slices"
+
+	"github.com/Zaba505/cpybkc/internal/layout"
+)
+
+// The tag this half of the record definitions layer reads. `record` is read for
+// its name alone, by [recordNames], because a rename is rooted at one.
+const tagRename = "rename"
+
+// Rename is one `rename` form: an item, and the name substituted for the one
+// the copybook gave it.
+//
+// docs/layout/SPEC.md's "A rename substitutes a name, and keeps the original"
+// is the whole of it. Both names survive — [Rename.Original] is the copybook's
+// and [Rename.Substitute] is the adopter's — because docs/ir/SPEC.md's "Names"
+// carries the substitute *beside* the original rather than in place of it, so
+// that generated code can still point back at the copybook it came from. There
+// is nowhere in this model for a name to be replaced.
+//
+// The substitute is language-neutral and is carried verbatim. Casing, reserved
+// words and what to do about a name that is not an identifier in some target
+// language are a generator's (#30, #50), and applying any of them here would
+// put one language's rules in the layer every language's generator reads.
+type Rename struct {
+	// Pos is the `rename` form.
+	Pos layout.Pos
+
+	// Item is what is renamed. It names its target in full: a reference is
+	// rooted at a record and carries one name per level down to the item, which
+	// is what makes it an identity where a bare name is not — duplicate data
+	// names are legal COBOL, and a rename that named one would not say which
+	// item it meant.
+	Item ItemRef
+
+	// Substitute is the name to carry beside the original, exactly as the
+	// layout wrote it.
+	Substitute string
+
+	// SubstitutePos is the string itself, which is what a diagnostic about the
+	// name rather than about the item points at.
+	SubstitutePos layout.Pos
+}
+
+// Original is the name the copybook gives the renamed item, which a substitute
+// stands beside and never replaces.
+func (r Rename) Original() string { return r.Item.Name() }
+
+// ReadRenames reads the renames out of a parsed layout, in the order the layout
+// writes them.
+//
+// It reports every fault it finds, joined, and returns nothing when it found
+// one, for [ReadProfile]'s reason: a rename an adopter cannot act on is worse
+// than none. A layout carrying no `rename` form carries no renames and is not a
+// fault — the form's arity is zero or more.
+//
+// What it enforces is what a declaration cannot state and a copybook is not
+// needed for: that a rename names its target as a reference rather than as a
+// bare name, that the record it is rooted at is one the layout defines, that at
+// most one rename names a given item, and the collisions decidable from the
+// layout alone — two renames substituting one name for two items under one
+// parent, and a substitute equal to the name of an item the layout itself
+// references under that parent. The rest of the collision rule needs the
+// copybook's sibling list and is `resolve`'s, as is whether the path names an
+// item at all (#31, #32).
+//
+// Nothing here restricts what a rename may name below the record. The reference
+// **MAY** name a group, and **MAY** name an item that repeats or sit inside
+// one, in which case the substitute is the name of the item and reaches every
+// occurrence of it: a rename is a name, and a name is per item rather than per
+// occurrence. Whether a given path is either of those needs the copybook, so a
+// rule keyed on it could not be enforced here even if the format had one.
+//
+// What a rename cannot name is the record's top-level item, and that is the
+// reference grammar's rather than this reader's: a path carries the names below
+// the top-level item and the `record` form has already stated that one.
+//
+// Top-level forms belonging to other layers are not read here and are not
+// faults, but their item references are: an item the layout names anywhere is
+// an item the copybook has, which is what makes a substitute colliding with one
+// answerable without reading the copybook.
+func ReadRenames(file *layout.File) ([]Rename, error) {
+	read := &renameReader{records: recordNames(file), named: itemsNamed(file)}
+
+	var renames []Rename
+
+	for _, form := range file.Forms {
+		if form.Tag != tagRename {
+			continue
+		}
+
+		rename, ok := read.rename(renames, form)
+		if !ok {
+			continue
+		}
+
+		renames = append(renames, rename)
+	}
+
+	if len(read.errs) > 0 {
+		return nil, errors.Join(read.errs...)
+	}
+
+	return renames, nil
+}
+
+// renameReader holds the state one [ReadRenames] accumulates.
+type renameReader struct {
+	faults
+
+	// records are the records the layout defines, which is what makes a rename
+	// rooted at a record nobody defined answerable.
+	records []recordDefinition
+
+	// named is every item reference the layout writes, which is the sibling set
+	// this layer has: an item nothing in the layout mentions is one only the
+	// copybook knows about.
+	named []ItemRef
+
+	// renamed is where each item was first renamed, which makes a second rename
+	// on one item reportable against the first.
+	renamed map[string]layout.Pos
+}
+
+// rename reads one `rename` form, against the renames already read.
+func (r *renameReader) rename(read []Rename, form layout.Form) (Rename, bool) {
+	if len(form.Elements) != 2 {
+		r.fail(&RenameFormError{Pos: form.Pos, Found: renameShortfall(form.Elements)})
+
+		return Rename{}, false
+	}
+
+	item, err := readItemRef(form.Elements[0])
+	if err != nil {
+		r.fail(err)
+
+		return Rename{}, false
+	}
+
+	name, ok := form.Elements[1].(layout.Text)
+	if !ok {
+		r.fail(&RenameFormError{Pos: form.Elements[1].Position(), Found: describe(form.Elements[1])})
+
+		return Rename{}, false
+	}
+
+	rename := Rename{Pos: form.Pos, Item: item, Substitute: name.Value, SubstitutePos: name.Pos}
+
+	// Every check below is run whatever the ones before it said, for the reason
+	// a discriminator's strategy is read past a misspelled record name: a rename
+	// rooted at a record nobody defined and substituting a name a sibling
+	// carries is two things to fix rather than one to discover on the next run.
+	sound := r.target(form, item)
+
+	if name.Value == "" {
+		r.fail(&EmptyRenameError{Pos: name.Pos, Item: item})
+
+		// A name of no characters collides with nothing, and every message the
+		// collision rules could produce about it would name the empty string.
+		return Rename{}, false
+	}
+
+	return rename, r.collisions(read, rename) && sound
+}
+
+// target holds the item a rename names to what can be checked without a
+// copybook: the record it is rooted at, and the renames already read.
+func (r *renameReader) target(form layout.Form, item ItemRef) bool {
+	sound := true
+
+	if !slices.ContainsFunc(r.records, func(record recordDefinition) bool { return record.name == item.Record }) {
+		r.fail(&UnknownRecordError{Pos: item.Pos, Record: item.Record, Form: form.Tag})
+
+		sound = false
+	}
+
+	if first, already := r.renamed[item.identity()]; already {
+		r.fail(&DuplicateRenameError{Pos: form.Pos, First: first, Item: item})
+
+		return false
+	}
+
+	if r.renamed == nil {
+		r.renamed = make(map[string]layout.Pos)
+	}
+
+	r.renamed[item.identity()] = form.Pos
+
+	return sound
+}
+
+// collisions reports a substitute that another name under one parent already
+// answers to.
+//
+// Two of them are decidable from the layout alone. A name substituted for two
+// items under one parent is one, and a name equal to the name of an item the
+// layout itself references under that parent is the other — an item a layout
+// names is an item the copybook has, whatever the copybook turns out to say
+// about the rest of them.
+//
+// The second holds even where that sibling is itself renamed. The original is
+// carried beside the substitute rather than in place of it
+// (docs/ir/SPEC.md's "Names"), so a renamed sibling still answers to the name
+// the copybook gave it, and two nodes under one parent answering to one name is
+// the ambiguity a rename exists to remove. Swapping two names is spelled by
+// renaming both to names nothing under that parent carries.
+//
+// An item is not its own sibling, so a rename substituting the name its target
+// already has is admitted: it says the same thing twice and leaves every name
+// where it was.
+func (r *renameReader) collisions(read []Rename, rename Rename) bool {
+	sound := true
+
+	earlier := slices.IndexFunc(read, func(other Rename) bool {
+		return other.Substitute == rename.Substitute && siblings(other.Item, rename.Item)
+	})
+	if earlier >= 0 {
+		r.fail(&RenameCollisionError{
+			Pos:   rename.SubstitutePos,
+			First: read[earlier].SubstitutePos,
+			Items: [2]ItemRef{read[earlier].Item, rename.Item},
+			Name:  rename.Substitute,
+		})
+
+		sound = false
+	}
+
+	sibling := slices.IndexFunc(r.named, func(other ItemRef) bool {
+		return siblings(other, rename.Item) &&
+			other.identity() != rename.Item.identity() &&
+			other.Name() == rename.Substitute
+	})
+	if sibling >= 0 {
+		r.fail(&RenameShadowsSiblingError{
+			Pos:     rename.SubstitutePos,
+			First:   r.named[sibling].Pos,
+			Item:    rename.Item,
+			Sibling: r.named[sibling],
+			Name:    rename.Substitute,
+		})
+
+		sound = false
+	}
+
+	return sound
+}
+
+// siblings reports whether two references name items under one parent.
+//
+// It is the reference's spelling and nothing else, which is what makes it
+// answerable here: a path is complete rather than qualified, so two items are
+// siblings exactly when they are reached through the same record by the same
+// names down to the last one. A reference carrying no name below the record is
+// nobody's sibling — no reader hands one back, and the zero value is not an
+// item.
+func siblings(a, b ItemRef) bool {
+	if len(a.Path) == 0 || len(b.Path) == 0 || a.Record != b.Record {
+		return false
+	}
+
+	return slices.Equal(a.Path[:len(a.Path)-1], b.Path[:len(b.Path)-1])
+}
+
+// itemsNamed gathers every item reference the layout writes, anywhere in it, in
+// source order.
+//
+// It walks every top-level form rather than the record definitions layer's,
+// because what it is after is the items a layout is *evidence* for: a
+// discriminator's target, a `times`'s count and an override's item are all
+// items the copybook declares, and a rename substituting one of their names
+// under one parent collides with it as surely as with another rename's target.
+//
+// A reference this cannot read is skipped rather than reported. Every position
+// admitting one belongs to a layer that reads it, and a second message about it
+// here would name the same line twice.
+func itemsNamed(file *layout.File) []ItemRef {
+	var named []ItemRef
+
+	for _, form := range file.Forms {
+		layout.Walk(form, func(node layout.Node) bool {
+			inner, ok := node.(layout.Form)
+			if !ok || inner.Tag != tagItem {
+				return true
+			}
+
+			if ref, err := readItemRef(inner); err == nil {
+				named = append(named, ref)
+			}
+
+			// A reference carries names and nothing else, so there is nothing
+			// below one to walk into.
+			return false
+		})
+	}
+
+	return named
+}
+
+// renameShortfall names what a `rename` form carries where an item and a name
+// belong.
+func renameShortfall(elements []layout.Node) string {
+	switch {
+	case len(elements) == 0:
+		return "no value"
+	case len(elements) > 2:
+		return "several"
+	default:
+		if _, ok := elements[0].(layout.Text); ok {
+			return "a name and no item"
+		}
+
+		return "an item and no name"
+	}
+}

--- a/internal/layoutmodel/rename_test.go
+++ b/internal/layoutmodel/rename_test.go
@@ -327,6 +327,20 @@ func TestReadRenamesRejects(t *testing.T) {
 			},
 		},
 		{
+			// The two are one statement made twice, which is what the duplicate
+			// rule is about. A collision message here would name one item on
+			// both sides of itself and read as though two were involved.
+			name: "one item renamed twice to one name",
+			source: renaming([]string{"DETAIL"},
+				`(rename (item DETAIL D-CUST-NO) "CustomerNumber")`,
+				`(rename (item DETAIL D-CUST-NO) "CustomerNumber")`,
+			),
+			want: []string{
+				"layout.sexpr:3:1: (item DETAIL D-CUST-NO) is renamed twice, and is renamed first at " +
+					"layout.sexpr:2:1; a rename names an item at most once",
+			},
+		},
+		{
 			name: "one name substituted for two items under one parent",
 			source: renaming([]string{"DETAIL"},
 				`(rename (item DETAIL D-KEY D-CUST-NO) "Customer")`,

--- a/internal/layoutmodel/rename_test.go
+++ b/internal/layoutmodel/rename_test.go
@@ -1,0 +1,561 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layoutmodel
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/layout"
+)
+
+// renamesOf is the whole pipeline a caller runs: parse the source, then read the
+// renames out of it.
+func renamesOf(t *testing.T, source string) ([]Rename, error) {
+	t.Helper()
+
+	file, err := layout.Parse("layout.sexpr", strings.NewReader(source))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	return ReadRenames(file)
+}
+
+// renaming wraps rename forms in the least a layout has to say for them to be
+// readable: one `record` form per record they are rooted at.
+//
+// The records come first and one to a line, so that the first form after them
+// always starts at line len(records)+1 and every position in it is the column it
+// was written at.
+func renaming(records []string, forms ...string) string {
+	lines := make([]string, 0, len(records)+len(forms))
+
+	for _, record := range records {
+		lines = append(lines, fmt.Sprintf("(record %s (copybook \"cpy/x.cpy\" %s-REC))", record, record))
+	}
+
+	return strings.Join(append(lines, forms...), "\n")
+}
+
+// renderRenames draws the layer the way the tests assert one: every rename in
+// source order, the item it is about, both of that item's names and where the
+// substitute was written.
+//
+// It is a rendering rather than a struct literal for [renderDiscrimination]'s
+// reason: what has to be right is the model *and* the position of every part of
+// it, and a rendering carrying both fails with the whole model in the message.
+func renderRenames(renames []Rename) string {
+	lines := make([]string, 0, len(renames))
+
+	for _, rename := range renames {
+		lines = append(lines, fmt.Sprintf(
+			"%s rename %s: %s -> %s at %s",
+			rename.Pos, rename.Item, quote(rename.Original()), quote(rename.Substitute), rename.SubstitutePos,
+		))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// TestReadRenamesModelsTheLayer is the criterion this reader exists for: a
+// layout's renames become typed values naming their targets in full, each
+// carrying the substitute beside the name the copybook gave the item.
+func TestReadRenamesModelsTheLayer(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		source string
+		want   []string
+	}{
+		{
+			name:   "a layout that renames nothing",
+			source: renaming([]string{"DETAIL"}),
+			want:   nil,
+		},
+		{
+			name:   "a field renamed for a generator",
+			source: renaming([]string{"DETAIL"}, `(rename (item DETAIL D-KEY D-CUST-NO) "CustomerNumber")`),
+			want: []string{
+				`layout.sexpr:2:1 rename (item DETAIL D-KEY D-CUST-NO): "D-CUST-NO" -> "CustomerNumber" at layout.sexpr:2:39`,
+			},
+		},
+		{
+			// A reference is rooted at a record and never at a copybook path, so
+			// two records over one `01`-level are renamed independently and
+			// neither reaches the other. The two substitutes below would collide
+			// if they did.
+			name: "two records over one copybook item, renamed independently",
+			source: renaming([]string{"ORDER-OPEN", "ORDER-CLOSE"},
+				`(rename (item ORDER-OPEN O-KEY O-NO) "OrderNumber")`,
+				`(rename (item ORDER-CLOSE O-KEY O-NO) "OrderNumber")`,
+			),
+			want: []string{
+				`layout.sexpr:3:1 rename (item ORDER-OPEN O-KEY O-NO): "O-NO" -> "OrderNumber" at layout.sexpr:3:38`,
+				`layout.sexpr:4:1 rename (item ORDER-CLOSE O-KEY O-NO): "O-NO" -> "OrderNumber" at layout.sexpr:4:39`,
+			},
+		},
+		{
+			// One name under two parents is two names, and neither is the other's
+			// sibling. Nothing here is a collision.
+			name: "one name substituted under two parents",
+			source: renaming([]string{"DETAIL"},
+				`(rename (item DETAIL D-BILL-TO D-NAME) "Name")`,
+				`(rename (item DETAIL D-SHIP-TO D-NAME) "Name")`,
+			),
+			want: []string{
+				`layout.sexpr:2:1 rename (item DETAIL D-BILL-TO D-NAME): "D-NAME" -> "Name" at layout.sexpr:2:40`,
+				`layout.sexpr:3:1 rename (item DETAIL D-SHIP-TO D-NAME): "D-NAME" -> "Name" at layout.sexpr:3:40`,
+			},
+		},
+		{
+			// A rename substituting the name the item already carries says the
+			// same thing twice. It leaves every name where it was, and an item is
+			// not its own sibling.
+			name:   "a rename substituting the item's own name",
+			source: renaming([]string{"DETAIL"}, `(rename (item DETAIL D-CUST-NO) "D-CUST-NO")`),
+			want: []string{
+				`layout.sexpr:2:1 rename (item DETAIL D-CUST-NO): "D-CUST-NO" -> "D-CUST-NO" at layout.sexpr:2:33`,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			read, err := renamesOf(t, testCase.source)
+			if err != nil {
+				t.Fatalf("the reader rejects %s: %v", testCase.source, err)
+			}
+
+			if got, want := renderRenames(read), strings.Join(testCase.want, "\n"); got != want {
+				t.Errorf("the reader reads\n%s\nwant\n%s", got, want)
+			}
+		})
+	}
+}
+
+// TestRenamesReachGroupsAndOccurrences is the half of the layer that is a
+// deliberate absence of a rule.
+//
+// docs/layout/SPEC.md admits a reference naming a group and a reference naming
+// an item that repeats or sits inside one, in which case the substitute is the
+// name of the item and reaches every occurrence of it. Which of those a given
+// path is needs the copybook, so a reader that rejected any depth or any shape
+// would be rejecting layouts on a guess.
+func TestRenamesReachGroupsAndOccurrences(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		item string
+	}{
+		{name: "an elementary item under the record", item: "(item POLICY PL-NUMBER)"},
+		{name: "a group under the record", item: "(item POLICY PL-ENTRIES)"},
+		{name: "a field inside a repeating group", item: "(item POLICY PL-ENTRIES PL-KIND)"},
+		{name: "a group inside a repeating group", item: "(item POLICY PL-ENTRIES PL-BODY-MOTOR)"},
+		{name: "a field inside a group inside a repeating group", item: "(item POLICY PL-ENTRIES PL-BODY-MOTOR PL-REG)"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			read, err := renamesOf(t, renaming([]string{"POLICY"}, fmt.Sprintf("(rename %s \"Substitute\")", testCase.item)))
+			if err != nil {
+				t.Fatalf("the reader rejects a rename on %s: %v", testCase.item, err)
+			}
+
+			if len(read) != 1 {
+				t.Fatalf("the reader reads %d renames, want 1", len(read))
+			}
+
+			if got := read[0].Item.String(); got != testCase.item {
+				t.Errorf("the rename is on %s, want %s", got, testCase.item)
+			}
+		})
+	}
+}
+
+// TestSubstitutesAreCarriedVerbatim is docs/layout/SPEC.md's "no implementation
+// MAY apply the casing or identifier conventions of any language to it".
+//
+// The substitute is a string in a file every generator reads, so anything done
+// to it here is done to it in every target language. Each of the names below is
+// one some language would munge and another would keep, and the reader carries
+// all of them through unchanged.
+func TestSubstitutesAreCarriedVerbatim(t *testing.T) {
+	t.Parallel()
+
+	substitutes := []string{
+		"CustomerNumber",
+		"customerNumber",
+		"customer_number",
+		"customer-number",
+		"customer number",
+		"CUSTOMER NUMBER",
+		"Kundennummer",
+		"9LIVES",
+		"type",
+		" leading and trailing ",
+	}
+
+	for _, substitute := range substitutes {
+		t.Run(substitute, func(t *testing.T) {
+			t.Parallel()
+
+			source := renaming([]string{"DETAIL"}, fmt.Sprintf("(rename (item DETAIL D-CUST-NO) %q)", substitute))
+
+			read, err := renamesOf(t, source)
+			if err != nil {
+				t.Fatalf("the reader rejects %s: %v", source, err)
+			}
+
+			if len(read) != 1 {
+				t.Fatalf("the reader reads %d renames, want 1", len(read))
+			}
+
+			if read[0].Substitute != substitute {
+				t.Errorf("the substitute is carried as %q, want %q", read[0].Substitute, substitute)
+			}
+
+			if read[0].Original() != "D-CUST-NO" {
+				t.Errorf("the original is %q, want \"D-CUST-NO\"; a substitute stands beside it", read[0].Original())
+			}
+		})
+	}
+}
+
+// TestReadRenamesRejects is the load-bearing half: a reader that accepts
+// everything passes every test above.
+//
+// Each case is a layout the format does not admit, and the whole joined message
+// is asserted rather than the first fault, because reporting every fault is the
+// reader's other requirement.
+func TestReadRenamesRejects(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		source string
+		want   []string
+	}{
+		{
+			// Duplicate data names are legal COBOL, so a bare name is not an
+			// identity and the format has no spelling for one.
+			name:   "a target named by a bare name",
+			source: renaming([]string{"DETAIL"}, `(rename D-CUST-NO "CustomerNumber")`),
+			want: []string{
+				"layout.sexpr:2:9: an item reference is written (item <record-name> <name> ...), and this is " +
+					"the symbol \"D-CUST-NO\"",
+			},
+		},
+		{
+			name:   "a target naming a record and no item below it",
+			source: renaming([]string{"DETAIL"}, `(rename (item DETAIL) "CustomerNumber")`),
+			want: []string{
+				"layout.sexpr:2:9: an item reference is written (item <record-name> <name> ...), and this is " +
+					"a reference naming a record and no item below it",
+			},
+		},
+		{
+			name:   "a target rooted at a record nobody defined",
+			source: renaming([]string{"DETAIL"}, `(rename (item HEADER H-CUST-NO) "CustomerNumber")`),
+			want: []string{
+				"layout.sexpr:2:9: form \"rename\" names record \"HEADER\", and the layout defines no record of " +
+					"that name",
+			},
+		},
+		{
+			name:   "a rename carrying no name",
+			source: renaming([]string{"DETAIL"}, `(rename (item DETAIL D-CUST-NO))`),
+			want: []string{
+				"layout.sexpr:2:1: a rename is written (rename <item-ref> \"<name>\"), and this has an item and " +
+					"no name",
+			},
+		},
+		{
+			name:   "a rename carrying no item",
+			source: renaming([]string{"DETAIL"}, `(rename "CustomerNumber")`),
+			want: []string{
+				"layout.sexpr:2:1: a rename is written (rename <item-ref> \"<name>\"), and this has a name and " +
+					"no item",
+			},
+		},
+		{
+			name:   "a rename carrying two names",
+			source: renaming([]string{"DETAIL"}, `(rename (item DETAIL D-CUST-NO) "CustomerNumber" "CustNo")`),
+			want: []string{
+				"layout.sexpr:2:1: a rename is written (rename <item-ref> \"<name>\"), and this has several",
+			},
+		},
+		{
+			// The substitute is text because it is a name and not a symbol: a
+			// name a target language would spell with a space in it is one this
+			// format has to be able to carry.
+			name:   "a name written as a symbol",
+			source: renaming([]string{"DETAIL"}, `(rename (item DETAIL D-CUST-NO) CustomerNumber)`),
+			want: []string{
+				"layout.sexpr:2:33: a rename is written (rename <item-ref> \"<name>\"), and this has the symbol " +
+					"\"CustomerNumber\"",
+			},
+		},
+		{
+			name:   "a rename substituting no name at all",
+			source: renaming([]string{"DETAIL"}, `(rename (item DETAIL D-CUST-NO) "")`),
+			want: []string{
+				"layout.sexpr:2:33: the rename on (item DETAIL D-CUST-NO) substitutes a name of no characters, " +
+					"and a name is at least one",
+			},
+		},
+		{
+			name: "one item renamed twice",
+			source: renaming([]string{"DETAIL"},
+				`(rename (item DETAIL D-CUST-NO) "CustomerNumber")`,
+				`(rename (item DETAIL D-CUST-NO) "CustNo")`,
+			),
+			want: []string{
+				"layout.sexpr:3:1: (item DETAIL D-CUST-NO) is renamed twice, and is renamed first at " +
+					"layout.sexpr:2:1; a rename names an item at most once",
+			},
+		},
+		{
+			name: "one name substituted for two items under one parent",
+			source: renaming([]string{"DETAIL"},
+				`(rename (item DETAIL D-KEY D-CUST-NO) "Customer")`,
+				`(rename (item DETAIL D-KEY D-CUST-NAME) "Customer")`,
+			),
+			want: []string{
+				"layout.sexpr:3:41: name \"Customer\" is substituted for (item DETAIL D-KEY D-CUST-NO) and for " +
+					"(item DETAIL D-KEY D-CUST-NAME), which stand under one parent, and is substituted first at " +
+					"layout.sexpr:2:39",
+			},
+		},
+		{
+			// The sibling is an item the layout itself names, which is what makes
+			// the collision answerable without reading the copybook.
+			name: "a substitute equal to the name of a sibling the layout names",
+			source: renaming([]string{"DETAIL"},
+				`(discriminate DETAIL (equals (item DETAIL D-KEY D-REC-TYPE) "20"))`,
+				`(rename (item DETAIL D-KEY D-CUST-NO) "D-REC-TYPE")`,
+			),
+			want: []string{
+				"layout.sexpr:3:39: the rename on (item DETAIL D-KEY D-CUST-NO) substitutes \"D-REC-TYPE\", " +
+					"which is the name of (item DETAIL D-KEY D-REC-TYPE) beside it at layout.sexpr:2:30; an " +
+					"original is carried beside a substitute rather than in place of it, so the item there " +
+					"answers to that name still",
+			},
+		},
+		{
+			// A swap is two collisions and not a pair that cancels: an original
+			// is carried beside a substitute, so both items answer to both names.
+			name: "two siblings whose names are swapped",
+			source: renaming([]string{"DETAIL"},
+				`(rename (item DETAIL D-KEY D-ONE) "D-TWO")`,
+				`(rename (item DETAIL D-KEY D-TWO) "D-ONE")`,
+			),
+			want: []string{
+				"layout.sexpr:2:35: the rename on (item DETAIL D-KEY D-ONE) substitutes \"D-TWO\", which is the " +
+					"name of (item DETAIL D-KEY D-TWO) beside it at layout.sexpr:3:9; an original is carried " +
+					"beside a substitute rather than in place of it, so the item there answers to that name still",
+				"layout.sexpr:3:35: the rename on (item DETAIL D-KEY D-TWO) substitutes \"D-ONE\", which is the " +
+					"name of (item DETAIL D-KEY D-ONE) beside it at layout.sexpr:2:9; an original is carried " +
+					"beside a substitute rather than in place of it, so the item there answers to that name still",
+			},
+		},
+		{
+			// Every fault the form carries is reported: a rename rooted at a
+			// record nobody defined and substituting a name its target's sibling
+			// carries is two things to fix rather than one to discover on the
+			// next run.
+			name: "a rename wrong in two ways at once",
+			source: renaming([]string{"DETAIL"},
+				`(rename (item HEADER H-KEY H-ONE) "H-TWO")`,
+				`(rename (item HEADER H-KEY H-TWO) "H-THREE")`,
+			),
+			want: []string{
+				"layout.sexpr:2:9: form \"rename\" names record \"HEADER\", and the layout defines no record of " +
+					"that name",
+				"layout.sexpr:2:35: the rename on (item HEADER H-KEY H-ONE) substitutes \"H-TWO\", which is the " +
+					"name of (item HEADER H-KEY H-TWO) beside it at layout.sexpr:3:9; an original is carried " +
+					"beside a substitute rather than in place of it, so the item there answers to that name still",
+				"layout.sexpr:3:9: form \"rename\" names record \"HEADER\", and the layout defines no record of " +
+					"that name",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			read, err := renamesOf(t, testCase.source)
+			if err == nil {
+				t.Fatalf("the reader accepts %s", testCase.source)
+			}
+
+			if read != nil {
+				t.Errorf("the reader hands back renames beside the fault: %+v", read)
+			}
+
+			if got, want := err.Error(), strings.Join(testCase.want, "\n"); got != want {
+				t.Errorf("the reader reports\n%s\nwant\n%s", got, want)
+			}
+		})
+	}
+}
+
+// TestRenameFaultsAreAssertable is the other requirement on a fault: a caller
+// deciding what to do about one reaches for the type rather than for the text of
+// the message.
+func TestRenameFaultsAreAssertable(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		source string
+		assert func(*testing.T, error)
+	}{
+		{
+			name:   "a bare name is a reference fault",
+			source: renaming([]string{"DETAIL"}, `(rename D-CUST-NO "CustomerNumber")`),
+			assert: func(t *testing.T, err error) {
+				var fault *ItemReferenceError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no ItemReferenceError in %v", err)
+				}
+			},
+		},
+		{
+			name: "a second rename on one item names both statements",
+			source: renaming([]string{"DETAIL"},
+				`(rename (item DETAIL D-CUST-NO) "CustomerNumber")`,
+				`(rename (item DETAIL D-CUST-NO) "CustNo")`,
+			),
+			assert: func(t *testing.T, err error) {
+				var fault *DuplicateRenameError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no DuplicateRenameError in %v", err)
+				}
+
+				if fault.Item.String() != "(item DETAIL D-CUST-NO)" || fault.First.Line != 2 || fault.Pos.Line != 3 {
+					t.Errorf("the fault is on %s at %s, first at %s", fault.Item, fault.Pos, fault.First)
+				}
+			},
+		},
+		{
+			name: "a collision names both items and the name they share",
+			source: renaming([]string{"DETAIL"},
+				`(rename (item DETAIL D-KEY D-CUST-NO) "Customer")`,
+				`(rename (item DETAIL D-KEY D-CUST-NAME) "Customer")`,
+			),
+			assert: func(t *testing.T, err error) {
+				var fault *RenameCollisionError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no RenameCollisionError in %v", err)
+				}
+
+				if fault.Name != "Customer" {
+					t.Errorf("the fault is over %q, want \"Customer\"", fault.Name)
+				}
+
+				if fault.Items[0].Name() != "D-CUST-NO" || fault.Items[1].Name() != "D-CUST-NAME" {
+					t.Errorf("the fault is over %s and %s, want the two items in source order", fault.Items[0], fault.Items[1])
+				}
+			},
+		},
+		{
+			name: "a shadowed sibling names the item that already carries the name",
+			source: renaming([]string{"DETAIL"},
+				`(discriminate DETAIL (equals (item DETAIL D-KEY D-REC-TYPE) "20"))`,
+				`(rename (item DETAIL D-KEY D-CUST-NO) "D-REC-TYPE")`,
+			),
+			assert: func(t *testing.T, err error) {
+				var fault *RenameShadowsSiblingError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no RenameShadowsSiblingError in %v", err)
+				}
+
+				if fault.Sibling.String() != "(item DETAIL D-KEY D-REC-TYPE)" || fault.First.Line != 2 {
+					t.Errorf("the fault names %s at %s, want the discriminator's target", fault.Sibling, fault.First)
+				}
+			},
+		},
+		{
+			name:   "a rename rooted at an undefined record names the record",
+			source: renaming([]string{"DETAIL"}, `(rename (item HEADER H-CUST-NO) "CustomerNumber")`),
+			assert: func(t *testing.T, err error) {
+				var fault *UnknownRecordError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no UnknownRecordError in %v", err)
+				}
+
+				if fault.Record != "HEADER" || fault.Form != tagRename {
+					t.Errorf("the fault is on record %q under form %q, want \"HEADER\" under %q", fault.Record, fault.Form, tagRename)
+				}
+			},
+		},
+		{
+			name:   "an empty substitute names the item it was written for",
+			source: renaming([]string{"DETAIL"}, `(rename (item DETAIL D-CUST-NO) "")`),
+			assert: func(t *testing.T, err error) {
+				var fault *EmptyRenameError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no EmptyRenameError in %v", err)
+				}
+
+				if fault.Item.String() != "(item DETAIL D-CUST-NO)" {
+					t.Errorf("the fault is on %s, want (item DETAIL D-CUST-NO)", fault.Item)
+				}
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := renamesOf(t, testCase.source)
+			if err == nil {
+				t.Fatal("read without a fault, want one")
+			}
+
+			testCase.assert(t, err)
+		})
+	}
+}
+
+// TestTheSpecsWorkedExampleRenames is the staleness gate over the layer.
+//
+// docs/layout/SPEC.md's "A layout, end to end" appendix is the layout the
+// document shows an adopter, and it is read out of the document rather than
+// copied here for [TestTheSpecsWorkedExampleDiscriminates]'s reason: a rename
+// the example writes and this reader does not read would otherwise be invisible
+// until somebody pasted the example into a file.
+func TestTheSpecsWorkedExampleRenames(t *testing.T) {
+	t.Parallel()
+
+	read, err := renamesOf(t, specExample(t))
+	if err != nil {
+		t.Fatalf("the reader rejects SPEC.md's own worked example: %v", err)
+	}
+
+	if len(read) != 1 {
+		t.Fatalf("the example carries %d renames, want 1", len(read))
+	}
+
+	if got := read[0].Item.String(); got != "(item ORDER-HEADER OH-KEY OH-CUST-NO)" {
+		t.Errorf("the rename is on %s, want (item ORDER-HEADER OH-KEY OH-CUST-NO)", got)
+	}
+
+	if read[0].Substitute != "CustomerNumber" || read[0].Original() != "OH-CUST-NO" {
+		t.Errorf("the example renames %q to %q, want \"OH-CUST-NO\" to \"CustomerNumber\"", read[0].Original(), read[0].Substitute)
+	}
+}


### PR DESCRIPTION
Closes #30

Adds `ReadRenames` to `internal/layoutmodel`: the record-definitions layer's
rename half, read out of a positioned layout AST with a fault per thing wrong
rather than a fault per run. `docs/layout/SPEC.md` gains the collision rule the
reader enforces, and the two halves of it are filed either side of the
reader/`resolve` split the document already draws.

## Acceptance criteria

- [x] **A rename names its target as a fully-qualified path; a bare or ambiguous
  name is an error.** The target is an `ItemRef` and nothing else: a bare symbol,
  a string, or `(item R)` with no name below the record is an
  `ItemReferenceError` naming what was written. A reference is rooted at a record
  and carries one name per level, so it has exactly one spelling and is an
  identity where a bare name — duplicate data names being legal COBOL — is not.
- [x] **Renames apply to group items and to fields within `OCCURS`.** This is an
  absence of a rule, and it is tested as one: depths one to four, groups and
  elementary items alike, are all accepted. Which of them a copybook makes a
  group or a table is not knowable here, so a reader keyed on it would be
  rejecting layouts on a guess.
- [x] **Collision detection naming both source spans.** Three faults, each
  carrying two positions: `DuplicateRenameError` (SPEC.md's at-most-one rule),
  `RenameCollisionError` (one name substituted for two items under one parent)
  and `RenameShadowsSiblingError` (a substitute equal to the name of an item the
  layout itself references under that parent).
- [x] **Substituted names are carried alongside originals, never replacing
  them.** `Rename.Original()` is the copybook's name and `Rename.Substitute` is
  the adopter's; there is nowhere in the model for one to overwrite the other.
- [x] **No language-specific casing or munging at this layer.** The substitute is
  carried verbatim, asserted over ten spellings some language would munge and
  another would keep.

## Judgment calls

**The sibling set this layer has is the items the layout names.** Deciding a
collision in general needs the copybook's sibling list, which is `resolve`'s. But
an item the layout references anywhere — a discriminator's target, a `times`'s
count, an override's item, another rename's target — is an item the copybook
has, so a substitute equal to one of those names under one parent is a collision
decidable from the layout alone. `itemsNamed` walks every top-level form for that
reason, and SPEC.md now says which half lands where.

**A shadowed sibling collides even where that sibling is itself renamed**, so a
swap of two names is two faults rather than a pair that cancels. `ir/SPEC.md`'s
"Names" carries an original beside a substitute rather than in place of it, so a
renamed item answers to the copybook's name still. Swapping is spelled by
renaming both to names nothing under that parent carries.

**A rename substituting the name its own target already has is admitted** — an
item is not its own sibling, and the rename leaves every name where it was.

**An empty substitute is rejected** (`EmptyRenameError`), as `ByteStringError`
rejects a byte string of no bytes: the schema declares the position to take text
and cannot say that the text says something.

## Verification

`dagger call ci` — green. (It first failed with `missing shared result`, a stale
result in the local engine session rather than anything in the tree; restarting
the engine container cleared it and the run then did its 58s of real work.)