### PR TITLE
story(layout): report validation errors with cross-file source spans

### DIFF
--- a/internal/diag/copybook.go
+++ b/internal/diag/copybook.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package diag
+
+import "fmt"
+
+// MissingCopybookError is a `copybook` child whose path names no file that can
+// be read.
+//
+// It names the path as the layout spells it, which docs/layout/SPEC.md requires
+// of it, and it carries one span: there is no file to point into, and a span
+// invented for one would point at nothing. Where the path was looked for is the
+// CLI's to explain, for the same reason resolving it is — so the cause is kept
+// and reachable with [errors.As] rather than written into the message, which
+// would name a path the adopter never wrote.
+type MissingCopybookError struct {
+	// Pos is the `copybook` child in the layout.
+	Pos Span
+
+	// Path is the path as the layout spells it.
+	Path string
+
+	// Err is what the read failed with.
+	Err error
+}
+
+// Error implements the error interface.
+func (e *MissingCopybookError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *MissingCopybookError) Diagnostic() Diagnostic {
+	return Diagnostic{
+		Message: fmt.Sprintf("there is no copybook to read at %q", e.Path),
+		Spans:   []Span{e.Pos},
+	}
+}
+
+// Unwrap gives up the read failure.
+func (e *MissingCopybookError) Unwrap() error { return e.Err }
+
+// UndeclaredItemError is a copybook that reads and does not declare the
+// top-level item the record names.
+//
+// It is the cross-file diagnostic docs/layout/SPEC.md requires by name: one
+// span into the layout at the `copybook` child, and one into the copybook. The
+// second points at what is *there* — the `01`-levels the copybook does
+// declare — because an absent item has no position, and the list an adopter
+// needs in order to fix the record is the list of the ones they could have
+// meant.
+//
+// A copybook declaring no `01`-level at all has nothing to point at but itself,
+// and the span is then the file: leave [UndeclaredItemError.Copybook]'s line at
+// zero and it renders as the file alone.
+type UndeclaredItemError struct {
+	// Pos is the `copybook` child in the layout.
+	Pos Span
+
+	// Path is the copybook's path as the layout spells it.
+	Path string
+
+	// Item is the top-level item as the layout spells it.
+	Item string
+
+	// Copybook is where in the copybook the second span points: the first
+	// `01`-level it declares, or the file itself where it declares none.
+	Copybook Span
+
+	// Declares are the `01`-levels the copybook does declare, in the order it
+	// declares them.
+	Declares []string
+}
+
+// Error implements the error interface.
+func (e *UndeclaredItemError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+//
+// The second span's note is built from [UndeclaredItemError.Declares] here
+// rather than taken from the caller, so that what the copybook half of the
+// message says is a property of the error and not of what whoever raised it
+// remembered to write.
+func (e *UndeclaredItemError) Diagnostic() Diagnostic {
+	copybook := e.Copybook
+
+	if len(e.Declares) == 0 {
+		copybook.Note = "it declares no 01-level at all"
+	} else {
+		copybook.Note = "it declares " + joinAnd(e.Declares)
+	}
+
+	return Diagnostic{
+		Message: fmt.Sprintf("the copybook %q declares no %s", e.Path, e.Item),
+		Spans:   []Span{e.Pos, copybook},
+	}
+}

--- a/internal/diag/copybook_test.go
+++ b/internal/diag/copybook_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package diag
+
+import (
+	"errors"
+	"io/fs"
+	"strings"
+	"testing"
+)
+
+// TestMissingCopybookNamesThePathAndNothingElse holds the first of the two
+// diagnostics docs/layout/SPEC.md's "A copybook that is not there, and an item
+// that is not in it" requires by name.
+//
+// It names the path as the layout spells it and carries exactly one span: there
+// is no file to point into, and a span invented for one would point at nothing.
+// The path it was looked for under stays out of the message, which is SPEC.md's
+// division — where a copybook was looked for is the CLI's to explain — and is
+// why the read failure is kept for [errors.As] rather than printed.
+func TestMissingCopybookNamesThePathAndNothingElse(t *testing.T) {
+	t.Parallel()
+
+	cause := &fs.PathError{Op: "open", Path: "/srv/cpy/order.cpy", Err: fs.ErrNotExist}
+	err := &MissingCopybookError{
+		Pos:  Span{File: "orders.sexpr", Line: 4, Column: 22},
+		Path: "cpy/order.cpy",
+		Err:  cause,
+	}
+
+	want := `orders.sexpr:4:22: there is no copybook to read at "cpy/order.cpy"`
+	if got := err.Error(); got != want {
+		t.Errorf("rendered %q, want %q", got, want)
+	}
+
+	if spans := err.Diagnostic().Spans; len(spans) != 1 {
+		t.Errorf("carries %d spans, want the one into the layout", len(spans))
+	}
+
+	if strings.Contains(err.Error(), "/srv/") {
+		t.Error("the message names where the copybook was looked for, which is the CLI's to explain")
+	}
+
+	var path *fs.PathError
+	if !errors.As(err, &path) || path != cause {
+		t.Error("the read failure is not reachable with errors.As")
+	}
+}
+
+// TestUndeclaredItemCarriesBothSpans is the acceptance criterion this issue
+// exists for: an error implicating both a layout and a copybook shows both.
+//
+// The second span points at what is *there*, because an absent item has no
+// position and the list an adopter needs is the list of the ones they could
+// have meant.
+func TestUndeclaredItemCarriesBothSpans(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		err  *UndeclaredItemError
+		want string
+	}{
+		{
+			name: "the 01-levels the copybook does declare",
+			err: &UndeclaredItemError{
+				Pos:      Span{File: "orders.sexpr", Line: 4, Column: 22},
+				Path:     "cpy/order.cpy",
+				Item:     "ORDER-HEADER-REC",
+				Copybook: Span{File: "cpy/order.cpy", Line: 1, Column: 8},
+				Declares: []string{"ORDER-REC", "ORDER-TRAILER-REC"},
+			},
+			want: "orders.sexpr:4:22: the copybook \"cpy/order.cpy\" declares no ORDER-HEADER-REC\n" +
+				"  cpy/order.cpy:1:8: it declares ORDER-REC and ORDER-TRAILER-REC",
+		},
+		{
+			name: "a copybook with nothing in it to point at",
+			err: &UndeclaredItemError{
+				Pos:      Span{File: "orders.sexpr", Line: 4, Column: 22},
+				Path:     "cpy/empty.cpy",
+				Item:     "ORDER-HEADER-REC",
+				Copybook: Span{File: "cpy/empty.cpy"},
+			},
+			want: "orders.sexpr:4:22: the copybook \"cpy/empty.cpy\" declares no ORDER-HEADER-REC\n" +
+				"  cpy/empty.cpy: it declares no 01-level at all",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := testCase.err.Error(); got != testCase.want {
+				t.Errorf("rendered:\n%s\nwant:\n%s", got, testCase.want)
+			}
+
+			spans := testCase.err.Diagnostic().Spans
+			if len(spans) != 2 {
+				t.Fatalf("carries %d spans, want one into the layout and one into the copybook", len(spans))
+			}
+
+			if spans[0].File != "orders.sexpr" {
+				t.Errorf("the first span is in %q, want the layout", spans[0].File)
+			}
+
+			if spans[1].File != testCase.err.Path {
+				t.Errorf("the second span is in %q, want the copybook", spans[1].File)
+			}
+		})
+	}
+}
+
+// TestCopybookDiagnosticsAreAssertable is the house pattern: a caller that has
+// to know which fault it is asserts against the type, whether or not the fault
+// was reported beside others.
+func TestCopybookDiagnosticsAreAssertable(t *testing.T) {
+	t.Parallel()
+
+	undeclared := &UndeclaredItemError{Path: "cpy/order.cpy", Item: "ORDER-HEADER-REC"}
+	err := errors.Join(errors.New("orders.sexpr:1:1: a layout carries exactly one framing form"), undeclared)
+
+	var found *UndeclaredItemError
+	if !errors.As(err, &found) || found != undeclared {
+		t.Errorf("the fault is not assertable out of %v", err)
+	}
+
+	var missing *MissingCopybookError
+	if errors.As(err, &missing) {
+		t.Error("a copybook that is not there was found in a layout that has one")
+	}
+}

