### PR TITLE
story(resolve): compute SYNCHRONIZED slack bytes

### DIFF
--- a/internal/resolve/doc.go
+++ b/internal/resolve/doc.go
@@ -91,10 +91,42 @@
 // [github.com/Zaba505/cpybkc/internal/layoutmodel.Strategy] a layout wrote
 // rather than a compiled predicate.
 //
-// Slack is the one of those with a foot in both stories. Which alignments a
-// dialect honours is `cobol-go`'s and the rest of the rule is #34's, but a
-// record whose redefines have been resolved away has bytes no item occupies
-// whatever a SYNCHRONIZED clause does, so this package emits a slack node for
-// every byte of a group's extent its members leave uncovered, wherever the gap
-// came from.
+// # Slack, and its four producers
+//
+// Every byte of a record that no item occupies is a slack node in the
+// containment order, whatever left it uncovered (docs/ir/SPEC.md, "Slack is a
+// node, not a rule"). Four things leave bytes uncovered and the node is the same
+// for all four: the gap ahead of a SYNCHRONIZED item, the storage a REDEFINES
+// alternative does not fill, the padding between one occurrence of a table and
+// the next, and the tail of a record whose items stop short of the `lrecl` a
+// fixed-length dataset states. Which boundary an aligned item sits on is
+// `cobol-go`'s answer and is not recomputed here; what this package does with
+// the bytes it left behind is the rest of the rule (#34).
+//
+// One node per *maximal* run, which is why the member list is merged rather than
+// appended to. Two runs of different origin that abut are one node of the summed
+// width, because "Slack survives a read" makes a consumer keep one run of bytes
+// per node, so how this stage divides a run of eight would otherwise decide the
+// shape of every record a generator emits.
+//
+// Two edges a run does not cross, and both are edges a merged node would belong
+// to neither side of. An arm's, because an arm's extent is the variant's width
+// and a node spanning the end of one arm and the bytes behind the variant would
+// make that arm wider than its siblings. And a repeating group's, because a node
+// inside one stands for a run per occurrence while a node behind it stands for
+// one run in the record, and no single width is both.
+//
+// # LRECL is the one thing a framing says about a record's members
+//
+// [Options.Framing] reaches this package for one check and one node. Under a
+// fixed-length dataset the next record begins a fixed distance on whatever the
+// record was, so a record type accounts for all of LRECL: one shorter carries
+// the difference as the trailing slack above, and one longer is a fault, since
+// no node takes bytes away. A record type whose extent moves with a count meets
+// that at one count and misses it at every other, and is rejected rather than
+// padded (docs/ir/SPEC.md, "A variable record does not fit a fixed-length
+// dataset", #92).
+//
+// Under the other three framings each record states its own length, so an
+// `lrecl` is a maximum that is checked and never padded to.
 package resolve

--- a/internal/resolve/errors.go
+++ b/internal/resolve/errors.go
@@ -332,6 +332,131 @@ func (e *UnresolvedEncodingError) Diagnostic() diag.Diagnostic {
 	}
 }
 
