### PR TITLE
story(resolve): resolve OCCURS DEPENDING ON

### DIFF
--- a/docs/layout/SPEC.md
+++ b/docs/layout/SPEC.md
@@ -1620,7 +1620,7 @@ computed once by `resolve`.
 | [The surface syntax](#the-surface-syntax) | #22 `layout` |
 | [The encoding profile](#the-encoding-profile) | #25 `layout` |
 | [Physical framing](#physical-framing) | #26 `layout` |
-| [Record definitions](#record-definitions) | #27, #30 `layout`; #35 `resolve` reads `copybook-reading` |
+| [Record definitions](#record-definitions) | #27, #30 `layout`; `copybook-reading` by #35 `resolve` |
 | [Discrimination](#discrimination) | #28 `layout` |
 | [Sequencing](#sequencing) | #29 `layout` |
 | [The published schema](#the-published-schema) | #23 `layout` |

--- a/docs/layout/SPEC.md
+++ b/docs/layout/SPEC.md
@@ -1620,7 +1620,7 @@ computed once by `resolve`.
 | [The surface syntax](#the-surface-syntax) | #22 `layout` |
 | [The encoding profile](#the-encoding-profile) | #25 `layout` |
 | [Physical framing](#physical-framing) | #26 `layout` |
-| [Record definitions](#record-definitions) | #27, #30 `layout` |
+| [Record definitions](#record-definitions) | #27, #30 `layout`; #35 `resolve` reads `copybook-reading` |
 | [Discrimination](#discrimination) | #28 `layout` |
 | [Sequencing](#sequencing) | #29 `layout` |
 | [The published schema](#the-published-schema) | #23 `layout` |

--- a/internal/layoutmodel/doc.go
+++ b/internal/layoutmodel/doc.go
@@ -17,17 +17,26 @@
 // Each layer of the format gets a reader here, and a type for what the layer
 // says. [ReadProfile] is the encoding profile (#25), [ReadFraming] is the
 // physical framing (#26), [ReadDiscrimination] is discrimination (#28),
-// [ReadSequence] is sequencing (#29) and [ReadRenames] is the record
-// definitions layer's renames (#27, #30). What they have in common is that a
-// value handed back is one the format admits: a [Profile] carries four stated
-// axes because a profile stating three is an error and not a value with a hole
-// in it, a [Framing] resolves to one of the IR's four framings because the one
-// record format that resolves to none is rejected while the layout is read,
-// every `record` in a [Discrimination] carries exactly one strategy out of a
-// closed set, every node of a [Sequence]'s expression is one of the eight terms
-// the algebra is made of, carrying what that term takes, and every [Rename]
-// names its item in full and carries the substitute beside the original rather
-// than in place of it.
+// [ReadSequence] is sequencing (#29), and [ReadRenames] and
+// [ReadCopybookReading] are the two halves of the record definitions layer this
+// package reads — its renames (#27, #30) and its `OCCURS DEPENDING ON` reading
+// (#27, #35). What they have in common is that a value handed back is one the
+// format admits: a [Profile] carries four stated axes because a profile stating
+// three is an error and not a value with a hole in it, a [Framing] resolves to
+// one of the IR's four framings because the one record format that resolves to
+// none is rejected while the layout is read, every `record` in a
+// [Discrimination] carries exactly one strategy out of a closed set, every node
+// of a [Sequence]'s expression is one of the eight terms the algebra is made of,
+// carrying what that term takes, every [Rename] names its item in full and
+// carries the substitute beside the original rather than in place of it, and a
+// [Reading] is one of the two vendor readings or the statement that the layout
+// made neither.
+//
+// The reading is the one value here whose absence is not this package's to
+// refuse. Whether a layout needed one is a question about the copybooks it binds
+// rather than about the layout, and this package never opens a copybook, so an
+// unstated reading leaves here as [ReadingUnstated] and `resolve` is what
+// rejects it — against the record and the table that needed the answer.
 //
 // # The one layer that prints as well as reads
 //

--- a/internal/layoutmodel/errors.go
+++ b/internal/layoutmodel/errors.go
@@ -1108,6 +1108,94 @@ func (e *RenameShadowsSiblingError) Error() string {
 	)
 }
 
+// ReadingCountError is a layout carrying more than one `copybook-reading` form.
+//
+// There is no counterpart for a layout carrying none, which is the difference
+// between this and [ProfileCountError] or [FramingCountError]. The form's arity
+// is zero or one, because whether the layout needed it is a question about the
+// copybooks it binds and not about the layout: only a record carrying an
+// `OCCURS DEPENDING ON` needs the answer, and `resolve` is what has one open.
+//
+// It carries both positions for [RepeatedAxisError]'s reason: either line is a
+// perfectly good statement on its own, and what an adopter has to decide is
+// which of the two they meant. A layout whose tables slide and whose other
+// tables do not describes a file no compiler produced, so the second line is
+// never a refinement of the first.
+type ReadingCountError struct {
+	// Pos is the second `copybook-reading` form.
+	Pos layout.Pos
+
+	// First is the one before it.
+	First layout.Pos
+
+	// Count is how many the layout carries.
+	Count int
+}
+
+// Error implements the error interface.
+func (e *ReadingCountError) Error() string {
+	return fmt.Sprintf(
+		"%s: a layout carries at most one copybook-reading form, and this one carries %d, the first at %s; "+
+			"the reading is a property of the compiler that wrote the file rather than of any record in it",
+		e.Pos, e.Count, e.First,
+	)
+}
+
+// ReadingValueError is a value written for `occurs-depending-on` that the child
+// does not admit.
+//
+// It is [FramingValueError]'s counterpart in this layer and names the whole set
+// for the same reason: this is a spelling question an adopter can answer from
+// the message, and the spellings are the compiler directives they looked the
+// setting up under.
+type ReadingValueError struct {
+	// Pos is the value, not the form carrying it.
+	Pos layout.Pos
+
+	// Value is what was written.
+	Value string
+
+	// Admits is the set the child takes.
+	Admits []string
+}
+
+// Error implements the error interface.
+func (e *ReadingValueError) Error() string {
+	return fmt.Sprintf(
+		"%s: occurs-depending-on is one of %s, and this one says %s",
+		e.Pos, and(e.Admits), quote(e.Value),
+	)
+}
+
+// ReadingFormError is a `copybook-reading` form, or its `occurs-depending-on`
+// child, that does not carry exactly one value of the sort it takes.
+//
+// `(copybook-reading)` states nothing and `(occurs-depending-on odoslide
+// noodoslide)` states both readings at once. Neither is a value with something
+// wrong with it, so neither is a [ReadingValueError].
+type ReadingFormError struct {
+	// Pos is the form the shortfall is in.
+	Pos layout.Pos
+
+	// Child is the tag, empty where the fault is in the `copybook-reading`
+	// form itself rather than in its child.
+	Child string
+
+	// Takes is what belongs there, and Found what was written.
+	Takes string
+	Found string
+}
+
+// Error implements the error interface.
+func (e *ReadingFormError) Error() string {
+	form := tagCopybookReading
+	if e.Child != "" {
+		form = e.Child
+	}
+
+	return fmt.Sprintf("%s: %s takes %s, and this one carries %s", e.Pos, form, e.Takes, e.Found)
+}
+
 // SequenceCountError is a layout that does not carry exactly one `sequence`
 // form.
 //

--- a/internal/layoutmodel/reading.go
+++ b/internal/layoutmodel/reading.go
@@ -1,0 +1,214 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layoutmodel
+
+import (
+	"github.com/Zaba505/cpybkc/internal/diag"
+	"github.com/Zaba505/cpybkc/internal/layout"
+)
+
+// The tags this half of the record definitions layer reads.
+const (
+	tagCopybookReading     = "copybook-reading"
+	childOccursDependingOn = "occurs-depending-on"
+)
+
+// Reading is which of the two vendor readings of `OCCURS DEPENDING ON` the file
+// a layout describes was written under.
+//
+// It is the adopter's own spelling rather than a word this project invented:
+// Micro Focus's directive is `ODOSLIDE`/`NOODOSLIDE` and GnuCOBOL carries the
+// same switch as the dialect option `odoslide`, so an adopter looks the setting
+// up in the compiler that wrote the file and finds it spelled this way. IBM
+// Enterprise COBOL slides unconditionally and has no directive to name, which is
+// why the value is not read off a dialect.
+//
+// The zero value is [ReadingUnstated], and it is a value rather than an absence
+// because the thing `resolve` has to reject is a layout that says nothing while
+// a bound copybook carries the clause. There is no default: the two readings put
+// every item behind a table somewhere different and nothing in the file
+// disagrees with the wrong one (docs/layout/SPEC.md, "The `OCCURS DEPENDING ON`
+// reading is one statement per layout").
+type Reading string
+
+const (
+	// ReadingUnstated is a layout carrying no `copybook-reading` form.
+	ReadingUnstated Reading = ""
+
+	// ODOSlide is IBM's layout, and Micro Focus's under `ODOSLIDE`: an item
+	// behind a table begins at the byte after the last occurrence the count
+	// states.
+	ODOSlide Reading = "odoslide"
+
+	// NoODOSlide is Micro Focus's `NOODOSLIDE` and GnuCOBOL's default: the
+	// items behind a table keep fixed addresses beginning after the space
+	// allocated for it at its maximum length.
+	NoODOSlide Reading = "noodoslide"
+)
+
+// readings is the closed set the form admits, in the order docs/layout/SPEC.md
+// writes them.
+var readings = []Reading{ODOSlide, NoODOSlide}
+
+// Stated reports whether the layout said which reading its file was written
+// under.
+func (r Reading) Stated() bool { return r != ReadingUnstated }
+
+// Slides reports whether an item behind a variable-length table begins at the
+// byte after the last occurrence the count states.
+//
+// It is false for [ReadingUnstated] as well as for [NoODOSlide], so a caller
+// that asks this without having asked [Reading.Stated] first gets the reading
+// that is safe to compute — a fixed table — rather than one silently taken as a
+// default. Refusing an unstated reading is `resolve`'s, and it is refused
+// against the copybook, where the table that needs the answer is.
+func (r Reading) Slides() bool { return r == ODOSlide }
+
+// String implements the [fmt.Stringer] interface.
+func (r Reading) String() string {
+	if r == ReadingUnstated {
+		return "unstated"
+	}
+
+	return string(r)
+}
+
+// ReadCopybookReading reads the `OCCURS DEPENDING ON` reading out of a parsed
+// layout, reporting [ReadingUnstated] for a layout that carries no
+// `copybook-reading` form.
+//
+// An absent form is not a fault here, and that is the division of labour this
+// reader is built on. Whether the layout needed one is a question about the
+// copybooks it binds — only a record carrying the clause needs the answer — and
+// this package never opens a copybook. So the layer reads what was written, and
+// `resolve` rejects the layout that wrote nothing, naming the record and the
+// table (docs/layout/SPEC.md, "The `OCCURS DEPENDING ON` reading is one
+// statement per layout", #27, #35).
+//
+// It reports every fault it finds, joined, and returns [ReadingUnstated] when it
+// found one, for [ReadProfile]'s reason: a reading an adopter cannot act on is
+// worse than none.
+//
+// Top-level forms belonging to other layers are not read here and are not
+// faults.
+func ReadCopybookReading(file *layout.File) (Reading, error) {
+	read := &readingReader{}
+	reading := ReadingUnstated
+
+	// Every `copybook-reading` form is read and not only the first, so that a
+	// layout carrying two malformed ones is told about both rather than about
+	// the count alone.
+	var forms []layout.Form
+
+	for _, form := range file.Forms {
+		if form.Tag != tagCopybookReading {
+			continue
+		}
+
+		forms = append(forms, form)
+
+		one := read.reading(form)
+		if len(forms) == 1 {
+			reading = one
+		}
+	}
+
+	// The count is a fact about the layout rather than about any one form, so
+	// it is reported after everything the forms themselves were wrong about.
+	// The second form is what the diagnostic points at: the first is a reading
+	// an adopter meant, and the second is the line making it ambiguous.
+	if len(forms) > 1 {
+		read.Fail(&ReadingCountError{Pos: forms[1].Pos, First: forms[0].Pos, Count: len(forms)})
+	}
+
+	if read.Failed() {
+		return ReadingUnstated, read.Err()
+	}
+
+	return reading, nil
+}
+
+// readingReader holds the state one [ReadCopybookReading] accumulates.
+type readingReader struct {
+	diag.List
+}
+
+// reading reads one `copybook-reading` form.
+//
+// The form carries exactly one child and the child carries exactly one symbol,
+// which is a shape shallow enough that a stated-child map would be a map with
+// one key in it. What replaces it is the count check below: a second
+// `occurs-depending-on` is a form with two elements, and that is already the
+// fault this reports.
+func (r *readingReader) reading(form layout.Form) Reading {
+	if len(form.Elements) != 1 {
+		r.Fail(&ReadingFormError{
+			Pos:   form.Pos,
+			Takes: "one " + quote(childOccursDependingOn) + " child",
+			Found: count(len(form.Elements)),
+		})
+
+		return ReadingUnstated
+	}
+
+	child, ok := form.Elements[0].(layout.Form)
+	if !ok || child.Tag != childOccursDependingOn {
+		r.Fail(&ChildError{
+			Pos:    form.Elements[0].Position(),
+			Form:   form.Tag,
+			Found:  describe(form.Elements[0]),
+			Admits: []string{childOccursDependingOn},
+		})
+
+		return ReadingUnstated
+	}
+
+	return r.value(child)
+}
+
+// value reads the one symbol the `occurs-depending-on` child is written with.
+func (r *readingReader) value(child layout.Form) Reading {
+	const takes = "one symbol naming its value"
+
+	if len(child.Elements) != 1 {
+		r.Fail(&ReadingFormError{Pos: child.Pos, Child: child.Tag, Takes: takes, Found: count(len(child.Elements))})
+
+		return ReadingUnstated
+	}
+
+	symbol, ok := child.Elements[0].(layout.Symbol)
+	if !ok {
+		r.Fail(&ReadingFormError{
+			Pos:   child.Elements[0].Position(),
+			Child: child.Tag,
+			Takes: takes,
+			Found: describe(child.Elements[0]),
+		})
+
+		return ReadingUnstated
+	}
+
+	for _, reading := range readings {
+		if Reading(symbol.Value) == reading {
+			return reading
+		}
+	}
+
+	r.Fail(&ReadingValueError{Pos: symbol.Pos, Value: symbol.Value, Admits: readingNames()})
+
+	return ReadingUnstated
+}
+
+// readingNames is the set the `occurs-depending-on` child takes, as an adopter
+// writes them.
+func readingNames() []string {
+	names := make([]string, 0, len(readings))
+	for _, reading := range readings {
+		names = append(names, string(reading))
+	}
+
+	return names
+}

--- a/internal/layoutmodel/reading_test.go
+++ b/internal/layoutmodel/reading_test.go
@@ -1,0 +1,202 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layoutmodel
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/layout"
+)
+
+// readingOf is the whole pipeline a caller runs: parse the source, then read the
+// `OCCURS DEPENDING ON` reading out of it.
+func readingOf(t *testing.T, source string) (Reading, error) {
+	t.Helper()
+
+	file, err := layout.Parse("layout.sexpr", strings.NewReader(source))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	return ReadCopybookReading(file)
+}
+
+// TestBothReadingsAreRead is the closed set, each one written the way the
+// compiler that produced the file spells it.
+func TestBothReadingsAreRead(t *testing.T) {
+	t.Parallel()
+
+	for _, want := range []Reading{ODOSlide, NoODOSlide} {
+		t.Run(string(want), func(t *testing.T) {
+			t.Parallel()
+
+			got, err := readingOf(t, "(copybook-reading\n  (occurs-depending-on "+string(want)+"))\n")
+			if err != nil {
+				t.Fatalf("reading: %v", err)
+			}
+			if got != want {
+				t.Fatalf("the layout reads as %s, want %s", got, want)
+			}
+			if !got.Stated() {
+				t.Error("a layout that states a reading reads as unstated")
+			}
+			if slides := got == ODOSlide; got.Slides() != slides {
+				t.Errorf("%s slides: %v, want %v", got, got.Slides(), slides)
+			}
+		})
+	}
+}
+
+// TestALayoutStatingNoReadingIsNotAFaultHere is the division of labour this
+// reader is built on.
+//
+// Whether the layout owed a reading is a question about the copybooks it binds —
+// only a record carrying the clause needs the answer — and this package never
+// opens a copybook. So an absent form reads as unstated, and `resolve` is what
+// refuses it against the table that needed it.
+func TestALayoutStatingNoReadingIsNotAFaultHere(t *testing.T) {
+	t.Parallel()
+
+	got, err := readingOf(t, "(record ORDER-HEADER\n  (copybook \"orders.cpy\" ORDER-HEADER))\n")
+	if err != nil {
+		t.Fatalf("reading: %v", err)
+	}
+	if got != ReadingUnstated {
+		t.Fatalf("a layout carrying no copybook-reading form reads as %s, want unstated", got)
+	}
+	if got.Stated() {
+		t.Error("an unstated reading reports itself stated")
+	}
+	if got.Slides() {
+		t.Error("an unstated reading slides, which is one of the two readings taken by default")
+	}
+}
+
+// TestASecondReadingIsReported: the form is one statement per layout because the
+// reading is a property of the compiler that wrote the file rather than of any
+// record in it, so a second one is not a refinement of the first.
+func TestASecondReadingIsReported(t *testing.T) {
+	t.Parallel()
+
+	_, err := readingOf(t, `(copybook-reading
+  (occurs-depending-on odoslide))
+(copybook-reading
+  (occurs-depending-on noodoslide))
+`)
+
+	var count *ReadingCountError
+	if !errors.As(err, &count) {
+		t.Fatalf("reading reported %v, want a ReadingCountError", err)
+	}
+	if count.Count != 2 {
+		t.Errorf("the diagnostic counts %d forms, want 2", count.Count)
+	}
+
+	// The second is where the fault is, and the first is named because
+	// deciding between them is what the adopter has to do.
+	if count.Pos.Line != 3 || count.First.Line != 1 {
+		t.Errorf("the diagnostic points at %s and %s, want line 3 and line 1", count.Pos, count.First)
+	}
+}
+
+// TestAReadingOutsideTheSetIsReported names the whole set, because this is a
+// spelling question an adopter answers from the message.
+func TestAReadingOutsideTheSetIsReported(t *testing.T) {
+	t.Parallel()
+
+	_, err := readingOf(t, "(copybook-reading\n  (occurs-depending-on slide))\n")
+
+	var value *ReadingValueError
+	if !errors.As(err, &value) {
+		t.Fatalf("reading reported %v, want a ReadingValueError", err)
+	}
+	for _, want := range []string{"odoslide", "noodoslide", `"slide"`, "layout.sexpr:2:24"} {
+		if !strings.Contains(value.Error(), want) {
+			t.Errorf("the diagnostic does not name %s: %s", want, value.Error())
+		}
+	}
+}
+
+// TestAMalformedReadingFormIsReported is the shortfall that is not a value with
+// something wrong with it: a form stating nothing, and one stating both readings
+// at once.
+func TestAMalformedReadingFormIsReported(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		source string
+		child  string
+	}{
+		{name: "no child", source: "(copybook-reading)\n", child: ""},
+		{
+			name:   "two children",
+			source: "(copybook-reading\n  (occurs-depending-on odoslide)\n  (occurs-depending-on noodoslide))\n",
+			child:  "",
+		},
+		{name: "no value", source: "(copybook-reading\n  (occurs-depending-on))\n", child: "occurs-depending-on"},
+		{
+			name:   "two values",
+			source: "(copybook-reading\n  (occurs-depending-on odoslide noodoslide))\n",
+			child:  "occurs-depending-on",
+		},
+		{name: "value is text", source: "(copybook-reading\n  (occurs-depending-on \"odoslide\"))\n", child: "occurs-depending-on"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			reading, err := readingOf(t, tc.source)
+
+			var form *ReadingFormError
+			if !errors.As(err, &form) {
+				t.Fatalf("reading reported %v, want a ReadingFormError", err)
+			}
+			if form.Child != tc.child {
+				t.Errorf("the diagnostic is about child %q, want %q", form.Child, tc.child)
+			}
+			if reading != ReadingUnstated {
+				t.Errorf("a rejected layout reads as %s, want unstated", reading)
+			}
+		})
+	}
+}
+
+// TestAReadingWrittenAsSomethingOtherThanItsChildIsReported: the form takes one
+// child, and what stands there is neither a value with something wrong with it
+// nor a second `copybook-reading`.
+func TestAReadingWrittenAsSomethingOtherThanItsChildIsReported(t *testing.T) {
+	t.Parallel()
+
+	for _, source := range []string{
+		"(copybook-reading odoslide)\n",
+		"(copybook-reading\n  (odoslide))\n",
+	} {
+		_, err := readingOf(t, source)
+
+		var child *ChildError
+		if !errors.As(err, &child) {
+			t.Fatalf("reading %q reported %v, want a ChildError", source, err)
+		}
+		if !strings.Contains(child.Error(), "occurs-depending-on") {
+			t.Errorf("the diagnostic does not name what the form admits: %s", child.Error())
+		}
+	}
+}
+
+// TestReadingRendersUnstatedAsAWord: the zero value is a value rather than an
+// absence, and a message quoting it says so rather than printing nothing.
+func TestReadingRendersUnstatedAsAWord(t *testing.T) {
+	t.Parallel()
+
+	if got := ReadingUnstated.String(); got != "unstated" {
+		t.Errorf("the unstated reading renders as %q, want %q", got, "unstated")
+	}
+	if got := ODOSlide.String(); got != "odoslide" {
+		t.Errorf("the sliding reading renders as %q, want %q", got, "odoslide")
+	}
+}

--- a/internal/resolve/doc.go
+++ b/internal/resolve/doc.go
@@ -81,15 +81,58 @@
 // copy on the node would be a second answer to a question the copybook has
 // answered. Spelling them into the descriptor's own members is #38's.
 //
+// # A table's extent moves with a count, under one of the two readings
+//
+// [Options.Reading] is the fork docs/ir/SPEC.md's "An item after a table slides,
+// and the other reading is a fixed table" records, and it reaches this package
+// for the same reason a framing does: a layout states it and `resolve` resolves
+// it. Under `odoslide` an `OCCURS DEPENDING ON` table becomes a [Repetition]
+// whose count is a reference to the field the DEPENDING ON phrase names, and
+// every item behind it begins at the byte after the last occurrence that count
+// states. Under `noodoslide` the same clause describes a fixed table at the
+// copybook's declared maximum, so it becomes a constant repetition and the count
+// field is resolved as an ordinary field of the record with nothing pointing at
+// it. There is no default: the two put every item behind the table somewhere
+// different and nothing in the file disagrees with the wrong one, so a copybook
+// carrying the clause under an unstated reading is rejected (#87).
+//
+// Both readings carry the copybook's own `OCCURS integer-1 TO integer-2` on the
+// repetition, and under the sliding one they are what a consumer holds a decoded
+// count to — a count outside them is malformed data. [Record.At] is that check
+// and the sum that follows from it, run here so that this package's tests run it
+// against the counts `cobol-go` resolves independently.
+//
+// What a count reference may name is held to before anything is laid out, and
+// each rule is docs/ir/SPEC.md's: it may not name a field that repeats or one
+// inside a group that repeats, because nothing carries an occurrence number and
+// a count with a value per occurrence makes the occurrences of its group
+// different widths (#84); it lies ahead of the item it counts and at a constant
+// position, because otherwise locating it needs the extent it decides (#88); and
+// where two repeating items of one record name it, their declared ranges have to
+// overlap, because otherwise no count sizes both tables (#89). Those run on the
+// copybook's items rather than on the resolved nodes, so a copybook with four
+// REDEFINES alternatives reports each fault once rather than four times.
+//
 // # What this package leaves to the stories after it
 //
-// Compiling a layout's discriminator strategies into predicate nodes is #37's, a
-// count read out of a record is #35's, and assembling nodes into a
+// Compiling a layout's discriminator strategies into predicate nodes is #37's,
+// binding a count that lives in an earlier record into a register is #36's, and
+// assembling nodes into a
 // [github.com/Zaba505/cpybkc/irpb.Descriptor] with identifiers on them is #38's.
-// A [Repetition] here therefore carries the count the layout was computed at
-// beside the item a DEPENDING ON phrase names, and an [Arm] carries the
+// A [Repetition] here therefore names a [github.com/Zaba505/cobol-go/copybook.Field]
+// rather than an identifier, and an [Arm] carries the
 // [github.com/Zaba505/cpybkc/internal/layoutmodel.Strategy] a layout wrote
 // rather than a compiled predicate.
+//
+// A count that lives in another record never reaches here at all, and that is
+// the division rather than a gap: a DEPENDING ON phrase names an item of the
+// copybook record carrying it, so every reference this package resolves is to a
+// field of the record being read. Where a layout's count comes from a header
+// admitted earlier, the automaton binds that field into a register as it admits
+// the header and the repetition names the register — which is a node this
+// package does not build, and is why a reference reaching across records is not
+// a shape it has to refuse (docs/ir/SPEC.md, "A variable record is a sum with a
+// variable term", #77).
 //
 // # Slack, and its four producers
 //

--- a/internal/resolve/errors.go
+++ b/internal/resolve/errors.go
@@ -484,8 +484,9 @@ func (e *UnstatedReadingError) Diagnostic() diag.Diagnostic {
 	return diag.Diagnostic{
 		Message: fmt.Sprintf(
 			"in record %s, %s occurs a number of times read from %s, and the layout does not say whether an "+
-				"item behind a table slides: state (copybook-reading (occurs-depending-on odoslide)) or "+
-				"noodoslide, whichever the compiler that wrote the file was set to",
+				"item behind a table slides: write (copybook-reading (occurs-depending-on odoslide)) or "+
+				"(copybook-reading (occurs-depending-on noodoslide)), whichever the compiler that wrote "+
+				"the file was set to",
 			e.Record, e.Table, e.Count),
 		Spans: []diag.Span{e.Pos},
 	}

--- a/internal/resolve/errors.go
+++ b/internal/resolve/errors.go
@@ -448,6 +448,295 @@ func (e *VariableExtentError) Diagnostic() diag.Diagnostic {
 	}
 }
 
+// UnstatedReadingError is a copybook carrying an `OCCURS DEPENDING ON` under a
+// layout that did not say which reading its file was written under.
+//
+// The two readings are not two arithmetics over one shape: under `odoslide` the
+// table's extent moves with the count and every item behind it moves with it,
+// and under `noodoslide` the occurrences stand at the copybook's declared
+// maximum, the items behind them are at constant offsets, and the count field
+// governs no byte at all. Reading one file as the other is wrong at every item
+// behind the table, silently, at every record.
+//
+// So there is nothing to fall back on and no side to take by default, which is
+// what makes this a fault rather than a warning with a resolution attached. It
+// names the table because that is where an adopter starts: the answer is a
+// property of the compiler that wrote the file, spelled `ODOSLIDE`/`NOODOSLIDE`
+// by Micro Focus, `odoslide` by GnuCOBOL and nothing at all by IBM Enterprise
+// COBOL, which slides unconditionally.
+type UnstatedReadingError struct {
+	// Pos is the entry carrying the DEPENDING ON phrase.
+	Pos diag.Span
+
+	// Record is the record being resolved.
+	Record string
+
+	// Table is the repeating item, and Count the item its count is read from.
+	Table string
+	Count string
+}
+
+// Error implements the error interface.
+func (e *UnstatedReadingError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *UnstatedReadingError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"in record %s, %s occurs a number of times read from %s, and the layout does not say whether an "+
+				"item behind a table slides: state (copybook-reading (occurs-depending-on odoslide)) or "+
+				"noodoslide, whichever the compiler that wrote the file was set to",
+			e.Record, e.Table, e.Count),
+		Spans: []diag.Span{e.Pos},
+	}
+}
+
+// CountOccurrenceError is an `OCCURS DEPENDING ON` count that repeats, or that
+// sits inside a group that repeats.
+//
+// Nothing in a repetition carries an occurrence number, so a reference that
+// could reach a later occurrence names bytes the descriptor cannot say it meant
+// — reading it as the first is a guess about intention that a consumer cannot
+// detect is wrong (docs/ir/SPEC.md, "A reference names a field, not an
+// occurrence of one").
+//
+// A count has a second reason the other two positions do not, and it is the one
+// that decides the shape of everything above it: a count with a value per
+// occurrence of its enclosing group is a group whose occurrences are not all the
+// same width, so "the width of one occurrence times that count" stops being
+// arithmetic and an aligned item inside such an occurrence needs a different
+// number of padding bytes in each one — which a slack node, carrying a single
+// width, cannot describe at all.
+//
+// The shape refused is the one an adopter expects: a count beside the table it
+// governs, both inside a repeating group, meaning "the count in this occurrence
+// governs this occurrence". It is an expectation rather than a file shape, and
+// COBOL's own rules already turn it away.
+type CountOccurrenceError struct {
+	// Pos is the count field's entry in the copybook.
+	Pos diag.Span
+
+	// Record is the record being resolved.
+	Record string
+
+	// Count is the field the count is read from, and Table the repeating item
+	// naming it.
+	Count string
+	Table string
+
+	// Group is the innermost repeating group the count sits in, empty where
+	// the count field is itself the thing that repeats.
+	Group string
+}
+
+// Error implements the error interface.
+func (e *CountOccurrenceError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *CountOccurrenceError) Diagnostic() diag.Diagnostic {
+	repeats := fmt.Sprintf("%s repeats", e.Count)
+	if e.Group != "" {
+		repeats = fmt.Sprintf("%s sits in the repeating group %s", e.Count, e.Group)
+	}
+
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"in record %s, %s occurs a number of times read from %s, and %s: a count has one value per record, "+
+				"because a count with one per occurrence makes the occurrences of its group different widths",
+			e.Record, e.Table, e.Count, repeats),
+		Spans: []diag.Span{e.Pos},
+	}
+}
+
+// CountPositionError is an `OCCURS DEPENDING ON` count whose own position is not
+// a constant, because some item ahead of it carries a repetition whose count is
+// a reference.
+//
+// docs/ir/SPEC.md's "A count is in hand before the extent it decides" states two
+// halves of one requirement — a count lies ahead of what it counts, and at a
+// constant position — and this is the second. The first is refused before a
+// record reaches this package at all: `cobol-go` will not lay out a copybook
+// whose DEPENDING ON object is defined after the table it controls, because
+// locating a trailing count needs the table's extent and the table's extent
+// needs the count, and [Resolve] returns that fault unchanged rather than
+// resolving the data-name a second time to restate it.
+//
+// A count behind some *other* variable table is readable — a walk in record
+// order reaches that table's own count first — and is refused all the same. It
+// is a count no compiler writes, Micro Focus states the rule for the clause
+// flatly (*Data-name-1 must have a fixed location, and must not follow an item
+// that contains an OCCURS DEPENDING ON clause*), and relaxing the restriction
+// later costs no version while imposing it later would be breaking.
+type CountPositionError struct {
+	// Pos is the count field's entry in the copybook.
+	Pos diag.Span
+
+	// Record is the record being resolved.
+	Record string
+
+	// Count is the field the count is read from, and Table the repeating item
+	// naming it.
+	Count string
+	Table string
+
+	// Behind is the variable item the count sits behind.
+	Behind string
+}
+
+// Error implements the error interface.
+func (e *CountPositionError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *CountPositionError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"in record %s, %s occurs a number of times read from %s, and %s sits behind %s, whose own extent "+
+				"moves with a count: a count lies ahead of what it counts and at a constant position",
+			e.Record, e.Table, e.Count, e.Count, e.Behind),
+		Spans: []diag.Span{e.Pos},
+	}
+}
+
+// SharedCountBoundsError is two repeating items of one record naming one count
+// whose declared ranges have no value in common.
+//
+// Sharing a count is admitted and is the plainest record with two variable
+// tables in it: two tables under separate counts oblige a record to carry both
+// count fields ahead of both tables, and one count ahead of two tables satisfies
+// that with nothing arranged. A consumer decodes the field once and sizes both
+// tables from that one value (docs/ir/SPEC.md, "One count may size two tables,
+// and a writer refuses to choose").
+//
+// The declared bounds are the one place the second reference is not simply a
+// second multiplication: each repetition carries its own, both bind the one
+// value, and the range a record can actually carry is the overlap. Where the
+// ranges do not overlap at all there is no count that sizes both tables, so
+// every record of the descriptor is malformed data — and the alternative to
+// rejecting the layout here is that diagnostic once per record for the life of
+// the file.
+type SharedCountBoundsError struct {
+	// Pos is the count field's entry in the copybook.
+	Pos diag.Span
+
+	// Record is the record being resolved.
+	Record string
+
+	// Count is the field both repetitions name.
+	Count string
+
+	// Tables are the two repeating items, and Bounds the minimum and maximum
+	// each one declares, in the same order.
+	Tables []string
+	Bounds [][2]int
+}
+
+// Error implements the error interface.
+func (e *SharedCountBoundsError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *SharedCountBoundsError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"in record %s, %s occurs %s and %s occurs %s, and both counts are read from %s: no value sizes "+
+				"both tables, so every record of this layout would be malformed",
+			e.Record, e.Tables[0], occurrences(e.Bounds[0]), e.Tables[1], occurrences(e.Bounds[1]), e.Count),
+		Spans: []diag.Span{e.Pos},
+	}
+}
+
+// MissingCountError is [Record.At] handed no count for a table whose repetition
+// names one.
+//
+// It is not an absent table and it is not zero occurrences. docs/ir/SPEC.md
+// requires a consumer to report a count it cannot decode as a number rather than
+// reading the group as absent, and a count field holding spaces is a real
+// mainframe occurrence — read as zero it produces a record that parses and is
+// wrong. So a count nobody supplied is refused here rather than defaulted, and a
+// caller whose decode failed reports that failure instead of leaving the entry
+// out.
+//
+// It points at no file, which it shares with [CountBoundsError] and with nothing
+// else in this package: the copybook declared the table correctly and the layout
+// chose a reading correctly, and what is wrong is one record's bytes.
+type MissingCountError struct {
+	// Record is the record being read.
+	Record string
+
+	// Count is the field the count is read from, and Table the repeating item
+	// naming it.
+	Count string
+	Table string
+}
+
+// Error implements the error interface.
+func (e *MissingCountError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *MissingCountError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"in record %s, %s occurs a number of times read from %s, and no count was decoded for it: a count "+
+				"that would not decode is malformed data rather than zero occurrences",
+			e.Record, e.Table, e.Count),
+	}
+}
+
+// CountBoundsError is a decoded count outside the occurrences the copybook
+// declared.
+//
+// The bounds are carried on a repetition for this check and for nothing else,
+// and it is the only thing in reach that bounds a number decoded out of a file:
+// a descriptor word stating the length a forbidden count implies agrees with the
+// record's extent exactly, so the framing check passes on a record the copybook
+// says cannot exist — which is what a file written against a later version of
+// that copybook looks like. Under **unframed** there is nothing to disagree with
+// it at all, and a corrupt count runs the read into the next record.
+//
+// A negative count is this fault and not one of its own. Every copybook's
+// declared minimum is at least zero, so a negative value is below it, and what
+// an adopter needs told is the range the count had to be in.
+//
+// One of these per repetition naming the count, rather than one per count.
+// Two repeating items may name one field, each carries its own declared minimum
+// and maximum, and both bind the one value, so a count admitted by one table and
+// refused by the other is refused.
+type CountBoundsError struct {
+	// Record is the record being read.
+	Record string
+
+	// Count is the field the count is read from, and Table the repeating item
+	// naming it.
+	Count string
+	Table string
+
+	// Value is what was decoded, and Min and Max the occurrences the copybook
+	// declares for this table.
+	Value int
+	Min   int
+	Max   int
+}
+
+// Error implements the error interface.
+func (e *CountBoundsError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *CountBoundsError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"in record %s, the count read from %s is %d, and %s occurs %s",
+			e.Record, e.Count, e.Value, e.Table, occurrences([2]int{e.Min, e.Max})),
+	}
+}
+
+// occurrences renders a declared range the way an OCCURS clause states one.
+func occurrences(bounds [2]int) string {
+	if bounds[0] == bounds[1] {
+		return fmt.Sprintf("%d times", bounds[0])
+	}
+
+	return fmt.Sprintf("%d to %d times", bounds[0], bounds[1])
+}
+
 // recordNamed is what a message calls a record, with the alternatives that tell
 // one resolution of it from another where the copybook has any.
 func recordNamed(record string, alternatives []string) string {

--- a/internal/resolve/lrecl_test.go
+++ b/internal/resolve/lrecl_test.go
@@ -51,6 +51,7 @@ func framed(t *testing.T, src string, framing *layoutmodel.Framing) ([]*Record, 
 		Copybook: "test.cpy",
 		Dialect:  copybook.IBMEnterprise(),
 		Encoding: mainframe(),
+		Reading:  layoutmodel.ODOSlide,
 		Framing:  framing,
 	})
 }

