### PR TITLE
story(resolve): apply the encoding profile to every field descriptor

### DIFF
--- a/internal/resolve/doc.go
+++ b/internal/resolve/doc.go
@@ -56,11 +56,35 @@
 // wrote to read one item two ways: every occurrence takes it, and no variant is
 // emitted at all.
 //
+// # The encoding is per field, and no default survives
+//
+// `codec` takes four encoding axes from its caller and defaults none of them,
+// because every one fails silently when wrong. docs/ir/SPEC.md's "The encoding
+// profile, applied" meets that requirement on the generator's behalf by putting
+// all four on every field node and carrying no profile node for one to inherit
+// from, and this package is where the pair a layout writes — one profile, and
+// per-item overrides over it — becomes that (#33).
+//
+// So [Options.Encoding] is required and complete, an [EncodingOverride] applies
+// over the encoding in effect where its item sits, and [Node.Encoding] on a
+// field is the result. A record whose fields disagree about charset needs
+// nothing special for it: the axes are per field, so the mixed file is the
+// ordinary case here rather than an exception. Which axis actually governs a
+// given field's bytes — charset does not touch packed decimal — is
+// `codec/SPEC.md`'s question and is not asked here.
+//
+// The rest of what docs/ir/SPEC.md puts on a field node beside the axes — its
+// USAGE, and the attributes that follow from its PICTURE — is not computed here
+// and is not copied here. `cobol-go` has already inherited the USAGE down the
+// entry tree and parsed the PICTURE, both onto the
+// [github.com/Zaba505/cobol-go/copybook.Field] every field node carries, and a
+// copy on the node would be a second answer to a question the copybook has
+// answered. Spelling them into the descriptor's own members is #38's.
+//
 // # What this package leaves to the stories after it
 //
-// The four encoding axes and a field's PICTURE attributes are #33's, compiling a
-// layout's discriminator strategies into predicate nodes is #37's, a count read
-// out of a record is #35's, and assembling nodes into a
+// Compiling a layout's discriminator strategies into predicate nodes is #37's, a
+// count read out of a record is #35's, and assembling nodes into a
 // [github.com/Zaba505/cpybkc/irpb.Descriptor] with identifiers on them is #38's.
 // A [Repetition] here therefore carries the count the layout was computed at
 // beside the item a DEPENDING ON phrase names, and an [Arm] carries the

