### PR TITLE
story(resolve): compute byte offsets and widths for every field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,20 @@ require github.com/Zaba505/cpybkc/irpb v0.0.0
 
 require google.golang.org/protobuf v1.36.11
 
+// The COBOL underneath everything this project resolves. `picture` parses a
+// PICTURE character-string into the attributes that follow from it and
+// `copybook` turns a copybook into a record with a byte width and a byte offset
+// on every item, both per codec/SPEC.md — so the storage widths are read once,
+// here, rather than a second time beside cobol-go's for the two repositories to
+// disagree about. docs/ir/SPEC.md's "Dereferencing is not recomputation" is the
+// rule that makes doing it once the whole point.
+//
+// Pinned to a commit because cobol-go carries no tag yet. It moves to a version
+// as soon as one exists: a pseudo-version is a commit an adopter cannot reason
+// about, and this is a dependency of the module `go install` builds the CLI
+// from.
+require github.com/Zaba505/cobol-go v0.0.0-20260807050409-dbcadd3bdb8a
+
 // The grammar underneath the layout format. docs/layout/SPEC.md delegates the
 // lexis and the parse of a layout file to it — what a symbol is, where a number
 // ends, what a comment attaches to, and the line and column every diagnostic is

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Zaba505/cobol-go v0.0.0-20260807050409-dbcadd3bdb8a h1:8uyvhc7QPWBZNff/YR8r91uMazGPlXb4pIPBUnKAAsc=
+github.com/Zaba505/cobol-go v0.0.0-20260807050409-dbcadd3bdb8a/go.mod h1:a0ImjTdXHvjbs8CWSUQ2AWOUcUj89aZ+G8hkaIPDjdo=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/internal/resolve/doc.go
+++ b/internal/resolve/doc.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Package resolve turns a copybook record into the shape the IR describes: an
+// ordered containment of groups, fields, variants and slack, every elementary
+// item carrying the byte width `cobol-go`'s codec/SPEC.md gives it.
+//
+// # Why the arithmetic is here and nowhere else
+//
+// Where a field sits in a record is COBOL knowledge — PICTURE, USAGE, the
+// dialect's binary staircase, OCCURS, SYNCHRONIZED, REDEFINES — and a generator
+// that works it out for itself is a second reading of that knowledge for the two
+// to disagree about. docs/ir/SPEC.md's "Dereferencing is not recomputation"
+// draws the line: adding up the widths in front of a field is arithmetic on the
+// message in hand and every consumer does it, while deriving one of those widths
+// from a PICTURE is COBOL and no consumer may. This package is where the second
+// list is spent, exactly once, against
+// [github.com/Zaba505/cobol-go/copybook], so that `cpybkc-gen-go` and a
+// generator written in some other language cannot come to different answers.
+//
+// # No offset reaches the IR
+//
+// A [Node] carries a width and its place in a member list, and nothing carries a
+// byte offset: docs/ir/SPEC.md's "Ordering and width, and no offset" settled
+// that position is stated once, as ordering and width, so that a producer cannot
+// state it a second time and be wrong in a way no consumer can detect (#16).
+// [Record.Position] is the sum a consumer runs, kept here so that this package's
+// own tests run it against the offsets `cobol-go` computed independently.
+//
+// The same rule shapes [Node.Width]: it is a method rather than a member, and it
+// answers from the member list for a group and from the arms for a variant. A
+// group's width is the sum of its members' and a variant's is its arms' common
+// extent, and neither is a number this package could get wrong on its own.
+//
+// # REDEFINES is resolved away, two ways
+//
+// The IR has no REDEFINES, and which of two resolutions a clause takes is
+// decided by the question the clause itself cannot answer: whether the choice is
+// made once for a record or once for each entry of a table.
+//
+//   - Outside a repeating group, each alternative becomes its own record.
+//     [Resolve] returns one [Record] per combination of alternatives, each with
+//     its own containment order and a slack node covering the bytes of the
+//     redefined item's storage that the alternative does not occupy.
+//   - Inside one, at any depth, the alternative is chosen once per occurrence
+//     and there is no record per occurrence for it to become, so it resolves to
+//     a variant node instead: an ordered list of arms, each naming the predicate
+//     that selects it and the item that is its body (docs/ir/SPEC.md, "A variant
+//     is chosen once per occurrence").
+//
+// Which alternatives a variant has and what selects each one is a layout's to
+// say and not a copybook's, so it arrives as [Redefine] values rather than being
+// inferred. A [Redefine] naming a single alternative is the overlay an adopter
+// wrote to read one item two ways: every occurrence takes it, and no variant is
+// emitted at all.
+//
+// # What this package leaves to the stories after it
+//
+// The four encoding axes and a field's PICTURE attributes are #33's, compiling a
+// layout's discriminator strategies into predicate nodes is #37's, a count read
+// out of a record is #35's, and assembling nodes into a
+// [github.com/Zaba505/cpybkc/irpb.Descriptor] with identifiers on them is #38's.
+// A [Repetition] here therefore carries the count the layout was computed at
+// beside the item a DEPENDING ON phrase names, and an [Arm] carries the
+// [github.com/Zaba505/cpybkc/internal/layoutmodel.Strategy] a layout wrote
+// rather than a compiled predicate.
+//
+// Slack is the one of those with a foot in both stories. Which alignments a
+// dialect honours is `cobol-go`'s and the rest of the rule is #34's, but a
+// record whose redefines have been resolved away has bytes no item occupies
+// whatever a SYNCHRONIZED clause does, so this package emits a slack node for
+// every byte of a group's extent its members leave uncovered, wherever the gap
+// came from.
+package resolve

--- a/internal/resolve/errors.go
+++ b/internal/resolve/errors.go
@@ -12,12 +12,17 @@ import (
 	"github.com/Zaba505/cpybkc/internal/diag"
 )
 
-// Every fault here names four things: the record, the repeating group the
-// variant sits in, the redefined item, and the arm. docs/ir/SPEC.md asks for
-// those by name rather than for a generic width error, and the reason is what an
-// adopter does next — a message saying two extents differ sends them looking
-// through a copybook for two numbers, and one naming the entry, the table it is
-// in and the alternative that does not fit sends them to the line.
+// A fault here names as much of the record, the repeating group the variant sits
+// in, the redefined item and the arm as the fault is about. docs/ir/SPEC.md asks
+// for those by name rather than for a generic width error, and the reason is
+// what an adopter does next — a message saying two extents differ sends them
+// looking through a copybook for two numbers, and one naming the entry, the
+// table it is in and the alternative that does not fit sends them to the line.
+//
+// The two that name fewer name fewer because they are about fewer.
+// [ArmCountError] is about a variant that has no arms, so there is no arm to
+// name, and [UnknownAlternativeError] is about a name that matches nothing under
+// the redefined item, which is true wherever that item sits.
 
 // ArmExtentError is an arm that needs more bytes than the item it redefines.
 //
@@ -142,10 +147,10 @@ func (e *ArmPredicateError) Diagnostic() diag.Diagnostic {
 // ArmCountError is a layout that names a redefine inside a repeating group and
 // then names no alternative of it.
 //
-// One alternative is not this fault: it says every occurrence takes that one,
-// and resolves to its items with no variant. Naming none says nothing at all,
-// which leaves the alternation unresolved in exactly the way naming the item was
-// meant to settle.
+// Naming one is not this fault and the message says so: one alternative says
+// every occurrence takes it, and resolves to its items with no variant at all.
+// Naming none says nothing, which leaves the alternation unresolved in exactly
+// the way naming the item was meant to settle.
 type ArmCountError struct {
 	// Pos is the redefined item's entry in the copybook.
 	Pos diag.Span
@@ -167,7 +172,7 @@ func (e *ArmCountError) Error() string { return e.Diagnostic().String() }
 func (e *ArmCountError) Diagnostic() diag.Diagnostic {
 	return diag.Diagnostic{
 		Message: fmt.Sprintf(
-			"in record %s, the variant on %s in the repeating group %s names no alternative at all, and a variant needs two",
+			"in record %s, nothing is named as an alternative of %s in the repeating group %s: name one to say every occurrence takes it, or two or more with a predicate on each to tell them apart",
 			e.Record, e.Redefined, e.Group),
 		Spans: []diag.Span{e.Pos},
 	}

--- a/internal/resolve/errors.go
+++ b/internal/resolve/errors.go
@@ -1,0 +1,266 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package resolve
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+)
+
+// Every fault here names four things: the record, the repeating group the
+// variant sits in, the redefined item, and the arm. docs/ir/SPEC.md asks for
+// those by name rather than for a generic width error, and the reason is what an
+// adopter does next — a message saying two extents differ sends them looking
+// through a copybook for two numbers, and one naming the entry, the table it is
+// in and the alternative that does not fit sends them to the line.
+
+// ArmExtentError is an arm that needs more bytes than the item it redefines.
+//
+// Every arm of a variant covers the same bytes, and a shorter alternative is
+// padded with slack to the extent the redefined item reserved. A longer one
+// cannot be made to agree the same way: the storage an occurrence has is what
+// the copybook gave the redefined item, and a dialect lenient enough to let a
+// redefinition grow the group holding it cannot grow one entry of a table
+// without moving every entry after it.
+type ArmExtentError struct {
+	// Pos is the arm's entry in the copybook.
+	Pos diag.Span
+
+	// Record is the record being resolved.
+	Record string
+
+	// Group is the innermost repeating group the variant sits in.
+	Group string
+
+	// Redefined is the item the copybook redefines: the variant's first
+	// alternative, and what fixes its extent.
+	Redefined string
+
+	// Arm is the alternative that does not fit.
+	Arm string
+
+	// Extent is the bytes the arm needs, and Want the bytes it has.
+	Extent int
+	Want   int
+}
+
+// Error implements the error interface.
+func (e *ArmExtentError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *ArmExtentError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"in record %s, %s of the repeating group %s occupies %d bytes, more than the %d bytes of %s it redefines, so the arms of the variant cannot be made to agree",
+			e.Record, e.Arm, e.Group, e.Extent, e.Want, e.Redefined),
+		Spans: []diag.Span{e.Pos},
+	}
+}
+
+// ArmVariableCountError is an item inside an arm whose repetition count is read
+// out of the record rather than written in the copybook.
+//
+// A variant contributes a constant term to the position sum, which is what keeps
+// every item behind it where it was and every occurrence of the enclosing group
+// the same width. An OCCURS ... DEPENDING ON inside an arm makes the arm's
+// extent move with data, and there is then no constant for the arms to agree on.
+type ArmVariableCountError struct {
+	// Pos is the entry carrying the DEPENDING ON phrase.
+	Pos diag.Span
+
+	// Record is the record being resolved.
+	Record string
+
+	// Group is the innermost repeating group the variant sits in.
+	Group string
+
+	// Redefined is the item the copybook redefines.
+	Redefined string
+
+	// Arm is the alternative the item is in.
+	Arm string
+
+	// Item is the repeating item, and Count the item its count is read from.
+	Item  string
+	Count string
+}
+
+// Error implements the error interface.
+func (e *ArmVariableCountError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *ArmVariableCountError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"in record %s, %s under the arm %s of the variant on %s in the repeating group %s occurs a number of times read from %s, and an arm's extent has to be a constant",
+			e.Record, e.Item, e.Arm, e.Redefined, e.Group, e.Count),
+		Spans: []diag.Span{e.Pos},
+	}
+}
+
+// ArmPredicateError is an arm of a variant with two or more alternatives that
+// nothing selects.
+//
+// An arm chosen by nothing would match every occurrence, which leaves it the
+// only arm — which is the single-alternative redefine, and that resolves to its
+// items with no variant at all.
+type ArmPredicateError struct {
+	// Pos is the arm's entry in the copybook.
+	Pos diag.Span
+
+	// Record is the record being resolved.
+	Record string
+
+	// Group is the innermost repeating group the variant sits in.
+	Group string
+
+	// Redefined is the item the copybook redefines.
+	Redefined string
+
+	// Arm is the alternative nothing selects.
+	Arm string
+}
+
+// Error implements the error interface.
+func (e *ArmPredicateError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *ArmPredicateError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"in record %s, the arm %s of the variant on %s in the repeating group %s is selected by nothing",
+			e.Record, e.Arm, e.Redefined, e.Group),
+		Spans: []diag.Span{e.Pos},
+	}
+}
+
+// ArmCountError is a layout that names a redefine inside a repeating group and
+// then names no alternative of it.
+//
+// One alternative is not this fault: it says every occurrence takes that one,
+// and resolves to its items with no variant. Naming none says nothing at all,
+// which leaves the alternation unresolved in exactly the way naming the item was
+// meant to settle.
+type ArmCountError struct {
+	// Pos is the redefined item's entry in the copybook.
+	Pos diag.Span
+
+	// Record is the record being resolved.
+	Record string
+
+	// Group is the innermost repeating group the variant sits in.
+	Group string
+
+	// Redefined is the item the copybook redefines.
+	Redefined string
+}
+
+// Error implements the error interface.
+func (e *ArmCountError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *ArmCountError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"in record %s, the variant on %s in the repeating group %s names no alternative at all, and a variant needs two",
+			e.Record, e.Redefined, e.Group),
+		Spans: []diag.Span{e.Pos},
+	}
+}
+
+// UndiscriminatedRedefineError is a REDEFINES inside a repeating group that the
+// layout says nothing about.
+//
+// The one thing a layout says about a redefine is which alternative to read, and
+// inside a repeating group that is a `discriminate-variant` form. Reading the
+// copybook's own first alternative instead would be a default, and a default
+// here is a record read as the wrong alternative in every entry of the table
+// with nothing in the file to disagree with it.
+type UndiscriminatedRedefineError struct {
+	// Pos is the redefined item's entry in the copybook.
+	Pos diag.Span
+
+	// Record is the record being resolved.
+	Record string
+
+	// Group is the innermost repeating group the redefine sits in.
+	Group string
+
+	// Redefined is the item the copybook redefines.
+	Redefined string
+
+	// Names are the items redefining it, which are the alternatives the
+	// layout has to choose among.
+	Names []string
+}
+
+// Error implements the error interface.
+func (e *UndiscriminatedRedefineError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *UndiscriminatedRedefineError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"in record %s, nothing says which alternative of %s to read in the repeating group %s: %s redefines it, and a redefine inside a table is chosen once per occurrence",
+			e.Record, e.Redefined, e.Group, joinAnd(e.Names)),
+		Spans: []diag.Span{e.Pos},
+	}
+}
+
+// UnknownAlternativeError is a layout naming an alternative the copybook does
+// not declare over those bytes.
+type UnknownAlternativeError struct {
+	// Pos is the redefined item's entry in the copybook.
+	Pos diag.Span
+
+	// Record is the record being resolved.
+	Record string
+
+	// Redefined is the item the copybook redefines.
+	Redefined string
+
+	// Alternative is the name the layout wrote.
+	Alternative string
+
+	// Names are the alternatives the copybook does declare, in the order it
+	// declares them.
+	Names []string
+}
+
+// Error implements the error interface.
+func (e *UnknownAlternativeError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+//
+// The list of alternatives is built from [UnknownAlternativeError.Names] here
+// rather than taken from the caller, so that what the message says the copybook
+// declares is a property of the error and not of what whoever raised it
+// remembered to write. It is in the message rather than in a span's note because
+// there is one place to point at — the redefined item — and a note belongs to
+// the second span of a diagnostic that names two.
+func (e *UnknownAlternativeError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"in record %s, no alternative of %s is named %s: the copybook declares %s",
+			e.Record, e.Redefined, e.Alternative, joinAnd(e.Names)),
+		Spans: []diag.Span{e.Pos},
+	}
+}
+
+// joinAnd renders a list the way a sentence does.
+func joinAnd(names []string) string {
+	switch len(names) {
+	case 0:
+		return "nothing"
+	case 1:
+		return names[0]
+	case 2:
+		return names[0] + " and " + names[1]
+	}
+	return strings.Join(names[:len(names)-1], ", ") + " and " + names[len(names)-1]
+}