+// LRECLExtentError is a record type whose extent the dataset's `lrecl` does not
+// admit.
+//
+// It is only ever the record that is too long. A record type that stops short of
+// an exact `lrecl` is padded rather than reported — those bytes are in the file
+// whatever the copybook says, and carrying them as slack is what makes the next
+// record start where the dataset puts it — so what is left here is a record type
+// with more bytes than the dataset has room for, which no slack node can take
+// away.
+//
+// The two bounds are one error and not two because an adopter fixes them the
+// same way, and the message says which it is: under an exact bound every record
+// type accounts for all of `lrecl`, and under a maximum one the dataset admits
+// anything up to it.
+//
+// It carries two spans, and the first is the layout's. The number comes from the
+// dataset the adopter wrote down and the extent from a copybook they may not
+// own, so a diagnostic naming only the copybook names the half they cannot
+// change.
+type LRECLExtentError struct {
+	// Pos is the `lrecl` form in the layout.
+	Pos diag.Span
+
+	// Item is the record's entry in the copybook.
+	Item diag.Span
+
+	// Record is the record being resolved.
+	Record string
+
+	// Alternatives are the alternatives chosen at each redefine outside a
+	// repeating group, and are empty for a copybook holding none. They are
+	// what tells one resolution of a record from another, which share a name.
+	Alternatives []string
+
+	// Bound is what the framing requires of the extent.
+	Bound layoutmodel.LRECLBound
+
+	// Extent is the bytes the record type occupies, and LRECL the length the
+	// dataset states.
+	Extent int
+	LRECL  int
+}
+
+// Error implements the error interface.
+func (e *LRECLExtentError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *LRECLExtentError) Diagnostic() diag.Diagnostic {
+	requirement := "and a record type of a fixed-length dataset accounts for all of it and no more"
+	if e.Bound == layoutmodel.LRECLMaximum {
+		requirement = "and the dataset admits no record longer than that"
+	}
+
+	item := e.Item
+	item.Note = fmt.Sprintf("%s is declared here", e.Record)
+
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"record %s occupies %d bytes, the dataset's lrecl is %d, %s",
+			recordNamed(e.Record, e.Alternatives), e.Extent, e.LRECL, requirement),
+		Spans: []diag.Span{e.Pos, item},
+	}
+}
+
+// VariableExtentError is a record type whose extent moves with a count, on a
+// fixed-length dataset.
+//
+// On such a dataset the next record begins a fixed distance on whatever the
+// record was, so a record type has one extent and not one per count. A record
+// type of a fixed part, a table and a pad meets that at one count and misses it
+// at every other, and the pad cannot take up the difference because a slack node
+// carries a width (docs/ir/SPEC.md, "A variable record does not fit a
+// fixed-length dataset", #92).
+//
+// It names the record and the repeating item, which that section asks for by
+// name rather than a generic framing error: the adopter's way out is a record
+// type per count value, and finding it starts at the table.
+//
+// It is keyed on the framing rather than on the `lrecl`, because the rule holds
+// whether or not a layout states one. Under RECFM F and FB a layout must state
+// one, so in practice the two arrive together; the check does not depend on it.
+type VariableExtentError struct {
+	// Pos is the `framing` form in the layout.
+	Pos diag.Span
+
+	// Item is the repeating item's entry in the copybook.
+	Item diag.Span
+
+	// Record is the record being resolved.
+	Record string
+
+	// RECFM is the record format the layout writes, which is what makes the
+	// dataset fixed-length.
+	RECFM layoutmodel.RECFM
+
+	// Table is the repeating item, and Count the item its count is read from.
+	Table string
+	Count string
+}
+
+// Error implements the error interface.
+func (e *VariableExtentError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *VariableExtentError) Diagnostic() diag.Diagnostic {
+	item := e.Item
+	item.Note = fmt.Sprintf("%s is declared here", e.Table)
+
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"in record %s, %s occurs a number of times read from %s, and under recfm %s every record of the dataset is the same length",
+			e.Record, e.Table, e.Count, e.RECFM),
+		Spans: []diag.Span{e.Pos, item},
+	}
+}
+
+// recordNamed is what a message calls a record, with the alternatives that tell
+// one resolution of it from another where the copybook has any.
+func recordNamed(record string, alternatives []string) string {
+	if len(alternatives) == 0 {
+		return record
+	}
+	return fmt.Sprintf("%s, reading %s", record, joinAnd(alternatives))
+}
+
 // axisNames is what a message calls a list of axes: the tag a layout writes each
 // one as, which is the word an adopter would have typed.
 func axisNames(axes []layoutmodel.Axis) []string {

--- a/internal/resolve/lrecl_test.go
+++ b/internal/resolve/lrecl_test.go
@@ -1,0 +1,295 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package resolve
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cobol-go/copybook"
+
+	"github.com/Zaba505/cpybkc/internal/layout"
+	"github.com/Zaba505/cpybkc/internal/layoutmodel"
+)
+
+// A fixed-length dataset gives every record the same number of bytes, so a
+// record type whose items stop short of LRECL ends in a run that belongs to no
+// item — the third producer of slack, beside an alignment gap and a REDEFINES
+// tail, and the same kind of node once emitted (docs/layout/SPEC.md, "`lrecl`
+// and `blksize` describe the dataset, not the stream").
+
+// fixed is a framing over a fixed-length dataset stating lrecl, which is the
+// framing under which a record type's extent has to *be* that number.
+func fixed(lrecl int64) *layoutmodel.Framing {
+	return &layoutmodel.Framing{
+		Pos:   layout.Pos{File: "layout.sexpr", Line: 3, Column: 3},
+		RECFM: layoutmodel.RECFMFB,
+		LRECL: layoutmodel.Size{Pos: layout.Pos{File: "layout.sexpr", Line: 5, Column: 5}, Value: lrecl},
+	}
+}
+
+// variable is a framing over a variable-length dataset stating lrecl, where the
+// same number is a maximum rather than a requirement: each record's own
+// descriptor word states its length.
+func variable(lrecl int64) *layoutmodel.Framing {
+	framing := fixed(lrecl)
+	framing.RECFM = layoutmodel.RECFMVB
+	return framing
+}
+
+// framed resolves a copybook source under a framing, reporting what resolution
+// said rather than failing on it, because half these tests are about the fault.
+func framed(t *testing.T, src string, framing *layoutmodel.Framing) ([]*Record, error) {
+	t.Helper()
+
+	return Resolve(recordOf(t, src), Options{
+		Copybook: "test.cpy",
+		Dialect:  copybook.IBMEnterprise(),
+		Encoding: mainframe(),
+		Framing:  framing,
+	})
+}
+
+// TestARecordShortOfLRECLCarriesTheDifferenceAsSlack is the trailing pad: the
+// bytes are in the file whatever the copybook says, so they are in the record's
+// containment order too, and the next record starts after them.
+func TestARecordShortOfLRECLCarriesTheDifferenceAsSlack(t *testing.T) {
+	t.Parallel()
+
+	records, err := framed(t, `01 R.
+   05 A PIC X(40).
+   05 B PIC X(32).
+`, fixed(80))
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+	record := records[0]
+
+	if got := slackWidths(record.Root); len(got) != 1 || got[0] != 8 {
+		t.Fatalf("the record's slack is %v, want one run of 8", got)
+	}
+	if got := record.Extent(); got != 80 {
+		t.Fatalf("the record is %d bytes, want the lrecl of 80", got)
+	}
+
+	// It is the *last* member, because the bytes it stands for are the last
+	// bytes of the record.
+	if last := record.Root.Members[len(record.Root.Members)-1]; last.Kind != KindSlack {
+		t.Errorf("the record ends in a %s, want the pad", last.Kind)
+	}
+}
+
+// TestTheLRECLPadDoesNotJoinARunInsideARepeatingGroup is the edge the
+// maximal-run rule does not cross, met from the pad's side rather than an arm's.
+//
+// The alignment slack that pads the table's occurrence out to its stride stands
+// for one run of bytes in *each* occurrence, and the pad stands for one run at
+// the end of the record. They abut in the last occurrence and nowhere else, so a
+// node covering both would be a node of a different width per occurrence — and
+// would make the last entry of the table wider than the ones in front of it.
+func TestTheLRECLPadDoesNotJoinARunInsideARepeatingGroup(t *testing.T) {
+	t.Parallel()
+
+	records, err := framed(t, `01 R.
+   05 T OCCURS 2 TIMES.
+      10 A PIC S9(9) COMP SYNCHRONIZED.
+      10 B PIC X.
+`, fixed(24))
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+	record := records[0]
+
+	if got := slackWidths(record.Root); len(got) != 2 || got[0] != 3 || got[1] != 8 {
+		t.Fatalf("the record's slack is %v, want a run of 3 inside the table and a pad of 8", got)
+	}
+	if got := record.Extent(); got != 24 {
+		t.Fatalf("the record is %d bytes, want the lrecl of 24", got)
+	}
+}
+
+// TestEveryAlternativeOfARecordIsPaddedToLRECL: splitting a REDEFINES into
+// records leaves each one its own length, and each one is a record type of the
+// dataset, so each one accounts for LRECL on its own.
+func TestEveryAlternativeOfARecordIsPaddedToLRECL(t *testing.T) {
+	t.Parallel()
+
+	records, err := Resolve(recordOf(t, `01 R.
+   05 KIND PIC X.
+   05 WIDE PIC X(20).
+   05 NARROW REDEFINES WIDE PIC X(6).
+`), Options{
+		Copybook: "test.cpy",
+		Dialect:  copybook.IBMEnterprise(),
+		Encoding: mainframe(),
+		Framing:  fixed(40),
+	})
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("resolved to %d records, want 2", len(records))
+	}
+
+	// The first alternative fills the redefined item's storage and meets only
+	// the pad; the second leaves 14 bytes of it, and those bytes abut the pad,
+	// so the two are one run of 33.
+	for _, tc := range []struct {
+		alternative string
+		want        []int
+	}{
+		{alternative: "WIDE", want: []int{19}},
+		{alternative: "NARROW", want: []int{33}},
+	} {
+		record := records[0]
+		if tc.alternative == "NARROW" {
+			record = records[1]
+		}
+
+		if got := slackWidths(record.Root); len(got) != len(tc.want) || got[0] != tc.want[0] {
+			t.Errorf("reading %s, the slack is %v, want %v", tc.alternative, got, tc.want)
+		}
+		if got := record.Extent(); got != 40 {
+			t.Errorf("reading %s, the record is %d bytes, want the lrecl of 40", tc.alternative, got)
+		}
+	}
+}
+
+// TestARecordLongerThanAnExactLRECLIsReported is the direction no slack node can
+// fix: bytes cannot be taken away, and a record type longer than the dataset's
+// records overruns the next one.
+func TestARecordLongerThanAnExactLRECLIsReported(t *testing.T) {
+	t.Parallel()
+
+	_, err := framed(t, "01 R.\n   05 A PIC X(96).\n", fixed(80))
+
+	var extent *LRECLExtentError
+	if !errors.As(err, &extent) {
+		t.Fatalf("resolving reported %v, want an LRECLExtentError", err)
+	}
+	if extent.Extent != 96 || extent.LRECL != 80 {
+		t.Errorf("the diagnostic says %d bytes against %d, want 96 against 80", extent.Extent, extent.LRECL)
+	}
+	if extent.Bound != layoutmodel.LRECLExact {
+		t.Errorf("the diagnostic reports a %s bound, want exact", extent.Bound)
+	}
+	for _, want := range []string{"R", "layout.sexpr:5:5", "test.cpy"} {
+		if !strings.Contains(extent.Error(), want) {
+			t.Errorf("the diagnostic does not name %s: %s", want, extent.Error())
+		}
+	}
+}
+
+// TestARecordLongerThanAMaximumLRECLIsReported: under a variable-length dataset
+// the same number is a maximum, and a copybook that exceeds it is a copybook
+// bound to the wrong dataset.
+func TestARecordLongerThanAMaximumLRECLIsReported(t *testing.T) {
+	t.Parallel()
+
+	_, err := framed(t, "01 R.\n   05 A PIC X(96).\n", variable(80))
+
+	var extent *LRECLExtentError
+	if !errors.As(err, &extent) {
+		t.Fatalf("resolving reported %v, want an LRECLExtentError", err)
+	}
+	if extent.Bound != layoutmodel.LRECLMaximum {
+		t.Errorf("the diagnostic reports a %s bound, want maximum", extent.Bound)
+	}
+}
+
+// TestARecordShortOfAMaximumLRECLIsNotPadded is the difference between the two
+// bounds, and it is why they are two: a variable-length record states its own
+// length, so there is no distance for a pad to make up.
+func TestARecordShortOfAMaximumLRECLIsNotPadded(t *testing.T) {
+	t.Parallel()
+
+	records, err := framed(t, "01 R.\n   05 A PIC X(40).\n", variable(80))
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+
+	if got := slackWidths(records[0].Root); len(got) != 0 {
+		t.Errorf("the record carries slack of %v under a maximum lrecl", got)
+	}
+	if got := records[0].Extent(); got != 40 {
+		t.Errorf("the record is %d bytes, want the 40 its items occupy", got)
+	}
+}
+
+// TestAVariableExtentDoesNotFitAFixedLengthDataset is #92's rule: a record type
+// of a fixed part, a table and a pad meets LRECL at one count and misses it at
+// every other, and a slack node carries one width.
+func TestAVariableExtentDoesNotFitAFixedLengthDataset(t *testing.T) {
+	t.Parallel()
+
+	_, err := framed(t, `01 R.
+   05 N PIC 9(2).
+   05 ENTRY OCCURS 1 TO 5 TIMES DEPENDING ON N PIC X(8).
+`, fixed(80))
+
+	var variable *VariableExtentError
+	if !errors.As(err, &variable) {
+		t.Fatalf("resolving reported %v, want a VariableExtentError", err)
+	}
+	for _, want := range []string{"R", "ENTRY", "N", "FB"} {
+		if !strings.Contains(variable.Error(), want) {
+			t.Errorf("the diagnostic does not name %s: %s", want, variable.Error())
+		}
+	}
+}
+
+// TestAVariableExtentIsRefusedOnAFixedDatasetStatingNoLRECL: the rule is about
+// the dataset and not about the number, so it holds whether or not a layout
+// states one.
+func TestAVariableExtentIsRefusedOnAFixedDatasetStatingNoLRECL(t *testing.T) {
+	t.Parallel()
+
+	framing := fixed(0)
+	framing.LRECL = layoutmodel.Size{}
+
+	_, err := framed(t, `01 R.
+   05 N PIC 9(2).
+   05 ENTRY OCCURS 1 TO 5 TIMES DEPENDING ON N PIC X(8).
+`, framing)
+
+	var variable *VariableExtentError
+	if !errors.As(err, &variable) {
+		t.Fatalf("resolving reported %v, want a VariableExtentError", err)
+	}
+}
+
+// TestAVariableExtentIsAdmittedOnAVariableLengthDataset is the other side of it:
+// there the record's descriptor word states its length, so an extent that moves
+// with a count is the ordinary case.
+func TestAVariableExtentIsAdmittedOnAVariableLengthDataset(t *testing.T) {
+	t.Parallel()
+
+	if _, err := framed(t, `01 R.
+   05 N PIC 9(2).
+   05 ENTRY OCCURS 1 TO 5 TIMES DEPENDING ON N PIC X(8).
+`, variable(80)); err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+}
+
+// TestARecordIsResolvedWithNoFramingAtAll is the default every other test in
+// this package runs under, asserted once: nothing about a record's members
+// depends on a framing, and a caller with none to state states none.
+func TestARecordIsResolvedWithNoFramingAtAll(t *testing.T) {
+	t.Parallel()
+
+	records, err := framed(t, "01 R.\n   05 A PIC X(40).\n", nil)
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+	if got := records[0].Extent(); got != 40 {
+		t.Fatalf("the record is %d bytes, want 40", got)
+	}
+	if got := slackWidths(records[0].Root); len(got) != 0 {
+		t.Errorf("the record carries slack of %v with no framing stated", got)
+	}
+}