--- a/internal/resolve/encoding_test.go
+++ b/internal/resolve/encoding_test.go
@@ -1,0 +1,618 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package resolve
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cobol-go/copybook"
+
+	"github.com/Zaba505/cpybkc/internal/layoutmodel"
+)
+
+// converted is the other profile every test here reads: a file a mainframe
+// wrote and a conversion turned into ASCII.
+//
+// It is not "the ASCII settings" — it is deliberately the combination
+// docs/layout/SPEC.md says no compiler produces and real files hit most often,
+// with ASCII characters, translated-EBCDIC signs and big-endian binary. A test
+// pairing a mainframe profile with an all-native one would pass just as well
+// against an implementation that treated the four axes as a single dialect flag,
+// which is the thing they exist not to be.
+func converted() layoutmodel.Axes {
+	return layoutmodel.Axes{
+		Charset:        layoutmodel.ASCII,
+		SignConvention: layoutmodel.SignTranslatedEBCDIC,
+		ByteOrder:      layoutmodel.BigEndian,
+		FloatFormat:    layoutmodel.IEEE754,
+	}
+}
+
+// resolveUnder resolves a copybook source under a profile and the overrides the
+// caller builds over its own copybook fields, which is the two-step a layout
+// takes: each item reference is resolved against the copybook, then the copybook
+// is resolved.
+func resolveUnder(
+	t *testing.T,
+	src string,
+	profile layoutmodel.Axes,
+	build func(*copybook.Field) []EncodingOverride,
+) *Record {
+	t.Helper()
+
+	field := recordOf(t, src)
+
+	var overrides []EncodingOverride
+	if build != nil {
+		overrides = build(field)
+	}
+
+	records, err := Resolve(field, Options{
+		Copybook:          "test.cpy",
+		Dialect:           copybook.IBMEnterprise(),
+		Encoding:          profile,
+		EncodingOverrides: overrides,
+	})
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("resolved to %d records, want 1", len(records))
+	}
+	return records[0]
+}
+
+// encodingOf is the resolved encoding of the field named name.
+func encodingOf(t *testing.T, record *Record, name string) layoutmodel.Axes {
+	t.Helper()
+
+	node := record.Find(name)
+	if node == nil {
+		t.Fatalf("the resolved record holds no %s", name)
+	}
+	if node.Kind != KindField {
+		t.Fatalf("%s resolved to a %s, want a field", name, node.Kind)
+	}
+	return node.Encoding
+}
+
+// mixedSource is one record whose fields do not agree about their encoding: the
+// ordinary shape of a converted file, where the text was translated and the
+// packed and binary fields were copied through untouched.
+const mixedSource = `01 CUSTOMER.
+   05 CUST-ID PIC X(6).
+   05 CUST-NAME PIC X(20).
+   05 CUST-BALANCE PIC S9(7)V99 COMP-3.
+   05 CUST-COUNT PIC S9(4) COMP.
+`
+
+// TestEveryFieldCarriesAllFourAxes is docs/ir/SPEC.md's "The encoding profile,
+// applied" as this package meets it: all four, on every field, with none left
+// for a generator to default.
+func TestEveryFieldCarriesAllFourAxes(t *testing.T) {
+	t.Parallel()
+
+	record := resolveUnder(t, mixedSource, mainframe(), nil)
+
+	seen := 0
+	record.Walk(func(node *Node) {
+		if node.Kind != KindField {
+			return
+		}
+		seen++
+
+		if missing := node.Encoding.Missing(); len(missing) > 0 {
+			t.Errorf("%s states no %v", itemName(node.Field), missing)
+		}
+		if node.Encoding != mainframe() {
+			t.Errorf("%s carries %+v, want the profile %+v", itemName(node.Field), node.Encoding, mainframe())
+		}
+	})
+
+	if seen != 4 {
+		t.Fatalf("walked %d fields, want the copybook's 4", seen)
+	}
+}
+
+// TestAFieldCarriesTheUsageTheCopybookGaveIt is the other half of what a
+// generator needs to read a field's bytes. It is not restated on the node: the
+// copybook has already inherited it down the entry tree, and a second copy here
+// would be a second answer to it.
+func TestAFieldCarriesTheUsageTheCopybookGaveIt(t *testing.T) {
+	t.Parallel()
+
+	record := resolveUnder(t, `01 R.
+   05 TEXT PIC X(4).
+   05 PACKED PIC S9(5) COMP-3.
+   05 G COMP.
+      10 INHERITED PIC S9(4).
+`, mainframe(), nil)
+
+	for _, tc := range []struct {
+		name string
+		want copybook.Usage
+	}{
+		{name: "TEXT", want: copybook.UsageDisplay},
+		{name: "PACKED", want: copybook.UsageComp3},
+		// The item states no USAGE of its own; the group above it does.
+		{name: "INHERITED", want: copybook.UsageComp},
+	} {
+		if got := record.Find(tc.name).Field.Usage; got != tc.want {
+			t.Errorf("%s is USAGE %s, want %s", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestNoNodeButAFieldCarriesAnEncoding holds the IR's refusal to carry a profile
+// for anything to inherit from: a group carrying a copy of the axes would be
+// that profile under another name.
+func TestNoNodeButAFieldCarriesAnEncoding(t *testing.T) {
+	t.Parallel()
+
+	// A dialect whose binary widths are not powers of two is what puts a
+	// repeating elementary item inside a group this package introduced, which
+	// is the one wrapper a field node sits in.
+	dialect := copybook.IBMEnterprise()
+	dialect.Binary = copybook.BinarySizeSmallest
+
+	field := recordOf(t, `01 R.
+   05 T PIC S9(5) COMP SYNCHRONIZED OCCURS 3 TIMES.
+   05 Z PIC X(2).
+`)
+	records, err := Resolve(field, Options{
+		Copybook: "test.cpy",
+		Dialect:  dialect,
+		Encoding: mainframe(),
+		EncodingOverrides: []EncodingOverride{
+			{Item: fieldNamed(t, field, "T"), Axes: layoutmodel.Axes{Charset: layoutmodel.ASCII}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+	record := records[0]
+
+	kinds := 0
+	record.Walk(func(node *Node) {
+		if node.Kind == KindField {
+			return
+		}
+		kinds++
+
+		if node.Encoding != (layoutmodel.Axes{}) {
+			t.Errorf("a %s node carries the encoding %+v", node.Kind, node.Encoding)
+		}
+	})
+
+	// The record's top level, the group holding the padded item, and the
+	// padding itself.
+	if kinds != 3 {
+		t.Fatalf("walked %d nodes that are not fields, want 3", kinds)
+	}
+
+	if got := record.Find("T").Encoding.Charset; got != layoutmodel.ASCII {
+		t.Errorf("the padded item's charset is %q, want the override's ascii", got)
+	}
+}
+
+// TestAnOverrideRestatesTheAxesItNamesAndLeavesTheRest is
+// docs/layout/SPEC.md's "An override naming one axis leaves the other three as
+// the profile states them; one naming all four replaces the profile entirely for
+// that item".
+func TestAnOverrideRestatesTheAxesItNamesAndLeavesTheRest(t *testing.T) {
+	t.Parallel()
+
+	record := resolveUnder(t, `01 R.
+   05 ONE PIC X(4).
+   05 SOME PIC X(4).
+   05 ALL PIC X(4).
+`, mainframe(), func(field *copybook.Field) []EncodingOverride {
+		return []EncodingOverride{
+			{
+				Item: fieldNamed(t, field, "ONE"),
+				Axes: layoutmodel.Axes{Charset: layoutmodel.ASCII},
+			},
+			{
+				Item: fieldNamed(t, field, "SOME"),
+				Axes: layoutmodel.Axes{
+					SignConvention: layoutmodel.SignRealia,
+					ByteOrder:      layoutmodel.LittleEndian,
+				},
+			},
+			{
+				Item: fieldNamed(t, field, "ALL"),
+				Axes: converted(),
+			},
+		}
+	})
+
+	for _, tc := range []struct {
+		name string
+		want layoutmodel.Axes
+	}{
+		{
+			name: "ONE",
+			want: layoutmodel.Axes{
+				Charset:        layoutmodel.ASCII,
+				SignConvention: layoutmodel.SignEBCDIC,
+				ByteOrder:      layoutmodel.BigEndian,
+				FloatFormat:    layoutmodel.HFP,
+			},
+		},
+		{
+			name: "SOME",
+			want: layoutmodel.Axes{
+				Charset:        layoutmodel.CP037,
+				SignConvention: layoutmodel.SignRealia,
+				ByteOrder:      layoutmodel.LittleEndian,
+				FloatFormat:    layoutmodel.HFP,
+			},
+		},
+		{name: "ALL", want: converted()},
+	} {
+		if got := encodingOf(t, record, tc.name); got != tc.want {
+			t.Errorf("%s carries %+v, want %+v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestAnOverrideOnAGroupReachesEveryElementaryItemUnderIt, at every depth, and
+// leaves the items beside it alone.
+func TestAnOverrideOnAGroupReachesEveryElementaryItemUnderIt(t *testing.T) {
+	t.Parallel()
+
+	record := resolveUnder(t, `01 R.
+   05 OUTSIDE PIC X(4).
+   05 G.
+      10 SHALLOW PIC X(4).
+      10 INNER.
+         15 DEEP PIC X(4).
+`, mainframe(), func(field *copybook.Field) []EncodingOverride {
+		return []EncodingOverride{{
+			Item: fieldNamed(t, field, "G"),
+			Axes: layoutmodel.Axes{Charset: layoutmodel.ASCII},
+		}}
+	})
+
+	for _, name := range []string{"SHALLOW", "DEEP"} {
+		if got := encodingOf(t, record, name).Charset; got != layoutmodel.ASCII {
+			t.Errorf("%s under the overridden group carries the charset %q, want ascii", name, got)
+		}
+	}
+	if got := encodingOf(t, record, "OUTSIDE").Charset; got != layoutmodel.CP037 {
+		t.Errorf("the item beside the overridden group carries the charset %q, want the profile's cp037", got)
+	}
+}
+
+// TestAnOverrideOnARepeatingItemReachesEveryOccurrence — which it does by
+// reaching the item, because an encoding is a property of an item's bytes
+// wherever they sit and a node states it once for every occurrence.
+func TestAnOverrideOnARepeatingItemReachesEveryOccurrence(t *testing.T) {
+	t.Parallel()
+
+	record := resolveUnder(t, `01 R.
+   05 T OCCURS 4 TIMES.
+      10 K PIC X(2).
+      10 V PIC X(3).
+`, mainframe(), func(field *copybook.Field) []EncodingOverride {
+		return []EncodingOverride{{
+			Item: fieldNamed(t, field, "T"),
+			Axes: layoutmodel.Axes{Charset: layoutmodel.ASCII},
+		}}
+	})
+
+	table := record.Find("T")
+	if table.Repetition == nil || table.Repetition.Count != 4 {
+		t.Fatal("the overridden item does not repeat four times")
+	}
+
+	for _, name := range []string{"K", "V"} {
+		if got := encodingOf(t, record, name).Charset; got != layoutmodel.ASCII {
+			t.Errorf("%s carries the charset %q, want the table's override of ascii", name, got)
+		}
+	}
+}
+
+// TestAnOverrideAppliesOverTheOneAboveItRatherThanOverTheProfile is the reading
+// this package settles, which docs/layout/SPEC.md leaves to it: an override
+// reaches every elementary item under the group it names, so an inner override
+// restates axes over what already governs the item. Under the other reading an
+// override naming one axis would silently undo an enclosing override of another.
+func TestAnOverrideAppliesOverTheOneAboveItRatherThanOverTheProfile(t *testing.T) {
+	t.Parallel()
+
+	record := resolveUnder(t, `01 R.
+   05 G.
+      10 PLAIN PIC X(4).
+      10 NESTED PIC S9(4) COMP.
+`, mainframe(), func(field *copybook.Field) []EncodingOverride {
+		return []EncodingOverride{
+			{
+				Item: fieldNamed(t, field, "G"),
+				Axes: layoutmodel.Axes{Charset: layoutmodel.ASCII},
+			},
+			{
+				Item: fieldNamed(t, field, "NESTED"),
+				Axes: layoutmodel.Axes{ByteOrder: layoutmodel.LittleEndian},
+			},
+		}
+	})
+
+	want := layoutmodel.Axes{
+		Charset:        layoutmodel.ASCII,
+		SignConvention: layoutmodel.SignEBCDIC,
+		ByteOrder:      layoutmodel.LittleEndian,
+		FloatFormat:    layoutmodel.HFP,
+	}
+	if got := encodingOf(t, record, "NESTED"); got != want {
+		t.Errorf("the inner override resolved to %+v, want %+v", got, want)
+	}
+	if got := encodingOf(t, record, "PLAIN").Charset; got != layoutmodel.ASCII {
+		t.Errorf("the sibling carries the charset %q, want the group's ascii", got)
+	}
+}
+
+// TestAMixedCharsetRecordNeedsNoSpecialTreatment is docs/ir/SPEC.md's "Two
+// things then follow without being separately specified": the axes are per
+// field, so a record whose fields disagree is the ordinary case rather than an
+// exception.
+func TestAMixedCharsetRecordNeedsNoSpecialTreatment(t *testing.T) {
+	t.Parallel()
+
+	record := resolveUnder(t, mixedSource, mainframe(), func(field *copybook.Field) []EncodingOverride {
+		// The text was translated on the way off the mainframe and the
+		// packed and binary fields were copied through byte for byte.
+		return []EncodingOverride{
+			{Item: fieldNamed(t, field, "CUST-ID"), Axes: layoutmodel.Axes{Charset: layoutmodel.ASCII}},
+			{Item: fieldNamed(t, field, "CUST-NAME"), Axes: layoutmodel.Axes{Charset: layoutmodel.ASCII}},
+		}
+	})
+
+	for _, tc := range []struct {
+		name string
+		want layoutmodel.Charset
+	}{
+		{name: "CUST-ID", want: layoutmodel.ASCII},
+		{name: "CUST-NAME", want: layoutmodel.ASCII},
+		{name: "CUST-BALANCE", want: layoutmodel.CP037},
+		{name: "CUST-COUNT", want: layoutmodel.CP037},
+	} {
+		if got := encodingOf(t, record, tc.name).Charset; got != tc.want {
+			t.Errorf("%s carries the charset %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestTheSameLayoutResolvesUnderASCIIAndUnderEBCDIC: the profile decides what
+// every field says about its bytes and decides nothing about where those bytes
+// are. Storage widths are the copybook's and the dialect's, so the two
+// resolutions differ in the axes and in nothing else.
+func TestTheSameLayoutResolvesUnderASCIIAndUnderEBCDIC(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		profile layoutmodel.Axes
+	}{
+		{name: "ebcdic", profile: mainframe()},
+		{name: "ascii", profile: converted()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			record := resolveUnder(t, mixedSource, tc.profile, nil)
+
+			for _, name := range []string{"CUST-ID", "CUST-NAME", "CUST-BALANCE", "CUST-COUNT"} {
+				if got := encodingOf(t, record, name); got != tc.profile {
+					t.Errorf("%s carries %+v, want the profile %+v", name, got, tc.profile)
+				}
+			}
+
+			// PIC X(6), PIC X(20), a nine-digit COMP-3, and a four-digit
+			// COMP under IBM Enterprise COBOL. None of them moves with the
+			// charset.
+			for _, want := range []struct {
+				name  string
+				width int
+				at    int
+			}{
+				{name: "CUST-ID", width: 6, at: 0},
+				{name: "CUST-NAME", width: 20, at: 6},
+				{name: "CUST-BALANCE", width: 5, at: 26},
+				{name: "CUST-COUNT", width: 2, at: 31},
+			} {
+				if got := widthOf(t, record, want.name); got != want.width {
+					t.Errorf("%s is %d bytes, want %d", want.name, got, want.width)
+				}
+				if got := positionOf(t, record, want.name); got != want.at {
+					t.Errorf("%s is at %d, want %d", want.name, got, want.at)
+				}
+			}
+		})
+	}
+}
+
+// TestAnOverrideReachesInsideAVariantsArms, because an arm's body is resolved
+// like anything else and an alternative is an item the layout can name.
+func TestAnOverrideReachesInsideAVariantsArms(t *testing.T) {
+	t.Parallel()
+
+	field := recordOf(t, tableSource)
+	records, err := Resolve(field, Options{
+		Copybook: "test.cpy",
+		Dialect:  copybook.IBMEnterprise(),
+		Encoding: mainframe(),
+		EncodingOverrides: []EncodingOverride{{
+			Item: fieldNamed(t, field, "SPLIT"),
+			Axes: layoutmodel.Axes{Charset: layoutmodel.ASCII},
+		}},
+		Redefines: []Redefine{{
+			Item: fieldNamed(t, field, "BODY"),
+			Alternatives: []Alternative{
+				{Name: "BODY", Predicate: selects("B")},
+				{Name: "SPLIT", Predicate: selects("S")},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+
+	record := records[0]
+	for _, name := range []string{"LEFT", "RIGHT"} {
+		if got := encodingOf(t, record, name).Charset; got != layoutmodel.ASCII {
+			t.Errorf("%s under the overridden arm carries the charset %q, want ascii", name, got)
+		}
+	}
+	if got := encodingOf(t, record, "BODY").Charset; got != layoutmodel.CP037 {
+		t.Errorf("the arm beside it carries the charset %q, want the profile's cp037", got)
+	}
+}
+
+// TestAnOverrideNamingAnItemOfAnotherRecordReachesNothing, so that a caller may
+// hand over the layout's whole list rather than filtering it per record.
+func TestAnOverrideNamingAnItemOfAnotherRecordReachesNothing(t *testing.T) {
+	t.Parallel()
+
+	elsewhere := recordOf(t, "01 OTHER.\n   05 A PIC X(4).\n")
+
+	record := resolveUnder(t, "01 R.\n   05 A PIC X(4).\n", mainframe(), func(*copybook.Field) []EncodingOverride {
+		return []EncodingOverride{{
+			Item: fieldNamed(t, elsewhere, "A"),
+			Axes: layoutmodel.Axes{Charset: layoutmodel.ASCII},
+		}}
+	})
+
+	// The two records name their items the same, which is what makes the match
+	// an identity rather than a name.
+	if got := encodingOf(t, record, "A").Charset; got != layoutmodel.CP037 {
+		t.Errorf("A carries the charset %q, want the profile's cp037", got)
+	}
+}
+
+// TestResolveRejectsAProfileWithAHoleInIt, naming every axis nobody stated:
+// there is no default for one, and completing it here would be the guess made
+// once and applied to every field of the record.
+func TestResolveRejectsAProfileWithAHoleInIt(t *testing.T) {
+	t.Parallel()
+
+	profile := mainframe()
+	profile.SignConvention = ""
+	profile.FloatFormat = ""
+
+	_, err := Resolve(recordOf(t, "01 R.\n   05 A PIC X(4).\n"), Options{
+		Copybook: "test.cpy",
+		Dialect:  copybook.IBMEnterprise(),
+		Encoding: profile,
+	})
+
+	var incomplete *IncompleteProfileError
+	if !errors.As(err, &incomplete) {
+		t.Fatalf("resolving reported %v, want an IncompleteProfileError", err)
+	}
+	if len(incomplete.Axes) != 2 {
+		t.Fatalf("the fault names %v, want both unstated axes", incomplete.Axes)
+	}
+
+	// The axes are named as a layout writes them, so an adopter can search for
+	// the word they would have typed.
+	for _, want := range []string{"sign-convention", "float-format"} {
+		if !strings.Contains(incomplete.Error(), want) {
+			t.Errorf("the message does not name %s: %s", want, incomplete.Error())
+		}
+	}
+}
+
+// TestResolveRejectsAnEmptyProfile is the same fault where nobody stated
+// anything, which is what a caller who forgot the field entirely produces.
+func TestResolveRejectsAnEmptyProfile(t *testing.T) {
+	t.Parallel()
+
+	_, err := Resolve(recordOf(t, "01 R.\n   05 A PIC X(4).\n"), Options{
+		Copybook: "test.cpy",
+		Dialect:  copybook.IBMEnterprise(),
+	})
+
+	var incomplete *IncompleteProfileError
+	if !errors.As(err, &incomplete) {
+		t.Fatalf("resolving reported %v, want an IncompleteProfileError", err)
+	}
+	if len(incomplete.Axes) != 4 {
+		t.Fatalf("the fault names %v, want all four axes", incomplete.Axes)
+	}
+}
+
+// TestTheCompletenessAssertionCatchesAFieldWithAnUnsetAxis drives the assertion
+// against a record no resolution produces, because none can: a complete profile
+// with overrides over it is complete.
+//
+// That is what it is for. docs/ir/SPEC.md puts the requirement on what leaves
+// resolution and forbids a consumer the only repair — a field missing an axis is
+// a malformed descriptor and **MUST NOT** be filled in — so the check has to be
+// over the result rather than over the argument, and a check that cannot be
+// reached through the front door is checked through this one.
+func TestTheCompletenessAssertionCatchesAFieldWithAnUnsetAxis(t *testing.T) {
+	t.Parallel()
+
+	record := recordOf(t, "01 R.\n   05 A PIC X(4).\n")
+	r := &resolver{opts: Options{Copybook: "test.cpy"}, record: record}
+
+	held := &Node{Kind: KindField, Field: fieldNamed(t, record, "A"), width: 4}
+	held.Encoding = mainframe()
+	held.Encoding.ByteOrder = ""
+
+	r.assertResolved([]*Record{{
+		Root: &Node{Kind: KindGroup, Field: record, Members: []*Node{held, slackNode(2)}},
+		Item: record,
+	}})
+
+	var unresolved *UnresolvedEncodingError
+	if !errors.As(r.faults.Err(), &unresolved) {
+		t.Fatalf("the assertion reported %v, want an UnresolvedEncodingError", r.faults.Err())
+	}
+	if unresolved.Item != "A" || len(unresolved.Axes) != 1 {
+		t.Fatalf("the fault is %+v, want A missing one axis", unresolved)
+	}
+	if got := unresolved.Diagnostic().Spans[0].File; got != "test.cpy" {
+		t.Errorf("the fault points at %q, want the copybook", got)
+	}
+	if !strings.Contains(unresolved.Error(), "byte-order") {
+		t.Errorf("the message does not name byte-order: %s", unresolved.Error())
+	}
+}
+
+// TestTheCompletenessAssertionPassesEveryResolutionThisPackageProduces is the
+// other side of it, run over the shapes that carry field nodes in the awkward
+// places: inside a variant's arms, inside a group this package introduced, and
+// beside slack.
+func TestTheCompletenessAssertionPassesEveryResolutionThisPackageProduces(t *testing.T) {
+	t.Parallel()
+
+	field := recordOf(t, tableSource)
+	records, err := Resolve(field, Options{
+		Copybook: "test.cpy",
+		Dialect:  copybook.IBMEnterprise(),
+		Encoding: mainframe(),
+		Redefines: []Redefine{{
+			Item: fieldNamed(t, field, "BODY"),
+			Alternatives: []Alternative{
+				{Name: "BODY", Predicate: selects("B")},
+				{Name: "SPLIT", Predicate: selects("S")},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+
+	r := &resolver{opts: Options{Copybook: "test.cpy"}, record: field}
+	r.assertResolved(records)
+	if r.faults.Failed() {
+		t.Fatalf("the assertion faulted on a resolution this package produced: %v", r.faults.Err())
+	}
+}

--- a/internal/resolve/errors.go
+++ b/internal/resolve/errors.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Zaba505/cpybkc/internal/diag"
+	"github.com/Zaba505/cpybkc/internal/layoutmodel"
 )
 
 // A fault here names as much of the record, the repeating group the variant sits
@@ -255,6 +256,90 @@ func (e *UnknownAlternativeError) Diagnostic() diag.Diagnostic {
 			e.Record, e.Redefined, e.Alternative, joinAnd(e.Names)),
 		Spans: []diag.Span{e.Pos},
 	}
+}
+
+// IncompleteProfileError is a record handed to [Resolve] with an encoding
+// profile stating fewer than all four axes.
+//
+// `codec/SPEC.md` requires all four from its caller and forbids a default for
+// any of them, because every one fails *silently* when it is wrong — a charset
+// yields a plausible string, a byte order a plausible number — and none is
+// recoverable from the file with certainty. Completing the profile here would be
+// that guess made once and applied to every field of the record.
+//
+// It points at no file, which is the one fault in this package that does not.
+// The profile is written in a layout rather than in a copybook, and
+// `layoutmodel` has already refused a layout that states three axes, with the
+// line: one that reaches here is a caller who assembled [Options] by hand, so a
+// span would name a copybook that is not wrong or a layout line that says the
+// right thing.
+type IncompleteProfileError struct {
+	// Record is the record being resolved.
+	Record string
+
+	// Axes are the axes the profile does not state, in docs/layout/SPEC.md's
+	// order.
+	Axes []layoutmodel.Axis
+}
+
+// Error implements the error interface.
+func (e *IncompleteProfileError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *IncompleteProfileError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"the encoding profile for record %s states no %s, and an encoding axis has no default",
+			e.Record, joinAnd(axisNames(e.Axes))),
+	}
+}
+
+// UnresolvedEncodingError is a field that left resolution with an encoding axis
+// unset.
+//
+// It is the completeness assertion docs/ir/SPEC.md's "The encoding profile,
+// applied" asks a producer for, and it is about this package rather than about
+// anything an adopter wrote: a complete profile with overrides applied over it
+// is complete, so nothing a layout or a copybook can say produces one. It exists
+// because the requirement is on what reaches a generator, where the only repair
+// available is the one that document forbids — a consumer **MUST** treat a field
+// missing an axis as a malformed descriptor and **MUST NOT** fill it in — so an
+// axis that escapes here escapes for good.
+type UnresolvedEncodingError struct {
+	// Pos is the field's entry in the copybook.
+	Pos diag.Span
+
+	// Record is the record being resolved.
+	Record string
+
+	// Item is the field the axis is unset on.
+	Item string
+
+	// Axes are the axes it does not state, in docs/layout/SPEC.md's order.
+	Axes []layoutmodel.Axis
+}
+
+// Error implements the error interface.
+func (e *UnresolvedEncodingError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *UnresolvedEncodingError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"in record %s, %s was resolved with no %s: every field carries all four encoding axes, and this is a bug in cpybkc rather than in the copybook or the layout",
+			e.Record, e.Item, joinAnd(axisNames(e.Axes))),
+		Spans: []diag.Span{e.Pos},
+	}
+}
+
+// axisNames is what a message calls a list of axes: the tag a layout writes each
+// one as, which is the word an adopter would have typed.
+func axisNames(axes []layoutmodel.Axis) []string {
+	names := make([]string, 0, len(axes))
+	for _, axis := range axes {
+		names = append(names, axis.String())
+	}
+	return names
 }
 
 // joinAnd renders a list the way a sentence does.

--- a/internal/resolve/node.go
+++ b/internal/resolve/node.go
@@ -87,6 +87,25 @@ type Node struct {
 	// inside the group that does, which is the only place it may sit.
 	Repetition *Repetition
 
+	// Encoding is the four encoding axes governing this field's bytes: the
+	// layout's profile with every override reaching this item applied over
+	// it. All four are stated on a field node this package hands back.
+	//
+	// The fifth thing a generator needs to read a field's bytes is its
+	// USAGE, and that is not here: it is a clause of the copybook, already
+	// inherited down the entry tree by
+	// [github.com/Zaba505/cobol-go/copybook.Field.Usage], and a copy on the
+	// node would be a second answer to a question the copybook has already
+	// answered. The axes are here because no copybook states them.
+	//
+	// It is carried by a field node and by no other kind. docs/ir/SPEC.md's
+	// "The encoding profile, applied" puts all four on every field node and
+	// carries no profile node for one to inherit from, so a group holding a
+	// copy would be that profile under another name — a second statement of
+	// an axis, for a member to disagree with. A slack node has no encoding
+	// for the reason it has no names: nothing reads those bytes as a value.
+	Encoding layoutmodel.Axes
+
 	// width is the bytes one occurrence of a field or a slack node occupies.
 	// It is unexported because a group and a variant must not be able to
 	// carry one: their widths follow from what they hold, and a member

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -37,6 +37,49 @@ type Options struct {
 	// apart. A redefine outside one needs no entry: its alternatives become
 	// records, and [Resolve] returns one per combination.
 	Redefines []Redefine
+
+	// Encoding is the layout's encoding profile: the four axes every field of
+	// the record is resolved against.
+	//
+	// It has no default, for the reason [Options.Dialect] has none and
+	// `codec/SPEC.md` requires all four of them from its caller. Each axis
+	// fails silently when it is wrong — a charset yields a plausible string
+	// and a byte order a plausible number, with nothing in the file to
+	// disagree — so a profile stating fewer than four is rejected here rather
+	// than completed.
+	Encoding layoutmodel.Axes
+
+	// EncodingOverrides are the layout's per-item encoding overrides, each
+	// already resolved to the copybook item it names.
+	//
+	// They arrive against fields rather than as the layout's item references
+	// for [Redefine]'s reason: resolving a reference against a copybook is one
+	// step and resolving the copybook is another, and a package doing both
+	// would read a layout's spelling of an item in two places. An override
+	// naming an item of some other record is one this record never meets, so
+	// a caller may hand over the layout's whole list.
+	EncodingOverrides []EncodingOverride
+}
+
+// EncodingOverride is what a layout restates about one item's encoding.
+//
+// docs/layout/SPEC.md's "An override is per item, and there is no second
+// profile" is the whole of it: the axes it states replace the profile's for the
+// item it names, and the ones it leaves unstated leave the profile's alone.
+type EncodingOverride struct {
+	// Item is the copybook item the override names.
+	//
+	// It **MAY** be a group, in which case the override reaches every
+	// elementary item under it, and it **MAY** repeat, in which case it
+	// reaches every occurrence: an encoding is a property of an item's bytes
+	// wherever those bytes sit.
+	Item *copybook.Field
+
+	// Axes are the axes it restates. An axis it leaves unstated is not
+	// restated and is not reset — [layoutmodel.Axes.Over] is the application
+	// — so an override naming one axis leaves the other three where they
+	// were.
+	Axes layoutmodel.Axes
 }
 
 // Redefine is what a layout says about one REDEFINES inside a repeating group.
@@ -84,6 +127,12 @@ type Alternative struct {
 // to exactly one Record. The order is the order the alternatives are met walking
 // the record, outermost and earliest first.
 //
+// Every field node comes back with all four encoding axes stated, per
+// docs/ir/SPEC.md, "The encoding profile, applied": [Options.Encoding] with the
+// overrides reaching that item applied over it. A profile stating fewer than
+// four is refused before the walk starts, and nothing that leaves here states
+// fewer.
+//
 // Every fault it finds is reported, joined with [errors.Join] and assertable
 // with [errors.As], rather than the first: a copybook and the layout over it go
 // wrong in the same way in several places at once. A record it found a fault in
@@ -94,13 +143,22 @@ func Resolve(record *copybook.Field, opts Options) ([]*Record, error) {
 		return nil, ErrNilRecord
 	}
 
+	// The profile is held to before anything is laid out, and on its own
+	// rather than joined with what the copybook turns out to be wrong about.
+	// An axis nobody stated is a hole in every field of the record at once, so
+	// resolving anyway would report the one fault once per field and bury the
+	// copybook's own faults among them.
+	if missing := opts.Encoding.Missing(); len(missing) > 0 {
+		return nil, &IncompleteProfileError{Record: record.Name, Axes: missing}
+	}
+
 	layout, err := copybook.NewLayout(record, opts.Dialect)
 	if err != nil {
 		return nil, err
 	}
 
 	r := &resolver{opts: opts, record: record}
-	options := r.item(layout.Record)
+	options := r.item(layout.Record, opts.Encoding)
 	if r.faults.Failed() {
 		return nil, r.faults.Err()
 	}
@@ -120,7 +178,48 @@ func Resolve(record *copybook.Field, opts Options) ([]*Record, error) {
 			Alternatives: option.alternatives,
 		})
 	}
+
+	r.assertResolved(records)
+	if r.faults.Failed() {
+		return nil, r.faults.Err()
+	}
 	return records, nil
+}
+
+// assertResolved holds every field of the records to docs/ir/SPEC.md's "The
+// encoding profile, applied": all four axes stated, on every field node, with
+// none left unset.
+//
+// It cannot fire against a profile this package accepted — [Options.Encoding] is
+// complete before the walk starts and [layoutmodel.Axes.Over] never unsets an
+// axis — and running it anyway is the point. The requirement is on what leaves
+// resolution rather than on what entered it, and the repair a consumer would
+// otherwise reach for is the one docs/ir/SPEC.md forbids: a field missing an
+// axis is a malformed descriptor and a generator **MUST NOT** fill it in, so an
+// unresolved axis that escapes here has nowhere downstream to be caught. The
+// assertion is therefore over the result, in the terms the requirement is
+// written in, and a resolution this package grows later is checked by it without
+// being asked to remember.
+func (r *resolver) assertResolved(records []*Record) {
+	for _, record := range records {
+		record.Walk(func(node *Node) {
+			if node.Kind != KindField {
+				return
+			}
+
+			missing := node.Encoding.Missing()
+			if len(missing) == 0 {
+				return
+			}
+
+			r.faults.Fail(&UnresolvedEncodingError{
+				Pos:    r.span(node.Field),
+				Record: r.record.Name,
+				Item:   itemName(node.Field),
+				Axes:   missing,
+			})
+		})
+	}
 }
 
 // resolver carries what the walk needs: the options it was given, the record it
@@ -142,27 +241,60 @@ type option struct {
 	alternatives []*copybook.Field
 }
 
-// item resolves one laid-out item into every option it admits.
-func (r *resolver) item(item *copybook.Item) []option {
+// item resolves one laid-out item into every option it admits, under the
+// encoding governing the item above it.
+func (r *resolver) item(item *copybook.Item, in layoutmodel.Axes) []option {
+	in = r.encoding(item.Field, in)
+
 	if item.Field.Kind != copybook.KindGroup {
-		return []option{{node: elementary(item)}}
+		return []option{{node: elementary(item, in)}}
 	}
-	return r.group(item)
+	return r.group(item, in)
 }
 
-// elementary builds the node for an item that holds no others.
+// encoding is the encoding governing field: the override naming it, where the
+// layout wrote one, over the encoding already in effect where it sits.
+//
+// Over the encoding in effect and not over the profile, which is the one thing
+// about overrides docs/layout/SPEC.md leaves to be settled here. An override
+// reaches every elementary item under the group it names, so a field under an
+// overridden group is already governed by that override when its own is met;
+// applying the inner one over the profile instead would let an override naming
+// one axis silently undo an enclosing override of another, which is the opposite
+// of what "leaves the other three as the profile states them" is for. Composed,
+// that sentence holds at every depth, and an axis nobody restated anywhere is
+// still the profile's.
+//
+// The first entry naming an item wins, as [resolver.redefine] takes the first.
+// `layoutmodel` already refuses a layout that overrides one item twice, so a
+// second entry here is a caller that assembled one by hand, and reporting it as
+// the adopter's fault would name a line the adopter wrote correctly.
+func (r *resolver) encoding(field *copybook.Field, in layoutmodel.Axes) layoutmodel.Axes {
+	for i := range r.opts.EncodingOverrides {
+		if r.opts.EncodingOverrides[i].Item == field {
+			return r.opts.EncodingOverrides[i].Axes.Over(in)
+		}
+	}
+	return in
+}
+
+// elementary builds the node for an item that holds no others, under the
+// encoding governing it.
 //
 // A repeating item whose stride exceeds its width has padding between one
 // occurrence and the next, and an elementary node has nowhere to put a slack
 // node. So it becomes a group that repeats, holding the item and the padding —
 // which is the same shape the IR would need for it, since alignment reaches a
-// generator as bytes it already has rather than as a rule it applies.
-func elementary(item *copybook.Item) *Node {
+// generator as bytes it already has rather than as a rule it applies. The
+// encoding stays on the field node inside it: the wrapper is this package's own
+// and stands for no copybook item, and the padding is not a field's bytes.
+func elementary(item *copybook.Item, in layoutmodel.Axes) *Node {
 	field := &Node{
 		Kind:       KindField,
 		Field:      item.Field,
 		width:      item.Length,
 		Repetition: repetitionOf(item),
+		Encoding:   in,
 	}
 	if item.Stride == item.Length {
 		return field
@@ -187,19 +319,20 @@ type run struct {
 	alternatives []*copybook.Field
 }
 
-// group resolves a group item into every option its member list admits.
+// group resolves a group item into every option its member list admits, under
+// the encoding governing the group.
 //
 // The member list is built cluster by cluster — an item and the items redefining
 // it are one cluster — and every byte of the group's extent no cluster covers
 // becomes slack, so that the members sum to the extent exactly and the position
 // of everything behind them is the sum and nothing else.
-func (r *resolver) group(item *copybook.Item) []option {
+func (r *resolver) group(item *copybook.Item, in layoutmodel.Axes) []option {
 	lists := []run{{}}
 	cursor := item.Offset
 
 	for _, c := range clustersOf(item) {
 		gap := c.start() - cursor
-		choices := r.cluster(c)
+		choices := r.cluster(c, in)
 		cursor = c.start() + c.extent()
 
 		next := make([]run, 0, len(lists)*len(choices))
@@ -247,10 +380,10 @@ func (r *resolver) group(item *copybook.Item) []option {
 }
 
 // cluster resolves one redefine cluster into every run its group's member list
-// admits.
-func (r *resolver) cluster(c cluster) []run {
+// admits, under the encoding governing the group holding it.
+func (r *resolver) cluster(c cluster, in layoutmodel.Axes) []run {
 	if len(c.members) == 1 {
-		options := r.item(c.members[0])
+		options := r.item(c.members[0], in)
 		runs := make([]run, 0, len(options))
 		for _, chosen := range options {
 			runs = append(runs, run{nodes: []*Node{chosen.node}, alternatives: chosen.alternatives})
@@ -259,14 +392,14 @@ func (r *resolver) cluster(c cluster) []run {
 	}
 
 	if inTable(c.members[0]) {
-		return []run{r.variant(c)}
+		return []run{r.variant(c, in)}
 	}
 
 	// Outside a repeating group every alternative becomes its own record, so
 	// the cluster multiplies the options rather than becoming a node.
 	var runs []run
 	for _, member := range c.members {
-		for _, chosen := range r.item(member) {
+		for _, chosen := range r.item(member, in) {
 			alternatives := make([]*copybook.Field, 0, len(chosen.alternatives)+1)
 			alternatives = append(alternatives, chosen.alternatives...)
 			alternatives = append(alternatives, member.Field)
@@ -284,7 +417,7 @@ func (r *resolver) cluster(c cluster) []run {
 // The layout says which alternatives there are and what selects each one. Two or
 // more make a variant; one says every occurrence takes it, and resolves to that
 // alternative's items with no variant at all.
-func (r *resolver) variant(c cluster) run {
+func (r *resolver) variant(c cluster, in layoutmodel.Axes) run {
 	redefined := c.members[0]
 	table := enclosingTable(redefined)
 
@@ -297,7 +430,7 @@ func (r *resolver) variant(c cluster) run {
 			Redefined: itemName(redefined.Field),
 			Names:     names(c.members[1:]),
 		})
-		return r.base(c)
+		return r.base(c, in)
 	}
 
 	// The redefined item's storage is what an occurrence reserved, and it is
@@ -360,7 +493,7 @@ func (r *resolver) variant(c cluster) run {
 		arms = append(arms, Arm{
 			Alternative: alternative.Name,
 			Predicate:   alternative.Predicate,
-			Body:        armBody(r.first(member), extent),
+			Body:        armBody(r.first(member, in), extent),
 		})
 	}
 
@@ -372,18 +505,18 @@ func (r *resolver) variant(c cluster) run {
 			Group:     groupName(table),
 			Redefined: itemName(redefined.Field),
 		})
-		return r.base(c)
+		return r.base(c, in)
 
 	case len(spec.Alternatives) == 1:
 		// Nothing is chosen, so there is no alternation to carry and no
 		// predicate to carry it under: the one alternative's items stand
 		// where the cluster stood, padded out like a record's.
 		if len(arms) == 0 {
-			return r.base(c)
+			return r.base(c, in)
 		}
 		member := c.find(spec.Alternatives[0].Name)
 		return run{
-			nodes:        pad(r.first(member), c.extent()),
+			nodes:        pad(r.first(member, in), c.extent()),
 			alternatives: []*copybook.Field{member.Field},
 		}
 	}
@@ -391,7 +524,7 @@ func (r *resolver) variant(c cluster) run {
 	if len(arms) < len(spec.Alternatives) {
 		// A fault was already reported for the arms that are missing, and a
 		// variant short of them would be a second, less useful one.
-		return r.base(c)
+		return r.base(c, in)
 	}
 
 	return run{nodes: pad(&Node{Kind: KindVariant, Arms: arms}, c.extent())}
@@ -401,8 +534,8 @@ func (r *resolver) variant(c cluster) run {
 // the redefined item, which is the copybook's own first description of those
 // bytes. It keeps the walk going so that a second fault is reported beside the
 // first, and nothing is returned to a caller while a fault stands.
-func (r *resolver) base(c cluster) run {
-	return run{nodes: pad(r.first(c.members[0]), c.extent())}
+func (r *resolver) base(c cluster, in layoutmodel.Axes) run {
+	return run{nodes: pad(r.first(c.members[0], in), c.extent())}
 }
 
 // first resolves an item to its one option.
@@ -410,8 +543,8 @@ func (r *resolver) base(c cluster) run {
 // Inside a repeating group there is only ever one: a redefine down there is
 // itself in a repeating group, so it becomes a variant rather than multiplying
 // the record's alternatives.
-func (r *resolver) first(item *copybook.Item) *Node {
-	options := r.item(item)
+func (r *resolver) first(item *copybook.Item, in layoutmodel.Axes) *Node {
+	options := r.item(item, in)
 	if len(options) == 0 {
 		return &Node{Kind: KindGroup, Field: item.Field}
 	}
@@ -429,8 +562,16 @@ func (r *resolver) redefine(field *copybook.Field) *Redefine {
 }
 
 // span is where in the copybook a field is.
+//
+// A node this package introduced stands for no field and has no line: what comes
+// back for one is the copybook itself, which diag renders as the file alone
+// rather than as a line zero nothing can jump to.
 func (r *resolver) span(field *copybook.Field) diag.Span {
-	return diag.Span{File: r.opts.Copybook, Line: field.Pos.Line, Column: field.Pos.Column}
+	span := diag.Span{File: r.opts.Copybook}
+	if field != nil {
+		span.Line, span.Column = field.Pos.Line, field.Pos.Column
+	}
+	return span
 }
 
 // pad returns the nodes a member list gets for node, followed by the slack

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -62,6 +62,22 @@ func fieldNamed(t *testing.T, record *copybook.Field, name string) *copybook.Fie
 	return found
 }
 
+// mainframe is the encoding profile every test here states unless it is testing
+// the profile: the four axes a file written and read on a mainframe has.
+//
+// A test states one because [Resolve] requires one — `codec` defaults no axis
+// and neither does this package — and states this one because a test about
+// widths and containment should be reading the same profile as the next test
+// about widths and containment.
+func mainframe() layoutmodel.Axes {
+	return layoutmodel.Axes{
+		Charset:        layoutmodel.CP037,
+		SignConvention: layoutmodel.SignEBCDIC,
+		ByteOrder:      layoutmodel.BigEndian,
+		FloatFormat:    layoutmodel.HFP,
+	}
+}
+
 // resolveAll resolves a copybook source under IBM Enterprise COBOL, which is the
 // dialect every test here states unless it is testing the dialect.
 func resolveAll(t *testing.T, src string, redefines ...Redefine) []*Record {
@@ -70,6 +86,7 @@ func resolveAll(t *testing.T, src string, redefines ...Redefine) []*Record {
 	records, err := Resolve(recordOf(t, src), Options{
 		Copybook:  "test.cpy",
 		Dialect:   copybook.IBMEnterprise(),
+		Encoding:  mainframe(),
 		Redefines: redefines,
 	})
 	if err != nil {
@@ -140,7 +157,7 @@ func TestResolveReportsACopybookItCannotLayOut(t *testing.T) {
 	// An elementary DISPLAY item with no PICTURE has no width, which is
 	// `cobol-go`'s to report: this package does not measure storage a second
 	// time, so it has nothing of its own to say about one.
-	_, err := Resolve(recordOf(t, "01 R.\n   05 A.\n"), Options{Dialect: copybook.IBMEnterprise()})
+	_, err := Resolve(recordOf(t, "01 R.\n   05 A.\n"), Options{Dialect: copybook.IBMEnterprise(), Encoding: mainframe()})
 	if err == nil {
 		t.Fatal("resolved a record whose width cannot be determined")
 	}

--- a/internal/resolve/slack_test.go
+++ b/internal/resolve/slack_test.go
@@ -91,7 +91,7 @@ func TestARepeatingItemPaddedToItsStrideCarriesThePaddingInsideItself(t *testing
    05 T PIC S9(5) COMP SYNCHRONIZED OCCURS 3 TIMES.
    05 Z PIC X(2).
 `)
-	records, err := Resolve(field, Options{Dialect: dialect})
+	records, err := Resolve(field, Options{Dialect: dialect, Encoding: mainframe()})
 	if err != nil {
 		t.Fatalf("resolving: %v", err)
 	}

--- a/internal/resolve/variant_test.go
+++ b/internal/resolve/variant_test.go
@@ -45,6 +45,7 @@ func resolveTable(t *testing.T, src string, build func(*copybook.Field) []Redefi
 	return Resolve(field, Options{
 		Copybook:  "test.cpy",
 		Dialect:   copybook.IBMEnterprise(),
+		Encoding:  mainframe(),
 		Redefines: build(field),
 	})
 }
@@ -305,7 +306,8 @@ func TestAVariantIsRejectedWhenItsAlternativesCannotBeMadeToAgree(t *testing.T) 
 		// A lenient dialect is what lets an oversized redefinition
 		// reach this package at all; a strict one refuses it while the
 		// copybook is being laid out.
-		Dialect: lenient(),
+		Dialect:  lenient(),
+		Encoding: mainframe(),
 		Redefines: []Redefine{{
 			Item: fieldNamed(t, field, "SHORT"),
 			Alternatives: []Alternative{

--- a/internal/resolve/width_test.go
+++ b/internal/resolve/width_test.go
@@ -240,7 +240,7 @@ func TestPositionsAgreeWithTheOffsetsTheCopybookWasLaidOutAt(t *testing.T) {
 				t.Fatalf("laying the copybook out: %v", err)
 			}
 
-			records, err := Resolve(field, Options{Dialect: copybook.IBMEnterprise()})
+			records, err := Resolve(field, Options{Dialect: copybook.IBMEnterprise(), Encoding: mainframe()})
 			if err != nil {
 				t.Fatalf("resolving: %v", err)
 			}


### PR DESCRIPTION
Closes #33

Resolution now leaves no encoding axis unresolved. Every field node comes back
carrying all four of `codec/SPEC.md`'s axes — charset, sign convention, byte
order, float format — as `docs/ir/SPEC.md`'s [The encoding profile,
applied](../blob/main/docs/ir/SPEC.md#the-encoding-profile-applied) requires,
and nothing else in the record carries one.

## Acceptance criteria

- [x] **Each field carries resolved usage, sign convention, charset, and byte
  order.** `Node.Encoding` is the four axes, on `KindField` nodes and on no
  other kind. USAGE is not restated there: `cobol-go` has already inherited it
  down the entry tree onto the `copybook.Field` every field node carries, and a
  copy on the node would be a second answer to a question the copybook has
  answered. `TestEveryFieldCarriesAllFourAxes` and
  `TestAFieldCarriesTheUsageTheCopybookGaveIt`.
- [x] **Per-field overrides applied over the record's profile.**
  `Options.Encoding` is the profile and `Options.EncodingOverrides` are the
  overrides; `layoutmodel.Axes.Over` is the application, so an override naming
  one axis leaves the other three where they were. An override on a group
  reaches every elementary item under it, one on a repeating item reaches every
  occurrence, and one reaches inside a variant's arms.
- [x] **Mixed-charset records handled per `codec/SPEC.md`.** It needs no
  special treatment, which is `ir/SPEC.md`'s point: the axes are per field, so
  a record whose fields disagree is the ordinary case.
  `TestAMixedCharsetRecordNeedsNoSpecialTreatment`.
- [x] **No field leaves resolution with an unresolved axis; a completeness
  assertion enforces this.** `assertResolved` walks every returned record before
  `Resolve` hands anything back and reports `UnresolvedEncodingError` per field
  and axis. A profile stating fewer than four axes is refused up front with
  `IncompleteProfileError`, naming each missing one as a layout spells it.
- [x] **Tests cover both ASCII and EBCDIC for the same layout.**
  `TestTheSameLayoutResolvesUnderASCIIAndUnderEBCDIC` resolves one copybook
  under both and asserts the axes differ while every width and position does
  not.

## Judgment calls that shaped the public API

**Overrides arrive resolved against `copybook.Field`, not as layout item
references.** This mirrors `Redefine`, which already takes a `*copybook.Field`:
resolving a reference against a copybook is one step and resolving the copybook
is another, and a package doing both would read a layout's spelling of an item
in two places. A caller may hand over the layout's whole override list, since an
override naming an item of another record is one this record never meets.

**An override applies over the encoding in effect where its item sits, not over
the profile.** `docs/layout/SPEC.md` says an override on a group reaches every
elementary item under it, and separately that an override naming one axis leaves
the other three as the profile states them; it does not say what happens when
both apply to one field. Composing is the only reading that does not break the
first sentence — under the other, an inner override naming `byte-order` would
silently undo an enclosing group's `charset` — and the second sentence still
holds at every depth, because an axis nobody restated anywhere is still the
profile's. `TestAnOverrideAppliesOverTheOneAboveItRatherThanOverTheProfile`.

**`Options.Encoding` has no default and an incomplete one is refused before the
walk starts.** Same argument `Options.Dialect` already carries: every axis fails
*silently* when wrong. Refusing up front reports the hole once instead of once
per field, and the error points at no file — `layoutmodel` already refuses a
layout that states three axes, with the line, so one that reaches here is a
caller who assembled `Options` by hand.

**The completeness assertion cannot fire through `Resolve`, and runs anyway.**
A complete profile with overrides over it is complete, so no copybook or layout
produces one. It exists because `ir/SPEC.md` puts the requirement on what
*leaves* resolution and forbids a consumer the only repair available — a field
missing an axis is a malformed descriptor and must not be filled in — so an
unresolved axis that escapes here escapes for good. It is tested directly
against a hand-built record, and against every shape this package does produce.

## Verification

`dagger call ci` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)