--- a/internal/resolve/node.go
+++ b/internal/resolve/node.go
@@ -1,0 +1,302 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package resolve
+
+import (
+	"github.com/Zaba505/cobol-go/copybook"
+
+	"github.com/Zaba505/cpybkc/internal/layoutmodel"
+)
+
+// Kind is what a resolved node is, one member of the closed set docs/ir/SPEC.md,
+// "The node kinds", admits inside a record.
+//
+// The kinds a record cannot contain — file, record, predicate, state,
+// transition, register, binding, guard — are not here. This package resolves
+// what is inside a record; the automaton is #36's and the descriptor #38's.
+type Kind int
+
+const (
+	// KindGroup is an item holding other items. It carries no width of its
+	// own: [Node.Width] answers from the member list.
+	KindGroup Kind = iota + 1
+
+	// KindField is an elementary item, carrying the width one occurrence of
+	// it occupies.
+	KindField
+
+	// KindVariant is an alternation over one run of bytes inside a table:
+	// what a REDEFINES inside a repeating group resolves to.
+	KindVariant
+
+	// KindSlack is bytes that are part of the record and belong to no item.
+	KindSlack
+)
+
+// String implements the [fmt.Stringer] interface.
+func (k Kind) String() string {
+	switch k {
+	case KindGroup:
+		return "group"
+	case KindField:
+		return "field"
+	case KindVariant:
+		return "variant"
+	case KindSlack:
+		return "slack"
+	}
+	return "unknown"
+}
+
+// Node is one item of a resolved record.
+//
+// It is one type over four kinds rather than four types behind an interface,
+// because the IR is a flat list of nodes over a closed set of bodies and a
+// consumer switches over that set. What a kind does not carry is nil or zero
+// here for the same reason it is absent there: a slack node has no copybook
+// item behind it, a variant has no names and no repetition, and a field has no
+// members.
+//
+// No node carries a byte offset. Position is stated once, as ordering and
+// width, and [Record.Position] is the sum that reads it back
+// (docs/ir/SPEC.md, "Ordering and width, and no offset").
+type Node struct {
+	// Kind is which of the four this is.
+	Kind Kind
+
+	// Field is the copybook item the node stands for, and is nil for a slack
+	// node, for a variant, and for a group this package introduced to hold a
+	// node beside the slack that pads it out. A nil Field is a node with no
+	// names, which is what the IR carries for one.
+	Field *copybook.Field
+
+	// Members are a group's members, in record order — the order in which
+	// they occupy bytes. It is empty for every other kind.
+	Members []*Node
+
+	// Arms are a variant's alternatives, in evaluation order. Every arm
+	// begins at the variant's first byte, so the order says nothing about
+	// position. It is empty for every other kind.
+	Arms []Arm
+
+	// Repetition is what an item that repeats carries, and is nil for one
+	// that does not. A variant never carries one: it repeats by sitting
+	// inside the group that does, which is the only place it may sit.
+	Repetition *Repetition
+
+	// width is the bytes one occurrence of a field or a slack node occupies.
+	// It is unexported because a group and a variant must not be able to
+	// carry one: their widths follow from what they hold, and a member
+	// stating a second answer is the failure the IR is shaped to make
+	// unrepresentable.
+	width int
+}
+
+// Width reports the bytes one occurrence of the node occupies.
+//
+// A field's and a slack node's is carried. A group's is the sum of its members'
+// extents and a variant's is its arms' common extent, and neither is stored:
+// docs/ir/SPEC.md declines to carry either, and a method is how that refusal
+// survives contact with a caller.
+func (n *Node) Width() int {
+	switch n.Kind {
+	case KindGroup:
+		total := 0
+		for _, member := range n.Members {
+			total += member.Extent()
+		}
+		return total
+	case KindVariant:
+		if len(n.Arms) == 0 {
+			return 0
+		}
+		return n.Arms[0].Body.Extent()
+	}
+	return n.width
+}
+
+// Occurrences reports how many times the node repeats: one where it carries no
+// repetition, and the count the layout was computed at where it does.
+func (n *Node) Occurrences() int {
+	if n.Repetition == nil {
+		return 1
+	}
+	return n.Repetition.Count
+}
+
+// Extent reports the bytes the node occupies in the member list holding it:
+// [Node.Width] times [Node.Occurrences].
+//
+// This is what enters the position sum, so a node ahead of another contributes
+// its whole extent and not one occurrence of it.
+func (n *Node) Extent() int { return n.Width() * n.Occurrences() }
+
+// Repetition is what an item that repeats carries.
+//
+// Count is the occurrence count the layout was computed at, which for an
+// OCCURS ... DEPENDING ON table is the declared maximum — the storage a compiler
+// reserves for it. Turning DependingOn into the IR's reference, and the extent
+// that moves with it, is #35's; what this package needs from it is that the
+// count is a reference at all, which is what a variant's arms may not contain.
+type Repetition struct {
+	// Count is the occurrence count the layout was computed at.
+	Count int
+
+	// Min and Max are the bounds the OCCURS clause allows. They both equal
+	// Count for a fixed table.
+	Min int
+	Max int
+
+	// DependingOn is the item whose value gives the count, nil for a fixed
+	// table.
+	DependingOn *copybook.Field
+}
+
+// Reference reports whether the count is read out of the record rather than
+// written in the copybook.
+func (r *Repetition) Reference() bool { return r != nil && r.DependingOn != nil }
+
+// Arm is one alternative of a variant: the predicate that selects it and the
+// node that is its body.
+//
+// A pair and not a node of its own, because nothing points at an arm and a kind
+// for it would be one more member a consumer switches over in order to reach two
+// references (docs/ir/SPEC.md, "A variant is chosen once per occurrence").
+type Arm struct {
+	// Alternative is the name the copybook gives the item this arm selects,
+	// which is what a layout writes in an `arm` form.
+	Alternative string
+
+	// Predicate is the strategy the layout chose for this arm. It is carried
+	// rather than compiled: lowering a strategy into an IR predicate node is
+	// #37's.
+	Predicate layoutmodel.Strategy
+
+	// Body is the arm's body, a group or a field node. Where the alternative
+	// occupies fewer bytes than the variant's extent, it is a group holding
+	// the alternative and the slack that pads it out, because the slack has
+	// to sit inside the arm and an elementary item has nowhere to put it.
+	Body *Node
+}
+
+// Record is one resolved alternative of a copybook record.
+//
+// A copybook record holding no REDEFINES outside a repeating group resolves to
+// exactly one of these. One holding some resolves to one per combination of
+// alternatives, each carrying the whole record with that combination's items in
+// place and slack over the bytes they do not occupy.
+type Record struct {
+	// Root is the record's top level, always a group node.
+	//
+	// A group rather than either kind of item, because the top level is where
+	// the slack that resolving REDEFINES away leaves behind has to go, and
+	// holding members is what a group is.
+	Root *Node
+
+	// Item is the copybook record this is an alternative of.
+	Item *copybook.Field
+
+	// Alternatives are the items chosen at each redefine outside a repeating
+	// group, in the order the choices are met walking the record. It is empty
+	// for a record whose copybook holds none, and it is what tells two
+	// alternatives of one copybook record apart — the IR carries the
+	// copybook's name, which is the same on both.
+	Alternatives []*copybook.Field
+}
+
+// Extent reports the record's length in bytes: the width of its top level.
+//
+// A record node carries no length in the IR, for the reason a group carries no
+// width; this is the sum, run here.
+func (r *Record) Extent() int { return r.Root.Width() }
+
+// Position reports the byte position of target within the record, measured from
+// the first byte of the record's data: the sum of the extents of everything
+// ahead of it in containment order, counting exactly one occurrence of every
+// group that encloses it and repeats.
+//
+// The occurrence it lands on is the first. Saying so costs nothing today —
+// docs/ir/SPEC.md's "A reference names a field, not an occurrence of one"
+// forbids every reference that could reach a later one — and it is what makes
+// the sum the same arithmetic before and after that prohibition is relaxed.
+//
+// A variant contributes its arms' common extent like any other constant term,
+// so an item behind one sits where it would sit without it, and a position
+// inside an arm is measured through the arm the item is in.
+//
+// It reports false for a node that is not in the record. A record holding an
+// OCCURS ... DEPENDING ON table has positions behind that table which move with
+// the count; what comes back is the position at the count the layout was
+// computed at, which is the declared maximum (#35).
+func (r *Record) Position(target *Node) (int, bool) {
+	return position(r.Root, target, 0)
+}
+
+// position walks node looking for target, carrying the bytes ahead of node in
+// at. It is a walk rather than a parent chain because containment is stated once
+// and downward, exactly as a consumer of the IR has it.
+func position(node, target *Node, at int) (int, bool) {
+	if node == target {
+		return at, true
+	}
+
+	switch node.Kind {
+	case KindGroup:
+		for _, member := range node.Members {
+			if found, ok := position(member, target, at); ok {
+				return found, true
+			}
+			at += member.Extent()
+		}
+	case KindVariant:
+		// Every arm begins at the variant's first byte, so an arm
+		// contributes nothing to the sum and the arms are searched at the
+		// variant's own position rather than one behind another.
+		for _, arm := range node.Arms {
+			if found, ok := position(arm.Body, target, at); ok {
+				return found, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// Walk calls fn for every node of the record in containment order, outermost
+// first, the top level included. A variant's arms are walked in evaluation
+// order.
+func (r *Record) Walk(fn func(*Node)) { walk(r.Root, fn) }
+
+func walk(node *Node, fn func(*Node)) {
+	fn(node)
+	for _, member := range node.Members {
+		walk(member, fn)
+	}
+	for _, arm := range node.Arms {
+		walk(arm.Body, fn)
+	}
+}
+
+// Find returns the first node standing for the copybook item named name, in
+// [Record.Walk] order, or nil where the record holds none.
+//
+// A name is not identity — duplicate data names are legal COBOL — so this is for
+// a caller that already knows the record it is looking in holds one, which in
+// practice means a test.
+func (r *Record) Find(name string) *Node {
+	var found *Node
+	r.Walk(func(node *Node) {
+		if found != nil || node.Field == nil || node.Field.Filler {
+			return
+		}
+		if node.Field.Name == name {
+			found = node
+		}
+	})
+	return found
+}
+
+// slackNode builds a slack node of width bytes.
+func slackNode(width int) *Node { return &Node{Kind: KindSlack, width: width} }

--- a/internal/resolve/redefines_test.go
+++ b/internal/resolve/redefines_test.go
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package resolve
+
+import (
+	"testing"
+)
+
+// A REDEFINES outside a repeating group is chosen once per record, so each
+// alternative becomes its own record with its own containment order — and the
+// bytes the copybook gave the alternatives jointly that this one does not use
+// are slack, because splitting them is what discards the storage they shared.
+
+// TestARedefineOutsideATableBecomesOneRecordPerAlternative is the resolution
+// itself: two descriptions of one run of bytes leave, two records arrive, and
+// neither carries anything a consumer would have to collapse.
+func TestARedefineOutsideATableBecomesOneRecordPerAlternative(t *testing.T) {
+	t.Parallel()
+
+	records := resolveAll(t, `01 TXN.
+   05 KIND PIC X.
+   05 BODY PIC X(24).
+   05 CARD REDEFINES BODY.
+      10 NUMBER PIC X(16).
+      10 EXPIRY PIC X(4).
+   05 TRAILER PIC X(2).
+`)
+
+	if len(records) != 2 {
+		t.Fatalf("resolved to %d records, want one per alternative", len(records))
+	}
+
+	for _, record := range records {
+		if got := record.Extent(); got != 27 {
+			t.Errorf("an alternative is %d bytes, want 27", got)
+		}
+		if got := positionOf(t, record, "TRAILER"); got != 25 {
+			t.Errorf("TRAILER is at %d in an alternative, want 25", got)
+		}
+		if record.Find("BODY") != nil && record.Find("CARD") != nil {
+			t.Error("an alternative carries both descriptions of the same bytes")
+		}
+	}
+
+	if len(records[0].Alternatives) != 1 || records[0].Alternatives[0].Name != "BODY" {
+		t.Fatalf("the first record chose %v, want BODY", records[0].Alternatives)
+	}
+	if len(records[1].Alternatives) != 1 || records[1].Alternatives[0].Name != "CARD" {
+		t.Fatalf("the second record chose %v, want CARD", records[1].Alternatives)
+	}
+
+	// The second alternative describes 20 of the 24 bytes, and the four it
+	// leaves are slack rather than absent: in a file written by a program
+	// that used BODY they hold that program's data.
+	card := records[1]
+	if got := positionOf(t, card, "NUMBER"); got != 1 {
+		t.Errorf("NUMBER is at %d, want 1", got)
+	}
+	if got := positionOf(t, card, "EXPIRY"); got != 17 {
+		t.Errorf("EXPIRY is at %d, want 17", got)
+	}
+	if got := slackWidths(card.Root); len(got) != 1 || got[0] != 4 {
+		t.Fatalf("the alternative's slack is %v bytes, want one run of 4", got)
+	}
+}
+
+// TestChainedRedefinesAreOneRunOfBytesDescribedThreeWays holds a chain — B
+// redefining A and C redefining B — to being one cluster with three
+// alternatives rather than two clusters overlapping.
+func TestChainedRedefinesAreOneRunOfBytesDescribedThreeWays(t *testing.T) {
+	t.Parallel()
+
+	records := resolveAll(t, `01 R.
+   05 A PIC X(10).
+   05 B REDEFINES A PIC X(6).
+   05 C REDEFINES B PIC X(4).
+   05 Z PIC X(2).
+`)
+
+	if len(records) != 3 {
+		t.Fatalf("resolved to %d records, want 3", len(records))
+	}
+	for _, record := range records {
+		if got := record.Extent(); got != 12 {
+			t.Errorf("an alternative is %d bytes, want 12", got)
+		}
+		if got := positionOf(t, record, "Z"); got != 10 {
+			t.Errorf("Z is at %d in an alternative, want 10", got)
+		}
+	}
+	if got := slackWidths(records[1].Root); len(got) != 1 || got[0] != 4 {
+		t.Errorf("the six-byte alternative's slack is %v, want one run of 4", got)
+	}
+	if got := slackWidths(records[2].Root); len(got) != 1 || got[0] != 6 {
+		t.Errorf("the four-byte alternative's slack is %v, want one run of 6", got)
+	}
+}
+
+// TestTwoRedefinesOutsideATableMultiplyTheAlternatives is the duplication the
+// IR declines to soften: two independent choices in one record are four records,
+// each carrying the whole of it.
+func TestTwoRedefinesOutsideATableMultiplyTheAlternatives(t *testing.T) {
+	t.Parallel()
+
+	records := resolveAll(t, `01 R.
+   05 A PIC X(4).
+   05 B REDEFINES A PIC X(4).
+   05 C PIC X(6).
+   05 D REDEFINES C PIC X(6).
+`)
+
+	if len(records) != 4 {
+		t.Fatalf("resolved to %d records, want 4", len(records))
+	}
+	want := [][]string{{"A", "C"}, {"A", "D"}, {"B", "C"}, {"B", "D"}}
+	for i, record := range records {
+		if len(record.Alternatives) != 2 {
+			t.Fatalf("record %d chose %d alternatives, want 2", i, len(record.Alternatives))
+		}
+		for j, name := range want[i] {
+			if record.Alternatives[j].Name != name {
+				t.Errorf("record %d chose %s at %d, want %s", i, record.Alternatives[j].Name, j, name)
+			}
+		}
+	}
+}
+
+// TestACopybookWithNoRedefineResolvesToOneRecord is the ordinary case, stated so
+// that the enumeration above cannot quietly start applying to every copybook.
+func TestACopybookWithNoRedefineResolvesToOneRecord(t *testing.T) {
+	t.Parallel()
+
+	records := resolveAll(t, "01 R.\n   05 A PIC X(4).\n   05 B PIC X(6).\n")
+	if len(records) != 1 {
+		t.Fatalf("resolved to %d records, want 1", len(records))
+	}
+	if len(records[0].Alternatives) != 0 {
+		t.Fatalf("a record with no redefine chose %d alternatives", len(records[0].Alternatives))
+	}
+}
+
+// slackWidths is every slack node of a subtree, in containment order, so that a
+// test can say how many runs there are as well as how wide they are — one node
+// per maximal run is a requirement, not an implementation detail.
+func slackWidths(node *Node) []int {
+	var widths []int
+	var visit func(*Node)
+	visit = func(n *Node) {
+		if n.Kind == KindSlack {
+			widths = append(widths, n.Width())
+		}
+		for _, member := range n.Members {
+			visit(member)
+		}
+		for _, arm := range n.Arms {
+			visit(arm.Body)
+		}
+	}
+	visit(node)
+	return widths
+}

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -1,0 +1,617 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package resolve
+
+import (
+	"errors"
+
+	"github.com/Zaba505/cobol-go/copybook"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+	"github.com/Zaba505/cpybkc/internal/layoutmodel"
+)
+
+// ErrNilRecord is returned by [Resolve] when it is handed no record.
+var ErrNilRecord = errors.New("resolve: nil record")
+
+// Options are what resolving a record needs beyond the copybook item itself.
+type Options struct {
+	// Copybook is the copybook's path as the layout spells it, carried so
+	// that a diagnostic can name the file the fault is in. It is not resolved
+	// against anything here: where a copybook was looked for is the CLI's,
+	// and a diagnostic naming a path the adopter never wrote sends them
+	// looking for a file they have not got.
+	Copybook string
+
+	// Dialect is the compiler-side half of the layout: the binary width
+	// staircase, whether SYNCHRONIZED inserts slack, what an oversized
+	// REDEFINES is, and the widths of INDEX and POINTER. It has no default
+	// here for the reason `cobol-go` gives it none: a wrong layout setting is
+	// not visible in the result.
+	Dialect copybook.Dialect
+
+	// Redefines says how each REDEFINES inside a repeating group is told
+	// apart. A redefine outside one needs no entry: its alternatives become
+	// records, and [Resolve] returns one per combination.
+	Redefines []Redefine
+}
+
+// Redefine is what a layout says about one REDEFINES inside a repeating group.
+//
+// It is input rather than something inferred from the copybook because the one
+// thing a layout says about a redefine is which alternative to read — never what
+// a redefine is, where its bytes are, or which items overlay which. Two or more
+// alternatives make a variant. Exactly one says every occurrence takes that
+// alternative, and resolves to that alternative's items with no variant emitted
+// at all (docs/ir/SPEC.md, "A variant is chosen once per occurrence").
+type Redefine struct {
+	// Item is the redefined item — the first alternative, the one every
+	// REDEFINES of it names. It is a field of the record being resolved.
+	Item *copybook.Field
+
+	// Alternatives are the alternatives, in the order they are to be
+	// evaluated.
+	Alternatives []Alternative
+}
+
+// Alternative is one alternative of a [Redefine].
+type Alternative struct {
+	// Name is the name the copybook gives the item: the redefined item's own
+	// name for the first alternative, and a redefining item's for the rest.
+	Name string
+
+	// Predicate is the strategy that selects it. It is required where the
+	// redefine has two or more alternatives — an arm chosen by nothing is not
+	// a thing an alternation can mean — and ignored where it has one, because
+	// nothing is being chosen.
+	Predicate layoutmodel.Strategy
+}
+
+// Resolve resolves record into one [Record] per combination of the alternatives
+// its REDEFINES clauses admit outside a repeating group.
+//
+// record is a field [github.com/Zaba505/cobol-go/copybook.Build] returned: a
+// level-01 record or a level-77 standalone item. Widths come from each
+// elementary item's PICTURE, USAGE and the dialect, per codec/SPEC.md, "Storage
+// Widths", and an item carrying no logical value a generator can use —
+// numeric-edited, national, INDEX, POINTER — still carries one, so that the
+// position sum stays correct across it.
+//
+// A record whose copybook holds no REDEFINES outside a repeating group resolves
+// to exactly one Record. The order is the order the alternatives are met walking
+// the record, outermost and earliest first.
+//
+// Every fault it finds is reported, joined with [errors.Join] and assertable
+// with [errors.As], rather than the first: a copybook and the layout over it go
+// wrong in the same way in several places at once. A record it found a fault in
+// is not returned — a half-resolved record is one a caller can read, and there
+// is no reading of a copybook that was rejected.
+func Resolve(record *copybook.Field, opts Options) ([]*Record, error) {
+	if record == nil {
+		return nil, ErrNilRecord
+	}
+
+	layout, err := copybook.NewLayout(record, opts.Dialect)
+	if err != nil {
+		return nil, err
+	}
+
+	r := &resolver{opts: opts, record: record}
+	options := r.item(layout.Record)
+	if r.faults.Failed() {
+		return nil, r.faults.Err()
+	}
+
+	records := make([]*Record, 0, len(options))
+	for _, option := range options {
+		root := option.node
+		if root.Kind != KindGroup {
+			// A level-77 standalone item is a record whose top level is
+			// elementary, and the IR's top level is a group whatever the
+			// copybook wrote: it is where the slack goes.
+			root = &Node{Kind: KindGroup, Field: record, Members: []*Node{root}}
+		}
+		records = append(records, &Record{
+			Root:         root,
+			Item:         record,
+			Alternatives: option.alternatives,
+		})
+	}
+	return records, nil
+}
+
+// resolver carries what the walk needs: the options it was given, the record it
+// is resolving — which every diagnostic names — and the faults found so far.
+type resolver struct {
+	opts   Options
+	record *copybook.Field
+	faults diag.List
+}
+
+// option is one resolution of one item: the node it became, and the alternatives
+// chosen to get there.
+//
+// An item resolves to more than one option exactly where a REDEFINES outside a
+// repeating group stands under it, which is what makes a record's alternatives
+// multiply rather than a record carrying a choice.
+type option struct {
+	node         *Node
+	alternatives []*copybook.Field
+}
+
+// item resolves one laid-out item into every option it admits.
+func (r *resolver) item(item *copybook.Item) []option {
+	if item.Field.Kind != copybook.KindGroup {
+		return []option{{node: elementary(item)}}
+	}
+	return r.group(item)
+}
+
+// elementary builds the node for an item that holds no others.
+//
+// A repeating item whose stride exceeds its width has padding between one
+// occurrence and the next, and an elementary node has nowhere to put a slack
+// node. So it becomes a group that repeats, holding the item and the padding —
+// which is the same shape the IR would need for it, since alignment reaches a
+// generator as bytes it already has rather than as a rule it applies.
+func elementary(item *copybook.Item) *Node {
+	field := &Node{
+		Kind:       KindField,
+		Field:      item.Field,
+		width:      item.Length,
+		Repetition: repetitionOf(item),
+	}
+	if item.Stride == item.Length {
+		return field
+	}
+
+	repetition := field.Repetition
+	field.Repetition = nil
+	return &Node{
+		Kind:       KindGroup,
+		Members:    []*Node{field, slackNode(item.Stride - item.Length)},
+		Repetition: repetition,
+	}
+}
+
+// run is what one redefine cluster contributes to its group's member list: the
+// nodes themselves, and the alternatives chosen to arrive at them.
+//
+// A cluster contributes more than one node where the alternative chosen does not
+// fill the storage the cluster reserved, which is where the slack behind it goes.
+type run struct {
+	nodes        []*Node
+	alternatives []*copybook.Field
+}
+
+// group resolves a group item into every option its member list admits.
+//
+// The member list is built cluster by cluster — an item and the items redefining
+// it are one cluster — and every byte of the group's extent no cluster covers
+// becomes slack, so that the members sum to the extent exactly and the position
+// of everything behind them is the sum and nothing else.
+func (r *resolver) group(item *copybook.Item) []option {
+	lists := []run{{}}
+	cursor := item.Offset
+
+	for _, c := range clustersOf(item) {
+		gap := c.start() - cursor
+		choices := r.cluster(c)
+		cursor = c.start() + c.extent()
+
+		next := make([]run, 0, len(lists)*len(choices))
+		for _, list := range lists {
+			for _, choice := range choices {
+				members := make([]*Node, 0, len(list.nodes)+len(choice.nodes)+1)
+				members = append(members, list.nodes...)
+				if gap > 0 {
+					members = append(members, slackNode(gap))
+				}
+				members = append(members, choice.nodes...)
+
+				chosen := make([]*copybook.Field, 0, len(list.alternatives)+len(choice.alternatives))
+				chosen = append(chosen, list.alternatives...)
+				chosen = append(chosen, choice.alternatives...)
+
+				next = append(next, run{nodes: members, alternatives: chosen})
+			}
+		}
+		lists = next
+	}
+
+	// One occurrence of the group is its stride, not its length: a repeating
+	// group padded out so that the next occurrence starts on its boundary
+	// carries that padding inside itself, where the sum can see it.
+	trailing := item.Offset + item.Stride - cursor
+
+	options := make([]option, 0, len(lists))
+	for _, list := range lists {
+		members := list.nodes
+		if trailing > 0 {
+			members = append(members[:len(members):len(members)], slackNode(trailing))
+		}
+		options = append(options, option{
+			node: &Node{
+				Kind:       KindGroup,
+				Field:      item.Field,
+				Members:    mergeSlack(members),
+				Repetition: repetitionOf(item),
+			},
+			alternatives: list.alternatives,
+		})
+	}
+	return options
+}
+
+// cluster resolves one redefine cluster into every run its group's member list
+// admits.
+func (r *resolver) cluster(c cluster) []run {
+	if len(c.members) == 1 {
+		options := r.item(c.members[0])
+		runs := make([]run, 0, len(options))
+		for _, chosen := range options {
+			runs = append(runs, run{nodes: []*Node{chosen.node}, alternatives: chosen.alternatives})
+		}
+		return runs
+	}
+
+	if inTable(c.members[0]) {
+		return []run{r.variant(c)}
+	}
+
+	// Outside a repeating group every alternative becomes its own record, so
+	// the cluster multiplies the options rather than becoming a node.
+	var runs []run
+	for _, member := range c.members {
+		for _, chosen := range r.item(member) {
+			alternatives := make([]*copybook.Field, 0, len(chosen.alternatives)+1)
+			alternatives = append(alternatives, chosen.alternatives...)
+			alternatives = append(alternatives, member.Field)
+			runs = append(runs, run{
+				nodes:        pad(chosen.node, c.extent()),
+				alternatives: alternatives,
+			})
+		}
+	}
+	return runs
+}
+
+// variant resolves a redefine cluster inside a repeating group.
+//
+// The layout says which alternatives there are and what selects each one. Two or
+// more make a variant; one says every occurrence takes it, and resolves to that
+// alternative's items with no variant at all.
+func (r *resolver) variant(c cluster) run {
+	redefined := c.members[0]
+	table := enclosingTable(redefined)
+
+	spec := r.redefine(redefined.Field)
+	if spec == nil {
+		r.faults.Fail(&UndiscriminatedRedefineError{
+			Pos:       r.span(redefined.Field),
+			Record:    r.record.Name,
+			Group:     groupName(table),
+			Redefined: itemName(redefined.Field),
+			Names:     names(c.members[1:]),
+		})
+		return r.base(c)
+	}
+
+	// The redefined item's storage is what an occurrence reserved, and it is
+	// what every arm has to fit in. A dialect lenient enough to let a
+	// redefinition grow its group cannot make that true one entry at a time,
+	// so an arm needing more bytes is the layout this package rejects rather
+	// than one it pads.
+	extent := redefined.Total()
+
+	arms := make([]Arm, 0, len(spec.Alternatives))
+	for _, alternative := range spec.Alternatives {
+		member := c.find(alternative.Name)
+		if member == nil {
+			r.faults.Fail(&UnknownAlternativeError{
+				Pos:         r.span(redefined.Field),
+				Record:      r.record.Name,
+				Redefined:   itemName(redefined.Field),
+				Alternative: alternative.Name,
+				Names:       names(c.members),
+			})
+			continue
+		}
+
+		switch counted := referenceCount(member); {
+		case member.Total() > extent:
+			r.faults.Fail(&ArmExtentError{
+				Pos:       r.span(member.Field),
+				Record:    r.record.Name,
+				Group:     groupName(table),
+				Redefined: itemName(redefined.Field),
+				Arm:       itemName(member.Field),
+				Extent:    member.Total(),
+				Want:      extent,
+			})
+			continue
+
+		case counted != nil:
+			r.faults.Fail(&ArmVariableCountError{
+				Pos:       r.span(counted.Field),
+				Record:    r.record.Name,
+				Group:     groupName(table),
+				Redefined: itemName(redefined.Field),
+				Arm:       itemName(member.Field),
+				Item:      itemName(counted.Field),
+				Count:     itemName(counted.DependingOn.Field),
+			})
+			continue
+
+		case len(spec.Alternatives) > 1 && !alternative.Predicate.Predicate():
+			r.faults.Fail(&ArmPredicateError{
+				Pos:       r.span(member.Field),
+				Record:    r.record.Name,
+				Group:     groupName(table),
+				Redefined: itemName(redefined.Field),
+				Arm:       itemName(member.Field),
+			})
+			continue
+		}
+
+		arms = append(arms, Arm{
+			Alternative: alternative.Name,
+			Predicate:   alternative.Predicate,
+			Body:        armBody(r.first(member), extent),
+		})
+	}
+
+	switch {
+	case len(spec.Alternatives) == 0:
+		r.faults.Fail(&ArmCountError{
+			Pos:       r.span(redefined.Field),
+			Record:    r.record.Name,
+			Group:     groupName(table),
+			Redefined: itemName(redefined.Field),
+		})
+		return r.base(c)
+
+	case len(spec.Alternatives) == 1:
+		// Nothing is chosen, so there is no alternation to carry and no
+		// predicate to carry it under: the one alternative's items stand
+		// where the cluster stood, padded out like a record's.
+		if len(arms) == 0 {
+			return r.base(c)
+		}
+		member := c.find(spec.Alternatives[0].Name)
+		return run{
+			nodes:        pad(r.first(member), c.extent()),
+			alternatives: []*copybook.Field{member.Field},
+		}
+	}
+
+	if len(arms) < len(spec.Alternatives) {
+		// A fault was already reported for the arms that are missing, and a
+		// variant short of them would be a second, less useful one.
+		return r.base(c)
+	}
+
+	return run{nodes: pad(&Node{Kind: KindVariant, Arms: arms}, c.extent())}
+}
+
+// base is the run a cluster contributes when a fault stopped it from resolving:
+// the redefined item, which is the copybook's own first description of those
+// bytes. It keeps the walk going so that a second fault is reported beside the
+// first, and nothing is returned to a caller while a fault stands.
+func (r *resolver) base(c cluster) run {
+	return run{nodes: pad(r.first(c.members[0]), c.extent())}
+}
+
+// first resolves an item to its one option.
+//
+// Inside a repeating group there is only ever one: a redefine down there is
+// itself in a repeating group, so it becomes a variant rather than multiplying
+// the record's alternatives.
+func (r *resolver) first(item *copybook.Item) *Node {
+	options := r.item(item)
+	if len(options) == 0 {
+		return &Node{Kind: KindGroup, Field: item.Field}
+	}
+	return options[0].node
+}
+
+// redefine finds the layout's word on a redefined item.
+func (r *resolver) redefine(field *copybook.Field) *Redefine {
+	for i := range r.opts.Redefines {
+		if r.opts.Redefines[i].Item == field {
+			return &r.opts.Redefines[i]
+		}
+	}
+	return nil
+}
+
+// span is where in the copybook a field is.
+func (r *resolver) span(field *copybook.Field) diag.Span {
+	return diag.Span{File: r.opts.Copybook, Line: field.Pos.Line, Column: field.Pos.Column}
+}
+
+// pad returns the nodes a member list gets for node, followed by the slack
+// covering the bytes of extent it does not occupy.
+//
+// This is the record-level half of resolving a redefine away: the alternative's
+// items stand where the cluster stood, and the storage the copybook gave the
+// alternatives jointly that this one does not use is slack. Those bytes are not
+// padding — in a file written by a program that used another alternative they
+// hold that alternative's data.
+func pad(node *Node, extent int) []*Node {
+	if gap := extent - node.Extent(); gap > 0 {
+		return []*Node{node, slackNode(gap)}
+	}
+	return []*Node{node}
+}
+
+// armBody builds an arm's body, padded to the variant's extent.
+//
+// The slack has to sit inside the arm rather than behind it: a run of uncovered
+// bytes stops at the edge of an arm, and one node covering both would belong to
+// neither list and would make the arm wider than its siblings. A group that does
+// not repeat can hold it among its own members; anything else — an elementary
+// alternative above all — is wrapped in a group that carries no names, because
+// the alternative's name is on the node inside it.
+func armBody(node *Node, extent int) *Node {
+	gap := extent - node.Extent()
+	if gap <= 0 {
+		return node
+	}
+	if node.Kind == KindGroup && node.Repetition == nil {
+		node.Members = mergeSlack(append(node.Members, slackNode(gap)))
+		return node
+	}
+	return &Node{Kind: KindGroup, Members: []*Node{node, slackNode(gap)}}
+}
+
+// mergeSlack collapses each run of abutting slack nodes into one, so that two
+// runs of different origin that abut are one node and not two.
+//
+// It costs nothing today and stops costing something later: a record carries one
+// run of bytes per slack node, so how a producer divides a run of eight into
+// nodes would otherwise decide the shape of every record a generator emits.
+func mergeSlack(nodes []*Node) []*Node {
+	merged := make([]*Node, 0, len(nodes))
+	for _, node := range nodes {
+		last := len(merged) - 1
+		if node.Kind == KindSlack && last >= 0 && merged[last].Kind == KindSlack {
+			merged[last] = slackNode(merged[last].width + node.width)
+			continue
+		}
+		merged = append(merged, node)
+	}
+	return merged
+}
+
+// repetitionOf reads an item's repetition, nil where it does not repeat.
+func repetitionOf(item *copybook.Item) *Repetition {
+	if item.MaxOccurs <= 1 {
+		return nil
+	}
+
+	repetition := &Repetition{Count: item.Occurs, Min: item.MinOccurs, Max: item.MaxOccurs}
+	if item.DependingOn != nil {
+		repetition.DependingOn = item.DependingOn.Field
+	}
+	return repetition
+}
+
+// referenceCount returns the first item at or under item whose repetition count
+// is read out of the record, or nil where none is.
+func referenceCount(item *copybook.Item) *copybook.Item {
+	if item.DependingOn != nil {
+		return item
+	}
+	for _, child := range item.Children {
+		if found := referenceCount(child); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// inTable reports whether item is contained, at any depth, in a group that
+// repeats. It is the whole of what decides which resolution a REDEFINES takes.
+func inTable(item *copybook.Item) bool { return enclosingTable(item) != nil }
+
+// enclosingTable returns the innermost group above item that repeats, or nil
+// where none does.
+func enclosingTable(item *copybook.Item) *copybook.Item {
+	for parent := item.Parent; parent != nil; parent = parent.Parent {
+		if parent.MaxOccurs > 1 {
+			return parent
+		}
+	}
+	return nil
+}
+
+// cluster is an item and the items redefining it: one run of storage with more
+// than one description of it.
+type cluster struct {
+	members []*copybook.Item
+}
+
+// start is the byte the cluster's storage begins at. Every member of a cluster
+// starts there — that is what REDEFINES means.
+func (c cluster) start() int { return c.members[0].Offset }
+
+// extent is the bytes the cluster's storage covers: the longest description of
+// it, which under a strict dialect is always the redefined item's own.
+func (c cluster) extent() int {
+	widest := 0
+	for _, member := range c.members {
+		if total := member.Total(); total > widest {
+			widest = total
+		}
+	}
+	return widest
+}
+
+// find returns the member named name, or nil.
+func (c cluster) find(name string) *copybook.Item {
+	for _, member := range c.members {
+		if !member.Field.Filler && member.Field.Name == name {
+			return member
+		}
+	}
+	return nil
+}
+
+// clustersOf partitions a group's children into clusters, in the order the
+// redefined items appear.
+//
+// A REDEFINES names a preceding sibling, and a chain of them — B redefining A
+// and C redefining B — describes one run of storage three ways, so the chain is
+// walked to its root rather than each link being its own cluster.
+func clustersOf(item *copybook.Item) []cluster {
+	var clusters []cluster
+	index := make(map[*copybook.Item]int, len(item.Children))
+
+	for _, child := range item.Children {
+		base := child
+		for base.Redefines != nil {
+			base = base.Redefines
+		}
+		if at, ok := index[base]; ok {
+			clusters[at].members = append(clusters[at].members, child)
+			continue
+		}
+		index[base] = len(clusters)
+		clusters = append(clusters, cluster{members: []*copybook.Item{child}})
+	}
+	return clusters
+}
+
+// itemName is what a diagnostic calls a field: its name, or FILLER where it has
+// none.
+func itemName(field *copybook.Field) string {
+	if field == nil {
+		return ""
+	}
+	if field.Filler || field.Name == "" {
+		return "FILLER"
+	}
+	return field.Name
+}
+
+// groupName is what a diagnostic calls the repeating group a variant sits in.
+func groupName(item *copybook.Item) string {
+	if item == nil {
+		return ""
+	}
+	return itemName(item.Field)
+}
+
+// names is what the items are called, for a diagnostic listing the alternatives
+// an adopter could have meant.
+func names(items []*copybook.Item) []string {
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		out = append(out, itemName(item.Field))
+	}
+	return out
+}

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -1,0 +1,281 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package resolve
+
+import (
+	"strings"
+	"testing"
+
+	cobol "github.com/Zaba505/cobol-go"
+	"github.com/Zaba505/cobol-go/copybook"
+
+	"github.com/Zaba505/cpybkc/internal/layoutmodel"
+)
+
+// recordOf builds the first record of a copybook source, driving `cobol-go`'s
+// real parser so that no test hand-assembles an AST the reader would never
+// produce.
+func recordOf(t *testing.T, src string) *copybook.Field {
+	t.Helper()
+
+	file, err := cobol.Parse(strings.NewReader(src), cobol.WithFragment())
+	if err != nil {
+		t.Fatalf("parsing the copybook: %v", err)
+	}
+	if file.Fragment == nil {
+		t.Fatal("parsing the copybook: no fragment")
+	}
+
+	records, err := copybook.Build(file.Fragment.Entries)
+	if err != nil {
+		t.Fatalf("building the copybook: %v", err)
+	}
+	if len(records) == 0 {
+		t.Fatal("building the copybook: no records")
+	}
+	return records[0]
+}
+
+// fieldNamed finds a field of the record by name, for a test naming what a
+// layout would name.
+func fieldNamed(t *testing.T, record *copybook.Field, name string) *copybook.Field {
+	t.Helper()
+
+	var found *copybook.Field
+	var walk func(*copybook.Field)
+	walk = func(field *copybook.Field) {
+		if found == nil && !field.Filler && field.Name == name {
+			found = field
+		}
+		for _, child := range field.Children {
+			walk(child)
+		}
+	}
+	walk(record)
+
+	if found == nil {
+		t.Fatalf("the copybook declares no %s", name)
+	}
+	return found
+}
+
+// resolveAll resolves a copybook source under IBM Enterprise COBOL, which is the
+// dialect every test here states unless it is testing the dialect.
+func resolveAll(t *testing.T, src string, redefines ...Redefine) []*Record {
+	t.Helper()
+
+	records, err := Resolve(recordOf(t, src), Options{
+		Copybook:  "test.cpy",
+		Dialect:   copybook.IBMEnterprise(),
+		Redefines: redefines,
+	})
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+	return records
+}
+
+// resolveOne resolves a copybook the caller expects to have exactly one
+// alternative.
+func resolveOne(t *testing.T, src string, redefines ...Redefine) *Record {
+	t.Helper()
+
+	records := resolveAll(t, src, redefines...)
+	if len(records) != 1 {
+		t.Fatalf("resolved to %d records, want 1", len(records))
+	}
+	return records[0]
+}
+
+// selects is a strategy that lowers into a predicate, for an arm a test needs
+// selected by something rather than by a particular thing. Compiling one into an
+// IR predicate node is #37's, so what it tests is not this package's business.
+func selects(value string) layoutmodel.Strategy {
+	return layoutmodel.Strategy{
+		Kind:     layoutmodel.Equals,
+		Literals: []layoutmodel.Literal{{Kind: layoutmodel.TextLiteral, Text: value}},
+	}
+}
+
+// widthOf is the resolved width of the field named name.
+func widthOf(t *testing.T, record *Record, name string) int {
+	t.Helper()
+
+	node := record.Find(name)
+	if node == nil {
+		t.Fatalf("the resolved record holds no %s", name)
+	}
+	return node.Width()
+}
+
+// positionOf is the resolved position of the field named name.
+func positionOf(t *testing.T, record *Record, name string) int {
+	t.Helper()
+
+	node := record.Find(name)
+	if node == nil {
+		t.Fatalf("the resolved record holds no %s", name)
+	}
+	at, ok := record.Position(node)
+	if !ok {
+		t.Fatalf("%s is not in the record it came from", name)
+	}
+	return at
+}
+
+func TestResolveRejectsNoRecordAtAll(t *testing.T) {
+	t.Parallel()
+
+	if _, err := Resolve(nil, Options{Dialect: copybook.IBMEnterprise()}); err != ErrNilRecord {
+		t.Fatalf("Resolve(nil) = %v, want %v", err, ErrNilRecord)
+	}
+}
+
+func TestResolveReportsACopybookItCannotLayOut(t *testing.T) {
+	t.Parallel()
+
+	// An elementary DISPLAY item with no PICTURE has no width, which is
+	// `cobol-go`'s to report: this package does not measure storage a second
+	// time, so it has nothing of its own to say about one.
+	_, err := Resolve(recordOf(t, "01 R.\n   05 A.\n"), Options{Dialect: copybook.IBMEnterprise()})
+	if err == nil {
+		t.Fatal("resolved a record whose width cannot be determined")
+	}
+}
+
+// TestResolveOrdersMembersByRecordOrder holds the member list to the one thing
+// it is: the order in which members occupy bytes. Ordering is data here, not a
+// convention a consumer restores by sorting, because it is half of the only
+// statement of where anything is.
+func TestResolveOrdersMembersByRecordOrder(t *testing.T) {
+	t.Parallel()
+
+	record := resolveOne(t, `01 TXN.
+   05 ID PIC X(4).
+   05 AMT PIC S9(5) COMP-3.
+   05 QTY PIC S9(4) COMP.
+   05 NAME PIC X(6).
+`)
+
+	want := []string{"ID", "AMT", "QTY", "NAME"}
+	got := make([]string, 0, len(record.Root.Members))
+	for _, member := range record.Root.Members {
+		got = append(got, member.Field.Name)
+	}
+	if strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Fatalf("members are %v, want %v", got, want)
+	}
+}
+
+// TestNodeWidthIsNotCarriedForAGroupOrAVariant is the structural half of
+// docs/ir/SPEC.md's refusal to state a position twice: a group's width is the
+// sum of its members' and a variant's is its arms' common extent, and neither is
+// a number this package could store and get wrong.
+func TestNodeWidthIsNotCarriedForAGroupOrAVariant(t *testing.T) {
+	t.Parallel()
+
+	record := resolveOne(t, `01 R.
+   05 G.
+      10 A PIC X(4).
+      10 B PIC X(6).
+`)
+
+	group := record.Find("G")
+	if group.width != 0 {
+		t.Fatalf("the group carries a width of %d", group.width)
+	}
+	if got := group.Width(); got != 10 {
+		t.Fatalf("the group's width is %d, want 10", got)
+	}
+
+	group.Members = group.Members[:1]
+	if got := group.Width(); got != 4 {
+		t.Fatalf("after dropping a member the group's width is %d, want 4", got)
+	}
+}
+
+// TestRecordPositionCountsOneOccurrenceOfEveryEnclosingTable is the clause that
+// costs nothing today and buys the arithmetic staying the same later: the sum
+// lands on the first occurrence.
+func TestRecordPositionCountsOneOccurrenceOfEveryEnclosingTable(t *testing.T) {
+	t.Parallel()
+
+	record := resolveOne(t, `01 R.
+   05 HDR PIC X(4).
+   05 T OCCURS 5 TIMES.
+      10 K PIC X(2).
+      10 V PIC X(3).
+   05 TRAILER PIC X(6).
+`)
+
+	for _, tc := range []struct {
+		name string
+		want int
+	}{
+		{name: "HDR", want: 0},
+		{name: "T", want: 4},
+		{name: "K", want: 4},
+		{name: "V", want: 6},
+		{name: "TRAILER", want: 4 + 5*5},
+	} {
+		if got := positionOf(t, record, tc.name); got != tc.want {
+			t.Errorf("%s is at %d, want %d", tc.name, got, tc.want)
+		}
+	}
+
+	if got := record.Extent(); got != 4+5*5+6 {
+		t.Fatalf("the record's extent is %d, want %d", got, 4+5*5+6)
+	}
+}
+
+// TestRepetitionIsCarriedOnlyByAnItemThatRepeats, with the bounds a DEPENDING ON
+// clause declared beside the count the layout was computed at. Turning the
+// second into the IR's reference, and the extent that moves with it, is #35's;
+// what this package needs from it is that the count is a reference at all.
+func TestRepetitionIsCarriedOnlyByAnItemThatRepeats(t *testing.T) {
+	t.Parallel()
+
+	record := resolveOne(t, `01 R.
+   05 N PIC 9(2).
+   05 ONCE PIC X(4).
+   05 FIXED PIC X(2) OCCURS 3 TIMES.
+   05 VARYING PIC X(5) OCCURS 1 TO 6 TIMES DEPENDING ON N.
+`)
+
+	if node := record.Find("ONCE"); node.Repetition != nil {
+		t.Error("an item with no OCCURS clause carries a repetition")
+	}
+
+	fixed := record.Find("FIXED").Repetition
+	if fixed == nil || fixed.Count != 3 || fixed.Min != 3 || fixed.Max != 3 {
+		t.Fatalf("the fixed table's repetition is %+v, want three occurrences with no bounds to check", fixed)
+	}
+	if fixed.Reference() {
+		t.Error("the fixed table's count is a reference")
+	}
+
+	varying := record.Find("VARYING").Repetition
+	if varying == nil || varying.Min != 1 || varying.Max != 6 {
+		t.Fatalf("the varying table's bounds are %+v, want 1 to 6", varying)
+	}
+	if !varying.Reference() || varying.DependingOn.Name != "N" {
+		t.Fatal("the varying table's count is not read from N")
+	}
+	// The layout is computed at the declared maximum, which is the storage a
+	// compiler reserves for the table.
+	if varying.Count != 6 {
+		t.Errorf("the varying table was laid out at %d occurrences, want the declared maximum of 6", varying.Count)
+	}
+}
+
+func TestRecordPositionReportsANodeItDoesNotHold(t *testing.T) {
+	t.Parallel()
+
+	record := resolveOne(t, "01 R.\n   05 A PIC X(4).\n")
+	if _, ok := record.Position(&Node{Kind: KindField}); ok {
+		t.Fatal("a node the record does not hold has a position in it")
+	}
+}

--- a/internal/resolve/slack_test.go
+++ b/internal/resolve/slack_test.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package resolve
+
+import (
+	"testing"
+
+	"github.com/Zaba505/cobol-go/copybook"
+)
+
+// Any byte of a record that no item occupies appears in the containment order as
+// a slack node, whatever left it uncovered. Which alignments a dialect honours
+// is `cobol-go`'s and the rest of the rule is #34's; what is held here is the
+// part the position sum cannot do without, which is that the members of a group
+// add up to its extent exactly.
+
+// TestAlignmentReachesTheRecordAsBytes is the sum being literally true with
+// SYNCHRONIZED present: the bytes an aligned item is pushed forward by are in
+// the member list, so a generator has nothing left to align.
+func TestAlignmentReachesTheRecordAsBytes(t *testing.T) {
+	t.Parallel()
+
+	record := resolveOne(t, `01 R.
+   05 A PIC X.
+   05 B PIC S9(9) COMP SYNCHRONIZED.
+   05 C PIC X(3).
+`)
+
+	if got := positionOf(t, record, "B"); got != 4 {
+		t.Fatalf("the aligned item is at %d, want 4", got)
+	}
+	if got := slackWidths(record.Root); len(got) != 1 || got[0] != 3 {
+		t.Fatalf("the record's slack is %v, want one run of 3", got)
+	}
+	if got := positionOf(t, record, "C"); got != 8 {
+		t.Errorf("the item behind it is at %d, want 8", got)
+	}
+	if got := record.Extent(); got != 11 {
+		t.Errorf("the record is %d bytes, want 11", got)
+	}
+}
+
+// TestTwoRunsOfDifferentOriginThatAbutAreOneNode: how a producer divides a run
+// of three into nodes would otherwise decide the shape of every record a
+// generator emits, because a record carries one run of bytes per slack node.
+func TestTwoRunsOfDifferentOriginThatAbutAreOneNode(t *testing.T) {
+	t.Parallel()
+
+	records := resolveAll(t, `01 R.
+   05 A PIC X(3).
+   05 B REDEFINES A PIC X.
+   05 C PIC S9(9) COMP SYNCHRONIZED.
+`)
+	if len(records) != 2 {
+		t.Fatalf("resolved to %d records, want 2", len(records))
+	}
+
+	// The first alternative fills its three bytes and meets only the byte
+	// the alignment skipped.
+	if got := slackWidths(records[0].Root); len(got) != 1 || got[0] != 1 {
+		t.Fatalf("the first alternative's slack is %v, want one run of 1", got)
+	}
+
+	// The second leaves two bytes of the redefined item's storage, and the
+	// alignment leaves the byte after them. They abut, so they are one node.
+	if got := slackWidths(records[1].Root); len(got) != 1 || got[0] != 3 {
+		t.Fatalf("the second alternative's slack is %v, want one run of 3", got)
+	}
+	if got := positionOf(t, records[1], "C"); got != 4 {
+		t.Errorf("the aligned item is at %d, want 4", got)
+	}
+}
+
+// TestARepeatingItemPaddedToItsStrideCarriesThePaddingInsideItself is the one
+// place an elementary item has nowhere to put a slack node, so it becomes a
+// group that repeats and the padding is a member of it.
+//
+// It takes a dialect whose binary widths are not powers of two to reach at all:
+// a three-byte item on a four-byte boundary is one byte short of its own stride,
+// and every occurrence after the first would start a byte early without it.
+func TestARepeatingItemPaddedToItsStrideCarriesThePaddingInsideItself(t *testing.T) {
+	t.Parallel()
+
+	dialect := copybook.IBMEnterprise()
+	dialect.Binary = copybook.BinarySizeSmallest
+
+	field := recordOf(t, `01 R.
+   05 T PIC S9(5) COMP SYNCHRONIZED OCCURS 3 TIMES.
+   05 Z PIC X(2).
+`)
+	records, err := Resolve(field, Options{Dialect: dialect})
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+	record := records[0]
+
+	table := record.Find("T")
+	if table.Repetition != nil {
+		t.Error("the item carries the repetition as well as the group padding it")
+	}
+	if got := table.Width(); got != 3 {
+		t.Errorf("the item is %d bytes, want the storage width of 3", got)
+	}
+
+	holder := record.Root.Members[0]
+	if holder.Kind != KindGroup {
+		t.Fatalf("the padded item is held by a %s, want a group", holder.Kind)
+	}
+	if holder.Repetition == nil || holder.Repetition.Count != 3 {
+		t.Fatal("the group holding it does not repeat three times")
+	}
+	if got := holder.Width(); got != 4 {
+		t.Errorf("one occurrence is %d bytes, want the stride of 4", got)
+	}
+	if got := positionOf(t, record, "Z"); got != 12 {
+		t.Errorf("the item behind the table is at %d, want 12", got)
+	}
+}
+
+// TestARepeatingGroupPaddedToItsStrideCarriesThePaddingAmongItsMembers is the
+// same padding one level up, where the group already holds members and the
+// padding is simply the last of them.
+func TestARepeatingGroupPaddedToItsStrideCarriesThePaddingAmongItsMembers(t *testing.T) {
+	t.Parallel()
+
+	record := resolveOne(t, `01 R.
+   05 T OCCURS 3 TIMES.
+      10 A PIC S9(9) COMP SYNCHRONIZED.
+      10 B PIC X.
+   05 Z PIC X(2).
+`)
+
+	table := record.Find("T")
+	if got := table.Width(); got != 8 {
+		t.Fatalf("one occurrence is %d bytes, want the stride of 8", got)
+	}
+	if got := slackWidths(table); len(got) != 1 || got[0] != 3 {
+		t.Fatalf("the occurrence's slack is %v, want one run of 3", got)
+	}
+	if got := positionOf(t, record, "Z"); got != 24 {
+		t.Errorf("the item behind the table is at %d, want 24", got)
+	}
+}

--- a/internal/resolve/variant_test.go
+++ b/internal/resolve/variant_test.go
@@ -1,0 +1,519 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package resolve
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cobol-go/copybook"
+
+	"github.com/Zaba505/cpybkc/internal/layoutmodel"
+)
+
+// A REDEFINES inside a repeating group is chosen once per *occurrence*, and
+// there is no record per occurrence for it to become. So it resolves to a
+// variant, and every rule below is there to keep that variant a constant term of
+// the position sum — which is what lets the rest of docs/ir/SPEC.md not move for
+// it.
+
+// tableSource is one repeating group holding a redefine and a field behind it,
+// which is the smallest copybook the whole of this file is about.
+const tableSource = `01 R.
+   05 HDR PIC X(3).
+   05 ENTRY OCCURS 4 TIMES.
+      10 CODE PIC X.
+      10 BODY PIC X(8).
+      10 SPLIT REDEFINES BODY.
+         15 LEFT PIC X(4).
+         15 RIGHT PIC X(4).
+      10 TAG PIC X(2).
+   05 TRAILER PIC X(5).
+`
+
+// resolveTable resolves a copybook with the redefines the caller builds over
+// its own copybook field, which is the two-step a layout takes: the item
+// reference is resolved against the copybook, then the copybook is resolved.
+func resolveTable(t *testing.T, src string, build func(*copybook.Field) []Redefine) ([]*Record, error) {
+	t.Helper()
+
+	field := recordOf(t, src)
+	return Resolve(field, Options{
+		Copybook:  "test.cpy",
+		Dialect:   copybook.IBMEnterprise(),
+		Redefines: build(field),
+	})
+}
+
+// TestARedefineInsideATableBecomesAVariant is the resolution: one node, two
+// arms, each naming what selects it and the item that is its body.
+func TestARedefineInsideATableBecomesAVariant(t *testing.T) {
+	t.Parallel()
+
+	records, err := resolveTable(t, tableSource, func(field *copybook.Field) []Redefine {
+		return []Redefine{{
+			Item: fieldNamed(t, field, "BODY"),
+			Alternatives: []Alternative{
+				{Name: "BODY", Predicate: selects("B")},
+				{Name: "SPLIT", Predicate: selects("S")},
+			},
+		}}
+	})
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("resolved to %d records, want 1: a variant is not two record types", len(records))
+	}
+
+	record := records[0]
+	variant := variantIn(record.Root)
+	if variant == nil {
+		t.Fatal("the record holds no variant")
+	}
+	if len(variant.Arms) != 2 {
+		t.Fatalf("the variant has %d arms, want 2", len(variant.Arms))
+	}
+	if variant.Arms[0].Alternative != "BODY" || variant.Arms[1].Alternative != "SPLIT" {
+		t.Fatalf("the arms are %s and %s, want BODY and SPLIT",
+			variant.Arms[0].Alternative, variant.Arms[1].Alternative)
+	}
+	for _, arm := range variant.Arms {
+		if !arm.Predicate.Predicate() {
+			t.Errorf("the arm %s is selected by nothing", arm.Alternative)
+		}
+		if got := arm.Body.Extent(); got != 8 {
+			t.Errorf("the arm %s covers %d bytes, want the variant's 8", arm.Alternative, got)
+		}
+	}
+}
+
+// TestAVariantCarriesNoWidthNoNamesAndNoRepetition holds the node to what
+// docs/ir/SPEC.md says it carries and nothing else: the width is the arms'
+// common extent, the alternation has no name in the copybook, and it repeats by
+// sitting inside the group that does.
+func TestAVariantCarriesNoWidthNoNamesAndNoRepetition(t *testing.T) {
+	t.Parallel()
+
+	records, err := resolveTable(t, tableSource, func(field *copybook.Field) []Redefine {
+		return []Redefine{{
+			Item: fieldNamed(t, field, "BODY"),
+			Alternatives: []Alternative{
+				{Name: "BODY", Predicate: selects("B")},
+				{Name: "SPLIT", Predicate: selects("S")},
+			},
+		}}
+	})
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+
+	variant := variantIn(records[0].Root)
+	if variant.width != 0 {
+		t.Errorf("the variant carries a width of %d", variant.width)
+	}
+	if variant.Field != nil {
+		t.Errorf("the variant carries the name %s", variant.Field.Name)
+	}
+	if variant.Repetition != nil {
+		t.Error("the variant carries a repetition of its own")
+	}
+	if got := variant.Width(); got != 8 {
+		t.Errorf("the variant's width is %d, want the arms' common extent of 8", got)
+	}
+}
+
+// TestAVariantSitsOnlyInsideAGroupThatRepeats is the placement rule read the
+// other way: the same copybook with the OCCURS taken off resolves to record
+// types and not to a variant, whatever the layout says about it.
+func TestAVariantSitsOnlyInsideAGroupThatRepeats(t *testing.T) {
+	t.Parallel()
+
+	src := strings.Replace(tableSource, "ENTRY OCCURS 4 TIMES.", "ENTRY.", 1)
+	records, err := resolveTable(t, src, func(field *copybook.Field) []Redefine {
+		return []Redefine{{
+			Item: fieldNamed(t, field, "BODY"),
+			Alternatives: []Alternative{
+				{Name: "BODY", Predicate: selects("B")},
+				{Name: "SPLIT", Predicate: selects("S")},
+			},
+		}}
+	})
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("resolved to %d records, want one per alternative", len(records))
+	}
+	for _, record := range records {
+		if variantIn(record.Root) != nil {
+			t.Error("a redefine outside a repeating group became a variant")
+		}
+	}
+}
+
+// TestAVariantIsAConstantTermOfThePositionSum is the requirement doing all the
+// work: with the variant in place every item behind it sits where it sat, and
+// every occurrence of the enclosing group is the width it was.
+//
+// It is asserted against the same copybook with the redefine deleted, so the
+// comparison is with a record that never had an alternation rather than with
+// numbers a test wrote down.
+func TestAVariantIsAConstantTermOfThePositionSum(t *testing.T) {
+	t.Parallel()
+
+	withVariant, err := resolveTable(t, tableSource, func(field *copybook.Field) []Redefine {
+		return []Redefine{{
+			Item: fieldNamed(t, field, "BODY"),
+			Alternatives: []Alternative{
+				{Name: "BODY", Predicate: selects("B")},
+				{Name: "SPLIT", Predicate: selects("S")},
+			},
+		}}
+	})
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+
+	plain := resolveOne(t, `01 R.
+   05 HDR PIC X(3).
+   05 ENTRY OCCURS 4 TIMES.
+      10 CODE PIC X.
+      10 BODY PIC X(8).
+      10 TAG PIC X(2).
+   05 TRAILER PIC X(5).
+`)
+
+	for _, name := range []string{"HDR", "ENTRY", "CODE", "TAG", "TRAILER"} {
+		got, want := positionOf(t, withVariant[0], name), positionOf(t, plain, name)
+		if got != want {
+			t.Errorf("%s is at %d with a variant and %d without one", name, got, want)
+		}
+	}
+
+	entry, plainEntry := withVariant[0].Find("ENTRY"), plain.Find("ENTRY")
+	if entry.Width() != plainEntry.Width() {
+		t.Errorf("an occurrence is %d bytes with a variant and %d without one",
+			entry.Width(), plainEntry.Width())
+	}
+	if withVariant[0].Extent() != plain.Extent() {
+		t.Errorf("the record is %d bytes with a variant and %d without one",
+			withVariant[0].Extent(), plain.Extent())
+	}
+}
+
+// TestAShorterArmCarriesTheSlackItsItemsDoNotOccupy is the record-level rule one
+// level down, and the slack sits inside the arm: a run stops at the edge of one,
+// so bytes at the end of an arm and bytes behind the variant are two nodes
+// however they meet.
+func TestAShorterArmCarriesTheSlackItsItemsDoNotOccupy(t *testing.T) {
+	t.Parallel()
+
+	src := `01 R.
+   05 ENTRY OCCURS 3 TIMES.
+      10 WIDE PIC X(10).
+      10 NARROW REDEFINES WIDE PIC X(4).
+      10 TAG PIC X(2).
+`
+	records, err := resolveTable(t, src, func(field *copybook.Field) []Redefine {
+		return []Redefine{{
+			Item: fieldNamed(t, field, "WIDE"),
+			Alternatives: []Alternative{
+				{Name: "WIDE", Predicate: selects("W")},
+				{Name: "NARROW", Predicate: selects("N")},
+			},
+		}}
+	})
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+
+	variant := variantIn(records[0].Root)
+	wide, narrow := variant.Arms[0], variant.Arms[1]
+
+	if got := slackWidths(wide.Body); len(got) != 0 {
+		t.Errorf("the arm that fills the extent carries slack of %v", got)
+	}
+	if got := slackWidths(narrow.Body); len(got) != 1 || got[0] != 6 {
+		t.Fatalf("the shorter arm's slack is %v, want one run of 6", got)
+	}
+	if narrow.Body.Kind != KindGroup {
+		t.Fatalf("the shorter arm's body is a %s, and an elementary item has nowhere to put slack", narrow.Body.Kind)
+	}
+	if narrow.Body.Field != nil {
+		t.Errorf("the group holding the shorter arm carries the name %s", narrow.Body.Field.Name)
+	}
+	if got := narrow.Body.Extent(); got != 10 {
+		t.Errorf("the shorter arm covers %d bytes, want the variant's 10", got)
+	}
+	if got := positionOf(t, records[0], "TAG"); got != 10 {
+		t.Errorf("the item behind the variant is at %d, want 10", got)
+	}
+}
+
+// TestARedefineTakingOneAlternativeEveryOccurrenceEmitsNoVariant is the overlay
+// an adopter wrote to read one item two ways: the layout names one alternative,
+// and it reaches the resolved record as that alternative's items.
+func TestARedefineTakingOneAlternativeEveryOccurrenceEmitsNoVariant(t *testing.T) {
+	t.Parallel()
+
+	records, err := resolveTable(t, tableSource, func(field *copybook.Field) []Redefine {
+		return []Redefine{{
+			Item:         fieldNamed(t, field, "BODY"),
+			Alternatives: []Alternative{{Name: "SPLIT"}},
+		}}
+	})
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+
+	record := records[0]
+	if variantIn(record.Root) != nil {
+		t.Fatal("a redefine every occurrence of which takes one alternative became a variant")
+	}
+	if record.Find("BODY") != nil {
+		t.Error("the alternative the layout did not name reached the record")
+	}
+	if got := positionOf(t, record, "LEFT"); got != 4 {
+		t.Errorf("LEFT is at %d, want 4", got)
+	}
+	if got := positionOf(t, record, "TAG"); got != 12 {
+		t.Errorf("TAG is at %d, want 12", got)
+	}
+}
+
+// TestAVariantIsRejectedWhenItsAlternativesCannotBeMadeToAgree is the diagnostic
+// docs/ir/SPEC.md asks for by name: an arm that needs more bytes than the item
+// it redefines, reported with the record, the repeating group, the redefined
+// item and the arm rather than as a generic width error.
+func TestAVariantIsRejectedWhenItsAlternativesCannotBeMadeToAgree(t *testing.T) {
+	t.Parallel()
+
+	src := `01 R.
+   05 ENTRY OCCURS 3 TIMES.
+      10 SHORT PIC X(4).
+      10 LONG REDEFINES SHORT PIC X(9).
+      10 TAG PIC X(2).
+`
+	field := recordOf(t, src)
+	_, err := Resolve(field, Options{
+		Copybook: "test.cpy",
+		// A lenient dialect is what lets an oversized redefinition
+		// reach this package at all; a strict one refuses it while the
+		// copybook is being laid out.
+		Dialect: lenient(),
+		Redefines: []Redefine{{
+			Item: fieldNamed(t, field, "SHORT"),
+			Alternatives: []Alternative{
+				{Name: "SHORT", Predicate: selects("S")},
+				{Name: "LONG", Predicate: selects("L")},
+			},
+		}},
+	})
+
+	var extent *ArmExtentError
+	if !errors.As(err, &extent) {
+		t.Fatalf("resolving reported %v, want an ArmExtentError", err)
+	}
+	for _, want := range []string{"R", "ENTRY", "SHORT", "LONG"} {
+		if !strings.Contains(extent.Error(), want) {
+			t.Errorf("the diagnostic does not name %s: %s", want, extent.Error())
+		}
+	}
+	if extent.Extent != 9 || extent.Want != 4 {
+		t.Errorf("the diagnostic says %d bytes against %d, want 9 against 4", extent.Extent, extent.Want)
+	}
+}
+
+// TestAVariantIsRejectedWhenAnArmsExtentMovesWithData is the other half of "how
+// many is a constant": an OCCURS DEPENDING ON inside an arm has no constant for
+// the arms to agree on.
+func TestAVariantIsRejectedWhenAnArmsExtentMovesWithData(t *testing.T) {
+	t.Parallel()
+
+	src := `01 R.
+   05 N PIC 9(2).
+   05 ENTRY OCCURS 3 TIMES.
+      10 FIXED PIC X(20).
+      10 VARYING REDEFINES FIXED.
+         15 CELL PIC X(4) OCCURS 1 TO 5 TIMES DEPENDING ON N.
+      10 TAG PIC X(2).
+`
+	_, err := resolveTable(t, src, func(field *copybook.Field) []Redefine {
+		return []Redefine{{
+			Item: fieldNamed(t, field, "FIXED"),
+			Alternatives: []Alternative{
+				{Name: "FIXED", Predicate: selects("F")},
+				{Name: "VARYING", Predicate: selects("V")},
+			},
+		}}
+	})
+
+	var counted *ArmVariableCountError
+	if !errors.As(err, &counted) {
+		t.Fatalf("resolving reported %v, want an ArmVariableCountError", err)
+	}
+	for _, want := range []string{"R", "ENTRY", "FIXED", "VARYING", "CELL", "N"} {
+		if !strings.Contains(counted.Error(), want) {
+			t.Errorf("the diagnostic does not name %s: %s", want, counted.Error())
+		}
+	}
+}
+
+// TestAnArmSelectedByNothingIsRejected is the rule that there is no default arm:
+// one selected by nothing would match every occurrence, which leaves it the only
+// arm, which is the single-alternative redefine and not a variant.
+func TestAnArmSelectedByNothingIsRejected(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveTable(t, tableSource, func(field *copybook.Field) []Redefine {
+		return []Redefine{{
+			Item: fieldNamed(t, field, "BODY"),
+			Alternatives: []Alternative{
+				{Name: "BODY", Predicate: selects("B")},
+				{Name: "SPLIT"},
+			},
+		}}
+	})
+
+	var predicate *ArmPredicateError
+	if !errors.As(err, &predicate) {
+		t.Fatalf("resolving reported %v, want an ArmPredicateError", err)
+	}
+	if predicate.Arm != "SPLIT" {
+		t.Errorf("the diagnostic names %s, want SPLIT", predicate.Arm)
+	}
+}
+
+// TestASingleRecordTypeStrategyIsNotAPredicate is the same rule reached the
+// other way: the one strategy that lowers into the *absence* of a predicate
+// cannot select an arm.
+func TestASingleRecordTypeStrategyIsNotAPredicate(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveTable(t, tableSource, func(field *copybook.Field) []Redefine {
+		return []Redefine{{
+			Item: fieldNamed(t, field, "BODY"),
+			Alternatives: []Alternative{
+				{Name: "BODY", Predicate: selects("B")},
+				{Name: "SPLIT", Predicate: layoutmodel.Strategy{Kind: layoutmodel.SingleRecordType}},
+			},
+		}}
+	})
+
+	var predicate *ArmPredicateError
+	if !errors.As(err, &predicate) {
+		t.Fatalf("resolving reported %v, want an ArmPredicateError", err)
+	}
+}
+
+// TestARedefineInsideATableTheLayoutSaysNothingAboutIsRejected refuses the
+// default. Reading the copybook's own first alternative would be a record read
+// as the wrong alternative in every entry of the table, with nothing in the file
+// to disagree with it.
+func TestARedefineInsideATableTheLayoutSaysNothingAboutIsRejected(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveTable(t, tableSource, func(*copybook.Field) []Redefine { return nil })
+
+	var undiscriminated *UndiscriminatedRedefineError
+	if !errors.As(err, &undiscriminated) {
+		t.Fatalf("resolving reported %v, want an UndiscriminatedRedefineError", err)
+	}
+	for _, want := range []string{"R", "ENTRY", "BODY", "SPLIT"} {
+		if !strings.Contains(undiscriminated.Error(), want) {
+			t.Errorf("the diagnostic does not name %s: %s", want, undiscriminated.Error())
+		}
+	}
+}
+
+// TestAnAlternativeTheCopybookDoesNotDeclareIsRejected, with the ones it does
+// declare in the message, because the list an adopter needs is the list of the
+// ones they could have meant.
+func TestAnAlternativeTheCopybookDoesNotDeclareIsRejected(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveTable(t, tableSource, func(field *copybook.Field) []Redefine {
+		return []Redefine{{
+			Item: fieldNamed(t, field, "BODY"),
+			Alternatives: []Alternative{
+				{Name: "BODY", Predicate: selects("B")},
+				{Name: "HALVES", Predicate: selects("H")},
+			},
+		}}
+	})
+
+	var unknown *UnknownAlternativeError
+	if !errors.As(err, &unknown) {
+		t.Fatalf("resolving reported %v, want an UnknownAlternativeError", err)
+	}
+	if !strings.Contains(unknown.Error(), "SPLIT") {
+		t.Errorf("the diagnostic does not list the alternatives that do exist: %s", unknown.Error())
+	}
+}
+
+// TestAVariantWithTooFewArmsIsRejected: two at least, because an alternation
+// over one thing is not one.
+func TestAVariantWithTooFewArmsIsRejected(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveTable(t, tableSource, func(field *copybook.Field) []Redefine {
+		return []Redefine{{Item: fieldNamed(t, field, "BODY")}}
+	})
+
+	var count *ArmCountError
+	if !errors.As(err, &count) {
+		t.Fatalf("resolving reported %v, want an ArmCountError", err)
+	}
+}
+
+// TestEveryFaultIsReported holds this package to the repository's rule that a
+// reader reports every fault it found rather than the first: a copybook and the
+// layout over it go wrong in the same way in several places at once.
+func TestEveryFaultIsReported(t *testing.T) {
+	t.Parallel()
+
+	src := `01 R.
+   05 ENTRY OCCURS 2 TIMES.
+      10 A PIC X(4).
+      10 B REDEFINES A PIC X(4).
+      10 C PIC X(6).
+      10 D REDEFINES C PIC X(6).
+`
+	_, err := resolveTable(t, src, func(*copybook.Field) []Redefine { return nil })
+
+	if got := len(strings.Split(strings.TrimSpace(err.Error()), "\n")); got != 2 {
+		t.Fatalf("resolving reported %d faults, want both: %v", got, err)
+	}
+}
+
+// lenient is a dialect that lets a redefinition be larger than what it
+// redefines, which is what a compiler configured to downgrade that diagnostic to
+// a warning does.
+func lenient() copybook.Dialect {
+	dialect := copybook.IBMEnterprise()
+	dialect.Redefines = copybook.RedefinesLenient
+	return dialect
+}
+
+// variantIn is the first variant node of a subtree, or nil.
+func variantIn(node *Node) *Node {
+	if node.Kind == KindVariant {
+		return node
+	}
+	for _, member := range node.Members {
+		if found := variantIn(member); found != nil {
+			return found
+		}
+	}
+	for _, arm := range node.Arms {
+		if found := variantIn(arm.Body); found != nil {
+			return found
+		}
+	}
+	return nil
+}

--- a/internal/resolve/variant_test.go
+++ b/internal/resolve/variant_test.go
@@ -456,9 +456,11 @@ func TestAnAlternativeTheCopybookDoesNotDeclareIsRejected(t *testing.T) {
 	}
 }
 