--- a/internal/resolve/lrecl_test.go
+++ b/internal/resolve/lrecl_test.go
@@ -18,9 +18,10 @@ import (
 
 // A fixed-length dataset gives every record the same number of bytes, so a
 // record type whose items stop short of LRECL ends in a run that belongs to no
-// item — the third producer of slack, beside an alignment gap and a REDEFINES
-// tail, and the same kind of node once emitted (docs/layout/SPEC.md, "`lrecl`
-// and `blksize` describe the dataset, not the stream").
+// item — the fourth producer of slack, beside an alignment gap, a REDEFINES tail
+// and a table's stride padding, and the same kind of node as any of them once
+// emitted (docs/layout/SPEC.md, "`lrecl` and `blksize` describe the dataset, not
+// the stream").
 
 // fixed is a framing over a fixed-length dataset stating lrecl, which is the
 // framing under which a record type's extent has to *be* that number.

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Zaba505/cobol-go/copybook"
 
 	"github.com/Zaba505/cpybkc/internal/diag"
+	"github.com/Zaba505/cpybkc/internal/layout"
 	"github.com/Zaba505/cpybkc/internal/layoutmodel"
 )
 
@@ -32,6 +33,25 @@ type Options struct {
 	// here for the reason `cobol-go` gives it none: a wrong layout setting is
 	// not visible in the result.
 	Dialect copybook.Dialect
+
+	// Framing is the layout's physical framing, or nil where the caller has
+	// none to state. What is read here is what the dataset requires of a
+	// record's extent and nothing else: [layoutmodel.Framing.LRECLBound],
+	// and the `lrecl` behind it.
+	//
+	// The rest of the framing is not this package's. A delimiter, a block
+	// size and a maximum segment describe the bytes around a record or the
+	// dataset it came out of, and neither moves an item inside one; they
+	// reach the file node, which is #38's. The whole value is taken all the
+	// same, because the bound is derived from the record format and the
+	// `lrecl` together and a caller decomposing it here would be a second
+	// reading of docs/layout/SPEC.md's table.
+	//
+	// It is a pointer because a layout that states no framing at all is a
+	// layout this package still resolves: nothing about a record's members
+	// depends on one, and the check below is simply not run. A zero
+	// [layoutmodel.Framing] states no `lrecl` and means the same thing.
+	Framing *layoutmodel.Framing
 
 	// Redefines says how each REDEFINES inside a repeating group is told
 	// apart. A redefine outside one needs no entry: its alternatives become
@@ -133,6 +153,15 @@ type Alternative struct {
 // four is refused before the walk starts, and nothing that leaves here states
 // fewer.
 //
+// Every byte of a record that no item occupies is a slack node in the
+// containment order, whatever left it uncovered — the gap ahead of a
+// SYNCHRONIZED item, the storage a REDEFINES alternative does not fill, the
+// padding between one occurrence of a table and the next, and the tail of a
+// record whose items stop short of the `lrecl` [Options.Framing] states. One
+// node per maximal run: two of those that abut are one node of the summed
+// width, and the one edge a run does not cross is an arm's (docs/ir/SPEC.md,
+// "Slack is a node, not a rule").
+//
 // Every fault it finds is reported, joined with [errors.Join] and assertable
 // with [errors.As], rather than the first: a copybook and the layout over it go
 // wrong in the same way in several places at once. A record it found a fault in
@@ -179,11 +208,119 @@ func Resolve(record *copybook.Field, opts Options) ([]*Record, error) {
 		})
 	}
 