--- a/internal/diag/diag.go
+++ b/internal/diag/diag.go
@@ -154,7 +154,16 @@ type List struct {
 
 // Fail records a fault. Reading continues after one, because the point of
 // collecting them is to report the second.
+//
+// A nil fault is not one, and is dropped rather than recorded: [errors.Join]
+// discards nils, so keeping one would leave [List.Failed] reporting a fault
+// that [List.Err] cannot produce — and a caller reading Failed would then
+// reject a layout while handing back no reason for it.
 func (l *List) Fail(err error) {
+	if err == nil {
+		return
+	}
+
 	l.errs = append(l.errs, err)
 }
 

--- a/internal/diag/diag.go
+++ b/internal/diag/diag.go
@@ -1,0 +1,239 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package diag
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Span is one place a diagnostic points at: a file, and where in it.
+//
+// The line and the column are one-based and are the reader's of whatever file
+// this is a place in — the layout grammar's for a layout, the copybook reader's
+// for a copybook. The file is what makes the two comparable, and is why a
+// position that cannot name one stops being usable exactly when a diagnostic
+// names two.
+type Span struct {
+	// File is the name the file was read under, as the thing that read it
+	// spells it. For a copybook that is the path the layout states, not a path
+	// resolved against anything: docs/layout/SPEC.md leaves where a copybook was
+	// looked for to the CLI, and a diagnostic naming a path the adopter never
+	// wrote sends them looking for a file they have not got.
+	File string
+
+	// Line and Column are one-based.
+	//
+	// Line is zero where the file is all there is to point at. That is not a
+	// missing position: a copybook declaring no `01`-level at all has nothing
+	// in it to name, and SPEC.md's "A copybook that is not there, and an item
+	// that is not in it" makes the file itself the span in that case.
+	Line   int
+	Column int
+
+	// Note is what is at this place, in the message's own words — "it declares
+	// ORDER-REC and ORDER-TRAILER-REC". It is what a span after the first is
+	// for: the first span is where the fault is and the message says what, and
+	// every one after it has to say why it is being shown.
+	Note string
+}
+
+// Stated reports whether the span names anywhere at all.
+func (s Span) Stated() bool { return s.File != "" || s.Line != 0 }
+
+// String renders a span the way a compiler does, so that an editor and a
+// terminal both know what to do with it.
+//
+// A span with a file and no line is the file alone rather than a line zero
+// nothing can jump to, and a span with neither renders as nothing at all — an
+// invented `0:0` is a position a reader would try to open.
+func (s Span) String() string {
+	switch {
+	case s.File != "" && s.Line != 0:
+		return fmt.Sprintf("%s:%d:%d", s.File, s.Line, s.Column)
+	case s.File != "":
+		return s.File
+	case s.Line != 0:
+		return fmt.Sprintf("%d:%d", s.Line, s.Column)
+	default:
+		return ""
+	}
+}
+
+// Diagnostic is one thing wrong, what it is, and every place it is.
+//
+// Spans[0] is where the fault is — the sub-form that is wrong, not the
+// top-level form containing it, which is what SPEC.md's "Every diagnostic
+// carries a span" requires. Every span after it is somewhere else the fault
+// implicates, carrying a [Span.Note] saying why it is being shown: the copybook
+// an item is not in, the statement a rename collides with, each item an
+// ambiguous reference matched.
+//
+// There is no severity. Everything reported through this type is something an
+// adopter has to fix.
+type Diagnostic struct {
+	// Message is what was found, with no position in it and no trailing
+	// newline. The position is [Diagnostic.String]'s to write, once, so that
+	// every diagnostic in this repository leads with its span in the same
+	// shape.
+	Message string
+
+	// Spans are the places the fault implicates, the first being where it is.
+	Spans []Span
+}
+
+// String renders a diagnostic: the message under the span it is at, and one
+// indented line per further place it implicates.
+//
+//	orders.sexpr:4:22: the copybook "cpy/order.cpy" declares no ORDER-HEADER-REC
+//	  cpy/order.cpy:1:8: it declares ORDER-REC and ORDER-TRAILER-REC
+//
+// The continuation lines are indented because the whole of it is one fault: a
+// reader scanning a column of diagnostics reads the unindented lines and finds
+// one per thing to fix, and the second file is there for the one they stop at.
+func (d Diagnostic) String() string {
+	if len(d.Spans) == 0 {
+		return d.Message
+	}
+
+	var b strings.Builder
+
+	if d.Spans[0].Stated() {
+		b.WriteString(d.Spans[0].String())
+		b.WriteString(": ")
+	}
+
+	b.WriteString(d.Message)
+
+	for _, span := range d.Spans[1:] {
+		b.WriteString("\n  ")
+
+		if span.Stated() {
+			b.WriteString(span.String())
+
+			if span.Note != "" {
+				b.WriteString(": ")
+			}
+		}
+
+		b.WriteString(span.Note)
+	}
+
+	return b.String()
+}
+
+// Error is an error that carries a diagnostic.
+//
+// A typed error implements it by building its [Diagnostic] in one place and
+// rendering that from Error, so that what a caller reads and what a caller
+// inspects cannot say different things. Every fault stays assertable with
+// [errors.As] against its own type, which is what this repository's callers
+// switch on; this interface is for the caller that wants to print a fault
+// rather than to know which one it is.
+type Error interface {
+	error
+
+	// Diagnostic is what the error says, and where.
+	Diagnostic() Diagnostic
+}
+
+// List accumulates the faults one pass found.
+//
+// Every reader in this repository collects rather than returning the first: a
+// generated layout is generated wrong in the same way in many places at once,
+// and a reader that reports one fault per run is a reader run once per fault.
+// It is one type here rather than a field on each reader so that "keep reading
+// after a fault" is decided once.
+type List struct {
+	errs []error
+}
+
+// Fail records a fault. Reading continues after one, because the point of
+// collecting them is to report the second.
+func (l *List) Fail(err error) {
+	l.errs = append(l.errs, err)
+}
+
+// Failed reports whether anything was recorded.
+func (l *List) Failed() bool { return len(l.errs) > 0 }
+
+// Err is every fault recorded, joined, or nil if there were none.
+//
+// [errors.Join] rather than a type of this package's own: a joined error is
+// traversed by [errors.As], so a caller asserting against one fault finds it
+// without knowing it was reported beside others.
+func (l *List) Err() error { return errors.Join(l.errs...) }
+
+// Diagnostics is every diagnostic in err, in the order it was reported.
+//
+// It walks what [errors.Join] built rather than asserting against it, because
+// [errors.As] finds the first match in a tree and a caller printing faults
+// wants all of them.
+//
+// An error carrying no diagnostic contributes one with its own text as the
+// message and no span. That is what makes this readable over a tree the layer
+// readers built: their faults already lead with the position they carry, so
+// they render through here as they render themselves, and a fault that names a
+// second file is the one that needs this package to say so. An error wrapping a
+// diagnostic is its wrapper's text for the same reason — the wrapping is
+// something a caller chose to say, and dropping it to reach inside would report
+// a fault under a description nobody wrote.
+func Diagnostics(err error) []Diagnostic {
+	if err == nil {
+		return nil
+	}
+
+	// The assertions below are against err itself rather than through
+	// [errors.As], which is the whole point: As descends a tree and stops at
+	// the first match, and this walk is here to reach every one of them.
+	if carrier, ok := err.(Error); ok {
+		return []Diagnostic{carrier.Diagnostic()}
+	}
+
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		var found []Diagnostic
+
+		for _, e := range joined.Unwrap() {
+			found = append(found, Diagnostics(e)...)
+		}
+
+		return found
+	}
+
+	return []Diagnostic{{Message: err.Error()}}
+}
+
+// Render draws every diagnostic in err, one fault per unindented line.
+//
+// It is what a caller with a joined error and a terminal wants, and what the
+// golden tests pin. A nil error renders as nothing rather than as an empty
+// line.
+func Render(err error) string {
+	found := Diagnostics(err)
+	lines := make([]string, 0, len(found))
+
+	for _, diagnostic := range found {
+		lines = append(lines, diagnostic.String())
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// joinAnd joins names the way a message does, so that a list of things an adopter
+// could have meant reads as a sentence rather than as a slice.
+func joinAnd(items []string) string {
+	switch len(items) {
+	case 0:
+		return ""
+	case 1:
+		return items[0]
+	case 2:
+		return items[0] + " and " + items[1]
+	default:
+		return strings.Join(items[:len(items)-1], ", ") + " and " + items[len(items)-1]
+	}
+}

--- a/internal/diag/diag_test.go
+++ b/internal/diag/diag_test.go
@@ -177,6 +177,41 @@ func TestListAccumulatesRatherThanFailingFast(t *testing.T) {
 	}
 }
 
+// TestListDropsAFaultThatIsNotOne keeps [List.Failed] and [List.Err] answering
+// the same question.
+//
+// [errors.Join] discards nils, so a recorded nil would leave a list reporting a
+// fault it cannot produce — and a reader asking Failed would then reject a
+// layout while handing its caller no reason for it.
+func TestListDropsAFaultThatIsNotOne(t *testing.T) {
+	t.Parallel()
+
+	var list List
+
+	list.Fail(nil)
+
+	if list.Failed() {
+		t.Error("a list holding one nil reports a fault")
+	}
+
+	if err := list.Err(); err != nil {
+		t.Errorf("a list holding one nil yields %v, want nil", err)
+	}
+
+	real := &MissingCopybookError{Path: "cpy/order.cpy"}
+
+	list.Fail(real)
+	list.Fail(nil)
+
+	if !list.Failed() {
+		t.Error("a list with a fault in it reports none")
+	}
+
+	if err := list.Err(); !errors.Is(err, error(real)) {
+		t.Errorf("the fault reported is %v, want the one recorded", err)
+	}
+}
+
 // TestDiagnosticsWalksEveryFaultAJoinCarries is why the walk is written out
 // rather than left to [errors.As]: As finds the first diagnostic in a tree, and
 // a caller printing faults wants all of them, in the order they were reported.

--- a/internal/diag/diag_test.go
+++ b/internal/diag/diag_test.go
@@ -1,0 +1,319 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package diag
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// TestSpanRendersWhereSomethingIs pins the four shapes a span takes.
+//
+// The third and the fourth are the ones that matter. A copybook declaring no
+// `01`-level has nothing to point at but itself, so a span with a file and no
+// line renders as the file — docs/layout/SPEC.md's "the span is the file" — and
+// a span naming nowhere renders as nothing, because an invented `0:0` is a
+// position a reader would try to open.
+func TestSpanRendersWhereSomethingIs(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		span Span
+		want string
+	}{
+		{
+			name: "a file, a line and a column",
+			span: Span{File: "orders.sexpr", Line: 4, Column: 22},
+			want: "orders.sexpr:4:22",
+		},
+		{
+			name: "a file with nothing in it to point at",
+			span: Span{File: "cpy/order.cpy"},
+			want: "cpy/order.cpy",
+		},
+		{
+			name: "a place in a source nobody named",
+			span: Span{Line: 7, Column: 3},
+			want: "7:3",
+		},
+		{
+			name: "nowhere at all",
+			span: Span{},
+			want: "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := testCase.span.String(); got != testCase.want {
+				t.Errorf("rendered %q, want %q", got, testCase.want)
+			}
+
+			if got := testCase.span.Stated(); got != (testCase.want != "") {
+				t.Errorf("Stated is %t on a span rendering %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestDiagnosticRendersEveryPlaceItImplicates is the acceptance criterion this
+// package exists for: a fault that implicates two files says so, and says it in
+// one shape.
+func TestDiagnosticRendersEveryPlaceItImplicates(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		diagnostic Diagnostic
+		want       string
+	}{
+		{
+			name: "one place",
+			diagnostic: Diagnostic{
+				Message: "form \"encoding\" states charset twice",
+				Spans:   []Span{{File: "orders.sexpr", Line: 3, Column: 3}},
+			},
+			want: "orders.sexpr:3:3: form \"encoding\" states charset twice",
+		},
+		{
+			name: "a layout and a copybook",
+			diagnostic: Diagnostic{
+				Message: "the copybook \"cpy/order.cpy\" declares no ORDER-HEADER-REC",
+				Spans: []Span{
+					{File: "orders.sexpr", Line: 4, Column: 22},
+					{File: "cpy/order.cpy", Line: 1, Column: 8, Note: "it declares ORDER-REC"},
+				},
+			},
+			want: "orders.sexpr:4:22: the copybook \"cpy/order.cpy\" declares no ORDER-HEADER-REC\n" +
+				"  cpy/order.cpy:1:8: it declares ORDER-REC",
+		},
+		{
+			name: "a copybook with nothing in it to point at",
+			diagnostic: Diagnostic{
+				Message: "the copybook \"cpy/empty.cpy\" declares no ORDER-HEADER-REC",
+				Spans: []Span{
+					{File: "orders.sexpr", Line: 4, Column: 22},
+					{File: "cpy/empty.cpy", Note: "it declares no 01-level at all"},
+				},
+			},
+			want: "orders.sexpr:4:22: the copybook \"cpy/empty.cpy\" declares no ORDER-HEADER-REC\n" +
+				"  cpy/empty.cpy: it declares no 01-level at all",
+		},
+		{
+			name: "more places than two",
+			diagnostic: Diagnostic{
+				Message: "the item reference (item ORDER-HEADER AMOUNT) names two items",
+				Spans: []Span{
+					{File: "orders.sexpr", Line: 9, Column: 5},
+					{File: "cpy/order.cpy", Line: 4, Column: 9, Note: "one of them is here"},
+					{File: "cpy/order.cpy", Line: 8, Column: 9, Note: "and one of them is here"},
+				},
+			},
+			want: "orders.sexpr:9:5: the item reference (item ORDER-HEADER AMOUNT) names two items\n" +
+				"  cpy/order.cpy:4:9: one of them is here\n" +
+				"  cpy/order.cpy:8:9: and one of them is here",
+		},
+		{
+			name:       "a message with nowhere to put it",
+			diagnostic: Diagnostic{Message: "the layout could not be read"},
+			want:       "the layout could not be read",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := testCase.diagnostic.String(); got != testCase.want {
+				t.Errorf("rendered:\n%s\nwant:\n%s", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestListAccumulatesRatherThanFailingFast is the criterion [List] exists for.
+// A pass that stopped at the first fault would be a pass run once per fault,
+// and each fault it did report has to stay assertable on its own.
+func TestListAccumulatesRatherThanFailingFast(t *testing.T) {
+	t.Parallel()
+
+	var list List
+
+	if list.Failed() {
+		t.Error("an empty list reports a fault")
+	}
+
+	if err := list.Err(); err != nil {
+		t.Errorf("an empty list yields %v, want nil", err)
+	}
+
+	first := &MissingCopybookError{Path: "cpy/order.cpy"}
+	second := &UndeclaredItemError{Path: "cpy/order.cpy", Item: "ORDER-HEADER-REC"}
+
+	list.Fail(first)
+	list.Fail(second)
+
+	if !list.Failed() {
+		t.Error("a list with two faults in it reports none")
+	}
+
+	err := list.Err()
+
+	var missing *MissingCopybookError
+	if !errors.As(err, &missing) || missing != first {
+		t.Errorf("the first fault is not assertable out of %v", err)
+	}
+
+	var undeclared *UndeclaredItemError
+	if !errors.As(err, &undeclared) || undeclared != second {
+		t.Errorf("the second fault is not assertable out of %v", err)
+	}
+}
+
+// TestDiagnosticsWalksEveryFaultAJoinCarries is why the walk is written out
+// rather than left to [errors.As]: As finds the first diagnostic in a tree, and
+// a caller printing faults wants all of them, in the order they were reported.
+func TestDiagnosticsWalksEveryFaultAJoinCarries(t *testing.T) {
+	t.Parallel()
+
+	if got := Diagnostics(nil); got != nil {
+		t.Errorf("a nil error yields %v, want nothing", got)
+	}
+
+	err := errors.Join(
+		&MissingCopybookError{
+			Pos:  Span{File: "orders.sexpr", Line: 4, Column: 22},
+			Path: "cpy/order.cpy",
+		},
+		errors.New("orders.sexpr:6:3: form \"framing\" states recfm twice"),
+		errors.Join(
+			&UndeclaredItemError{
+				Pos:      Span{File: "orders.sexpr", Line: 9, Column: 22},
+				Path:     "cpy/detail.cpy",
+				Item:     "ORDER-DETAIL-REC",
+				Copybook: Span{File: "cpy/detail.cpy", Line: 1, Column: 5},
+				Declares: []string{"ORDER-DTL-REC"},
+			},
+		),
+	)
+
+	want := []string{
+		"there is no copybook to read at \"cpy/order.cpy\"",
+		"orders.sexpr:6:3: form \"framing\" states recfm twice",
+		"the copybook \"cpy/detail.cpy\" declares no ORDER-DETAIL-REC",
+	}
+
+	found := Diagnostics(err)
+	if len(found) != len(want) {
+		t.Fatalf("found %d diagnostics, want %d:\n%s", len(found), len(want), Render(err))
+	}
+
+	for i, diagnostic := range found {
+		if diagnostic.Message != want[i] {
+			t.Errorf("diagnostic %d says %q, want %q", i, diagnostic.Message, want[i])
+		}
+	}
+}
+
+// TestDiagnosticsKeepsTheWrapperAWrapperWrote is the other half of the walk. An
+// error wrapping a diagnostic is reported as its wrapper wrote it: the wrapping
+// is something a caller chose to say, and reaching inside would report a fault
+// under a description nobody wrote.
+func TestDiagnosticsKeepsTheWrapperAWrapperWrote(t *testing.T) {
+	t.Parallel()
+
+	inner := &MissingCopybookError{
+		Pos:  Span{File: "orders.sexpr", Line: 4, Column: 22},
+		Path: "cpy/order.cpy",
+	}
+
+	found := Diagnostics(fmt.Errorf("failed to resolve ORDER-HEADER: %w", inner))
+	if len(found) != 1 {
+		t.Fatalf("found %d diagnostics, want 1", len(found))
+	}
+
+	want := "failed to resolve ORDER-HEADER: orders.sexpr:4:22: there is no copybook to read at \"cpy/order.cpy\""
+	if found[0].Message != want {
+		t.Errorf("the diagnostic says %q, want %q", found[0].Message, want)
+	}
+}
+
+// goldenRender is the rendering of the whole of one rejected layout, written
+// out in full.
+//
+// It is the pinned output docs/layout/SPEC.md's "Every diagnostic carries a
+// span, and some carry two" is checked against: three faults reported together
+// rather than one per run, every one of them naming the file it is in, and the
+// one about a copybook naming the copybook as well as the layout. A golden is
+// the right shape for it because every part of the rendering — the order, the
+// indent, the colon after a span — is something somebody reads.
+const goldenRender = `orders.sexpr:2:12: charset is one of cp037, cp500, cp1047, cp1140 or ascii, and this one says "cp999"
+orders.sexpr:5:22: there is no copybook to read at "cpy/order.cpy"
+orders.sexpr:9:22: the copybook "cpy/detail.cpy" declares no ORDER-DETAIL-REC
+  cpy/detail.cpy:1:8: it declares ORDER-DTL-REC and ORDER-TRAILER-REC`
+
+// TestRenderIsTheGolden pins what a caller with a joined error and a terminal
+// sees.
+func TestRenderIsTheGolden(t *testing.T) {
+	t.Parallel()
+
+	err := errors.Join(
+		errors.New(`orders.sexpr:2:12: charset is one of cp037, cp500, cp1047, cp1140 or ascii, and this one says "cp999"`),
+		&MissingCopybookError{
+			Pos:  Span{File: "orders.sexpr", Line: 5, Column: 22},
+			Path: "cpy/order.cpy",
+			Err:  errors.New("open /srv/cpy/order.cpy: no such file or directory"),
+		},
+		&UndeclaredItemError{
+			Pos:      Span{File: "orders.sexpr", Line: 9, Column: 22},
+			Path:     "cpy/detail.cpy",
+			Item:     "ORDER-DETAIL-REC",
+			Copybook: Span{File: "cpy/detail.cpy", Line: 1, Column: 8},
+			Declares: []string{"ORDER-DTL-REC", "ORDER-TRAILER-REC"},
+		},
+	)
+
+	if got := Render(err); got != goldenRender {
+		t.Errorf("the rendering is not the golden\n got:\n%s\nwant:\n%s", got, goldenRender)
+	}
+
+	if got := Render(nil); got != "" {
+		t.Errorf("a nil error renders as %q, want nothing", got)
+	}
+}
+
+// TestJoinAndReadsAsASentence covers the joining a message does when it lists what
+// an adopter could have meant.
+func TestJoinAndReadsAsASentence(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		items []string
+		want  string
+	}{
+		{items: nil, want: ""},
+		{items: []string{"ORDER-REC"}, want: "ORDER-REC"},
+		{items: []string{"ORDER-REC", "ORDER-TRAILER-REC"}, want: "ORDER-REC and ORDER-TRAILER-REC"},
+		{
+			items: []string{"ORDER-REC", "ORDER-DTL-REC", "ORDER-TRAILER-REC"},
+			want:  "ORDER-REC, ORDER-DTL-REC and ORDER-TRAILER-REC",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.want, func(t *testing.T) {
+			t.Parallel()
+
+			if got := joinAnd(testCase.items); got != testCase.want {
+				t.Errorf("joined to %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}

--- a/internal/diag/doc.go
+++ b/internal/diag/doc.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Package diag is the vocabulary every layer of cpybkc reports a fault in.
+//
+// docs/layout/SPEC.md's "Every diagnostic carries a span, and some carry two"
+// is what this package holds the rest of the repository to. A diagnostic names
+// what it found and where, the where is a file with a line and a column in it,
+// and a diagnostic about something in a copybook names the copybook too. Three
+// things follow from that and all three are here: a [Span], a [Diagnostic] that
+// carries as many of them as it implicates, and one rendering of the pair so
+// that a fault reads the same however it was reached.
+//
+// # Why a span is not a layout position
+//
+// [github.com/Zaba505/cpybkc/internal/layout.Pos] already names a file, a line
+// and a column, and it is the right type for a place in a layout. It is the
+// wrong type for a place in a copybook: a copybook is not a layout, nothing
+// parses one into that AST, and a position out of the copybook reader (#32)
+// would have to be laundered through a package it has nothing to do with to be
+// reportable.
+//
+// So a [Span] is a place in a file and belongs to no reader. This package
+// imports nothing outside the standard library, which is what lets the layout
+// reader, the layer readers and `resolve` all report through it without one of
+// them becoming a dependency of the others.
+//
+// # What a second span is for
+//
+// A diagnostic about something in a copybook carries a span into the layout and
+// a span into the copybook, because the adopter is usually holding a file they
+// did not author and a copybook they did not write, and a message naming one of
+// the two leaves them to find the other by hand. SPEC.md's "A copybook that is
+// not there, and an item that is not in it" requires both by name, and
+// [MissingCopybookError] and [UndeclaredItemError] are those two.
+//
+// Neither is raised here. Both checks need a copybook read, so both are
+// `resolve`'s (#32–#38) and SPEC.md says so; what is here is the shape of the
+// diagnostic, which is a requirement on the message rather than on the stage
+// that finds it. A [Diagnostic] takes as many spans as a fault implicates
+// rather than exactly two, because an item reference that resolves to more than
+// one item names every match, and "two" is the smallest case of that rather
+// than the rule.
+//
+// # Why accumulation is here
+//
+// A generated layout is generated wrong in the same way in many places at once,
+// so every reader in this repository reports every fault it found rather than
+// the first, joined with [errors.Join]. [List] is that accumulation, in one
+// place: "keep reading after a fault" is decided once, and a third reader does
+// not arrive with a third copy of it.
+//
+// [Diagnostics] is the other end. It walks what [errors.Join] built and hands
+// back one [Diagnostic] per fault, in the order they were reported, so that a
+// caller printing them never has to know how they were joined.
+//
+// # Why rendering is here
+//
+// A fault that names two files cannot render itself on one line, and a
+// [Diagnostic] that rendered differently in the CLI and in a test would be
+// pinned by the test and read by nobody. [Diagnostic.String] is the rendering,
+// [Render] applies it to a whole joined error, and the golden tests beside this
+// file are what the output is held to.
+//
+// An error that does not carry a diagnostic is rendered as it renders itself.
+// Every typed error in this repository already leads with the position it
+// carries, so a reader's fault reads the same through [Render] as it does
+// through [error.Error]; what [Render] adds is the span such an error cannot
+// state, which is one in a file the layout is not.
+//
+// # What it does not do
+//
+// There are no severities: everything reported here is something an adopter has
+// to fix, and a warning nobody has to act on is a line of output that teaches a
+// reader to skip the others. There is no source excerpt, no caret line and no
+// colour — a span an editor and a terminal both understand is what a diagnostic
+// owes its reader, and quoting the source back is a decision about a terminal
+// that the CLI is closer to than this package.
+package diag

--- a/internal/layout/doc.go
+++ b/internal/layout/doc.go
@@ -60,7 +60,10 @@
 // diagnostics: a generated layout is generated wrong in the same way in many
 // places at once, and a reader that reports one fault per run is a reader run
 // once per fault. Each is still assertable with [errors.As], because that is
-// what errors.Join is traversed by.
+// what errors.Join is traversed by. The list they accumulate in is
+// [github.com/Zaba505/cpybkc/internal/diag.List], and the rendering of the
+// result is that package's too — a fault this reader found and a fault
+// `resolve` found in a copybook are the same kind of thing, and read the same.
 //
 // # What it does not check
 //

--- a/internal/layout/parse.go
+++ b/internal/layout/parse.go
@@ -6,11 +6,11 @@
 package layout
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
 
+	"github.com/Zaba505/cpybkc/internal/diag"
 	sexpr "github.com/z5labs/sexpr-go"
 )
 
@@ -57,11 +57,11 @@ func Parse(name string, r io.Reader) (*File, error) {
 		file.Forms = append(file.Forms, form)
 	}
 
-	if len(read.errs) > 0 {
+	if read.Failed() {
 		// The half-built file is dropped rather than returned beside the
 		// errors. A layout that was rejected has no AST anything downstream
 		// should be reading, and handing one back invites a caller to read it.
-		return nil, errors.Join(read.errs...)
+		return nil, read.Err()
 	}
 
 	return file, nil
@@ -70,19 +70,14 @@ func Parse(name string, r io.Reader) (*File, error) {
 // reader holds the state one parse accumulates: the name every position carries
 // and the faults found so far.
 type reader struct {
+	diag.List
+
 	name string
-	errs []error
 }
 
 // pos lifts a grammar position into a layout one by naming the file it is in.
 func (r *reader) pos(pos sexpr.Pos) Pos {
 	return Pos{File: r.name, Line: pos.Line, Column: pos.Column}
-}
-
-// fail records a fault. Parsing continues after one, because the point of
-// collecting them is to report the second.
-func (r *reader) fail(err error) {
-	r.errs = append(r.errs, err)
 }
 
 // topLevel converts one of the layout's top-level nodes, which may only be a
@@ -94,7 +89,7 @@ func (r *reader) topLevel(node sexpr.Node) (Form, bool) {
 
 	list, ok := node.(sexpr.List)
 	if !ok {
-		r.fail(&NotAFormError{Pos: r.pos(positionOfNode(node)), Found: describe(node)})
+		r.Fail(&NotAFormError{Pos: r.pos(positionOfNode(node)), Found: describe(node)})
 
 		return Form{}, false
 	}
@@ -118,7 +113,7 @@ func (r *reader) form(list sexpr.List) (Form, bool) {
 
 	tag, ok := list.Elements[0].(sexpr.Symbol)
 	if !ok {
-		r.fail(&UntaggedFormError{
+		r.Fail(&UntaggedFormError{
 			Pos:   r.pos(positionOfNode(list.Elements[0])),
 			Found: describe(list.Elements[0]),
 		})
@@ -171,7 +166,7 @@ func (r *reader) node(node sexpr.Node) (Node, bool) {
 		// and reported rather than dropped if that ever stops being true: a
 		// node kind nobody has heard of is exactly what this package must not
 		// pass over in silence.
-		r.fail(&NotAFormError{Pos: r.pos(positionOfNode(node)), Found: describe(node)})
+		r.Fail(&NotAFormError{Pos: r.pos(positionOfNode(node)), Found: describe(node)})
 
 		return nil, false
 	}
@@ -188,20 +183,20 @@ func (r *reader) node(node sexpr.Node) (Node, bool) {
 func (r *reader) admissible(node sexpr.Node) bool {
 	switch node := node.(type) {
 	case sexpr.Quote:
-		r.fail(&ConstructError{Pos: r.pos(node.Pos), Construct: ConstructQuoteShorthand})
+		r.Fail(&ConstructError{Pos: r.pos(node.Pos), Construct: ConstructQuoteShorthand})
 	case sexpr.Nil:
-		r.fail(&ConstructError{Pos: r.pos(node.Pos), Construct: ConstructNil})
+		r.Fail(&ConstructError{Pos: r.pos(node.Pos), Construct: ConstructNil})
 	case sexpr.Bool:
-		r.fail(&ConstructError{Pos: r.pos(node.Pos), Construct: ConstructBoolean})
+		r.Fail(&ConstructError{Pos: r.pos(node.Pos), Construct: ConstructBoolean})
 	case sexpr.List:
 		if len(node.Elements) == 0 {
-			r.fail(&ConstructError{Pos: r.pos(node.Pos), Construct: ConstructEmptyList})
+			r.Fail(&ConstructError{Pos: r.pos(node.Pos), Construct: ConstructEmptyList})
 
 			return false
 		}
 
 		if node.Tail != nil {
-			r.fail(&ConstructError{Pos: r.pos(node.Pos), Construct: ConstructImproperList})
+			r.Fail(&ConstructError{Pos: r.pos(node.Pos), Construct: ConstructImproperList})
 
 			return false
 		}

--- a/internal/layoutmodel/diagnostics_test.go
+++ b/internal/layoutmodel/diagnostics_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layoutmodel
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+	"github.com/Zaba505/cpybkc/internal/layout"
+)
+
+// brokenLayout is one layout with three independent faults in it, in three
+// different places.
+//
+// Nothing here depends on any two of them: a charset nobody has a table for, an
+// axis the profile never states, and an override naming no axis at all are
+// three things an adopter has to fix, and a reader that stopped at the first
+// would be a reader they ran three times.
+const brokenLayout = `(encoding
+  (charset cp999)
+  (sign-convention ebcdic)
+  (byte-order big-endian))
+(encoding-override (item ORDER-HEADER OH-AMOUNT))`
+
+// goldenDiagnostics is what a caller holding the rejected read and a terminal
+// sees, written out in full.
+//
+// It is the golden docs/layout/SPEC.md's "Every diagnostic carries a span" is
+// checked against on the way a reader's faults actually reach a reader: every
+// line names the file, the line and the column of the sub-form that is wrong,
+// and all three faults are there rather than the first alone.
+const goldenDiagnostics = `orders.sexpr:2:12: charset is one of cp037, cp500, cp1047, cp1140 or ascii, and this one says "cp999"
+orders.sexpr:1:1: the encoding profile states no float-format; all four axes are required and none of them has a default
+orders.sexpr:5:1: the override on (item ORDER-HEADER OH-AMOUNT) states no axis; an override states at least one of charset, sign-convention, byte-order or float-format`
+
+// TestEveryFaultRendersWithItsFileLineAndColumn is the acceptance criterion
+// [github.com/Zaba505/cpybkc/internal/diag] exists to hold this package to.
+//
+// A reader here returns its faults joined, and [diag.Render] is what turns that
+// into something an adopter reads. The two halves this pins are that the faults
+// are accumulated rather than cut off at the first, and that each names where
+// it is — which is what makes a rejected layout a list of places to open rather
+// than a report that something is wrong with it.
+func TestEveryFaultRendersWithItsFileLineAndColumn(t *testing.T) {
+	t.Parallel()
+
+	file, err := layout.Parse("orders.sexpr", strings.NewReader(brokenLayout))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	profile, err := ReadProfile(file)
+	if err == nil {
+		t.Fatalf("the reader accepted a layout with three faults in it: %+v", profile)
+	}
+
+	if got := diag.Render(err); got != goldenDiagnostics {
+		t.Errorf("the rendering is not the golden\n got:\n%s\nwant:\n%s", got, goldenDiagnostics)
+	}
+
+	found := diag.Diagnostics(err)
+	if len(found) != 3 {
+		t.Fatalf("reported %d faults, want 3:\n%s", len(found), diag.Render(err))
+	}
+
+	for _, diagnostic := range found {
+		if !strings.HasPrefix(diagnostic.Message, "orders.sexpr:") {
+			t.Errorf("a fault does not name the file it is in: %s", diagnostic.Message)
+		}
+	}
+}

--- a/internal/layoutmodel/discriminate.go
+++ b/internal/layoutmodel/discriminate.go
@@ -6,10 +6,10 @@
 package layoutmodel
 
 import (
-	"errors"
 	"slices"
 	"strconv"
 
+	"github.com/Zaba505/cpybkc/internal/diag"
 	"github.com/Zaba505/cpybkc/internal/layout"
 )
 
@@ -290,12 +290,12 @@ func ReadDiscrimination(file *layout.File) (*Discrimination, error) {
 	// the forms are.
 	for _, record := range read.records {
 		if _, discriminated := read.discriminated[record.name]; !discriminated {
-			read.fail(&MissingDiscriminatorError{Pos: record.pos, Record: record.name})
+			read.Fail(&MissingDiscriminatorError{Pos: record.pos, Record: record.name})
 		}
 	}
 
-	if len(read.errs) > 0 {
-		return nil, errors.Join(read.errs...)
+	if read.Failed() {
+		return nil, read.Err()
 	}
 
 	return discrimination, nil
@@ -332,7 +332,7 @@ func recordNames(file *layout.File) []recordDefinition {
 
 // discriminationReader holds the state one [ReadDiscrimination] accumulates.
 type discriminationReader struct {
-	faults
+	diag.List
 
 	// records are the records the layout defines, which is what makes "one
 	// discriminator per record" and "a discriminator on a record nobody defined"
@@ -351,14 +351,14 @@ type discriminationReader struct {
 // discriminate reads one `discriminate` form.
 func (r *discriminationReader) discriminate(into *Discrimination, form layout.Form) {
 	if len(form.Elements) != 2 {
-		r.fail(&DiscriminateFormError{Pos: form.Pos, Found: count(len(form.Elements))})
+		r.Fail(&DiscriminateFormError{Pos: form.Pos, Found: count(len(form.Elements))})
 
 		return
 	}
 
 	name, ok := form.Elements[0].(layout.Symbol)
 	if !ok {
-		r.fail(&DiscriminateFormError{Pos: form.Elements[0].Position(), Found: describe(form.Elements[0])})
+		r.Fail(&DiscriminateFormError{Pos: form.Elements[0].Position(), Found: describe(form.Elements[0])})
 
 		// The strategy is read anyway, for the reason an override's axes are
 		// read after a misspelled item reference: a discriminator whose record
@@ -371,9 +371,9 @@ func (r *discriminationReader) discriminate(into *Discrimination, form layout.Fo
 	}
 
 	if !slices.ContainsFunc(r.records, func(record recordDefinition) bool { return record.name == name.Value }) {
-		r.fail(&UnknownRecordError{Pos: name.Pos, Record: name.Value, Form: form.Tag})
+		r.Fail(&UnknownRecordError{Pos: name.Pos, Record: name.Value, Form: form.Tag})
 	} else if first, already := r.discriminated[name.Value]; already {
-		r.fail(&DuplicateDiscriminatorError{Pos: form.Pos, First: first, Record: name.Value})
+		r.Fail(&DuplicateDiscriminatorError{Pos: form.Pos, First: first, Record: name.Value})
 	} else {
 		if r.discriminated == nil {
 			r.discriminated = make(map[string]layout.Pos)
@@ -395,7 +395,7 @@ func (r *discriminationReader) discriminate(into *Discrimination, form layout.Fo
 	// is `resolve`'s; this half is the reference's own spelling and is checkable
 	// here (#84).
 	if strategy.Predicate() && strategy.Item.Record != name.Value {
-		r.fail(&ForeignTargetError{Pos: strategy.Item.Pos, Item: strategy.Item, Record: name.Value})
+		r.Fail(&ForeignTargetError{Pos: strategy.Item.Pos, Item: strategy.Item, Record: name.Value})
 
 		return
 	}
@@ -411,14 +411,14 @@ func (r *discriminationReader) discriminate(into *Discrimination, form layout.Fo
 // variant reads one `discriminate-variant` form.
 func (r *discriminationReader) variant(into *Discrimination, form layout.Form) {
 	if len(form.Elements) == 0 {
-		r.fail(&VariantFormError{Pos: form.Pos, Found: "a variant discriminator naming no item at all"})
+		r.Fail(&VariantFormError{Pos: form.Pos, Found: "a variant discriminator naming no item at all"})
 
 		return
 	}
 
 	item, err := readItemRef(form.Elements[0])
 	if err != nil {
-		r.fail(err)
+		r.Fail(err)
 
 		return
 	}
@@ -434,7 +434,7 @@ func (r *discriminationReader) variant(into *Discrimination, form layout.Form) {
 		}
 
 		if first, already := armNamed(discriminator.Arms, arm.Alternative); already {
-			r.fail(&DuplicateArmError{Pos: arm.Pos, First: first, Variant: item, Alternative: arm.Alternative})
+			r.Fail(&DuplicateArmError{Pos: arm.Pos, First: first, Variant: item, Alternative: arm.Alternative})
 
 			continue
 		}
@@ -448,7 +448,7 @@ func (r *discriminationReader) variant(into *Discrimination, form layout.Form) {
 	// the elements written, so a variant carrying two arms one of which is
 	// malformed is not also reported as a variant carrying one.
 	if len(discriminator.Arms) < 2 {
-		r.fail(&VariantArmCountError{Pos: form.Pos, Variant: item, Count: len(discriminator.Arms)})
+		r.Fail(&VariantArmCountError{Pos: form.Pos, Variant: item, Count: len(discriminator.Arms)})
 
 		return
 	}
@@ -460,11 +460,11 @@ func (r *discriminationReader) variant(into *Discrimination, form layout.Form) {
 // reference can be checked against without a copybook.
 func (r *discriminationReader) variantItem(form layout.Form, item ItemRef) {
 	if !slices.ContainsFunc(r.records, func(record recordDefinition) bool { return record.name == item.Record }) {
-		r.fail(&UnknownRecordError{Pos: item.Pos, Record: item.Record, Form: form.Tag})
+		r.Fail(&UnknownRecordError{Pos: item.Pos, Record: item.Record, Form: form.Tag})
 	}
 
 	if first, already := r.variants[item.identity()]; already {
-		r.fail(&DuplicateVariantError{Pos: form.Pos, First: first, Variant: item})
+		r.Fail(&DuplicateVariantError{Pos: form.Pos, First: first, Variant: item})
 	} else {
 		if r.variants == nil {
 			r.variants = make(map[string]layout.Pos)
@@ -478,7 +478,7 @@ func (r *discriminationReader) variantItem(form layout.Form, item ItemRef) {
 	// ancestor is that item — and a record does not repeat, so no copybook can
 	// make such a reference name a variant.
 	if len(item.Path) < 2 {
-		r.fail(&VariantDepthError{Pos: item.Pos, Variant: item})
+		r.Fail(&VariantDepthError{Pos: item.Pos, Variant: item})
 	}
 }
 
@@ -486,26 +486,26 @@ func (r *discriminationReader) variantItem(form layout.Form, item ItemRef) {
 func (r *discriminationReader) arm(node layout.Node, variant ItemRef) (Arm, bool) {
 	form, ok := node.(layout.Form)
 	if !ok {
-		r.fail(&ArmFormError{Pos: node.Position(), Found: describe(node)})
+		r.Fail(&ArmFormError{Pos: node.Position(), Found: describe(node)})
 
 		return Arm{}, false
 	}
 
 	if form.Tag != tagArm {
-		r.fail(&ArmFormError{Pos: form.TagPos, Found: "form " + quote(form.Tag)})
+		r.Fail(&ArmFormError{Pos: form.TagPos, Found: "form " + quote(form.Tag)})
 
 		return Arm{}, false
 	}
 
 	if len(form.Elements) != 2 {
-		r.fail(&ArmFormError{Pos: form.Pos, Found: count(len(form.Elements))})
+		r.Fail(&ArmFormError{Pos: form.Pos, Found: count(len(form.Elements))})
 
 		return Arm{}, false
 	}
 
 	name, ok := form.Elements[0].(layout.Symbol)
 	if !ok {
-		r.fail(&ArmFormError{Pos: form.Elements[0].Position(), Found: describe(form.Elements[0])})
+		r.Fail(&ArmFormError{Pos: form.Elements[0].Position(), Found: describe(form.Elements[0])})
 
 		return Arm{}, false
 	}
@@ -516,7 +516,7 @@ func (r *discriminationReader) arm(node layout.Node, variant ItemRef) (Arm, bool
 	}
 
 	if !predicate.Predicate() {
-		r.fail(&StrategyError{
+		r.Fail(&StrategyError{
 			Pos:     predicate.Pos,
 			Subject: subjectArm,
 			Found:   "the symbol " + quote(string(predicate.Kind)),
@@ -527,7 +527,7 @@ func (r *discriminationReader) arm(node layout.Node, variant ItemRef) (Arm, bool
 	}
 
 	if found, ok := armTargetFault(predicate.Item, variant, name.Value); ok {
-		r.fail(&ArmTargetError{
+		r.Fail(&ArmTargetError{
 			Pos:         predicate.Item.Pos,
 			Alternative: name.Value,
 			Item:        predicate.Item,
@@ -563,7 +563,7 @@ func (r *discriminationReader) overlap(read []Arm, arm Arm, variant ItemRef) {
 				continue
 			}
 
-			r.fail(&ArmOverlapError{
+			r.Fail(&ArmOverlapError{
 				Pos:     literal.Pos,
 				First:   earlier.Predicate.Literals[index].Pos,
 				Variant: variant,
@@ -595,40 +595,40 @@ func (r *discriminationReader) strategy(node layout.Node, subject string) (Strat
 			return Strategy{Pos: symbol.Pos, Kind: SingleRecordType}, true
 		}
 
-		r.fail(&StrategyError{Pos: symbol.Pos, Subject: subject, Found: describe(symbol), Admits: admits})
+		r.Fail(&StrategyError{Pos: symbol.Pos, Subject: subject, Found: describe(symbol), Admits: admits})
 
 		return Strategy{}, false
 	}
 
 	form, ok := node.(layout.Form)
 	if !ok {
-		r.fail(&StrategyError{Pos: node.Position(), Subject: subject, Found: describe(node), Admits: admits})
+		r.Fail(&StrategyError{Pos: node.Position(), Subject: subject, Found: describe(node), Admits: admits})
 
 		return Strategy{}, false
 	}
 
 	kind := StrategyKind(form.Tag)
 	if !slices.Contains(predicates, kind) {
-		r.fail(&StrategyError{Pos: form.TagPos, Subject: subject, Found: describe(form), Admits: admits})
+		r.Fail(&StrategyError{Pos: form.TagPos, Subject: subject, Found: describe(form), Admits: admits})
 
 		return Strategy{}, false
 	}
 
 	if len(form.Elements) < 2 {
-		r.fail(&StrategyFormError{Pos: form.Pos, Kind: kind, Found: strategyShortfall(form.Elements)})
+		r.Fail(&StrategyFormError{Pos: form.Pos, Kind: kind, Found: strategyShortfall(form.Elements)})
 
 		return Strategy{}, false
 	}
 
 	if kind == Equals && len(form.Elements) > 2 {
-		r.fail(&StrategyFormError{Pos: form.Elements[2].Position(), Kind: kind, Found: "several"})
+		r.Fail(&StrategyFormError{Pos: form.Elements[2].Position(), Kind: kind, Found: "several"})
 
 		return Strategy{}, false
 	}
 
 	item, err := readItemRef(form.Elements[0])
 	if err != nil {
-		r.fail(err)
+		r.Fail(err)
 
 		return Strategy{}, false
 	}
@@ -638,7 +638,7 @@ func (r *discriminationReader) strategy(node layout.Node, subject string) (Strat
 	for _, element := range form.Elements[1:] {
 		literal, err := readLiteral(element)
 		if err != nil {
-			r.fail(err)
+			r.Fail(err)
 
 			return Strategy{}, false
 		}

--- a/internal/layoutmodel/doc.go
+++ b/internal/layoutmodel/doc.go
@@ -76,6 +76,12 @@
 // wrong in the same way in many places at once, and a reader that reports one
 // fault per run is a reader run once per fault.
 //
+// The accumulation is [github.com/Zaba505/cpybkc/internal/diag.List], which
+// every reader in this repository shares so that "keep reading after a fault"
+// is decided once, and
+// [github.com/Zaba505/cpybkc/internal/diag.Render] is what turns the joined
+// result into what an adopter reads.
+//
 // A reader that found a fault returns no model. A half-built value is one a
 // caller can read, and there is no reading of a layout that was rejected.
 package layoutmodel

--- a/internal/layoutmodel/errors.go
+++ b/internal/layoutmodel/errors.go
@@ -13,24 +13,6 @@ import (
 	"github.com/Zaba505/cpybkc/internal/layout"
 )
 
-// faults is the fault list a layer reader accumulates.
-//
-// Every reader here collects rather than returning the first, for the reason
-// [github.com/Zaba505/cpybkc/internal/layout]'s parser gives: a generated layout
-// is generated wrong in the same way in many places at once, and a reader that
-// reports one fault per run is a reader run once per fault. It is one type
-// rather than a field on each reader so that "keep reading after a fault" is
-// decided once.
-type faults struct {
-	errs []error
-}
-
-// fail records a fault. Reading continues after one, because the point of
-// collecting them is to report the second.
-func (f *faults) fail(err error) {
-	f.errs = append(f.errs, err)
-}
-
 // ProfileCountError is a layout that does not carry exactly one `encoding` form.
 //
 // Both halves are faults an adopter can act on and neither has a default:

--- a/internal/layoutmodel/framing.go
+++ b/internal/layoutmodel/framing.go
@@ -6,11 +6,11 @@
 package layoutmodel
 
 import (
-	"errors"
 	"fmt"
 	"slices"
 	"strings"
 
+	"github.com/Zaba505/cpybkc/internal/diag"
 	"github.com/Zaba505/cpybkc/internal/layout"
 )
 
@@ -404,11 +404,11 @@ func ReadFraming(file *layout.File) (*Framing, error) {
 			pos = forms[1].Pos
 		}
 
-		read.fail(&FramingCountError{Pos: pos, Count: len(forms)})
+		read.Fail(&FramingCountError{Pos: pos, Count: len(forms)})
 	}
 
-	if len(read.errs) > 0 {
-		return nil, errors.Join(read.errs...)
+	if read.Failed() {
+		return nil, read.Err()
 	}
 
 	return framing, nil
@@ -416,7 +416,7 @@ func ReadFraming(file *layout.File) (*Framing, error) {
 
 // framingReader holds the state one [ReadFraming] accumulates.
 type framingReader struct {
-	faults
+	diag.List
 }
 
 // framing reads one `framing` form.
@@ -437,19 +437,19 @@ func (r *framingReader) framing(form layout.Form) *Framing {
 	for _, element := range form.Elements {
 		child, ok := element.(layout.Form)
 		if !ok {
-			r.fail(&ChildError{Pos: element.Position(), Form: form.Tag, Found: describe(element), Admits: framingChildren})
+			r.Fail(&ChildError{Pos: element.Position(), Form: form.Tag, Found: describe(element), Admits: framingChildren})
 
 			continue
 		}
 
 		if !slices.Contains(framingChildren, child.Tag) {
-			r.fail(&ChildError{Pos: child.TagPos, Form: form.Tag, Found: describe(child), Admits: framingChildren})
+			r.Fail(&ChildError{Pos: child.TagPos, Form: form.Tag, Found: describe(child), Admits: framingChildren})
 
 			continue
 		}
 
 		if pos, repeated := stated[child.Tag]; repeated {
-			r.fail(&RepeatedChildError{Pos: child.Pos, First: pos, Child: child.Tag, Form: form.Tag})
+			r.Fail(&RepeatedChildError{Pos: child.Pos, First: pos, Child: child.Tag, Form: form.Tag})
 
 			continue
 		}
@@ -462,7 +462,7 @@ func (r *framingReader) framing(form layout.Form) *Framing {
 	}
 
 	if _, ok := stated[tagRECFM]; !ok {
-		r.fail(&MissingRECFMError{Pos: form.Pos})
+		r.Fail(&MissingRECFMError{Pos: form.Pos})
 	}
 
 	// Which children a framing requires and which it refuses follows from the
@@ -493,11 +493,11 @@ func (r *framingReader) children(form layout.Form, recfm RECFM, stated map[strin
 		switch admits(child, recfm) {
 		case arityRequired:
 			if !present {
-				r.fail(&RequiredChildError{Pos: form.Pos, Child: child, RECFM: recfm})
+				r.Fail(&RequiredChildError{Pos: form.Pos, Child: child, RECFM: recfm})
 			}
 		case arityRefused:
 			if present {
-				r.fail(&UnadmittedChildError{Pos: pos, Child: child, RECFM: recfm})
+				r.Fail(&UnadmittedChildError{Pos: pos, Child: child, RECFM: recfm})
 			}
 		case arityAdmitted:
 		}
@@ -519,7 +519,7 @@ func (r *framingReader) blockSize(framing *Framing, usable map[string]bool) {
 	switch framing.RECFM {
 	case RECFMFB:
 		if framing.BlockSize.Value%framing.LRECL.Value != 0 {
-			r.fail(&BlockSizeNotAMultipleError{
+			r.Fail(&BlockSizeNotAMultipleError{
 				Pos:       framing.BlockSize.Pos,
 				RECFM:     framing.RECFM,
 				BlockSize: framing.BlockSize.Value,
@@ -528,7 +528,7 @@ func (r *framingReader) blockSize(framing *Framing, usable map[string]bool) {
 		}
 	case RECFMVB, RECFMVBS:
 		if framing.BlockSize.Value < framing.LRECL.Value+blockDescriptorWord {
-			r.fail(&BlockSizeTooSmallError{
+			r.Fail(&BlockSizeTooSmallError{
 				Pos:       framing.BlockSize.Pos,
 				RECFM:     framing.RECFM,
 				BlockSize: framing.BlockSize.Value,
@@ -573,7 +573,7 @@ func (r *framingReader) recfm(framing *Framing, child layout.Form) bool {
 
 	if slices.Contains(recfms, value) {
 		if value == RECFMU {
-			r.fail(&UndefinedLengthError{Pos: symbol.Pos})
+			r.Fail(&UndefinedLengthError{Pos: symbol.Pos})
 
 			return false
 		}
@@ -584,12 +584,12 @@ func (r *framingReader) recfm(framing *Framing, child layout.Form) bool {
 	}
 
 	if base, control, ok := carriageControl(symbol.Value); ok {
-		r.fail(&CarriageControlError{Pos: symbol.Pos, Value: symbol.Value, Control: control, RECFM: base})
+		r.Fail(&CarriageControlError{Pos: symbol.Pos, Value: symbol.Value, Control: control, RECFM: base})
 
 		return false
 	}
 
-	r.fail(&FramingValueError{Pos: symbol.Pos, Child: child.Tag, Value: symbol.Value, Admits: recfmNames()})
+	r.Fail(&FramingValueError{Pos: symbol.Pos, Child: child.Tag, Value: symbol.Value, Admits: recfmNames()})
 
 	return false
 }
@@ -607,12 +607,12 @@ func (r *framingReader) blocks(framing *Framing, child layout.Form) bool {
 
 		return true
 	case InStream:
-		r.fail(&BlockedStreamError{Pos: symbol.Pos})
+		r.Fail(&BlockedStreamError{Pos: symbol.Pos})
 
 		return false
 	}
 
-	r.fail(&FramingValueError{Pos: symbol.Pos, Child: child.Tag, Value: symbol.Value, Admits: blocksNames()})
+	r.Fail(&FramingValueError{Pos: symbol.Pos, Child: child.Tag, Value: symbol.Value, Admits: blocksNames()})
 
 	return false
 }
@@ -626,7 +626,7 @@ func (r *framingReader) placement(framing *Framing, child layout.Form) bool {
 
 	value := Placement(symbol.Value)
 	if !slices.Contains(placements, value) {
-		r.fail(&FramingValueError{Pos: symbol.Pos, Child: child.Tag, Value: symbol.Value, Admits: placementNames()})
+		r.Fail(&FramingValueError{Pos: symbol.Pos, Child: child.Tag, Value: symbol.Value, Admits: placementNames()})
 
 		return false
 	}
@@ -639,14 +639,14 @@ func (r *framingReader) placement(framing *Framing, child layout.Form) bool {
 // delimiter reads the bytes a delimited file's records are wrapped in.
 func (r *framingReader) delimiter(framing *Framing, child layout.Form) bool {
 	if len(child.Elements) != 1 {
-		r.fail(&FramingFormError{Pos: child.Pos, Child: child.Tag, Takes: "one byte string", Found: count(len(child.Elements))})
+		r.Fail(&FramingFormError{Pos: child.Pos, Child: child.Tag, Takes: "one byte string", Found: count(len(child.Elements))})
 
 		return false
 	}
 
 	value, err := readByteString(child.Elements[0])
 	if err != nil {
-		r.fail(err)
+		r.Fail(err)
 
 		return false
 	}
@@ -661,7 +661,7 @@ func (r *framingReader) size(into *Size, child layout.Form) bool {
 	const takes = "one positive number of bytes"
 
 	if len(child.Elements) != 1 {
-		r.fail(&FramingFormError{Pos: child.Pos, Child: child.Tag, Takes: takes, Found: count(len(child.Elements))})
+		r.Fail(&FramingFormError{Pos: child.Pos, Child: child.Tag, Takes: takes, Found: count(len(child.Elements))})
 
 		return false
 	}
@@ -669,7 +669,7 @@ func (r *framingReader) size(into *Size, child layout.Form) bool {
 	switch value := child.Elements[0].(type) {
 	case layout.Int:
 		if value.Value <= 0 {
-			r.fail(&SizeError{Pos: value.Pos, Child: child.Tag, Value: value.Value})
+			r.Fail(&SizeError{Pos: value.Pos, Child: child.Tag, Value: value.Value})
 
 			return false
 		}
@@ -680,9 +680,9 @@ func (r *framingReader) size(into *Size, child layout.Form) bool {
 	case layout.Float:
 		// A number with a fraction is not a number of bytes, and describe would
 		// call it "a number", which is what the position takes.
-		r.fail(&FramingFormError{Pos: value.Pos, Child: child.Tag, Takes: takes, Found: "a number with a fraction"})
+		r.Fail(&FramingFormError{Pos: value.Pos, Child: child.Tag, Takes: takes, Found: "a number with a fraction"})
 	default:
-		r.fail(&FramingFormError{
+		r.Fail(&FramingFormError{
 			Pos:   child.Elements[0].Position(),
 			Child: child.Tag,
 			Takes: takes,
@@ -699,14 +699,14 @@ func (r *framingReader) symbol(child layout.Form) (layout.Symbol, bool) {
 	const takes = "one symbol naming its value"
 
 	if len(child.Elements) != 1 {
-		r.fail(&FramingFormError{Pos: child.Pos, Child: child.Tag, Takes: takes, Found: count(len(child.Elements))})
+		r.Fail(&FramingFormError{Pos: child.Pos, Child: child.Tag, Takes: takes, Found: count(len(child.Elements))})
 
 		return layout.Symbol{}, false
 	}
 
 	symbol, ok := child.Elements[0].(layout.Symbol)
 	if !ok {
-		r.fail(&FramingFormError{
+		r.Fail(&FramingFormError{
 			Pos:   child.Elements[0].Position(),
 			Child: child.Tag,
 			Takes: takes,

--- a/internal/layoutmodel/profile.go
+++ b/internal/layoutmodel/profile.go
@@ -6,8 +6,7 @@
 package layoutmodel
 
 import (
-	"errors"
-
+	"github.com/Zaba505/cpybkc/internal/diag"
 	"github.com/Zaba505/cpybkc/internal/layout"
 )
 
@@ -103,7 +102,7 @@ func ReadProfile(file *layout.File) (*Profile, error) {
 			// time.
 			for _, axis := range allAxes {
 				if _, ok := stated[axis]; !ok {
-					read.fail(&MissingAxisError{Pos: form.Pos, Axis: axis})
+					read.Fail(&MissingAxisError{Pos: form.Pos, Axis: axis})
 				}
 			}
 
@@ -126,11 +125,11 @@ func ReadProfile(file *layout.File) (*Profile, error) {
 			pos = encodings[1].Pos
 		}
 
-		read.fail(&ProfileCountError{Pos: pos, Count: len(encodings)})
+		read.Fail(&ProfileCountError{Pos: pos, Count: len(encodings)})
 	}
 
-	if len(read.errs) > 0 {
-		return nil, errors.Join(read.errs...)
+	if read.Failed() {
+		return nil, read.Err()
 	}
 
 	return profile, nil
@@ -139,7 +138,7 @@ func ReadProfile(file *layout.File) (*Profile, error) {
 // profileReader holds the state one [ReadProfile] accumulates: the faults found
 // so far, and the items already overridden.
 type profileReader struct {
-	faults
+	diag.List
 
 	// overridden is where each item was first overridden, keyed by the
 	// reference's identity. It is what makes a second override on one item
@@ -150,14 +149,14 @@ type profileReader struct {
 // override reads one `encoding-override` and appends it to the profile.
 func (r *profileReader) override(profile *Profile, form layout.Form) {
 	if len(form.Elements) == 0 {
-		r.fail(&ItemReferenceError{Pos: form.Pos, Found: "an override naming no item at all"})
+		r.Fail(&ItemReferenceError{Pos: form.Pos, Found: "an override naming no item at all"})
 
 		return
 	}
 
 	item, err := readItemRef(form.Elements[0])
 	if err != nil {
-		r.fail(err)
+		r.Fail(err)
 
 		// The axes are read anyway. An override whose reference is misspelled is
 		// still an override, and a charset misspelled underneath it is a second
@@ -168,7 +167,7 @@ func (r *profileReader) override(profile *Profile, form layout.Form) {
 	}
 
 	if first, already := r.overridden[item.identity()]; already {
-		r.fail(&DuplicateOverrideError{Pos: form.Pos, First: first, Item: item})
+		r.Fail(&DuplicateOverrideError{Pos: form.Pos, First: first, Item: item})
 	} else {
 		if r.overridden == nil {
 			r.overridden = make(map[string]layout.Pos)
@@ -184,7 +183,7 @@ func (r *profileReader) override(profile *Profile, form layout.Form) {
 	// account is not also an override that names no axis: the layout plainly
 	// names one, and the fault is already reported against the value.
 	if len(stated) == 0 {
-		r.fail(&EmptyOverrideError{Pos: form.Pos, Item: item})
+		r.Fail(&EmptyOverrideError{Pos: form.Pos, Item: item})
 
 		return
 	}
@@ -212,20 +211,20 @@ func (r *profileReader) axes(form layout.Form, elements []layout.Node) (Axes, ma
 	for _, element := range elements {
 		child, ok := element.(layout.Form)
 		if !ok {
-			r.fail(&ChildError{Pos: element.Position(), Form: form.Tag, Found: describe(element), Admits: axisNames()})
+			r.Fail(&ChildError{Pos: element.Position(), Form: form.Tag, Found: describe(element), Admits: axisNames()})
 
 			continue
 		}
 
 		axis, ok := lookupAxis(child.Tag)
 		if !ok {
-			r.fail(&ChildError{Pos: child.TagPos, Form: form.Tag, Found: describe(child), Admits: axisNames()})
+			r.Fail(&ChildError{Pos: child.TagPos, Form: form.Tag, Found: describe(child), Admits: axisNames()})
 
 			continue
 		}
 
 		if pos, repeated := first[axis]; repeated {
-			r.fail(&RepeatedAxisError{Pos: child.Pos, First: pos, Axis: axis, Form: form.Tag})
+			r.Fail(&RepeatedAxisError{Pos: child.Pos, First: pos, Axis: axis, Form: form.Tag})
 
 			continue
 		}
@@ -252,20 +251,20 @@ func (r *profileReader) axisValue(form layout.Form, axis Axis) (string, bool) {
 			found = "several"
 		}
 
-		r.fail(&AxisFormError{Pos: form.Pos, Axis: axis, Found: found})
+		r.Fail(&AxisFormError{Pos: form.Pos, Axis: axis, Found: found})
 
 		return "", false
 	}
 
 	symbol, ok := form.Elements[0].(layout.Symbol)
 	if !ok {
-		r.fail(&AxisFormError{Pos: form.Elements[0].Position(), Axis: axis, Found: describe(form.Elements[0])})
+		r.Fail(&AxisFormError{Pos: form.Elements[0].Position(), Axis: axis, Found: describe(form.Elements[0])})
 
 		return "", false
 	}
 
 	if !axis.admits(symbol.Value) {
-		r.fail(&AxisValueError{Pos: symbol.Pos, Axis: axis, Value: symbol.Value})
+		r.Fail(&AxisValueError{Pos: symbol.Pos, Axis: axis, Value: symbol.Value})
 
 		return "", false
 	}

--- a/internal/layoutmodel/rename.go
+++ b/internal/layoutmodel/rename.go
@@ -6,9 +6,9 @@
 package layoutmodel
 
 import (
-	"errors"
 	"slices"
 
+	"github.com/Zaba505/cpybkc/internal/diag"
 	"github.com/Zaba505/cpybkc/internal/layout"
 )
 
@@ -105,8 +105,8 @@ func ReadRenames(file *layout.File) ([]Rename, error) {
 		renames = append(renames, rename)
 	}
 
-	if len(read.errs) > 0 {
-		return nil, errors.Join(read.errs...)
+	if read.Failed() {
+		return nil, read.Err()
 	}
 
 	return renames, nil
@@ -114,7 +114,7 @@ func ReadRenames(file *layout.File) ([]Rename, error) {
 
 // renameReader holds the state one [ReadRenames] accumulates.
 type renameReader struct {
-	faults
+	diag.List
 
 	// records are the records the layout defines, which is what makes a rename
 	// rooted at a record nobody defined answerable.
@@ -133,21 +133,21 @@ type renameReader struct {
 // rename reads one `rename` form, against the renames already read.
 func (r *renameReader) rename(read []Rename, form layout.Form) (Rename, bool) {
 	if len(form.Elements) != 2 {
-		r.fail(&RenameFormError{Pos: form.Pos, Found: renameShortfall(form.Elements)})
+		r.Fail(&RenameFormError{Pos: form.Pos, Found: renameShortfall(form.Elements)})
 
 		return Rename{}, false
 	}
 
 	item, err := readItemRef(form.Elements[0])
 	if err != nil {
-		r.fail(err)
+		r.Fail(err)
 
 		return Rename{}, false
 	}
 
 	name, ok := form.Elements[1].(layout.Text)
 	if !ok {
-		r.fail(&RenameFormError{Pos: form.Elements[1].Position(), Found: describe(form.Elements[1])})
+		r.Fail(&RenameFormError{Pos: form.Elements[1].Position(), Found: describe(form.Elements[1])})
 
 		return Rename{}, false
 	}
@@ -161,7 +161,7 @@ func (r *renameReader) rename(read []Rename, form layout.Form) (Rename, bool) {
 	sound := r.target(form, item)
 
 	if name.Value == "" {
-		r.fail(&EmptyRenameError{Pos: name.Pos, Item: item})
+		r.Fail(&EmptyRenameError{Pos: name.Pos, Item: item})
 
 		// A name of no characters collides with nothing, and every message the
 		// collision rules could produce about it would name the empty string.
@@ -177,13 +177,13 @@ func (r *renameReader) target(form layout.Form, item ItemRef) bool {
 	sound := true
 
 	if !slices.ContainsFunc(r.records, func(record recordDefinition) bool { return record.name == item.Record }) {
-		r.fail(&UnknownRecordError{Pos: item.Pos, Record: item.Record, Form: form.Tag})
+		r.Fail(&UnknownRecordError{Pos: item.Pos, Record: item.Record, Form: form.Tag})
 
 		sound = false
 	}
 
 	if first, already := r.renamed[item.identity()]; already {
-		r.fail(&DuplicateRenameError{Pos: form.Pos, First: first, Item: item})
+		r.Fail(&DuplicateRenameError{Pos: form.Pos, First: first, Item: item})
 
 		return false
 	}
@@ -229,7 +229,7 @@ func (r *renameReader) collisions(read []Rename, rename Rename) bool {
 			siblings(other.Item, rename.Item)
 	})
 	if earlier >= 0 {
-		r.fail(&RenameCollisionError{
+		r.Fail(&RenameCollisionError{
 			Pos:   rename.SubstitutePos,
 			First: read[earlier].SubstitutePos,
 			Items: [2]ItemRef{read[earlier].Item, rename.Item},
@@ -245,7 +245,7 @@ func (r *renameReader) collisions(read []Rename, rename Rename) bool {
 			other.Name() == rename.Substitute
 	})
 	if sibling >= 0 {
-		r.fail(&RenameShadowsSiblingError{
+		r.Fail(&RenameShadowsSiblingError{
 			Pos:     rename.SubstitutePos,
 			First:   r.named[sibling].Pos,
 			Item:    rename.Item,

--- a/internal/layoutmodel/sequence.go
+++ b/internal/layoutmodel/sequence.go
@@ -6,11 +6,11 @@
 package layoutmodel
 
 import (
-	"errors"
 	"slices"
 	"strconv"
 	"strings"
 
+	"github.com/Zaba505/cpybkc/internal/diag"
 	"github.com/Zaba505/cpybkc/internal/layout"
 )
 
@@ -286,7 +286,7 @@ func ReadSequence(file *layout.File) (*Sequence, error) {
 			pos = forms[1].Pos
 		}
 
-		read.fail(&SequenceCountError{Pos: pos, Count: len(forms)})
+		read.Fail(&SequenceCountError{Pos: pos, Count: len(forms)})
 	}
 
 	// A record the expression never names is a fact about the layout rather than
@@ -301,13 +301,13 @@ func ReadSequence(file *layout.File) (*Sequence, error) {
 	if len(forms) > 0 {
 		for _, record := range read.records {
 			if _, sequenced := read.sequenced[record.name]; !sequenced {
-				read.fail(&UnsequencedRecordError{Pos: record.pos, Record: record.name})
+				read.Fail(&UnsequencedRecordError{Pos: record.pos, Record: record.name})
 			}
 		}
 	}
 
-	if len(read.errs) > 0 {
-		return nil, errors.Join(read.errs...)
+	if read.Failed() {
+		return nil, read.Err()
 	}
 
 	return sequence, nil
@@ -315,7 +315,7 @@ func ReadSequence(file *layout.File) (*Sequence, error) {
 
 // sequenceReader holds the state one [ReadSequence] accumulates.
 type sequenceReader struct {
-	faults
+	diag.List
 
 	// records are the records the layout defines, which is what makes "a record
 	// name the layout defines" and "a record the expression never names"
@@ -330,7 +330,7 @@ type sequenceReader struct {
 // sequence reads one `sequence` form.
 func (r *sequenceReader) sequence(form layout.Form) (*Sequence, bool) {
 	if len(form.Elements) != 1 {
-		r.fail(&SequenceFormError{Pos: form.Pos, Found: count(len(form.Elements))})
+		r.Fail(&SequenceFormError{Pos: form.Pos, Found: count(len(form.Elements))})
 
 		// Every element is read anyway, for the reason a discriminator's
 		// strategy is read after a misspelled record name: a `sequence` carrying
@@ -365,7 +365,7 @@ func (r *sequenceReader) expression(node layout.Node, within string) (Expression
 	case layout.Form:
 		return r.operator(node)
 	default:
-		r.fail(&ExpressionError{Pos: node.Position(), Found: describe(node), Admits: operatorNames()})
+		r.Fail(&ExpressionError{Pos: node.Position(), Found: describe(node), Admits: operatorNames()})
 
 		return Expression{}, false
 	}
@@ -385,7 +385,7 @@ func (r *sequenceReader) operator(form layout.Form) (Expression, bool) {
 	case kind == When:
 		return r.when(form)
 	default:
-		r.fail(&ExpressionError{Pos: form.TagPos, Found: describe(form), Admits: operatorNames()})
+		r.Fail(&ExpressionError{Pos: form.TagPos, Found: describe(form), Admits: operatorNames()})
 
 		return Expression{}, false
 	}
@@ -409,7 +409,7 @@ func (r *sequenceReader) branch(form layout.Form, kind ExpressionKind) (Expressi
 	// of two one of which is malformed is reported against that subexpression
 	// and against this rule, and not twice against this one.
 	if len(expression.Sub) < 2 {
-		r.fail(&ExpressionFormError{Pos: form.Pos, Kind: kind, Found: subexpressions(len(expression.Sub))})
+		r.Fail(&ExpressionFormError{Pos: form.Pos, Kind: kind, Found: subexpressions(len(expression.Sub))})
 
 		return Expression{}, false
 	}
@@ -420,7 +420,7 @@ func (r *sequenceReader) branch(form layout.Form, kind ExpressionKind) (Expressi
 // repetition reads a `*`, a `+` or a `?`, which take exactly one subexpression.
 func (r *sequenceReader) repetition(form layout.Form, kind ExpressionKind) (Expression, bool) {
 	if len(form.Elements) != 1 {
-		r.fail(&ExpressionFormError{Pos: form.Pos, Kind: kind, Found: subexpressions(len(form.Elements))})
+		r.Fail(&ExpressionFormError{Pos: form.Pos, Kind: kind, Found: subexpressions(len(form.Elements))})
 
 		for _, element := range form.Elements {
 			_, _ = r.expression(element, form.Tag)
@@ -440,7 +440,7 @@ func (r *sequenceReader) repetition(form layout.Form, kind ExpressionKind) (Expr
 // times reads `(times <e> <item-ref>)`.
 func (r *sequenceReader) times(form layout.Form) (Expression, bool) {
 	if len(form.Elements) != 2 {
-		r.fail(&ExpressionFormError{Pos: form.Pos, Kind: Times, Found: timesShortfall(form.Elements)})
+		r.Fail(&ExpressionFormError{Pos: form.Pos, Kind: Times, Found: timesShortfall(form.Elements)})
 
 		// What was written is read anyway, for the reason a `sequence` carrying
 		// two expressions has both read: an operator with the wrong number of
@@ -459,7 +459,7 @@ func (r *sequenceReader) times(form layout.Form) (Expression, bool) {
 	// should not have to run again to be told about the other.
 	item, err := readItemRef(form.Elements[1])
 	if err != nil {
-		r.fail(err)
+		r.Fail(err)
 
 		return Expression{}, false
 	}
@@ -476,7 +476,7 @@ func (r *sequenceReader) times(form layout.Form) (Expression, bool) {
 // when reads `(when <item-ref> <match> <e>)`.
 func (r *sequenceReader) when(form layout.Form) (Expression, bool) {
 	if len(form.Elements) != 3 {
-		r.fail(&ExpressionFormError{Pos: form.Pos, Kind: When, Found: whenShortfall(form.Elements)})
+		r.Fail(&ExpressionFormError{Pos: form.Pos, Kind: When, Found: whenShortfall(form.Elements)})
 
 		// As in [sequenceReader.times]: the arity is one fault and what stands
 		// inside the operator may be another.
@@ -487,7 +487,7 @@ func (r *sequenceReader) when(form layout.Form) (Expression, bool) {
 
 	item, err := readItemRef(form.Elements[0])
 	if err != nil {
-		r.fail(err)
+		r.Fail(err)
 
 		return Expression{}, false
 	}
@@ -552,7 +552,7 @@ func (r *sequenceReader) whenParts(form layout.Form) {
 func (r *sequenceReader) count(node layout.Node, within string) {
 	item, err := readItemRef(node)
 	if err != nil {
-		r.fail(err)
+		r.Fail(err)
 
 		return
 	}
@@ -576,7 +576,7 @@ func (r *sequenceReader) match(node layout.Node) (Match, bool) {
 	form, ok := node.(layout.Form)
 	if ok && form.Tag == tagOneOf {
 		if len(form.Elements) == 0 {
-			r.fail(&MatchFormError{Pos: form.Pos, Found: "no literal"})
+			r.Fail(&MatchFormError{Pos: form.Pos, Found: "no literal"})
 
 			return Match{}, false
 		}
@@ -586,7 +586,7 @@ func (r *sequenceReader) match(node layout.Node) (Match, bool) {
 		for _, element := range form.Elements {
 			literal, err := readLiteral(element)
 			if err != nil {
-				r.fail(err)
+				r.Fail(err)
 
 				return Match{}, false
 			}
@@ -602,7 +602,7 @@ func (r *sequenceReader) match(node layout.Node) (Match, bool) {
 	// is a [LiteralError] naming what was written.
 	literal, err := readLiteral(node)
 	if err != nil {
-		r.fail(err)
+		r.Fail(err)
 
 		return Match{}, false
 	}
@@ -622,7 +622,7 @@ func (r *sequenceReader) name(symbol layout.Symbol, within string) {
 	}
 
 	if !r.defines(symbol.Value) {
-		r.fail(&UnknownRecordError{Pos: symbol.Pos, Record: symbol.Value, Form: within})
+		r.Fail(&UnknownRecordError{Pos: symbol.Pos, Record: symbol.Value, Form: within})
 	}
 }
 
@@ -635,7 +635,7 @@ func (r *sequenceReader) name(symbol layout.Symbol, within string) {
 // referred to by an operator and never actually sequenced.
 func (r *sequenceReader) itemRecord(item ItemRef, within string) {
 	if !r.defines(item.Record) {
-		r.fail(&UnknownRecordError{Pos: item.Pos, Record: item.Record, Form: within})
+		r.Fail(&UnknownRecordError{Pos: item.Pos, Record: item.Record, Form: within})
 	}
 }
 

--- a/internal/layoutschema/doc.go
+++ b/internal/layoutschema/doc.go
@@ -46,4 +46,10 @@
 // once per fault. Each carries the position of the sub-form that is wrong rather
 // than of the top-level form containing it, which is what SPEC.md's "Positions
 // survive" buys and what the layout reader's spans are built out of.
+//
+// A diagnostic's position is a
+// [github.com/Zaba505/cpybkc/internal/diag.Span] and names the file the layout
+// was checked under, which is why [Schema.Validate] takes a name: an adopter
+// checking a layout against a copybook is holding two files, and a position
+// that cannot say which one it is in stops being usable exactly then.
 package layoutschema

--- a/internal/layoutschema/validate.go
+++ b/internal/layoutschema/validate.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/Zaba505/cpybkc/internal/diag"
 	sexpr "github.com/z5labs/sexpr-go"
 )
 
@@ -22,36 +23,55 @@ import (
 // the schema describes what a layout may be, so everything reported here is a
 // layout the schema does not admit.
 type Diagnostic struct {
-	Pos     sexpr.Pos
+	// Span is where the fault is: the file the layout was checked under, and
+	// the line and the column within it.
+	//
+	// The file is carried rather than left to the caller because a diagnostic
+	// naming a line and a column alone stops being usable the moment there are
+	// two files, which is what
+	// [github.com/Zaba505/cpybkc/internal/diag]'s cross-file spans are about.
+	Span diag.Span
+
 	Message string
 }
 
 // String renders a diagnostic as one line, opening with the position for the
 // reason every compiler does: the file an adopter has to edit is the first
 // thing they need from it.
+//
+// It renders through [github.com/Zaba505/cpybkc/internal/diag] rather than
+// formatting a line of its own, so that a fault the schema found and a fault a
+// reader found read the same in a terminal.
 func (d Diagnostic) String() string {
-	return fmt.Sprintf("%s: %s", at(d.Pos), d.Message)
+	return diag.Diagnostic{Message: d.Message, Spans: []diag.Span{d.Span}}.String()
 }
 
-// Validate parses a layout from r and checks it against the schema.
+// Validate parses a layout from r and checks it against the schema, under the
+// name name.
+//
+// The name is what every diagnostic carries — a path, or something else naming
+// the source — for the same reason
+// [github.com/Zaba505/cpybkc/internal/layout.Parse] takes one: a check reads
+// bytes and has no name to attach to them, and a fault an adopter can act on
+// names the file they have to open.
 //
 // A parse failure is an error rather than a diagnostic. It comes from the
 // grammar this format delegates to, carries that package's own position, and
 // stops there being a layout to check at all — so reporting it beside a list of
 // forms the checker never saw would claim a coverage this call does not have.
-func (s *Schema) Validate(r io.Reader) ([]Diagnostic, error) {
+func (s *Schema) Validate(name string, r io.Reader) ([]Diagnostic, error) {
 	file, err := sexpr.Parse(r)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse the layout: %w", err)
 	}
 
-	return s.Check(file), nil
+	return s.Check(name, file), nil
 }
 
 // Check holds a parsed layout to the schema and returns every diagnostic it
 // finds, in the order the layout states the forms they are about.
-func (s *Schema) Check(file *sexpr.File) []Diagnostic {
-	check := &checker{schema: s, declared: make(map[string][]string)}
+func (s *Schema) Check(name string, file *sexpr.File) []Diagnostic {
+	check := &checker{schema: s, name: name, declared: make(map[string][]string)}
 
 	check.collectReferents(file)
 	check.topLevel(file)
@@ -64,6 +84,10 @@ type checker struct {
 	schema      *Schema
 	diagnostics []Diagnostic
 
+	// name is what the layout was checked under, and is on every span the
+	// check reports.
+	name string
+
 	// declared holds, per reference sort, the names that sort may name. It is
 	// gathered from the whole layout before anything is checked, so that a
 	// reference to a record defined further down the file resolves — the forms
@@ -73,7 +97,13 @@ type checker struct {
 
 // report records a diagnostic.
 func (c *checker) report(pos sexpr.Pos, format string, args ...any) {
-	c.diagnostics = append(c.diagnostics, Diagnostic{Pos: pos, Message: fmt.Sprintf(format, args...)})
+	c.diagnostics = append(c.diagnostics, Diagnostic{Span: c.span(pos), Message: fmt.Sprintf(format, args...)})
+}
+
+// span lifts a grammar position into a diagnostic one by naming the file it is
+// in.
+func (c *checker) span(pos sexpr.Pos) diag.Span {
+	return diag.Span{File: c.name, Line: pos.Line, Column: pos.Column}
 }
 
 // collectReferents gathers the names every reference sort may name.

--- a/internal/layoutschema/validate.go
+++ b/internal/layoutschema/validate.go
@@ -46,8 +46,8 @@ func (d Diagnostic) String() string {
 	return diag.Diagnostic{Message: d.Message, Spans: []diag.Span{d.Span}}.String()
 }
 
-// Validate parses a layout from r and checks it against the schema, under the
-// name name.
+// Validate parses a layout from r under the name name and checks it against the
+// schema.
 //
 // The name is what every diagnostic carries — a path, or something else naming
 // the source — for the same reason

--- a/internal/layoutschema/validate_test.go
+++ b/internal/layoutschema/validate_test.go
@@ -40,7 +40,7 @@ func TestValidLayoutsValidate(t *testing.T) {
 
 	for _, name := range layouts(t, "valid") {
 		t.Run(name, func(t *testing.T) {
-			diagnostics, err := schema.Validate(bytes.NewReader(layout(t, "valid", name)))
+			diagnostics, err := schema.Validate(name, bytes.NewReader(layout(t, "valid", name)))
 			if err != nil {
 				t.Fatalf("validate: %v", err)
 			}
@@ -71,7 +71,7 @@ func TestInvalidLayoutsAreRejected(t *testing.T) {
 				t.Fatalf("%s carries no `;; want:` line saying which diagnostic it expects", name)
 			}
 
-			diagnostics, err := schema.Validate(bytes.NewReader(source))
+			diagnostics, err := schema.Validate(name, bytes.NewReader(source))
 			if err != nil {
 				t.Fatalf("validate: %v", err)
 			}
@@ -103,7 +103,7 @@ func TestInvalidLayoutsAreRejected(t *testing.T) {
 func TestTheSpecsWorkedExampleValidates(t *testing.T) {
 	example := fencedBlock(t, section(t, "## Appendix: A layout, end to end"))
 
-	diagnostics, err := publishedSchema(t).Validate(strings.NewReader(example))
+	diagnostics, err := publishedSchema(t).Validate("SPEC.md", strings.NewReader(example))
 	if err != nil {
 		t.Fatalf("validate the SPEC's example: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestADiagnosticPointsAtTheSubFormThatIsWrong(t *testing.T) {
   (float-format hfp))
 `
 
-	diagnostics, err := publishedSchema(t).Validate(strings.NewReader(source))
+	diagnostics, err := publishedSchema(t).Validate("orders.sexpr", strings.NewReader(source))
 	if err != nil {
 		t.Fatalf("validate: %v", err)
 	}
@@ -140,13 +140,49 @@ func TestADiagnosticPointsAtTheSubFormThatIsWrong(t *testing.T) {
 
 		found = true
 
-		if diagnostic.Pos.Line != 4 {
-			t.Errorf("the diagnostic points at line %d, want line 4 — the sub-form that is wrong", diagnostic.Pos.Line)
+		if diagnostic.Span.Line != 4 {
+			t.Errorf("the diagnostic points at line %d, want line 4 — the sub-form that is wrong", diagnostic.Span.Line)
 		}
 	}
 
 	if !found {
 		t.Errorf("no diagnostic about the byte-order axis; got:\n%s", strings.Join(messages(diagnostics), "\n"))
+	}
+}
+
+// TestADiagnosticNamesTheFileItIsIn is the other half of the span SPEC.md
+// requires. A line and a column say where in a file, and an adopter checking a
+// layout against a copybook is holding two of them — so a diagnostic that
+// cannot say which file it is in stops being usable exactly when it matters.
+//
+// The name is the caller's, which is why it is a parameter rather than
+// something this package invents: a layout validated out of a stream has
+// whatever name the caller knows it by.
+func TestADiagnosticNamesTheFileItIsIn(t *testing.T) {
+	const source = `(encoding
+  (charset cp037)
+  (sign-convention ebcdic)
+  (byte-order sideways)
+  (float-format hfp))
+`
+
+	diagnostics, err := publishedSchema(t).Validate("orders.sexpr", strings.NewReader(source))
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+
+	if len(diagnostics) == 0 {
+		t.Fatal("the schema accepted an axis value outside the closed set")
+	}
+
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Span.File != "orders.sexpr" {
+			t.Errorf("a diagnostic is in file %q, want the name the layout was checked under", diagnostic.Span.File)
+		}
+
+		if !strings.HasPrefix(diagnostic.String(), "orders.sexpr:") {
+			t.Errorf("a diagnostic renders as %q, which does not open with the file", diagnostic)
+		}
 	}
 }
 
@@ -161,7 +197,7 @@ func TestValidateReportsEveryFaultRatherThanTheFirst(t *testing.T) {
   (float-format hfp))
 `
 
-	diagnostics, err := publishedSchema(t).Validate(strings.NewReader(source))
+	diagnostics, err := publishedSchema(t).Validate("orders.sexpr", strings.NewReader(source))
 	if err != nil {
 		t.Fatalf("validate: %v", err)
 	}
@@ -184,7 +220,7 @@ func TestValidateReportsEveryFaultRatherThanTheFirst(t *testing.T) {
 // and leaves no layout to check, so reporting it as one finding among a list
 // would claim a coverage the call does not have.
 func TestValidateFailsOnSourceThatIsNotSExpressions(t *testing.T) {
-	if _, err := publishedSchema(t).Validate(strings.NewReader("(encoding")); err == nil {
+	if _, err := publishedSchema(t).Validate("orders.sexpr", strings.NewReader("(encoding")); err == nil {
 		t.Error("Validate accepted source the grammar cannot parse")
 	}
 }


### PR DESCRIPTION
Closes #31

Layout errors span two file types — the layout an adopter wrote and the copybooks they did not — and a diagnostic naming one of them leaves the reader to find the other by hand. This adds `internal/diag`, the vocabulary every layer reports a fault in, and closes the two places where a location could not say which file it was in.

## What landed

**`internal/diag`.** A `Span` is a file with a line and a column in it, and belongs to no reader — the package imports nothing outside the standard library, which is what lets the layout reader, the layer readers and `resolve` all report through it without becoming dependencies of one another. A `Diagnostic` carries a message and as many spans as the fault implicates, the first being where it is and every one after it carrying a note saying why it is shown. `Diagnostics` walks what `errors.Join` built — written out rather than left to `errors.As`, which stops at the first match — and `Render` draws the lot.

**The two cross-file diagnostics SPEC.md requires by name.** `MissingCopybookError` carries one span, because there is no file to point into and a span invented for one would point at nothing; `UndeclaredItemError` carries two, the second pointing at the `01`-levels the copybook *does* declare, or at the file itself where it declares none.

**Accumulation in one place.** `diag.List` replaces the private fault list the layout reader and each layer reader carried, so "keep reading after a fault" is decided once rather than a fourth time when `resolve` arrives.

**A file on every schema diagnostic.** `layoutschema.Diagnostic` carried a `sexpr.Pos` — a line and a column and no file — and rendered as `line 3, column 5: …`, which is a different shape from every other diagnostic in the repository. It now carries a `diag.Span`, renders through `diag`, and `Validate`/`Check` take the name the layout is known by, the way `layout.Parse` already does.

## Acceptance criteria

- [x] **Diagnostics carry file, line, and column for every referenced location** — `Span` carries all three; the layout reader and the layer readers already did through `layout.Pos`, and `layoutschema` now does too. `TestADiagnosticNamesTheFileItIsIn` and `TestEveryFaultRendersWithItsFileLineAndColumn` hold them to it.
- [x] **An error implicating both a layout and a copybook shows both spans** — `UndeclaredItemError`, pinned by `TestUndeclaredItemCarriesBothSpans`, including the case where the copybook has nothing in it to point at and the span is the file.
- [x] **Independent errors are accumulated and reported together** — `diag.List` plus `errors.Join`; `TestListAccumulatesRatherThanFailingFast` and, over a real reader's output, `TestEveryFaultRendersWithItsFileLineAndColumn`.
- [x] **Typed errors assertable with `errors.As`, per the house pattern** — both new errors are struct types with their own fields; `MissingCopybookError` unwraps to the read failure. `TestCopybookDiagnosticsAreAssertable` asserts one out of a join and asserts the other is not there.
- [x] **Golden tests pin the rendered diagnostic output** — `goldenRender` in `internal/diag`, and `goldenDiagnostics` in `internal/layoutmodel` over three real faults from one rejected layout.

## Judgment calls

- **The two copybook diagnostics live in `diag`, and nothing raises them yet.** SPEC.md assigns both checks to `resolve` (#32–#38), which does not exist; what this issue owes is the *shape* of the message, which SPEC.md states as a requirement on the diagnostic rather than on the stage. Defining them here is what makes "shows both spans" a tested property rather than a promise, and gives #32 the vocabulary to raise them.
- **`Render` treats an error carrying no diagnostic as a message with no span.** Every typed error in this repository already leads with the position it carries, so a reader's fault reads the same through `Render` as through `Error`; what `diag` adds is the span such an error cannot state, which is one in a file the layout is not. An error *wrapping* a diagnostic is reported as its wrapper wrote it, rather than reaching inside to a description nobody chose.
- **A span with a file and no line renders as the file alone**, per SPEC.md's "A file declaring no `01`-level at all has nothing to point at but itself, and the span is the file". A span naming nowhere renders as nothing rather than as `0:0`, which is a position a reader would try to open.
- **The message does not name where a copybook was looked for.** SPEC.md leaves that to the CLI, so the read failure is kept for `errors.As` rather than printed — a diagnostic naming a resolved path sends an adopter looking for a file they have not got.
- **`Schema.Validate` gained a `name` parameter** rather than inventing one. A layout validated out of a stream has whatever name the caller knows it by; all call sites are in this repository's tests.

## Verified

`dagger call ci` — fmt, vet, lint, `go test -race`, the schema lint, the IR module's own stages and the release artifacts — passes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)