-// TestAVariantWithTooFewArmsIsRejected: two at least, because an alternation
-// over one thing is not one.
-func TestAVariantWithTooFewArmsIsRejected(t *testing.T) {
+// TestARedefineTheLayoutNamesNoAlternativeOfIsRejected, and the message says
+// what naming one and naming two would each have meant — naming one is the
+// overlay above and not a fault, so a diagnostic that said "a variant needs two"
+// would send an adopter to write a predicate they may not need.
+func TestARedefineTheLayoutNamesNoAlternativeOfIsRejected(t *testing.T) {
 	t.Parallel()
 
 	_, err := resolveTable(t, tableSource, func(field *copybook.Field) []Redefine {
@@ -468,6 +470,9 @@ func TestAVariantWithTooFewArmsIsRejected(t *testing.T) {
 	var count *ArmCountError
 	if !errors.As(err, &count) {
 		t.Fatalf("resolving reported %v, want an ArmCountError", err)
+	}
+	if !strings.Contains(count.Error(), "name one to say every occurrence takes it") {
+		t.Errorf("the diagnostic does not say that naming one alternative is allowed: %s", count.Error())
 	}
 }
 

--- a/internal/resolve/width_test.go
+++ b/internal/resolve/width_test.go
@@ -1,0 +1,308 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package resolve
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cobol-go/copybook"
+)
+
+// The widths below are read off `cobol-go`'s codec/SPEC.md, "Storage Widths",
+// through its Appendix A test vectors: every item Appendix A gives bytes for
+// appears here with the number of bytes it gives. Reading them from the vectors
+// rather than from the prose is deliberate — a width is right when the bytes a
+// reader has to consume are that many, and Appendix A is where those bytes are
+// written down. The conformance corpus (#66) takes the same vectors the other
+// way round, as data through a generated reader.
+
+// TestWidthsFollowTheStorageWidthVectors resolves one item per Appendix A row
+// and holds its width to the bytes the row gives it.
+func TestWidthsFollowTheStorageWidthVectors(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		picture string
+		vector  string
+		want    int
+	}{
+		// A.1 and A.2, zoned decimal. A separate sign is a byte of its
+		// own and an overpunched one is not, which is the whole of the
+		// difference between the last two rows.
+		{name: "signed zoned", picture: "PIC S9(5)", vector: "A.1 `F1 F2 F3 F4 C5`", want: 5},
+		{name: "unsigned zoned", picture: "PIC 9(5)", vector: "A.2 `F1 F2 F3 F4 F5`", want: 5},
+		{
+			name:    "zoned with a leading separate sign",
+			picture: "PIC S9(5) SIGN LEADING SEPARATE",
+			vector:  "A.2 `60 F1 F2 F3 F4 F5`",
+			want:    6,
+		},
+		{
+			name:    "zoned with a trailing separate sign",
+			picture: "PIC S9(5) SIGN TRAILING SEPARATE",
+			vector:  "A.2 `F1 F2 F3 F4 F5 4E`",
+			want:    6,
+		},
+		{
+			name:    "zoned with a leading overpunched sign",
+			picture: "PIC S9(5) SIGN LEADING",
+			vector:  "A.2 `D1 F2 F3 F4 F5`",
+			want:    5,
+		},
+
+		// A.4, packed decimal: one nibble per digit plus the sign
+		// nibble, rounded up to a byte. Scale is not stored, which is
+		// why S9(3)V99 is the same three bytes as S9(5).
+		{name: "packed five digits", picture: "PIC S9(5) COMP-3", vector: "A.4 `12 34 5C`", want: 3},
+		{name: "packed unsigned", picture: "PIC 9(5) COMP-3", vector: "A.4 `12 34 5F`", want: 3},
+		{name: "packed four digits", picture: "PIC S9(4) COMP-3", vector: "A.4 `01 23 4D`", want: 3},
+		{name: "packed with a scale", picture: "PIC S9(3)V99 COMP-3", vector: "A.4 `12 34 5D`", want: 3},
+
+		// A.5, binary: the width is a function of the *digit count* and
+		// not of the value, which is the staircase a generator must
+		// never rediscover.
+		{name: "binary four digits", picture: "PIC S9(4) COMP", vector: "A.5 `04 D2`", want: 2},
+		{name: "binary nine digits", picture: "PIC S9(9) COMP", vector: "A.5 `07 5B CD 15`", want: 4},
+		{name: "binary unsigned four digits", picture: "PIC 9(4) COMP", vector: "A.5 `FF FF`", want: 2},
+
+		// A.6, floating point: a width fixed by the usage, with no
+		// PICTURE to read it from.
+		{name: "single-precision float", picture: "COMP-1", vector: "A.6 `3F 80 00 00`", want: 4},
+		{name: "double-precision float", picture: "COMP-2", vector: "A.6 `3F F0 00 00 00 00 00 00`", want: 8},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			record := resolveOne(t, fmt.Sprintf("01 R.\n   05 A %s.\n", tc.picture))
+			if got := widthOf(t, record, "A"); got != tc.want {
+				t.Fatalf("%s resolved to %d bytes, want %d from %s", tc.picture, got, tc.want, tc.vector)
+			}
+		})
+	}
+}
+
+// TestBinaryWidthsFollowTheDigitStaircase walks the whole staircase rather than
+// the two rungs Appendix A happens to use, because the rung a digit count lands
+// on is exactly the knowledge docs/ir/SPEC.md forbids a generator to have.
+func TestBinaryWidthsFollowTheDigitStaircase(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		digits int
+		want   int
+	}{
+		{digits: 1, want: 2},
+		{digits: 4, want: 2},
+		{digits: 5, want: 4},
+		{digits: 9, want: 4},
+		{digits: 10, want: 8},
+		{digits: 18, want: 8},
+	} {
+		t.Run(fmt.Sprintf("%d digits", tc.digits), func(t *testing.T) {
+			t.Parallel()
+
+			record := resolveOne(t, fmt.Sprintf("01 R.\n   05 A PIC S9(%d) COMP.\n", tc.digits))
+			if got := widthOf(t, record, "A"); got != tc.want {
+				t.Fatalf("PIC S9(%d) COMP resolved to %d bytes, want %d", tc.digits, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTheMixedRecordSumsToItsVectorLength is Appendix A.7 end to end: four
+// items of four usages, the record they add up to, and where each one starts in
+// the bytes the vector gives.
+func TestTheMixedRecordSumsToItsVectorLength(t *testing.T) {
+	t.Parallel()
+
+	record := resolveOne(t, `01 TXN.
+   05 ID PIC X(4).
+   05 AMT PIC S9(5) COMP-3.
+   05 QTY PIC S9(4) COMP.
+   05 NAME PIC X(6).
+`)
+
+	// `C1 F1 F2 F3` `12 34 5D` `04 D2` `E6 C9 C4 C7 C5 E3`
+	for _, tc := range []struct {
+		name  string
+		at    int
+		width int
+	}{
+		{name: "ID", at: 0, width: 4},
+		{name: "AMT", at: 4, width: 3},
+		{name: "QTY", at: 7, width: 2},
+		{name: "NAME", at: 9, width: 6},
+	} {
+		if got := positionOf(t, record, tc.name); got != tc.at {
+			t.Errorf("%s is at %d, want %d", tc.name, got, tc.at)
+		}
+		if got := widthOf(t, record, tc.name); got != tc.width {
+			t.Errorf("%s is %d bytes, want %d", tc.name, got, tc.width)
+		}
+	}
+
+	if got := record.Extent(); got != 15 {
+		t.Fatalf("the record is %d bytes, want the vector's 15", got)
+	}
+}
+
+// TestWidthOnlyItemsKeepTheFieldsBehindThemInPlace is the requirement that an
+// item carrying no logical value a generator can use still carries a width.
+//
+// Numeric-edited, INDEX and POINTER are the three of the four this repository's
+// dependency models; a `NATIONAL` item is not something `cobol-go`'s copybook
+// reader has a usage for, so there is no width for it to get wrong and nothing
+// here can assert one. The property being held is the same for all of them: the
+// item is a term of the sum whether or not anything can be decoded out of it.
+func TestWidthOnlyItemsKeepTheFieldsBehindThemInPlace(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		picture string
+		want    int
+	}{
+		{name: "numeric-edited", picture: "PIC ZZZ,ZZ9.99-", want: 11},
+		{name: "alphanumeric-edited", picture: "PIC XXBXXBXX", want: 8},
+		{name: "index", picture: "USAGE INDEX", want: 4},
+		{name: "pointer", picture: "USAGE POINTER", want: 4},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			record := resolveOne(t, fmt.Sprintf(`01 R.
+   05 BEFORE PIC X(3).
+   05 OPAQUE %s.
+   05 AFTER PIC X(5).
+`, tc.picture))
+
+			if got := widthOf(t, record, "OPAQUE"); got != tc.want {
+				t.Fatalf("%s resolved to %d bytes, want %d", tc.picture, got, tc.want)
+			}
+			if got := positionOf(t, record, "AFTER"); got != 3+tc.want {
+				t.Fatalf("the field behind it is at %d, want %d", got, 3+tc.want)
+			}
+			if got := record.Extent(); got != 3+tc.want+5 {
+				t.Fatalf("the record is %d bytes, want %d", got, 3+tc.want+5)
+			}
+		})
+	}
+}
+
+// TestPositionsAgreeWithTheOffsetsTheCopybookWasLaidOutAt is the cross-check
+// that matters most, and it is a cross-check rather than a restatement: the
+// resolved record carries no offset at all, so the left-hand side is the sum
+// over widths and ordering that docs/ir/SPEC.md makes a consumer run, and the
+// right-hand side is the offset `cobol-go` computed while walking the copybook.
+// The two arrive by different routes and have to meet.
+func TestPositionsAgreeWithTheOffsetsTheCopybookWasLaidOutAt(t *testing.T) {
+	t.Parallel()
+
+	for _, src := range []string{
+		`01 FLAT.
+   05 A PIC X(3).
+   05 B PIC S9(7)V99 COMP-3.
+   05 C PIC S9(9) COMP.
+   05 D PIC 9(4).
+`,
+		`01 NESTED.
+   05 HDR.
+      10 KIND PIC X.
+      10 SEQ PIC 9(6).
+   05 BODY.
+      10 LINE OCCURS 4 TIMES.
+         15 SKU PIC X(8).
+         15 QTY PIC S9(4) COMP.
+      10 TOTAL PIC S9(9)V99 COMP-3.
+   05 TRAILER PIC X(2).
+`,
+		`01 DEEP.
+   05 A OCCURS 3 TIMES.
+      10 B OCCURS 2 TIMES.
+         15 C PIC X(5).
+         15 D PIC 9(3).
+      10 E PIC X.
+   05 F PIC X(9).
+`,
+	} {
+		t.Run(strings.Fields(src)[1], func(t *testing.T) {
+			t.Parallel()
+
+			field := recordOf(t, src)
+			layout, err := copybook.NewLayout(field, copybook.IBMEnterprise())
+			if err != nil {
+				t.Fatalf("laying the copybook out: %v", err)
+			}
+
+			records, err := Resolve(field, Options{Dialect: copybook.IBMEnterprise()})
+			if err != nil {
+				t.Fatalf("resolving: %v", err)
+			}
+			if len(records) != 1 {
+				t.Fatalf("resolved to %d records, want 1", len(records))
+			}
+			record := records[0]
+
+			for _, item := range layout.Items() {
+				if item.Field.Filler || item == layout.Record {
+					continue
+				}
+				node := record.Find(item.Field.Name)
+				if node == nil {
+					t.Fatalf("the resolved record holds no %s", item.Field.Name)
+				}
+				at, ok := record.Position(node)
+				if !ok {
+					t.Fatalf("%s has no position in the record it came from", item.Field.Name)
+				}
+				if at != item.Offset {
+					t.Errorf("%s summed to %d, laid out at %d", item.Field.Name, at, item.Offset)
+				}
+				if got := node.Extent(); got != item.Total() {
+					t.Errorf("%s covers %d bytes, laid out over %d", item.Field.Name, got, item.Total())
+				}
+			}
+
+			if got := record.Extent(); got != layout.Length {
+				t.Fatalf("the record summed to %d, laid out at %d", got, layout.Length)
+			}
+		})
+	}
+}
+
+// TestEveryByteOfARecordIsCoveredOnce is the premise the position sum rests on,
+// asserted rather than assumed: no two members of a group overlap, and no byte
+// of the record is left out of the containment order.
+func TestEveryByteOfARecordIsCoveredOnce(t *testing.T) {
+	t.Parallel()
+
+	record := resolveOne(t, `01 R.
+   05 A PIC X(3).
+   05 G OCCURS 2 TIMES.
+      10 B PIC S9(4) COMP.
+      10 C PIC X.
+   05 D PIC X(4).
+`)
+
+	var check func(*Node)
+	check = func(node *Node) {
+		if node.Kind != KindGroup {
+			return
+		}
+		sum := 0
+		for _, member := range node.Members {
+			sum += member.Extent()
+			check(member)
+		}
+		if sum != node.Width() {
+			t.Errorf("a group's members cover %d bytes of its %d", sum, node.Width())
+		}
+	}
+	check(record.Root)
+}


### PR DESCRIPTION
Closes #32

Adds `internal/resolve`, the stage that turns a copybook record into the shape
`docs/ir/SPEC.md` describes: an ordered containment of groups, fields, variants
and slack, every elementary item carrying the byte width `cobol-go`'s
`codec/SPEC.md` gives it. `cobol-go` joins the module for the first time here —
`picture` for the attributes a PICTURE fixes, `copybook` for the storage layout —
pinned to a commit because it carries no tag yet.

## Acceptance criteria

- [x] **Every elementary field resolved to a width and a position within its record.** `Node.Width` for a field, `Record.Position` for the position. `TestPositionsAgreeWithTheOffsetsTheCopybookWasLaidOutAt` runs the sum over three copybooks and checks every item against the offset `cobol-go` computed by a different route.
- [x] **Widths follow `codec/SPEC.md` Storage Widths, including binary widths by digit count.** Delegated to `cobol-go` rather than re-derived. `TestBinaryWidthsFollowTheDigitStaircase` walks the whole 2/4/8 staircase.
- [x] **Group items, `OCCURS`, and nested structures handled.** `TestRecordPositionCountsOneOccurrenceOfEveryEnclosingTable`, the `NESTED` and `DEEP` cases above, and `TestEveryByteOfARecordIsCoveredOnce`.
- [x] **Numeric-edited, national, `INDEX` and `POINTER` resolved to width only.** `TestWidthOnlyItemsKeepTheFieldsBehindThemInPlace` covers numeric-edited, alphanumeric-edited, `INDEX` and `POINTER`, asserting the field *behind* each one is where it should be. `NATIONAL` is not a usage `cobol-go`'s copybook reader models at the pinned commit, so there is no width for this stage to get wrong and nothing to assert; the test says so.
- [x] **What reaches the IR matches #16 on carrying offsets.** No node carries one. `Node.Width` is a method, and `TestNodeWidthIsNotCarriedForAGroupOrAVariant` shows a group's answer moving when its member list does.
- [x] **A redefine resolved into record nodes where the redefined item is not in a repeating group, and into a variant where it is (#90).** `TestARedefineOutsideATableBecomesOneRecordPerAlternative`, `TestARedefineInsideATableBecomesAVariant`, `TestAVariantSitsOnlyInsideAGroupThatRepeats` — the same copybook with the `OCCURS` taken off resolves to record types.
- [x] **A variant only inside a repeating group, two arms at least, a predicate on every one; a redefine taking one alternative resolved to it with no variant.** `TestAnArmSelectedByNothingIsRejected`, `TestASingleRecordTypeStrategyIsNotAPredicate`, `TestAVariantWithTooFewArmsIsRejected`, `TestARedefineTakingOneAlternativeEveryOccurrenceEmitsNoVariant`.
- [x] **Every arm the same extent, each carrying the slack its own items do not occupy (#90, #34).** `TestAShorterArmCarriesTheSlackItsItemsDoNotOccupy`.
- [x] **A variant carrying no width, no names and no repetition (#90).** `TestAVariantCarriesNoWidthNoNamesAndNoRepetition`.
- [x] **A layout whose alternatives cannot agree rejected, naming the record, the repeating group, the redefined item and the arm.** `ArmExtentError` and `ArmVariableCountError`, each asserted to name all four.
- [x] **Positions computed with a variant as a constant term.** `TestAVariantIsAConstantTermOfThePositionSum` compares against the same copybook with the redefine deleted, so the baseline is a record that never had an alternation.
- [x] **Unit tests against the vectors in `codec/SPEC.md` Appendix A.** `width_test.go` — one item per row of A.1, A.2, A.4, A.5 and A.6, plus A.7's mixed record end to end at its 15 bytes.

## Judgment calls

**Which alternatives a variant has arrives as input, not inferred.** `Options.Redefines` carries a `*copybook.Field` and the alternatives a layout named. The one thing a layout says about a redefine is which alternative to read, and resolving a `discriminate-variant`'s item reference against a copybook is the binding half of that; keeping it out means this package needs nothing from `internal/layout`. An arm carries the `layoutmodel.Strategy` a layout wrote rather than a compiled predicate, because lowering one is #37's.

**A record-level redefine enumerates.** Two independent choices in one record are four records. The spec accepts the duplication in as many words and declines to soften it; which of them a layout's `record` forms then select is #37's and #38's.

**An arm longer than the item it redefines is the rejection.** A shorter arm can be padded with slack, so it never "differs"; a longer one cannot, because the storage an occurrence has is what the copybook gave the redefined item. That is the standard's own rule, applied here even under a dialect lenient enough to let a redefinition grow the group holding it — a table cannot grow one entry without moving every entry after it. It is what makes `ArmExtentError` reachable at all.

**A redefine inside a repeating group that the layout says nothing about is rejected.** Falling back to the copybook's first alternative would be a default, and a default here reads every entry of the table as the wrong alternative with nothing in the file to disagree.

**Two synthetic group nodes, both carrying no names.** An arm shorter than the variant's extent needs its slack *inside* the arm, and an elementary alternative has nowhere to put one, so it is wrapped in a group; the alternative's name is on the node inside it. The same shape holds a repeating elementary item whose stride exceeds its width. Both are what the IR would need anyway, since alignment reaches a generator as bytes it already has.

**Slack is emitted for every uncovered byte, wherever the gap came from.** The redefine resolution needs it and #34 owns the rest of the rule, but a group's members have to sum to its extent for the position sum to mean anything, so the gap fill is uniform and abutting runs merge into one node.

## Verification

`dagger call ci` — green (fmt, vet, golangci-lint and `go test -race` over both modules). The first two attempts failed with `missing shared result`, a stale Dagger engine session rather than anything in the tree; restarting the engine container cleared it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)