+	r.frame(records)
 	r.assertResolved(records)
 	if r.faults.Failed() {
 		return nil, r.faults.Err()
 	}
 	return records, nil
+}
+
+// frame holds each resolved record to what the dataset's framing requires of its
+// extent, and carries the difference as slack where that is what the requirement
+// means.
+//
+// Two rules, and they are keyed on different things. The variable-extent
+// rejection is keyed on the framing being **unframed**, because it holds
+// whatever `lrecl` a layout states and whether or not it states one; the extent
+// check is keyed on [layoutmodel.Framing.LRECLBound], which is the `lrecl` and
+// the record format read together (docs/layout/SPEC.md, "`lrecl` and `blksize`
+// describe the dataset, not the stream").
+//
+// Under [layoutmodel.LRECLExact] a record type accounts for all of LRECL, so a
+// record type whose items stop short carries the difference as a trailing slack
+// node — the third producer of slack, beside an alignment gap and a REDEFINES
+// tail, and indistinguishable from either once emitted (#26, #34). It is
+// appended through [mergeSlack] for that reason: a record whose last member is
+// already slack ends in one run of the summed width and not in two nodes that
+// abut.
+func (r *resolver) frame(records []*Record) {
+	framing := r.opts.Framing
+	if framing == nil {
+		return
+	}
+
+	fixedLength := framing.Kind() == layoutmodel.Unframed
+	bound, lrecl := framing.LRECLBound(), int(framing.LRECL.Value)
+
+	for _, record := range records {
+		if node, item := variableTerm(record); fixedLength && node != nil {
+			// One fault per record: a record type that does not fit the
+			// dataset at all has no extent for the check below to be
+			// about.
+			r.faults.Fail(&VariableExtentError{
+				Pos:    framingSpan(framing.Pos),
+				Item:   r.span(item),
+				Record: r.record.Name,
+				RECFM:  framing.RECFM,
+				Table:  itemName(item),
+				Count:  itemName(node.Repetition.DependingOn),
+			})
+			continue
+		}
+
+		if bound == layoutmodel.LRECLUnstated {
+			continue
+		}
+
+		extent := record.Extent()
+		switch {
+		case extent > lrecl:
+			r.faults.Fail(&LRECLExtentError{
+				Pos:          framingSpan(framing.LRECL.Pos),
+				Item:         r.span(r.record),
+				Record:       r.record.Name,
+				Alternatives: alternativeNames(record),
+				Bound:        bound,
+				Extent:       extent,
+				LRECL:        lrecl,
+			})
+		case extent < lrecl && bound == layoutmodel.LRECLExact:
+			// A record type shorter than LRECL is padded rather than
+			// reported: the bytes are in the file whatever the copybook
+			// says, and the next record begins after them.
+			members := record.Root.Members
+			record.Root.Members = mergeSlack(append(members[:len(members):len(members)], slackNode(lrecl-extent)))
+		}
+	}
+}
+
+// variableTerm returns the first node of the record whose repetition count is
+// read out of the record rather than written in the copybook, together with the
+// copybook item it stands for. Both are nil where the record's extent is a
+// constant.
+//
+// The item is not always the node's own. An elementary item padded out to its
+// stride is wrapped in a group this package introduced, and it is the wrapper
+// that carries the repetition while the field inside it carries the name.
+func variableTerm(record *Record) (*Node, *copybook.Field) {
+	var found *Node
+	var item *copybook.Field
+
+	record.Walk(func(node *Node) {
+		if found != nil || !node.Repetition.Reference() {
+			return
+		}
+
+		found = node
+		item = node.Field
+		if item == nil && len(node.Members) > 0 {
+			item = node.Members[0].Field
+		}
+	})
+	return found, item
+}
+
+// alternativeNames is what the record's alternatives are called, so that a
+// diagnostic about one alternative of a copybook says which. It is empty for a
+// copybook holding no REDEFINES outside a repeating group, where the record's
+// own name is already unambiguous.
+func alternativeNames(record *Record) []string {
+	out := make([]string, 0, len(record.Alternatives))
+	for _, alternative := range record.Alternatives {
+		out = append(out, itemName(alternative))
+	}
+	return out
 }
 
 // assertResolved holds every field of the records to docs/ir/SPEC.md's "The