--- a/internal/resolve/node.go
+++ b/internal/resolve/node.go
@@ -153,24 +153,42 @@ func (n *Node) Occurrences() int {
 // its whole extent and not one occurrence of it.
 func (n *Node) Extent() int { return n.Width() * n.Occurrences() }
 
-// Repetition is what an item that repeats carries.
+// Repetition is what an item that repeats carries: a constant number of
+// occurrences, or a reference to the field a count is read from together with
+// the bounds the copybook declared (docs/ir/SPEC.md, "A variable record is a sum
+// with a variable term").
 //
-// Count is the occurrence count the layout was computed at, which for an
-// OCCURS ... DEPENDING ON table is the declared maximum — the storage a compiler
-// reserves for it. Turning DependingOn into the IR's reference, and the extent
-// that moves with it, is #35's; what this package needs from it is that the
-// count is a reference at all, which is what a variant's arms may not contain.
+// A repetition whose count is a reference is what the *sliding* reading of
+// `OCCURS DEPENDING ON` resolves to. Under the other reading the same clause is
+// a fixed table at its declared maximum, and what stands here is a constant with
+// no reference in it at all — see [Options.Reading] (#87).
 type Repetition struct {
-	// Count is the occurrence count the layout was computed at.
+	// Count is the occurrence count this repetition stands at: the constant
+	// the copybook wrote for a fixed table, the declared maximum for a
+	// reference as [Resolve] hands it back — the storage a compiler reserves
+	// — and the count a consumer decoded after [Record.At].
 	Count int
 
-	// Min and Max are the bounds the OCCURS clause allows. They both equal
-	// Count for a fixed table.
+	// Min and Max are the bounds the OCCURS clause allows, and they both
+	// equal Count for a fixed table.
+	//
+	// They are the copybook's own `OCCURS integer-1 TO integer-2`, neither
+	// narrowed nor widened to what a layout would prefer, and they are
+	// carried for one check and nothing else: a count outside them is
+	// malformed data, which is [Record.At]'s to report. Without them there is
+	// nothing in a record to bound a number decoded out of a file.
 	Min int
 	Max int
 
-	// DependingOn is the item whose value gives the count, nil for a fixed
+	// DependingOn is the field whose value gives the count, nil for a fixed
 	// table.
+	//
+	// A field of the record being read, at any depth, and never a field of
+	// another record: a DEPENDING ON phrase names an item of the copybook
+	// record carrying it, and a count that comes from an earlier record
+	// arrives as a register the automaton bound rather than as a reference
+	// reaching across records (docs/ir/SPEC.md, #77). A register is #36's
+	// node, so nothing here stands for one.
 	DependingOn *copybook.Field
 }
 
@@ -246,10 +264,17 @@ func (r *Record) Extent() int { return r.Root.Width() }
 // so an item behind one sits where it would sit without it, and a position
 // inside an arm is measured through the arm the item is in.
 //
-// It reports false for a node that is not in the record. A record holding an
-// OCCURS ... DEPENDING ON table has positions behind that table which move with
-// the count; what comes back is the position at the count the layout was
-// computed at, which is the declared maximum (#35).
+// It reports false for a node that is not in the record.
+//
+// A record holding a table whose count is a reference has positions behind that
+// table which move with the count, and this is the sum at the count every
+// repetition currently stands at — the declared maximum, as [Resolve] hands a
+// record back, and one record's own counts after [Record.At]. That is the whole
+// of how a data-dependent offset is modelled: ordering and width, with a term in
+// the sum that is not a constant. Nothing carries a second, different mechanism
+// for a field behind a variable table, and no node carries an offset for one to
+// be wrong in (docs/ir/SPEC.md, "A variable record is a sum with a variable
+// term", #35).
 func (r *Record) Position(target *Node) (int, bool) {
 	return position(r.Root, target, 0)
 }

--- a/internal/resolve/odo.go
+++ b/internal/resolve/odo.go
@@ -1,0 +1,429 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package resolve
+
+import (
+	"github.com/Zaba505/cobol-go/copybook"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+)
+
+// This file is the whole of what an `OCCURS DEPENDING ON` clause costs this
+// package: which reading the layout stated, what a count reference is held to
+// under the one reading that has any, and reading a resolved record back at the
+// counts a consumer decoded.
+//
+// # The reading decides whether there is a reference at all
+//
+// docs/ir/SPEC.md's "An item after a table slides, and the other reading is a
+// fixed table" forks here and nowhere else. Under `odoslide` a table becomes a
+// repetition whose count is a reference and the record's extent moves with it;
+// under `noodoslide` the same copybook describes a *fixed* table of the declared
+// maximum beside a field saying how many entries the writing program filled,
+// which is an ordinary shape this package already resolved before ODO reached
+// it. So the second reading adds no arithmetic: it drops the reference, and
+// every rule below has nothing left to bind.
+//
+// There is no default, because the two readings put every item behind the table
+// somewhere different and nothing in the file disagrees with the wrong one. A
+// layout that states neither is rejected against the table that needed the
+// answer (#27, #35, #87).
+//
+// # Why the checks run on the copybook's items rather than on the nodes
+//
+// Every rule here is about the copybook's own shape — where the count sits, what
+// repeats, what two OCCURS clauses declare — and none of it is about which
+// REDEFINES alternative a caller is reading. A record whose copybook holds four
+// alternatives resolves to four [Record]s, and running these over the nodes
+// would report one copybook fault four times.
+
+// tables returns every item of the record whose OCCURS clause names a count, in
+// source order.
+//
+// It is what decides whether the layout owed a reading: a copybook holding no
+// such clause needs no answer, and requiring one of every layout would make a
+// setting about tables into a setting about layouts that have none.
+func tables(items []*copybook.Item) []*copybook.Item {
+	var found []*copybook.Item
+
+	for _, item := range items {
+		if item.DependingOn != nil {
+			found = append(found, item)
+		}
+	}
+
+	return found
+}
+
+// requireReading holds a layout binding a copybook with an `OCCURS DEPENDING ON`
+// in it to having said which reading its file was written under.
+//
+// One fault per table, and each names the table, because that is where the
+// adopter looks the setting up: the answer is a property of the compiler that
+// wrote the file, and finding out which compiler that was starts at the clause.
+func (r *resolver) requireReading(odo []*copybook.Item) {
+	for _, table := range odo {
+		r.faults.Fail(&UnstatedReadingError{
+			Pos:    r.span(table.Field),
+			Record: r.record.Name,
+			Table:  itemName(table.Field),
+			Count:  itemName(table.DependingOn.Field),
+		})
+	}
+}
+
+// checkCounts holds every count reference of the record to what docs/ir/SPEC.md
+// admits in one.
+//
+// It runs under the sliding reading alone. A non-sliding record carries no count
+// reference for any of this to bind — "None of this reaches a record of a
+// non-sliding file", as "A count is in hand before the extent it decides" puts
+// it — and running the checks anyway would reject a layout over bytes that are a
+// fixed table and a field.
+func (r *resolver) checkCounts(items, odo []*copybook.Item) {
+	for _, table := range odo {
+		count := table.DependingOn
+
+		switch group := enclosingTable(count); {
+		case count.MaxOccurs > 1 || group != nil:
+			// docs/ir/SPEC.md, "A reference names a field, not an
+			// occurrence of one": a count with a value per occurrence of
+			// its enclosing group is a group whose occurrences are not all
+			// the same width, and the extent sum stops being arithmetic.
+			r.faults.Fail(&CountOccurrenceError{
+				Pos:    r.span(count.Field),
+				Record: r.record.Name,
+				Count:  itemName(count.Field),
+				Table:  itemName(table.Field),
+				Group:  groupName(group),
+			})
+
+		default:
+			// docs/ir/SPEC.md, "A count is in hand before the extent it
+			// decides", second half: a count whose own position is a sum
+			// with a variable term in it.
+			//
+			// That section's first half — a count lying behind the very
+			// table it sizes — is not checked here, and not because it is
+			// admitted. `cobol-go` refuses it while it lays the copybook
+			// out, naming the count and the table ("item N is defined
+			// after the table it controls"), and [Resolve] returns that
+			// unchanged. Restating it would mean resolving the DEPENDING
+			// ON data-name out of the raw OCCURS clause a second time, to
+			// answer a question the layout has already answered.
+			if ahead := variableAhead(items, count); ahead != nil {
+				r.faults.Fail(&CountPositionError{
+					Pos:    r.span(count.Field),
+					Record: r.record.Name,
+					Count:  itemName(count.Field),
+					Table:  itemName(table.Field),
+					Behind: itemName(ahead.Field),
+				})
+			}
+		}
+	}
+
+	r.checkSharedBounds(odo)
+}
+
+// variableAhead returns the first item lying wholly ahead of count whose own
+// repetition count is a reference, or nil where none does.
+//
+// "Ahead of" is the record's byte order, which is the order a consumer walks it
+// in. An item that ends at or before the count's first byte is one whose extent
+// enters the sum that locates the count, so a variable one leaves that sum
+// without a value at the moment the count is needed.
+func variableAhead(items []*copybook.Item, count *copybook.Item) *copybook.Item {
+	for _, item := range items {
+		if item.DependingOn != nil && item.End() <= count.Offset {
+			return item
+		}
+	}
+
+	return nil
+}
+
+// checkSharedBounds refuses a record whose repeating items name one count and
+// declare ranges with no value in common.
+//
+// Sharing itself is admitted: a consumer decodes the count once and sizes every
+// table naming it from that one value, and nothing about locating an item
+// changes (docs/ir/SPEC.md, "One count may size two tables, and a writer refuses
+// to choose", #89). What cannot hold is two declared ranges that do not overlap,
+// because then no count sizes both tables and every record of the descriptor is
+// malformed data — so the layout is rejected once here rather than diagnosed
+// once per record for the life of the file.
+//
+// One fault per count field, naming the first pair that cannot hold. A third
+// table disjoint from the same two is the same mistake, and three diagnostics
+// about it would send an adopter to the same clause three times.
+func (r *resolver) checkSharedBounds(odo []*copybook.Item) {
+	sharing := make(map[*copybook.Item][]*copybook.Item, len(odo))
+
+	var counts []*copybook.Item
+
+	for _, table := range odo {
+		count := table.DependingOn
+		if _, seen := sharing[count]; !seen {
+			counts = append(counts, count)
+		}
+
+		sharing[count] = append(sharing[count], table)
+	}
+
+	for _, count := range counts {
+		if pair := disjoint(sharing[count]); pair != nil {
+			r.faults.Fail(&SharedCountBoundsError{
+				Pos:    r.span(count.Field),
+				Record: r.record.Name,
+				Count:  itemName(count.Field),
+				Tables: []string{itemName(pair[0].Field), itemName(pair[1].Field)},
+				Bounds: [][2]int{
+					{pair[0].MinOccurs, pair[0].MaxOccurs},
+					{pair[1].MinOccurs, pair[1].MaxOccurs},
+				},
+			})
+		}
+	}
+}
+
+// disjoint returns the first pair of the tables whose declared ranges have no
+// value in common, or nil where every pair overlaps.
+//
+// Two alternatives of one REDEFINES are skipped, because they never both stand
+// in one record: each becomes a record of its own, and a count sizing the one
+// being read is never asked to size the other.
+func disjoint(sharing []*copybook.Item) []*copybook.Item {
+	for i, a := range sharing {
+		for _, b := range sharing[i+1:] {
+			if exclusive(a, b) {
+				continue
+			}
+
+			if max(a.MinOccurs, b.MinOccurs) > min(a.MaxOccurs, b.MaxOccurs) {
+				return []*copybook.Item{a, b}
+			}
+		}
+	}
+
+	return nil
+}
+
+// exclusive reports whether two items are alternatives of one another: two
+// descriptions of one run of storage, at whatever depth the REDEFINES was
+// written, which never both stand in one resolved record.
+func exclusive(a, b *copybook.Item) bool {
+	for x := a; x != nil; x = x.Parent {
+		for y := b; y != nil; y = y.Parent {
+			if x == y || x.Parent != y.Parent {
+				continue
+			}
+
+			if redefineBase(x) == redefineBase(y) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// redefineBase is the item a chain of REDEFINES is rooted at, which is the
+// identity of the run of storage the chain describes.
+func redefineBase(item *copybook.Item) *copybook.Item {
+	for item.Redefines != nil {
+		item = item.Redefines
+	}
+
+	return item
+}
+
+// repetitionOf reads an item's repetition under the layout's reading, nil where
+// the item does not repeat.
+//
+// The fork is here and in one line of [resolver.referenceCount], and nothing
+// else in this package asks which reading it is running under. Under `odoslide`
+// the count is the reference the copybook wrote and the bounds are the
+// copybook's own `OCCURS integer-1 TO integer-2`, carried for the one check
+// docs/ir/SPEC.md makes with them — a count outside them is malformed data — and
+// neither narrowed nor widened to what a layout would prefer. Under `noodoslide`
+// the same clause describes a fixed table at its declared maximum, so the
+// repetition is a constant, the bounds equal it as they do for any fixed table,
+// and the count field is left an ordinary field of the record with nothing
+// pointing at it.
+func (r *resolver) repetitionOf(item *copybook.Item) *Repetition {
+	if item.MaxOccurs <= 1 {
+		return nil
+	}
+
+	if item.DependingOn == nil {
+		return &Repetition{Count: item.Occurs, Min: item.MinOccurs, Max: item.MaxOccurs}
+	}
+
+	if !r.opts.Reading.Slides() {
+		return &Repetition{Count: item.MaxOccurs, Min: item.MaxOccurs, Max: item.MaxOccurs}
+	}
+
+	return &Repetition{
+		Count:       item.Occurs,
+		Min:         item.MinOccurs,
+		Max:         item.MaxOccurs,
+		DependingOn: item.DependingOn.Field,
+	}
+}
+
+// referenceCount returns the first item at or under item whose repetition count
+// is read out of the record, or nil where none is.
+//
+// It answers under the reading for [resolver.repetitionOf]'s reason: on a
+// non-sliding file the same clause is a fixed table, so an arm holding one has
+// the constant extent an arm needs and there is nothing to report.
+func (r *resolver) referenceCount(item *copybook.Item) *copybook.Item {
+	if !r.opts.Reading.Slides() {
+		return nil
+	}
+
+	if item.DependingOn != nil {
+		return item
+	}
+
+	for _, child := range item.Children {
+		if found := r.referenceCount(child); found != nil {
+			return found
+		}
+	}
+
+	return nil
+}
+
+// Counts are the occurrence counts a consumer decoded out of one record's bytes,
+// keyed by the field each one was read from.
+//
+// Keyed by the count rather than by the table because that is how a consumer
+// holds them: docs/ir/SPEC.md admits two repeating items naming one count, and a
+// consumer decodes that field once and sizes both tables from the one value. A
+// map keyed by the table would carry that value twice, for the two copies to
+// disagree.
+type Counts map[*copybook.Field]int
+
+// At returns the record as it stands at counts: the same containment order, with
+// every repetition whose count is a reference standing at the value decoded for
+// it, so that [Record.Extent] and [Record.Position] answer for one record's
+// bytes rather than at the declared maximum.
+//
+// This is docs/ir/SPEC.md's "A variable record is a sum with a variable term"
+// run here, for the reason [Record.Position] is: the sum is the arithmetic every
+// consumer performs, and this package's tests run it against the offsets
+// `cobol-go` computed independently. It is not a decoder — nothing here reads
+// bytes — and a count that would not decode as a number at all is reported by
+// whoever decoded it.
+//
+// What it will not do is default. A count the map does not carry is a
+// [MissingCountError] rather than an absent table, because reading a count field
+// holding spaces as zero produces a record that parses and is wrong, and that is
+// a real mainframe occurrence. A count outside the bounds the copybook declared
+// — negative among them — is a [CountBoundsError] against *every* repetition
+// naming it, not against the first, because each carries its own declared
+// minimum and maximum and both bind the one value.
+//
+// The nodes of the record it returns are copies, so a caller naming one of them
+// names it through [Record.Find] or [Record.Walk] rather than by holding a
+// pointer into the record it started from.
+//
+// A record carrying no count reference — every record of a non-sliding file, and
+// every record with no table in it — comes back unchanged, and an empty map is
+// the right argument for one.
+func (r *Record) At(counts Counts) (*Record, error) {
+	var faults diag.List
+
+	r.Walk(func(node *Node) {
+		if !node.Repetition.Reference() {
+			return
+		}
+
+		count, ok := counts[node.Repetition.DependingOn]
+		if !ok {
+			faults.Fail(&MissingCountError{
+				Record: itemName(r.Item),
+				Count:  itemName(node.Repetition.DependingOn),
+				Table:  tableName(node),
+			})
+
+			return
+		}
+
+		if count < node.Repetition.Min || count > node.Repetition.Max {
+			faults.Fail(&CountBoundsError{
+				Record: itemName(r.Item),
+				Count:  itemName(node.Repetition.DependingOn),
+				Table:  tableName(node),
+				Value:  count,
+				Min:    node.Repetition.Min,
+				Max:    node.Repetition.Max,
+			})
+		}
+	})
+
+	if faults.Failed() {
+		return nil, faults.Err()
+	}
+
+	return &Record{
+		Root:         r.Root.at(counts),
+		Item:         r.Item,
+		Alternatives: r.Alternatives,
+	}, nil
+}
+
+// at copies the node with every reference repetition under it standing at the
+// count decoded for it.
+func (n *Node) at(counts Counts) *Node {
+	copied := *n
+
+	if n.Repetition != nil {
+		repetition := *n.Repetition
+		if repetition.Reference() {
+			repetition.Count = counts[repetition.DependingOn]
+		}
+
+		copied.Repetition = &repetition
+	}
+
+	if len(n.Members) > 0 {
+		copied.Members = make([]*Node, 0, len(n.Members))
+		for _, member := range n.Members {
+			copied.Members = append(copied.Members, member.at(counts))
+		}
+	}
+
+	if len(n.Arms) > 0 {
+		copied.Arms = make([]Arm, 0, len(n.Arms))
+		for _, arm := range n.Arms {
+			arm.Body = arm.Body.at(counts)
+			copied.Arms = append(copied.Arms, arm)
+		}
+	}
+
+	return &copied
+}
+
+// tableName is what a diagnostic calls the repeating item a count sizes.
+//
+// A node this package introduced to hold an elementary item beside the slack
+// padding it out to its stride carries the repetition while the field inside it
+// carries the name, so the name is taken from the first member where the node
+// has none of its own — the same reading [variableTerm] makes.
+func tableName(node *Node) string {
+	if node.Field != nil {
+		return itemName(node.Field)
+	}
+
+	if len(node.Members) > 0 {
+		return itemName(node.Members[0].Field)
+	}
+
+	return itemName(nil)
+}

--- a/internal/resolve/odo_test.go
+++ b/internal/resolve/odo_test.go
@@ -1,0 +1,700 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package resolve
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cobol-go/copybook"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+	"github.com/Zaba505/cpybkc/internal/layoutmodel"
+)
+
+// An `OCCURS DEPENDING ON` table is the one thing in a record whose extent is
+// not a number the copybook states, and docs/ir/SPEC.md's "A variable record is
+// a sum with a variable term" is what these hold this package to: the extent is
+// the width of one occurrence times a count read out of the record, and the item
+// behind it begins at the byte after the last occurrence that count states.
+//
+// Under the *other* reading of the same clause there is no variable table at all
+// — "An item after a table slides, and the other reading is a fixed table" — so
+// half of what follows is the same copybook resolved twice.
+
+// varying is the shape every test here starts from: a count, a table sized by
+// it, and an item behind the table for the count to move.
+const varying = `01 R.
+   05 N PIC 9(2).
+   05 ENTRY OCCURS 1 TO 4 TIMES DEPENDING ON N PIC X(5).
+   05 TRAILER PIC X(3).
+`
+
+// reading resolves a copybook source under one of the two readings, reporting
+// what resolution said rather than failing on it, because half these tests are
+// about the fault.
+func reading(t *testing.T, src string, r layoutmodel.Reading) ([]*Record, error) {
+	t.Helper()
+
+	return Resolve(recordOf(t, src), Options{
+		Copybook: "test.cpy",
+		Dialect:  copybook.IBMEnterprise(),
+		Encoding: mainframe(),
+		Reading:  r,
+	})
+}
+
+// slid resolves a copybook the caller expects to resolve under the sliding
+// reading, which is IBM Enterprise COBOL's and unconditional there.
+func slid(t *testing.T, src string) *Record {
+	t.Helper()
+
+	records, err := reading(t, src, layoutmodel.ODOSlide)
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("resolved to %d records, want 1", len(records))
+	}
+
+	return records[0]
+}
+
+// countOf is the field a repetition's count is read from, which is what a test
+// keys [Counts] by.
+func countOf(t *testing.T, record *Record, table string) *copybook.Field {
+	t.Helper()
+
+	node := record.Find(table)
+	if node == nil || node.Repetition == nil || node.Repetition.DependingOn == nil {
+		t.Fatalf("%s carries no count reference", table)
+	}
+
+	return node.Repetition.DependingOn
+}
+
+// TestASlidingTableCarriesTheReferenceAndTheCopybooksOwnBounds is the resolution
+// under `odoslide`: the count is the field the DEPENDING ON phrase names, and
+// the bounds are the copybook's `OCCURS integer-1 TO integer-2` unchanged.
+func TestASlidingTableCarriesTheReferenceAndTheCopybooksOwnBounds(t *testing.T) {
+	t.Parallel()
+
+	record := slid(t, varying)
+
+	repetition := record.Find("ENTRY").Repetition
+	if repetition == nil || !repetition.Reference() {
+		t.Fatalf("the table's repetition is %+v, want a count read out of the record", repetition)
+	}
+	if repetition.DependingOn.Name != "N" {
+		t.Errorf("the count is read from %s, want N", repetition.DependingOn.Name)
+	}
+	if repetition.Min != 1 || repetition.Max != 4 {
+		t.Errorf("the declared bounds are %d to %d, want the copybook's 1 to 4", repetition.Min, repetition.Max)
+	}
+
+	// The count the record stands at as it leaves resolution is the storage a
+	// compiler reserves, which is the declared maximum.
+	if repetition.Count != 4 {
+		t.Errorf("the table stands at %d occurrences, want the declared maximum of 4", repetition.Count)
+	}
+
+	// The count is a field of the record being read, at any depth, and never a
+	// reference reaching into another record: a DEPENDING ON phrase names an
+	// item of the copybook record carrying it. A count that comes from a
+	// header admitted earlier reaches a repetition as a register the automaton
+	// bound (#36), which is a node this package does not build — so there is
+	// no shape here for a cross-record reference to take.
+	if record.Find(repetition.DependingOn.Name) == nil {
+		t.Error("the count is not a field of the record being read")
+	}
+}
+
+// TestAnItemBehindASlidingTableMovesWithTheCount is the whole of the model: no
+// node carries an offset, the extent of the table is one occurrence times the
+// count, and the item behind it is wherever that sum lands.
+func TestAnItemBehindASlidingTableMovesWithTheCount(t *testing.T) {
+	t.Parallel()
+
+	record := slid(t, varying)
+	count := countOf(t, record, "ENTRY")
+
+	for _, tc := range []struct {
+		occurrences int
+		trailer     int
+		extent      int
+	}{
+		{occurrences: 1, trailer: 2 + 5, extent: 2 + 5 + 3},
+		{occurrences: 2, trailer: 2 + 10, extent: 2 + 10 + 3},
+		{occurrences: 4, trailer: 2 + 20, extent: 2 + 20 + 3},
+	} {
+		at, err := record.At(Counts{count: tc.occurrences})
+		if err != nil {
+			t.Fatalf("reading at %d occurrences: %v", tc.occurrences, err)
+		}
+
+		if got := positionOf(t, at, "TRAILER"); got != tc.trailer {
+			t.Errorf("at %d occurrences TRAILER is at %d, want %d", tc.occurrences, got, tc.trailer)
+		}
+		if got := at.Extent(); got != tc.extent {
+			t.Errorf("at %d occurrences the record is %d bytes, want %d", tc.occurrences, got, tc.extent)
+		}
+
+		// The count itself is ahead of the table, so nothing moves it.
+		if got := positionOf(t, at, "N"); got != 0 {
+			t.Errorf("at %d occurrences N is at %d, want 0", tc.occurrences, got)
+		}
+	}
+
+	// The record it was read from is untouched: [Record.At] hands back a copy,
+	// so a caller holding one count's reading still holds the maximum.
+	if got := record.Find("ENTRY").Repetition.Count; got != 4 {
+		t.Errorf("reading at a count moved the record it was read from to %d occurrences", got)
+	}
+}
+
+// TestAGroupThatVariesIsFollowedByFieldsThatMove is the same sum over a table
+// whose occurrences are groups rather than elementary items, which is the shape
+// a real layout has.
+func TestAGroupThatVariesIsFollowedByFieldsThatMove(t *testing.T) {
+	t.Parallel()
+
+	record := slid(t, `01 R.
+   05 N PIC 9(2).
+   05 T OCCURS 1 TO 3 TIMES DEPENDING ON N.
+      10 A PIC X(3).
+      10 B PIC X(2).
+   05 TRAILER PIC X(4).
+   05 TAIL PIC X.
+`)
+	count := countOf(t, record, "T")
+
+	at, err := record.At(Counts{count: 2})
+	if err != nil {
+		t.Fatalf("reading at 2 occurrences: %v", err)
+	}
+
+	// A position inside the table is the first occurrence's, which is where
+	// the sum lands whatever the count.
+	for _, tc := range []struct {
+		name string
+		want int
+	}{
+		{name: "N", want: 0},
+		{name: "A", want: 2},
+		{name: "B", want: 5},
+		{name: "TRAILER", want: 2 + 10},
+		{name: "TAIL", want: 2 + 10 + 4},
+	} {
+		if got := positionOf(t, at, tc.name); got != tc.want {
+			t.Errorf("%s is at %d, want %d", tc.name, got, tc.want)
+		}
+	}
+
+	if got := at.Extent(); got != 2+10+4+1 {
+		t.Errorf("the record is %d bytes, want %d", got, 2+10+4+1)
+	}
+}
+
+// TestTheSameCopybookResolvesTwoWaysUnderTheTwoReadings is the fork, met from
+// both sides at once.
+//
+// Under `noodoslide` the bytes are a fixed table at the declared maximum beside a
+// field saying how many entries the writing program filled: no reference, no
+// bounds to check, a constant extent, and a count field resolved like any other
+// field of the record. Under `odoslide` the same copybook is the variable record
+// above. Nothing in the file distinguishes them, which is why the layout has to.
+func TestTheSameCopybookResolvesTwoWaysUnderTheTwoReadings(t *testing.T) {
+	t.Parallel()
+
+	slides := slid(t, varying)
+
+	records, err := reading(t, varying, layoutmodel.NoODOSlide)
+	if err != nil {
+		t.Fatalf("resolving under noodoslide: %v", err)
+	}
+	fixed := records[0]
+
+	repetition := fixed.Find("ENTRY").Repetition
+	if repetition == nil || repetition.Reference() {
+		t.Fatalf("under noodoslide the table's repetition is %+v, want a constant", repetition)
+	}
+	if repetition.Count != 4 || repetition.Min != 4 || repetition.Max != 4 {
+		t.Errorf(
+			"under noodoslide the table occurs %d times with bounds %d to %d, want the declared maximum of 4 throughout",
+			repetition.Count, repetition.Min, repetition.Max)
+	}
+
+	// The count field is still there and is an ordinary field: it governs no
+	// byte, and a caller reads it to learn how many entries were filled.
+	if node := fixed.Find("N"); node == nil || node.Kind != KindField || node.Repetition != nil {
+		t.Errorf("under noodoslide N resolved to %+v, want an ordinary field", node)
+	}
+
+	// The two readings agree at the maximum and nowhere else, which is the
+	// whole of why neither can be a default.
+	if fixed.Extent() != slides.Extent() {
+		t.Errorf("at the maximum the two readings give %d and %d bytes", fixed.Extent(), slides.Extent())
+	}
+
+	one, err := slides.At(Counts{countOf(t, slides, "ENTRY"): 1})
+	if err != nil {
+		t.Fatalf("reading the sliding record at one occurrence: %v", err)
+	}
+	if one.Extent() == fixed.Extent() {
+		t.Errorf("at one occurrence both readings give %d bytes, and the readings differ there", one.Extent())
+	}
+}
+
+// TestANonSlidingRecordHasNothingForTheCountRulesToBindOn is docs/ir/SPEC.md's
+// "None of this reaches a record of a non-sliding file", met with the shape the
+// sliding reading refuses.
+//
+// A count behind another variable table is rejected under `odoslide` and is
+// nothing at all under `noodoslide`, because under that reading neither table is
+// variable and neither count field governs a byte.
+func TestANonSlidingRecordHasNothingForTheCountRulesToBindOn(t *testing.T) {
+	t.Parallel()
+
+	src := `01 R.
+   05 M PIC 9(2).
+   05 FIRST OCCURS 1 TO 5 TIMES DEPENDING ON M PIC X(4).
+   05 N PIC 9(2).
+   05 SECOND OCCURS 1 TO 3 TIMES DEPENDING ON N PIC X(2).
+`
+
+	if _, err := reading(t, src, layoutmodel.NoODOSlide); err != nil {
+		t.Fatalf("resolving under noodoslide: %v", err)
+	}
+
+	_, err := reading(t, src, layoutmodel.ODOSlide)
+
+	var position *CountPositionError
+	if !errors.As(err, &position) {
+		t.Fatalf("resolving under odoslide reported %v, want a CountPositionError", err)
+	}
+}
+
+// TestANonSlidingRecordFitsAFixedLengthDataset is the other consequence of the
+// resolution, and the escape #92 named: such a record has a constant extent, so
+// it meets what a fixed-length dataset requires of its record types exactly as a
+// record with no table does.
+func TestANonSlidingRecordFitsAFixedLengthDataset(t *testing.T) {
+	t.Parallel()
+
+	src := `01 R.
+   05 N PIC 9(2).
+   05 ENTRY OCCURS 1 TO 4 TIMES DEPENDING ON N PIC X(5).
+`
+
+	records, err := Resolve(recordOf(t, src), Options{
+		Copybook: "test.cpy",
+		Dialect:  copybook.IBMEnterprise(),
+		Encoding: mainframe(),
+		Reading:  layoutmodel.NoODOSlide,
+		Framing:  fixed(22),
+	})
+	if err != nil {
+		t.Fatalf("resolving under noodoslide on a fixed-length dataset: %v", err)
+	}
+	if got := records[0].Extent(); got != 22 {
+		t.Errorf("the record is %d bytes, want the lrecl of 22", got)
+	}
+}
+
+// TestALayoutStatingNoReadingIsRejected: there is nothing to fall back on, and a
+// default here is every item behind the table read at the wrong offset, at every
+// record, with nothing in the file to disagree.
+func TestALayoutStatingNoReadingIsRejected(t *testing.T) {
+	t.Parallel()
+
+	_, err := reading(t, varying, layoutmodel.ReadingUnstated)
+
+	var unstated *UnstatedReadingError
+	if !errors.As(err, &unstated) {
+		t.Fatalf("resolving reported %v, want an UnstatedReadingError", err)
+	}
+	for _, want := range []string{"R", "ENTRY", "N", "odoslide", "noodoslide", "test.cpy"} {
+		if !strings.Contains(unstated.Error(), want) {
+			t.Errorf("the diagnostic does not name %s: %s", want, unstated.Error())
+		}
+	}
+}
+
+// TestACopybookWithNoTableNeedsNoReading is the other half of the arity: the
+// setting is about tables, and requiring it of every layout would make it a
+// setting about layouts that have none.
+func TestACopybookWithNoTableNeedsNoReading(t *testing.T) {
+	t.Parallel()
+
+	if _, err := reading(t, "01 R.\n   05 A PIC X(4).\n   05 T PIC X OCCURS 3 TIMES.\n", layoutmodel.ReadingUnstated); err != nil {
+		t.Fatalf("resolving a copybook with no DEPENDING ON: %v", err)
+	}
+}
+
+// TestACountThatRepeatsIsRejected and its neighbour below are docs/ir/SPEC.md's
+// "A reference names a field, not an occurrence of one": nothing carries an
+// occurrence number, and a count with one value per occurrence makes the
+// occurrences of its group different widths.
+func TestACountThatRepeatsIsRejected(t *testing.T) {
+	t.Parallel()
+
+	_, err := reading(t, `01 R.
+   05 N PIC 9(2) OCCURS 2 TIMES.
+   05 ENTRY OCCURS 1 TO 5 TIMES DEPENDING ON N PIC X(4).
+`, layoutmodel.ODOSlide)
+
+	var occurrence *CountOccurrenceError
+	if !errors.As(err, &occurrence) {
+		t.Fatalf("resolving reported %v, want a CountOccurrenceError", err)
+	}
+	if occurrence.Group != "" {
+		t.Errorf("the diagnostic names the enclosing group %s, and the count is what repeats", occurrence.Group)
+	}
+	for _, want := range []string{"R", "N", "ENTRY"} {
+		if !strings.Contains(occurrence.Error(), want) {
+			t.Errorf("the diagnostic does not name %s: %s", want, occurrence.Error())
+		}
+	}
+}
+
+// TestACountInsideARepeatingGroupIsRejected is the same rule met at depth, and
+// the diagnostic names the group as well as the field: it is the group that
+// gives the count a value per occurrence.
+func TestACountInsideARepeatingGroupIsRejected(t *testing.T) {
+	t.Parallel()
+
+	_, err := reading(t, `01 R.
+   05 G OCCURS 2 TIMES.
+      10 N PIC 9(2).
+   05 ENTRY OCCURS 1 TO 5 TIMES DEPENDING ON N PIC X(4).
+`, layoutmodel.ODOSlide)
+
+	var occurrence *CountOccurrenceError
+	if !errors.As(err, &occurrence) {
+		t.Fatalf("resolving reported %v, want a CountOccurrenceError", err)
+	}
+	if occurrence.Group != "G" {
+		t.Errorf("the diagnostic names the enclosing group %q, want G", occurrence.Group)
+	}
+	for _, want := range []string{"R", "N", "ENTRY", "G"} {
+		if !strings.Contains(occurrence.Error(), want) {
+			t.Errorf("the diagnostic does not name %s: %s", want, occurrence.Error())
+		}
+	}
+}
+
+// TestACountBehindTheTableItSizesIsRejected is docs/ir/SPEC.md's "A count is in
+// hand before the extent it decides", first half.
+//
+// The rejection is `cobol-go`'s rather than this package's, and deliberately so:
+// locating a trailing count needs the table's extent and the table's extent
+// needs the count, and the layout refuses that while it is being computed. What
+// this pins is that the fault reaches a caller naming both the count and the
+// table rather than as a width that came out wrong.
+func TestACountBehindTheTableItSizesIsRejected(t *testing.T) {
+	t.Parallel()
+
+	_, err := reading(t, `01 R.
+   05 ENTRY OCCURS 1 TO 5 TIMES DEPENDING ON N PIC X(4).
+   05 N PIC 9(2).
+`, layoutmodel.ODOSlide)
+	if err == nil {
+		t.Fatal("a record whose count sits behind the table it sizes resolved")
+	}
+	for _, want := range []string{"N", "ENTRY"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the diagnostic does not name %s: %s", want, err)
+		}
+	}
+}
+
+// TestACountBehindAnotherVariableTableIsRejected is that section's second half:
+// a count whose own position is the sum of the widths ahead of it, and one of
+// those widths moves with a count of its own.
+//
+// It is readable — a walk in record order reaches the first table's count first
+// — and it is refused all the same, because it is a count no compiler writes and
+// relaxing the rule later costs no version.
+func TestACountBehindAnotherVariableTableIsRejected(t *testing.T) {
+	t.Parallel()
+
+	_, err := reading(t, `01 R.
+   05 M PIC 9(2).
+   05 FIRST OCCURS 1 TO 5 TIMES DEPENDING ON M PIC X(4).
+   05 N PIC 9(2).
+   05 SECOND OCCURS 1 TO 3 TIMES DEPENDING ON N PIC X(2).
+`, layoutmodel.ODOSlide)
+
+	var position *CountPositionError
+	if !errors.As(err, &position) {
+		t.Fatalf("resolving reported %v, want a CountPositionError", err)
+	}
+	if position.Count != "N" || position.Table != "SECOND" || position.Behind != "FIRST" {
+		t.Errorf(
+			"the diagnostic is about count %s, table %s, behind %s; want N, SECOND and FIRST",
+			position.Count, position.Table, position.Behind)
+	}
+	for _, want := range []string{"R", "N", "SECOND", "FIRST"} {
+		if !strings.Contains(position.Error(), want) {
+			t.Errorf("the diagnostic does not name %s: %s", want, position.Error())
+		}
+	}
+}
+
+// TestTwoTablesMayShareOneCount is docs/ir/SPEC.md's "One count may size two
+// tables, and a writer refuses to choose": a reference is a reference, and the
+// field it names does not become the property of the first item that named it.
+//
+// Reading never notices. A consumer decodes the field once and sizes both tables
+// from that one value, and the tables need share neither a width per occurrence
+// nor a declared range.
+func TestTwoTablesMayShareOneCount(t *testing.T) {
+	t.Parallel()
+
+	record := slid(t, `01 R.
+   05 N PIC 9(2).
+   05 FIRST OCCURS 1 TO 5 TIMES DEPENDING ON N PIC X(4).
+   05 SECOND OCCURS 1 TO 9 TIMES DEPENDING ON N PIC X(2).
+   05 TRAILER PIC X(3).
+`)
+
+	count := countOf(t, record, "FIRST")
+	if countOf(t, record, "SECOND") != count {
+		t.Fatal("the two tables name two different count fields")
+	}
+
+	at, err := record.At(Counts{count: 3})
+	if err != nil {
+		t.Fatalf("reading at 3 occurrences: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		want int
+	}{
+		{name: "FIRST", want: 2},
+		{name: "SECOND", want: 2 + 12},
+		{name: "TRAILER", want: 2 + 12 + 6},
+	} {
+		if got := positionOf(t, at, tc.name); got != tc.want {
+			t.Errorf("at 3 occurrences %s is at %d, want %d", tc.name, got, tc.want)
+		}
+	}
+	if got := at.Extent(); got != 2+12+6+3 {
+		t.Errorf("at 3 occurrences the record is %d bytes, want %d", got, 2+12+6+3)
+	}
+}
+
+// TestASharedCountIsCheckedAgainstEveryRepetitionNamingIt is the one place the
+// second reference is not simply a second multiplication: each repetition
+// carries its own declared bounds, both bind the one value, and the range a
+// record can actually carry is the overlap rather than either.
+func TestASharedCountIsCheckedAgainstEveryRepetitionNamingIt(t *testing.T) {
+	t.Parallel()
+
+	record := slid(t, `01 R.
+   05 N PIC 9(2).
+   05 NARROW OCCURS 1 TO 3 TIMES DEPENDING ON N PIC X(4).
+   05 WIDE OCCURS 1 TO 9 TIMES DEPENDING ON N PIC X(2).
+`)
+	count := countOf(t, record, "NARROW")
+
+	// Inside both ranges, so both tables are sized and nothing is reported.
+	if _, err := record.At(Counts{count: 2}); err != nil {
+		t.Fatalf("reading at 2 occurrences, which both tables admit: %v", err)
+	}
+
+	// Inside the second range and outside the first. Checking against one of
+	// the two would read this as well-formed.
+	_, err := record.At(Counts{count: 5})
+
+	var bounds *CountBoundsError
+	if !errors.As(err, &bounds) {
+		t.Fatalf("reading at 5 occurrences reported %v, want a CountBoundsError", err)
+	}
+	if bounds.Table != "NARROW" || bounds.Value != 5 || bounds.Min != 1 || bounds.Max != 3 {
+		t.Errorf("the diagnostic is %+v, want 5 against NARROW's 1 to 3", bounds)
+	}
+	if got := len(diag.Diagnostics(err)); got != 1 {
+		t.Errorf("reading at 5 occurrences reported %d faults, want the one table that refuses it", got)
+	}
+}
+
+// TestTwoTablesSharingACountWithDisjointRangesAreRejected: no value sizes both
+// tables, so every record of the descriptor is malformed data, and the
+// alternative to rejecting the layout is that diagnostic once per record for the
+// life of the file.
+func TestTwoTablesSharingACountWithDisjointRangesAreRejected(t *testing.T) {
+	t.Parallel()
+
+	_, err := reading(t, `01 R.
+   05 N PIC 9(2).
+   05 FIRST OCCURS 1 TO 3 TIMES DEPENDING ON N PIC X(4).
+   05 SECOND OCCURS 5 TO 9 TIMES DEPENDING ON N PIC X(2).
+`, layoutmodel.ODOSlide)
+
+	var shared *SharedCountBoundsError
+	if !errors.As(err, &shared) {
+		t.Fatalf("resolving reported %v, want a SharedCountBoundsError", err)
+	}
+	if len(shared.Tables) != 2 || shared.Tables[0] != "FIRST" || shared.Tables[1] != "SECOND" {
+		t.Errorf("the diagnostic names %v, want both repeating items", shared.Tables)
+	}
+	for _, want := range []string{"R", "N", "FIRST", "SECOND", "1 to 3", "5 to 9"} {
+		if !strings.Contains(shared.Error(), want) {
+			t.Errorf("the diagnostic does not name %s: %s", want, shared.Error())
+		}
+	}
+}
+
+// TestRangesThatMeetAtOneValueOverlap is the boundary of that rule: one value
+// sizing both tables is a record a consumer can read, so the layout stands.
+func TestRangesThatMeetAtOneValueOverlap(t *testing.T) {
+	t.Parallel()
+
+	record := slid(t, `01 R.
+   05 N PIC 9(2).
+   05 FIRST OCCURS 1 TO 3 TIMES DEPENDING ON N PIC X(4).
+   05 SECOND OCCURS 3 TO 9 TIMES DEPENDING ON N PIC X(2).
+`)
+
+	if _, err := record.At(Counts{countOf(t, record, "FIRST"): 3}); err != nil {
+		t.Fatalf("reading at the one count both tables admit: %v", err)
+	}
+}
+
+// TestACountOutsideTheDeclaredBoundsIsMalformedData is the check the bounds are
+// carried for, and the only thing in reach that bounds a number decoded out of a
+// file: a descriptor word stating the length a forbidden count implies agrees
+// with the extent exactly, so the framing check passes on a record the copybook
+// says cannot exist.
+func TestACountOutsideTheDeclaredBoundsIsMalformedData(t *testing.T) {
+	t.Parallel()
+
+	record := slid(t, varying)
+	count := countOf(t, record, "ENTRY")
+
+	for _, tc := range []struct {
+		name  string
+		value int
+	}{
+		{name: "below the minimum", value: 0},
+		{name: "above the maximum", value: 5},
+		// A count field holding spaces is the case that matters, and a
+		// consumer that decoded one as a negative number reports it rather
+		// than reading the table as absent.
+		{name: "negative", value: -1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			at, err := record.At(Counts{count: tc.value})
+
+			var bounds *CountBoundsError
+			if !errors.As(err, &bounds) {
+				t.Fatalf("reading at %d reported %v, want a CountBoundsError", tc.value, err)
+			}
+			if at != nil {
+				t.Error("a record was handed back beside the fault")
+			}
+			if bounds.Value != tc.value || bounds.Min != 1 || bounds.Max != 4 {
+				t.Errorf("the diagnostic is %+v, want %d against 1 to 4", bounds, tc.value)
+			}
+			for _, want := range []string{"R", "N", "ENTRY"} {
+				if !strings.Contains(bounds.Error(), want) {
+					t.Errorf("the diagnostic does not name %s: %s", want, bounds.Error())
+				}
+			}
+		})
+	}
+}
+
+// TestACountNobodyDecodedIsNotZeroOccurrences: reading a count field holding
+// spaces as zero produces a record that parses and is wrong, so a count that is
+// not in hand is refused rather than defaulted.
+func TestACountNobodyDecodedIsNotZeroOccurrences(t *testing.T) {
+	t.Parallel()
+
+	record := slid(t, varying)
+
+	_, err := record.At(Counts{})
+
+	var missing *MissingCountError
+	if !errors.As(err, &missing) {
+		t.Fatalf("reading with no count reported %v, want a MissingCountError", err)
+	}
+	if missing.Count != "N" || missing.Table != "ENTRY" {
+		t.Errorf("the diagnostic is about count %s and table %s, want N and ENTRY", missing.Count, missing.Table)
+	}
+}
+
+// TestReadingARecordWithNoCountAtAllChangesNothing: every record of a
+// non-sliding file is one of these, and so is every record with no table, so the
+// empty map is the right argument for one.
+func TestReadingARecordWithNoCountAtAllChangesNothing(t *testing.T) {
+	t.Parallel()
+
+	record := slid(t, "01 R.\n   05 A PIC X(4).\n   05 T PIC X OCCURS 3 TIMES.\n")
+
+	at, err := record.At(Counts{})
+	if err != nil {
+		t.Fatalf("reading a record with no count reference: %v", err)
+	}
+	if at.Extent() != record.Extent() {
+		t.Errorf("the record read at no counts is %d bytes, want the %d it already was", at.Extent(), record.Extent())
+	}
+	if got := at.Find("T").Repetition.Count; got != 3 {
+		t.Errorf("the fixed table stands at %d occurrences, want the copybook's 3", got)
+	}
+}
+
+// TestASlidingTableInsideAnArmIsStillRefused holds the reading to changing what
+// a repetition is and nothing else: an arm's extent has to be a constant, and
+// under `odoslide` a table inside one is not.
+//
+// Under the other reading it is, which is why this is a pair rather than a
+// single assertion — the same copybook that cannot be described under one is
+// ordinary under the other.
+func TestASlidingTableInsideAnArmIsStillRefused(t *testing.T) {
+	t.Parallel()
+
+	src := `01 R.
+   05 N PIC 9(2).
+   05 T OCCURS 2 TIMES.
+      10 A PIC X(12).
+      10 B REDEFINES A.
+         15 CELL OCCURS 1 TO 3 TIMES DEPENDING ON N PIC X(4).
+`
+	resolve := func(r layoutmodel.Reading) error {
+		field := recordOf(t, src)
+
+		_, err := Resolve(field, Options{
+			Copybook: "test.cpy",
+			Dialect:  copybook.IBMEnterprise(),
+			Encoding: mainframe(),
+			Reading:  r,
+			Redefines: []Redefine{{
+				Item: fieldNamed(t, field, "A"),
+				Alternatives: []Alternative{
+					{Name: "A", Predicate: selects("A")},
+					{Name: "B", Predicate: selects("B")},
+				},
+			}},
+		})
+
+		return err
+	}
+
+	var variable *ArmVariableCountError
+	if err := resolve(layoutmodel.ODOSlide); !errors.As(err, &variable) {
+		t.Fatalf("resolving under odoslide reported %v, want an ArmVariableCountError", err)
+	}
+
+	if err := resolve(layoutmodel.NoODOSlide); err != nil {
+		t.Fatalf("resolving under noodoslide, where the same arm is a fixed table: %v", err)
+	}
+}

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -53,6 +53,25 @@ type Options struct {
 	// [layoutmodel.Framing] states no `lrecl` and means the same thing.
 	Framing *layoutmodel.Framing
 
+	// Reading is which of the two vendor readings of `OCCURS DEPENDING ON`
+	// the layout says its file was written under.
+	//
+	// It has no default, and [layoutmodel.ReadingUnstated] is what a layout
+	// that stated neither hands over. Under `odoslide` a table becomes a
+	// repetition whose count is a reference and every item behind it moves
+	// with that count; under `noodoslide` the same clause describes a fixed
+	// table at the copybook's declared maximum beside a field saying how many
+	// entries the writing program filled. The two put every item behind the
+	// table somewhere different and nothing in the file disagrees with the
+	// wrong one, so a record carrying the clause under an unstated reading is
+	// rejected rather than resolved either way (docs/ir/SPEC.md, "An item
+	// after a table slides, and the other reading is a fixed table", #87).
+	//
+	// A copybook carrying no such clause needs no reading, and one stated for
+	// it is ignored: the setting is about tables and a record with none is
+	// resolved identically under both.
+	Reading layoutmodel.Reading
+
 	// Redefines says how each REDEFINES inside a repeating group is told
 	// apart. A redefine outside one needs no entry: its alternatives become
 	// records, and [Resolve] returns one per combination.
@@ -187,6 +206,25 @@ func Resolve(record *copybook.Field, opts Options) ([]*Record, error) {
 	}
 
 	r := &resolver{opts: opts, record: record}
+
+	// The reading is held to before anything is laid out, and on its own, for
+	// the profile's reason: it decides what every item behind every table in
+	// the record resolves to, so resolving without one would report a
+	// resolution nobody chose and bury the copybook's own faults among its
+	// consequences.
+	items := layout.Items()
+	if odo := tables(items); len(odo) > 0 {
+		if !opts.Reading.Stated() {
+			r.requireReading(odo)
+
+			return nil, r.faults.Err()
+		}
+
+		if opts.Reading.Slides() {
+			r.checkCounts(items, odo)
+		}
+	}
+
 	options := r.item(layout.Record, opts.Encoding)
 	if r.faults.Failed() {
 		return nil, r.faults.Err()
@@ -384,7 +422,7 @@ func (r *resolver) item(item *copybook.Item, in layoutmodel.Axes) []option {
 	in = r.encoding(item.Field, in)
 
 	if item.Field.Kind != copybook.KindGroup {
-		return []option{{node: elementary(item, in)}}
+		return []option{{node: r.elementary(item, in)}}
 	}
 	return r.group(item, in)
 }
@@ -425,12 +463,12 @@ func (r *resolver) encoding(field *copybook.Field, in layoutmodel.Axes) layoutmo
 // generator as bytes it already has rather than as a rule it applies. The
 // encoding stays on the field node inside it: the wrapper is this package's own
 // and stands for no copybook item, and the padding is not a field's bytes.
-func elementary(item *copybook.Item, in layoutmodel.Axes) *Node {
+func (r *resolver) elementary(item *copybook.Item, in layoutmodel.Axes) *Node {
 	field := &Node{
 		Kind:       KindField,
 		Field:      item.Field,
 		width:      item.Length,
-		Repetition: repetitionOf(item),
+		Repetition: r.repetitionOf(item),
 		Encoding:   in,
 	}
 	if item.Stride == item.Length {
@@ -508,7 +546,7 @@ func (r *resolver) group(item *copybook.Item, in layoutmodel.Axes) []option {
 				Kind:       KindGroup,
 				Field:      item.Field,
 				Members:    mergeSlack(members),
-				Repetition: repetitionOf(item),
+				Repetition: r.repetitionOf(item),
 			},
 			alternatives: list.alternatives,
 		})
@@ -591,7 +629,7 @@ func (r *resolver) variant(c cluster, in layoutmodel.Axes) run {
 			continue
 		}
 
-		switch counted := referenceCount(member); {
+		switch counted := r.referenceCount(member); {
 		case member.Total() > extent:
 			r.faults.Fail(&ArmExtentError{
 				Pos:       r.span(member.Field),
@@ -773,33 +811,6 @@ func mergeSlack(nodes []*Node) []*Node {
 		merged = append(merged, node)
 	}
 	return merged
-}
-
-// repetitionOf reads an item's repetition, nil where it does not repeat.
-func repetitionOf(item *copybook.Item) *Repetition {
-	if item.MaxOccurs <= 1 {
-		return nil
-	}
-
-	repetition := &Repetition{Count: item.Occurs, Min: item.MinOccurs, Max: item.MaxOccurs}
-	if item.DependingOn != nil {
-		repetition.DependingOn = item.DependingOn.Field
-	}
-	return repetition
-}
-
-// referenceCount returns the first item at or under item whose repetition count
-// is read out of the record, or nil where none is.
-func referenceCount(item *copybook.Item) *copybook.Item {
-	if item.DependingOn != nil {
-		return item
-	}
-	for _, child := range item.Children {
-		if found := referenceCount(child); found != nil {
-			return found
-		}
-	}
-	return nil
 }
 
 // inTable reports whether item is contained, at any depth, in a group that

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -207,19 +207,26 @@ func Resolve(record *copybook.Field, opts Options) ([]*Record, error) {
 
 	r := &resolver{opts: opts, record: record}
 
-	// The reading is held to before anything is laid out, and on its own, for
-	// the profile's reason: it decides what every item behind every table in
-	// the record resolves to, so resolving without one would report a
-	// resolution nobody chose and bury the copybook's own faults among its
-	// consequences.
 	items := layout.Items()
 	if odo := tables(items); len(odo) > 0 {
+		// The reading is held to before anything is laid out and on its
+		// own, for the profile's reason: it decides what every item behind
+		// every table in the record resolves to, so resolving without one
+		// would report a resolution nobody chose and bury the copybook's
+		// own faults among its consequences.
 		if !opts.Reading.Stated() {
 			r.requireReading(odo)
 
 			return nil, r.faults.Err()
 		}
 
+		// The count-reference rules are ordinary faults and are joined with
+		// whatever else the walk finds, rather than returned on their own.
+		// A copybook and the layout over it go wrong in the same way in
+		// several places at once, and a count in the wrong place does not
+		// stop the record being laid out — `cobol-go` already computed it —
+		// so stopping here would be one fault per run over a copybook this
+		// package can say more about.
 		if opts.Reading.Slides() {
 			r.checkCounts(items, odo)
 		}

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -80,6 +80,11 @@ func mainframe() layoutmodel.Axes {
 
 // resolveAll resolves a copybook source under IBM Enterprise COBOL, which is the
 // dialect every test here states unless it is testing the dialect.
+//
+// The reading is that dialect's too: IBM Enterprise COBOL slides
+// unconditionally, so a test about a copybook laid out under it reads its tables
+// the way that compiler does. A test about the fork itself states its own
+// (odo_test.go).
 func resolveAll(t *testing.T, src string, redefines ...Redefine) []*Record {
 	t.Helper()
 
@@ -87,6 +92,7 @@ func resolveAll(t *testing.T, src string, redefines ...Redefine) []*Record {
 		Copybook:  "test.cpy",
 		Dialect:   copybook.IBMEnterprise(),
 		Encoding:  mainframe(),
+		Reading:   layoutmodel.ODOSlide,
 		Redefines: redefines,
 	})
 	if err != nil {

--- a/internal/resolve/variant_test.go
+++ b/internal/resolve/variant_test.go
@@ -46,6 +46,7 @@ func resolveTable(t *testing.T, src string, build func(*copybook.Field) []Redefi
 		Copybook:  "test.cpy",
 		Dialect:   copybook.IBMEnterprise(),
 		Encoding:  mainframe(),
+		Reading:   layoutmodel.ODOSlide,
 		Redefines: build(field),
 	})
 }


### PR DESCRIPTION
Closes #35

Resolves `OCCURS DEPENDING ON` under the reading its layout states, and holds
every count reference to what `docs/ir/SPEC.md` admits.

## What landed

**The fork is resolved, not carried.** `Options.Reading` reaches `resolve` the
way a framing does. Under `odoslide` a table becomes a `Repetition` whose count
is the field the `DEPENDING ON` phrase names, carrying the copybook's own
`OCCURS integer-1 TO integer-2` as `Min`/`Max`; under `noodoslide` the same
clause is a constant repetition at the declared maximum and the count field is
resolved as an ordinary field with nothing pointing at it. Nothing on a node
says which reading a file was written under.

**Count references are checked once, on the copybook's items, before anything is
laid out.** A copybook with four `REDEFINES` alternatives resolves to four
records, and running these over the resolved nodes would report one copybook
fault four times.

**`Record.At(Counts)`** reads a resolved record back at the counts a consumer
decoded, so the position sum and the extent answer for one record's bytes.

**`layoutmodel.ReadCopybookReading`** reads the `copybook-reading` form the
published schema and `docs/layout/SPEC.md` already declare.

## Acceptance criteria

- [x] **ODO object located, including outside the `OCCURS` group but inside the
  record** — `cobol-go`'s `Item.DependingOn` is the resolution, at any depth; a
  hoisted count is the ordinary case and the one the rules below keep.
- [x] **A count in another record resolved to a register, never a cross-record
  field reference** — a `DEPENDING ON` phrase names an item of the copybook
  record carrying it, so no reference this package builds can reach across
  records. The cross-record count arrives as a register `#36`'s automaton binds;
  `Repetition.DependingOn`'s doc and a test state that division.
- [x] **Variable-length records represented with an explicit ODO binding** —
  `Repetition.DependingOn` plus the declared bounds, which is `VariableCount` in
  the IR schema.
- [x] **Fields following an ODO group carry data-dependent offsets, modelled
  explicitly** — ordering and width with one non-constant term in the sum; no
  node carries an offset and there is no second mechanism for an item behind a
  table. `Record.At` is that sum run at a count.
- [x] **The layout's stated reading consumed (#87)** — `Options.Reading`;
  `TestTheSameCopybookResolvesTwoWaysUnderTheTwoReadings`.
- [x] **A layout stating no reading rejected, naming the record and the table
  (#87)** — `UnstatedReadingError`, one per table, reported before the walk.
- [x] **The repetition carries the copybook's own bounds (#87)** — taken from
  `MinOccurs`/`MaxOccurs`, neither narrowed nor widened.
- [x] **A count outside the declared bounds is malformed data (#87)** —
  `CountBoundsError` from `Record.At`.
- [x] **A count that will not decode, or is negative, is malformed data rather
  than zero** — a count the `Counts` map does not carry is a `MissingCountError`
  rather than an absent table, and a negative value is below every declared
  minimum. Decoding itself is the caller's; `Record.At` takes decoded counts.
- [x] **A count that repeats, or sits in a group that repeats, rejected naming
  the record and the field** — `CountOccurrenceError`, which also names the
  enclosing group where there is one.
- [x] **A count behind the item it counts rejected (#88)** — see the judgment
  call below.
- [x] **A count whose own position is not constant rejected (#88)** —
  `CountPositionError`, naming the record, the count, the table and the variable
  item it sits behind.
- [x] **Two repeating items may share one count, checked against every
  repetition's bounds (#89)** — `Record.At` walks every repetition naming the
  count; a value inside one declared range and outside the other is reported
  against the table that refuses it.
- [x] **Disjoint declared ranges rejected, naming the record, the count and both
  items (#89)** — `SharedCountBoundsError`. Two alternatives of one `REDEFINES`
  are skipped, since they never both stand in one record.
- [x] **Before support lands, ODO produces an explicit unsupported error** — no
  longer applicable; support is what this lands. The unstated-reading rejection
  is the explicit error a layout now gets where it has said too little.
- [x] **Tests** — `internal/resolve/odo_test.go` covers an ODO group followed by
  further fields, the cross-record division, a count inside a repeating group, a
  count that repeats, a count behind the table it sizes, a count behind another
  variable table, a count outside its bounds (below, above and negative), two
  tables sharing one count, two whose declared ranges are disjoint, ranges
  meeting at one value, and the same copybook resolved under both readings.

## Judgment calls

**A count behind the table it sizes is refused by `cobol-go`, not restated
here.** `copybook.NewLayout` will not lay out a copybook whose `DEPENDING ON`
object is defined after the table it controls — the sum that locates the count
contains the extent the count decides — and `Resolve` returns that fault
unchanged. Restating it in `resolve` would mean resolving the `DEPENDING ON`
data-name out of the raw `OCCURS` clause a second time, which is exactly the
second reading of COBOL the package comment exists to refuse. The cost is that
the diagnostic is `cobol-go`'s wording rather than a `cpybkc` one naming the
record; it does name the count and the table, and
`TestACountBehindTheTableItSizesIsRejected` pins that.

**`Record.At` is new public API of the package.** `docs/ir/SPEC.md` puts the
bounds check and the variable-term sum on a *consumer*, and this package emits
IR rather than reading files — so without it, three acceptance criteria would
have been met by documentation alone. It is the sibling of `Record.Position`
and exists for the same stated reason: the arithmetic every consumer performs,
run here so that this package's tests run it against what `cobol-go` computes
independently. It takes decoded counts and reads no bytes.

**`layoutmodel.ReadCopybookReading` landed here.** No open story owns the model
side of the `copybook-reading` form — `#27` delivered its spelling in
`docs/layout/SPEC.md` and `schema/layout.sexpr` — and a `Reading` type in
`layoutmodel` that no reader there produces would have left the setting
unwritable. An absent form is not a fault in that reader: whether a layout owed
a reading is a question about the copybooks it binds, and `layoutmodel` never
opens one.

**`ReadingUnstated.Slides()` is false.** A caller that asks without asking
`Stated()` first gets the reading that is safe to compute rather than the
sliding one by default; refusing the unstated reading is `resolve`'s, against
the table that needed the answer.

## Verified

`dagger call ci` (fmt, vet, lint, `go test -race` over both modules, buf lint
and the artifact stages) — clean. `go test -race ./...` and the `irpb` module
run again directly.

Existing tests that resolve an ODO copybook now state `layoutmodel.ODOSlide`
alongside `copybook.IBMEnterprise()`, which is that compiler's unconditional
reading.