@@ -559,6 +696,16 @@ func (r *resolver) redefine(field *copybook.Field) *Redefine {
 		}
 	}
 	return nil
+}
+
+// framingSpan is where in the layout a framing form is.
+//
+// It is the other file a fault about a record's extent implicates: the number
+// comes from the dataset the adopter wrote down and the extent from a copybook
+// they may not own, so a diagnostic naming only one of the two names the one
+// they cannot change (docs/layout/SPEC.md, "Every diagnostic carries a span").
+func framingSpan(pos layout.Pos) diag.Span {
+	return diag.Span{File: pos.File, Line: pos.Line, Column: pos.Column}
 }
 
 // span is where in the copybook a field is.

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -229,11 +229,11 @@ func Resolve(record *copybook.Field, opts Options) ([]*Record, error) {
 //
 // Under [layoutmodel.LRECLExact] a record type accounts for all of LRECL, so a
 // record type whose items stop short carries the difference as a trailing slack
-// node — the third producer of slack, beside an alignment gap and a REDEFINES
-// tail, and indistinguishable from either once emitted (#26, #34). It is
-// appended through [mergeSlack] for that reason: a record whose last member is
-// already slack ends in one run of the summed width and not in two nodes that
-// abut.
+// node — the fourth producer of slack, beside an alignment gap, a REDEFINES tail
+// and a table's stride padding, and indistinguishable from any of them once
+// emitted (#26, #34). It is appended through [mergeSlack] for that reason: a
+// record whose last member is already slack ends in one run of the summed width
+// and not in two nodes that abut.
 func (r *resolver) frame(records []*Record) {
 	framing := r.opts.Framing
 	if framing == nil {

--- a/internal/resolve/slack_test.go
+++ b/internal/resolve/slack_test.go
@@ -6,16 +6,20 @@
 package resolve
 
 import (
+	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/Zaba505/cobol-go/copybook"
 )
 
 // Any byte of a record that no item occupies appears in the containment order as
-// a slack node, whatever left it uncovered. Which alignments a dialect honours
-// is `cobol-go`'s and the rest of the rule is #34's; what is held here is the
-// part the position sum cannot do without, which is that the members of a group
-// add up to its extent exactly.
+// a slack node, whatever left it uncovered. Which alignments a dialect honours is
+// `cobol-go`'s and is asserted here as vectors rather than derived; what is held
+// here is the part the position sum cannot do without, which is that the members
+// of a group add up to its extent exactly. The fourth producer of slack — the
+// tail of a record short of `lrecl` — is in lrecl_test.go, beside the check it
+// comes out of.
 
 // TestAlignmentReachesTheRecordAsBytes is the sum being literally true with
 // SYNCHRONIZED present: the bytes an aligned item is pushed forward by are in
@@ -41,6 +45,130 @@ func TestAlignmentReachesTheRecordAsBytes(t *testing.T) {
 	if got := record.Extent(); got != 11 {
 		t.Errorf("the record is %d bytes, want 11", got)
 	}
+}
+
+// TestAlignmentVectorsAtEachBinaryWidth walks every boundary a SYNCHRONIZED item
+// sits on, because a generator implements no alignment rule at all: the bytes
+// reach it in the member list, so a boundary this stage gets wrong is one
+// nothing downstream is looking for.
+//
+// One byte in front of the item is the vector. It is the offset that is wrong
+// for every boundary at once, so the slack a boundary of n needs is n-1 and the
+// item lands on n, and one table covers the whole staircase rather than a case
+// per width with a different lead-in.
+func TestAlignmentVectorsAtEachBinaryWidth(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		picture  string
+		width    int
+		boundary int
+	}{
+		// The binary staircase under IBM Enterprise COBOL's 2/4/8, each
+		// rung on the boundary of the machine datum it is held in.
+		{name: "binary halfword", picture: "PIC S9(4) COMP", width: 2, boundary: 2},
+		{name: "binary fullword", picture: "PIC S9(9) COMP", width: 4, boundary: 4},
+		{name: "binary doubleword", picture: "PIC S9(18) COMP", width: 8, boundary: 8},
+
+		// Floating point, index and pointer take their boundary from the
+		// usage and the dialect rather than from a PICTURE.
+		{name: "single-precision float", picture: "COMP-1", width: 4, boundary: 4},
+		{name: "double-precision float", picture: "COMP-2", width: 8, boundary: 8},
+		{name: "index", picture: "USAGE INDEX", width: 4, boundary: 4},
+		{name: "pointer", picture: "USAGE POINTER", width: 4, boundary: 4},
+
+		// The two usages the clause is syntax-checked on and has no effect
+		// for: characters and nibbles have no machine boundary to sit on,
+		// so the item stays where it was and there is no slack at all.
+		{name: "display", picture: "PIC X(3)", width: 3, boundary: 1},
+		{name: "packed decimal", picture: "PIC S9(5) COMP-3", width: 3, boundary: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			record := resolveOne(t, fmt.Sprintf(`01 R.
+   05 LEAD PIC X.
+   05 A %s SYNCHRONIZED.
+   05 TRAIL PIC X.
+`, tc.picture))
+
+			if got, want := slackWidths(record.Root), gap(tc.boundary); !slices.Equal(got, want) {
+				t.Fatalf("%s left slack of %v, want %v ahead of a %d-byte boundary", tc.picture, got, want, tc.boundary)
+			}
+			if got := positionOf(t, record, "A"); got != tc.boundary {
+				t.Errorf("%s is at %d, want the %d-byte boundary", tc.picture, got, tc.boundary)
+			}
+			if got := widthOf(t, record, "A"); got != tc.width {
+				t.Errorf("%s is %d bytes, want %d", tc.picture, got, tc.width)
+			}
+			if got := record.Extent(); got != tc.boundary+tc.width+1 {
+				t.Errorf("the record is %d bytes, want %d", got, tc.boundary+tc.width+1)
+			}
+		})
+	}
+}
+
+// TestAlignmentVectorsAtEachSmallestBinaryWidth is the same staircase under a
+// dialect whose binary widths are not powers of two, which is the only way to
+// reach the rounding in the boundary rule at all: a three-byte item sits on a
+// fullword and a five-byte item on a doubleword, so the boundary is not the
+// width and a generator deriving one from the other would be wrong on half the
+// staircase.
+func TestAlignmentVectorsAtEachSmallestBinaryWidth(t *testing.T) {
+	t.Parallel()
+
+	dialect := copybook.IBMEnterprise()
+	dialect.Binary = copybook.BinarySizeSmallest
+
+	for _, tc := range []struct {
+		digits   int
+		width    int
+		boundary int
+	}{
+		{digits: 2, width: 1, boundary: 1},
+		{digits: 4, width: 2, boundary: 2},
+		{digits: 6, width: 3, boundary: 4},
+		{digits: 9, width: 4, boundary: 4},
+		{digits: 11, width: 5, boundary: 8},
+		{digits: 14, width: 6, boundary: 8},
+		{digits: 16, width: 7, boundary: 8},
+		{digits: 18, width: 8, boundary: 8},
+	} {
+		t.Run(fmt.Sprintf("%d digits", tc.digits), func(t *testing.T) {
+			t.Parallel()
+
+			field := recordOf(t, fmt.Sprintf(`01 R.
+   05 LEAD PIC X.
+   05 A PIC S9(%d) COMP SYNCHRONIZED.
+   05 TRAIL PIC X.
+`, tc.digits))
+			records, err := Resolve(field, Options{Dialect: dialect, Encoding: mainframe()})
+			if err != nil {
+				t.Fatalf("resolving: %v", err)
+			}
+			record := records[0]
+
+			if got, want := slackWidths(record.Root), gap(tc.boundary); !slices.Equal(got, want) {
+				t.Fatalf("%d digits left slack of %v, want %v ahead of a %d-byte boundary", tc.digits, got, want, tc.boundary)
+			}
+			if got := positionOf(t, record, "A"); got != tc.boundary {
+				t.Errorf("%d digits is at %d, want the %d-byte boundary", tc.digits, got, tc.boundary)
+			}
+			if got := widthOf(t, record, "A"); got != tc.width {
+				t.Errorf("%d digits is %d bytes, want %d", tc.digits, got, tc.width)
+			}
+		})
+	}
+}
+
+// gap is the slack a boundary leaves behind the one byte in front of the item:
+// one run of boundary-1, and no run at all where the item aligns to a byte.
+func gap(boundary int) []int {
+	if boundary <= 1 {
+		return nil
+	}
+	return []int{boundary - 1}
 }
 
 // TestTwoRunsOfDifferentOriginThatAbutAreOneNode: how a producer divides a run


### PR DESCRIPTION
Closes #34

Slack is one node per maximal run of bytes no item occupies, and this completes the set of things that leave one behind. Alignment gaps, a `REDEFINES` tail and a table's stride padding already reached the member list; the fourth is the tail of a record whose items stop short of the `lrecl` a fixed-length dataset states, and that one needs a framing to see.

## What changed

- `Options.Framing` — the layout's physical framing, or nil. Read for the LRECL bound and nothing else.
- Under `LRECLExact` (RECFM F/FB) a record type accounts for all of LRECL: one shorter carries the difference as a **trailing slack node**, appended through `mergeSlack` so it joins a run it abuts rather than sitting beside it; one longer is an `LRECLExtentError`, since no node takes bytes away.
- On an **unframed** dataset a record type whose extent moves with a count is a `VariableExtentError` naming the record and the repeating item — #92's rule, keyed on the framing rather than on the number, because it holds whether or not a layout states an `lrecl`.
- Under the other three framings each record states its own length, so an `lrecl` is a maximum that is checked and never padded to.
- Two tables of alignment vectors, and the package doc rewritten around slack's four producers and the two edges a run does not cross.

## Acceptance criteria

- [x] **Slack bytes computed per the `cobol-go` rules once cobol-go#79 lands** — it landed (closed 2026-08-07) and the pinned `cobol-go` carries it. Offsets, strides and slack are read off `copybook.NewLayout`; nothing here recomputes a boundary.
- [x] **Records using `SYNC` produce correct offsets** — asserted as vectors, and cross-checked against the offsets `cobol-go` computed independently in `TestPositionsAgreeWithTheOffsetsTheCopybookWasLaidOutAt`.
- [x] **Before support lands, an explicit unsupported error rather than wrong offsets** — moot, and deliberately not added. Support has landed, so an error guarding its absence would refuse layouts that now resolve correctly.
- [x] **Every uncovered byte emitted as a slack node in containment order, whatever produced it** — the fourth producer, the fixed-length record's trailing pad, is what this PR adds; the other three were already there.
- [x] **One slack node per maximal run** — `mergeSlack` covers the pad too: `TestEveryAlternativeOfARecordIsPaddedToLRECL` has a `REDEFINES` tail of 14 abutting a pad of 19 and asserts one node of 33.
- [x] **Each `REDEFINES` alternative's record node carries its slack, emitted explicitly** — already held by `TestARedefinesAlternativeCarriesTheSlackItDoesNotOccupy`; each alternative is now padded to LRECL on its own too, since each is a record type of the dataset.
- [x] **A slack node carries a width and nothing else** — unchanged: `slackNode` sets `Kind` and `width`, and `Node.Field`/`Encoding` stay zero.
- [x] **Each arm carries a slack node over the common extent its items do not occupy** — already held by `TestAShorterArmCarriesTheSlackItsItemsDoNotOccupy`.
- [x] **A run never crosses the edge of an arm** — already held; the same edge is now asserted from the pad's side in `TestTheLRECLPadDoesNotJoinARunInsideARepeatingGroup`, where a run inside a repeating group stands for one run *per occurrence* and so cannot merge with a run behind it.
- [x] **Test vectors covering alignment at each binary width** — `TestAlignmentVectorsAtEachBinaryWidth` (halfword/fullword/doubleword, `COMP-1`, `COMP-2`, `INDEX`, `POINTER`, and the two usages the clause has no effect for) and `TestAlignmentVectorsAtEachSmallestBinaryWidth` (widths 1–8 under `BinarySizeSmallest`, where a 3-byte item sits on a fullword and a 5-byte item on a doubleword).

## Judgment calls that shaped the public API

- **`Framing` is taken whole, as `*layoutmodel.Framing`.** The bound is derived from the record format and the `lrecl` together, so a caller decomposing it into two fields here would be a second reading of docs/layout/SPEC.md's table — and two fields that can be made to disagree. Nil means "no framing stated", and resolution proceeds unchanged, which is what every existing test does.
- **The `LRECLMaximum` arm is implemented, not deferred.** It is not named in the acceptance criteria, but `LRECLBound` has three values and honouring two of them would leave the third silently unchecked on an `Options` field that claims to carry the requirement.
- **A record short of a maximum `lrecl` is not padded.** Padding is the mechanism that makes *unframed* work; under a descriptor word the record states its own length and a pad would be bytes nobody wrote.
- **The variable-extent rejection lands here rather than in #35.** docs/ir/SPEC.md cites #35 for it, but this is the story that teaches `resolve` about LRECL, and emitting a pad computed at the declared maximum for a record whose extent moves would be exactly the silent misread the rule exists to prevent. #35 can refine the diagnostic with the shape distinction docs/layout/SPEC.md describes.
- **No spec change.** Every requirement implemented here is already written in `docs/ir/SPEC.md` and `docs/layout/SPEC.md` with #34 traced against it.

## Verification

`dagger call ci` — green. Also run directly: `gofmt -l .` (clean), `go vet ./...`, `go test -race ./...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)