### PR TITLE
story(resolve): compile the sequencing grammar to an automaton

### DIFF
--- a/docs/layout/SPEC.md
+++ b/docs/layout/SPEC.md
@@ -1622,6 +1622,6 @@ computed once by `resolve`.
 | [Physical framing](#physical-framing) | #26 `layout` |
 | [Record definitions](#record-definitions) | #27, #30 `layout`; `copybook-reading` by #35 `resolve` |
 | [Discrimination](#discrimination) | #28 `layout` |
-| [Sequencing](#sequencing) | #29 `layout` |
+| [Sequencing](#sequencing) | #29 `layout`; the expression compiled to an automaton, and the rules on `times` and `when` that need a copybook, by #36 `resolve` |
 | [The published schema](#the-published-schema) | #23 `layout` |
 | [Validation and diagnostics](#validation-and-diagnostics) | #24, #31 `layout` |

--- a/internal/layoutmodel/discriminate.go
+++ b/internal/layoutmodel/discriminate.go
@@ -116,7 +116,7 @@ type Literal struct {
 
 	// Number is what a [NumberLiteral] said, rendered back from the value the
 	// grammar read. Two spellings of one number — `12` and `12.0` — render the
-	// same, which is what makes two of them one literal for [Literal.identity].
+	// same, which is what makes two of them one literal for [Literal.Identity].
 	Number string
 
 	// Bytes is what a [BytesLiteral] said.
@@ -138,7 +138,7 @@ func (l Literal) String() string {
 	}
 }
 
-// identity is what makes two literals the same one.
+// Identity is what makes two literals the same one.
 //
 // The spelling *and* the sort, because the sort decides the resolution: `"01"`
 // is text through the item's charset and `01` is a number through its `PICTURE`,
@@ -146,7 +146,14 @@ func (l Literal) String() string {
 // answer. Two literals that are the same here are the same under every charset,
 // which is what makes an overlap decided on this identity one decidable from the
 // layout alone.
-func (l Literal) identity() string { return string(l.Kind) + " " + l.String() }
+//
+// It is exported because the overlap this layer can decide is not the only one.
+// `resolve` decides two more against the same identity and for the same reason —
+// whether two transitions leaving one state can both match a record, and whether
+// two guards over one register can hold at once — and a second reading of what
+// makes two literals equal is a second answer for them to disagree about (#36,
+// #37).
+func (l Literal) Identity() string { return string(l.Kind) + " " + l.String() }
 
 // Strategy is one discrimination strategy, read.
 //
@@ -557,7 +564,7 @@ func (r *discriminationReader) overlap(read []Arm, arm Arm, variant ItemRef) {
 
 		for _, literal := range arm.Predicate.Literals {
 			index := slices.IndexFunc(earlier.Predicate.Literals, func(other Literal) bool {
-				return other.identity() == literal.identity()
+				return other.Identity() == literal.Identity()
 			})
 			if index < 0 {
 				continue

--- a/internal/resolve/automaton.go
+++ b/internal/resolve/automaton.go
@@ -1,0 +1,884 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package resolve
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/Zaba505/cobol-go/copybook"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+	"github.com/Zaba505/cpybkc/internal/layout"
+	"github.com/Zaba505/cpybkc/internal/layoutmodel"
+)
+
+// This file is the record automaton: the nodes docs/ir/SPEC.md's "The
+// sequencing automaton" describes, and the compilation of a layout's sequencing
+// expression into them.
+//
+// # Why a layout's expression does not reach a generator
+//
+// The IR carries states and transitions and **MUST NOT** carry the expression
+// they were compiled from. A regex-like algebra implemented independently in
+// four languages is four slightly different algebras, and the disagreements
+// surface as files one generator reads and another rejects. So the algebra is
+// spent here, exactly once, and what leaves is a graph a plugin author walks
+// knowing no COBOL and no regular expressions.
+//
+// # The construction, and why it has no epsilon transitions
+//
+// The graph is a position automaton: one state per appearance of a record name
+// in the expression, plus a start state that is nothing's target. A transition
+// leaves the state for one appearance and enters the state for another exactly
+// where the second may follow the first, and it admits the second's record.
+// Every transition therefore consumes exactly one record, which is
+// docs/ir/SPEC.md's "No epsilon transitions, and what the graph pays instead"
+// falling out of the construction rather than being enforced over it.
+//
+// It is also what makes the start state expressible. docs/layout/SPEC.md's "The
+// first record of a file is the first thing the expression admits, and nothing
+// is written to say so" needs a state no transition re-enters, and a position
+// automaton has one for free: the start state stands for no appearance, so no
+// position can follow it (#80).
+//
+// The graph pays for the missing epsilons in transitions, as that section says
+// it does: a segment that may be skipped is compiled by letting every record
+// that can follow the skip be reachable directly, each under the guards saying
+// the skipped segment is done. What a state carries follows the number of
+// segments that can be skipped past it and never the values in the file.
+//
+// # Registers, and what compiles into one
+//
+// `times` and `when` are the only operators that read a value out of the file,
+// and each becomes a register: an integer one for `times`, holding what is left
+// of a count, and a bytes one for `when`, holding the value a guard compares.
+// Every transition admitting the record that holds the named item binds the
+// register from that item, and the transitions the operator governs carry the
+// guards that read it (docs/ir/SPEC.md, "The automaton remembers, in
+// registers", #76, #77).
+//
+// Nothing else becomes a register, and that is the SHOULD in "When a value
+// becomes a state, and when it becomes a register" kept rather than restated: a
+// value tested only on the transition admitting the record that holds it is a
+// record's own discriminator, and a discriminator compiles into the predicate on
+// that transition. It is a branch — two transitions admitting two records and
+// moving to different states — and no register is emitted for it, because a
+// register the graph does not need is memory every consumer in every language
+// carries for nothing.
+//
+// A `times` register is one per operator, because a pass of the run takes one
+// off it: two counted runs naming one item are two counts, and sharing the
+// register would leave the second run at whatever the first left behind. A
+// `when` register is one per item, because nothing ever writes it but the
+// transitions admitting the record it is read from, and two `when`s over one
+// item are two guards over one value.
+//
+// # A counted run is one register and one guard
+//
+// The transition entering a pass carries the guard that the counter is above
+// zero and the binding that takes one off it, and the run is left where the
+// counter has reached zero. So a `PIC 9(4)` count is one register and one guard
+// whatever the number in the file is, and never ten thousand states — which is
+// what docs/ir/SPEC.md promises in exchange for the register file it asks a
+// consumer to carry.
+//
+// The guard is also the rule that a counter cannot run below zero: the only
+// transition that takes one off is the one the guard makes ineligible at zero.
+//
+// # What `when` cannot say, and what that costs
+//
+// A guard is one of three tests and none of them is a negation
+// (docs/ir/SPEC.md, "Three tests, and no fourth"). So `(when <item> "Y" <e>)`
+// compiles into a guard on the transitions entering `<e>` and into nothing at
+// all on the path that skips it: there is no test for *the flag is not `Y`* to
+// put there, and inventing one is a fourth member of a closed set.
+//
+// What that costs is stated here because it is a real loss and an adopter can
+// buy it back. docs/ir/SPEC.md's "A counted run, as nodes" carries the guard
+// `flag one-of N or space` on its accepting state, and detects a file whose
+// summary is missing where the flag said `Y`. A layout writing `(when flag "Y"
+// SUMMARY)` gets the other three detections that appendix lists and not that
+// one, because the complement of `Y` is not a set this compiler can know. An
+// adopter who needs it states the count instead of the flag — `(times SUMMARY
+// (item HEADER SUM-COUNT))` compiles into an acceptance guard, because zero is
+// a test the set has.
+//
+// # What is proved before a byte is read
+//
+// Two proofs run over the assembled graph, and each is docs/ir/SPEC.md asking
+// for a layout to be rejected rather than a file to be misread.
+//
+// Every read of a register is preceded, on every path from the start state, by
+// a binding of that register on a transition taken strictly earlier than the
+// reading one (#88). Strictly earlier is the whole of it: a transition's
+// bindings apply at step 7 of the read loop and its guards are evaluated at step
+// 3, so a transition that binds a register it also reads reads the value the
+// binding was about to replace, or nothing at all. That is what rejects `(times
+// R (item R N))` — a run counted by a field of the record being counted — and
+// what admits `(times D (item H N))`, where the transition admitting a detail
+// reads the counter an earlier transition bound and takes one off it in the same
+// step.
+//
+// And no two transitions leaving one state are eligible together and selected by
+// predicates that can both match one record ("When two match, and when none
+// does"). Guards narrow which pairs that is about: two transitions whose guards
+// cannot hold at the same time may be selected by the very same test on the very
+// same bytes, which is what makes a counted run expressible at all. A transition
+// carrying no predicate is inside that rule rather than beside it — it matches
+// every record, so it overlaps every sibling whose guards can hold at the same
+// time as its own (#80).
+
+// RegisterKind is what a register holds, one member of the closed set
+// docs/ir/SPEC.md's "The automaton remembers, in registers" admits.
+//
+// The zero value is not a kind. A register handed back by [CompileSequence]
+// always names one.
+type RegisterKind int
+
+const (
+	// RegisterBytes holds its source field's bytes as they appear in the
+	// record, so a guard over one is a byte comparison and needs no charset
+	// knowledge — the same reason a predicate tests bytes.
+	RegisterBytes RegisterKind = iota + 1
+
+	// RegisterInteger holds a number, decoded from the source field by that
+	// field's own four encoding axes, because a count is arithmetic and the
+	// field holding one may be zoned, packed or binary.
+	RegisterInteger
+)
+
+// String implements the [fmt.Stringer] interface.
+func (k RegisterKind) String() string {
+	switch k {
+	case RegisterBytes:
+		return "bytes"
+	case RegisterInteger:
+		return "integer"
+	}
+	return "unknown"
+}
+
+// Register is a value the automaton carries forward between records.
+//
+// The IR's register node declares its kind and nothing more. What is carried
+// beside it here is what a binding and a diagnostic need: the item reference the
+// layout wrote, and the copybook field it resolved to. Both are read by this
+// package and neither is a member of the IR node.
+type Register struct {
+	// ID is the register's identifier, assigned in the order the operators
+	// that need one are met walking the expression.
+	ID int
+
+	// Kind is what it holds.
+	Kind RegisterKind
+
+	// Source is the item reference the operator wrote, which is what a
+	// diagnostic about this register quotes.
+	Source layoutmodel.ItemRef
+
+	// Field is the copybook item that reference resolved to: the field every
+	// binding of this register reads.
+	Field *copybook.Field
+}
+
+// String renders the register the way a diagnostic names one: the reference the
+// layout wrote.
+func (r *Register) String() string {
+	if r == nil {
+		return "nothing"
+	}
+	return r.Source.String()
+}
+
+// BindingValue is what a binding writes, one member of the closed set
+// docs/ir/SPEC.md admits.
+type BindingValue int
+
+const (
+	// BindField writes the value of a field contained in the record the
+	// transition admits.
+	BindField BindingValue = iota + 1
+
+	// BindLessOne writes the register's own value less one. It is what
+	// counts: a transition that admits one detail and takes one off the
+	// counter is how a run of n records is read without n states.
+	BindLessOne
+)
+
+// String implements the [fmt.Stringer] interface.
+func (v BindingValue) String() string {
+	switch v {
+	case BindField:
+		return "field"
+	case BindLessOne:
+		return "less one"
+	}
+	return "unknown"
+}
+
+// Binding is a write of a register, applied when the transition carrying it is
+// taken.
+//
+// Bindings are the last thing a transition does, so nothing that transition
+// reads sees what one writes: not its guards, and not the extent of the record
+// it admits. Each reads the register file as it stood on entry to the state, so
+// the order of one transition's bindings is not significant.
+type Binding struct {
+	// Register is the register written.
+	Register *Register
+
+	// Value is what is written.
+	Value BindingValue
+
+	// Field is the field the value comes from under [BindField], and nil
+	// under [BindLessOne]. It is a field of the record the transition
+	// admits, at any depth.
+	Field *copybook.Field
+}
+
+// GuardTest is what a guard tests, one member of the closed set of three
+// docs/ir/SPEC.md admits. There is no fourth, and no negation: conjunction is
+// the guard list, disjunction is a second transition leaving the same state, and
+// a state already is a disjunction.
+type GuardTest int
+
+const (
+	// GuardEquals is the register equal to one carried literal.
+	GuardEquals GuardTest = iota + 1
+
+	// GuardOneOf is the register equal to one of a carried set of literals.
+	GuardOneOf
+
+	// GuardPositive is the register holding an integer greater than zero.
+	GuardPositive
+)
+
+// String implements the [fmt.Stringer] interface.
+func (t GuardTest) String() string {
+	switch t {
+	case GuardEquals:
+		return "equals"
+	case GuardOneOf:
+		return "one-of"
+	case GuardPositive:
+		return "positive"
+	}
+	return "unknown"
+}
+
+// Guard is a test of a register that decides whether a transition is eligible,
+// or whether a state accepts end of input.
+//
+// A guard is evaluated before the record in front of the consumer is examined at
+// all, and against the register file as it stands on entry to the state, so a
+// guard never reads what its own transition binds. All of a transition's guards
+// must hold for it to be eligible, and their order is therefore not significant.
+type Guard struct {
+	// Register is the register tested.
+	Register *Register
+
+	// Test is the test.
+	Test GuardTest
+
+	// Literals are what the register is compared against, in the order the
+	// layout writes them: exactly one under [GuardEquals], at least one under
+	// [GuardOneOf], and none under [GuardPositive].
+	//
+	// They are the layout's literals rather than the bytes a consumer
+	// compares, for the reason [Arm.Predicate] carries a strategy: resolving
+	// a literal to bytes through an item's charset, PICTURE and width is
+	// #37's, and doing it in two places is two answers.
+	Literals []layoutmodel.Literal
+}
+
+// key is what makes two guards the same guard, so that composing an expression
+// out of its parts cannot put one test on a transition twice.
+func (g Guard) key() string {
+	parts := make([]string, 0, len(g.Literals)+2)
+	parts = append(parts, strconv.Itoa(g.Register.ID), g.Test.String())
+	for _, literal := range g.Literals {
+		parts = append(parts, literal.Identity())
+	}
+	return strings.Join(parts, " ")
+}
+
+// Transition is one edge of the automaton: it consumes exactly one record, and
+// there is no transition that moves without reading.
+type Transition struct {
+	// Record is the name of the `record` form whose record this transition
+	// admits.
+	//
+	// It is what the transition *produces* and never what selects it: a
+	// transition is not labelled with a record name, because which record the
+	// consumer is looking at is precisely the thing it does not yet know
+	// (docs/ir/SPEC.md, "The sequencing automaton").
+	Record string
+
+	// Predicate is the discriminator that selects this transition, and is nil
+	// where it carries none.
+	//
+	// A transition carrying no predicate matches every record and is selected
+	// by its guards alone — or, where it carries none of those either, by
+	// being the only thing its state offers. That is the *absence* of a
+	// predicate and not a member of the set testing nothing
+	// (docs/ir/SPEC.md, "A transition may carry no predicate", #80).
+	//
+	// It is the layout's strategy rather than a compiled predicate node, for
+	// [Arm.Predicate]'s reason: lowering one is #37's.
+	Predicate *layoutmodel.Strategy
+
+	// Guards are the tests that make this transition eligible, all of which
+	// must hold. A transition carrying none is always eligible.
+	Guards []Guard
+
+	// Bindings are the register writes applied when it is taken.
+	Bindings []Binding
+
+	// To is the state the automaton moves to.
+	To *State
+}
+
+// State is a state of the record automaton.
+//
+// States carry identifiers and no names. A consumer reads a file by evaluating
+// the current state's transitions in the order given, skipping any whose guards
+// do not all hold, and taking the first of the rest that carries no predicate or
+// whose predicate matches.
+type State struct {
+	// ID is the state's identifier. The start state's is zero.
+	ID int
+
+	// Accepts reports whether end of input in this state is a complete file.
+	//
+	// A consumer reaching end of input in a state that does not accept, or
+	// whose acceptance guards do not all hold, reports the file as truncated
+	// rather than returning the records it managed to read.
+	Accepts bool
+
+	// Acceptance are the guards qualifying acceptance: the state accepts end
+	// of input only when all of them hold. A state that does not accept
+	// carries none.
+	//
+	// Guarded acceptance is what makes the last iteration of a count
+	// detectable. A state that reads details while a counter is positive
+	// would otherwise accept a file stopping three details short of what its
+	// own header promised.
+	Acceptance []Guard
+
+	// Transitions are the edges leaving the state, in evaluation order.
+	Transitions []*Transition
+}
+
+// Automaton is a layout's sequencing expression, compiled.
+type Automaton struct {
+	// Start is the state the read begins in. No transition enters it, which
+	// is what makes *the first record of the file* expressible: a state is
+	// the only thing the automaton knows about position, and there is no
+	// predicate for *first* to lower into (#80).
+	Start *State
+
+	// States are every state, the start state first, in a deterministic
+	// order.
+	States []*State
+
+	// Registers are every register the automaton carries, in the order they
+	// were allocated. It is empty for a layout whose sequencing needs no
+	// memory, which is every layout naming neither `times` nor `when`.
+	Registers []*Register
+}
+
+// SequencedRecord is one record type the sequencing expression may name.
+//
+// It arrives resolved rather than as the layout's forms, for [Redefine]'s
+// reason: reading a layout is one step and resolving a copybook against it is
+// another, and a package doing both would read a layout's spelling of a record
+// in two places.
+type SequencedRecord struct {
+	// Name is the name the layout's `record` form defines, which is what the
+	// sequencing expression writes.
+	Name string
+
+	// Copybook is the copybook's path as the layout spells it, carried so
+	// that a diagnostic about an item can name the file the fault is in.
+	Copybook string
+
+	// Item is the copybook's top-level item this record is bound to.
+	Item *copybook.Field
+
+	// Discriminator is the strategy the layout's `discriminate` form chose
+	// for this record, and becomes the predicate on every transition
+	// admitting it — or, under [layoutmodel.SingleRecordType], the absence of
+	// one.
+	Discriminator layoutmodel.Strategy
+}
+
+// Sequencing is what compiling a sequencing expression needs beyond the
+// expression itself.
+type Sequencing struct {
+	// Sequence is the layout's sequencing layer, as
+	// [layoutmodel.ReadSequence] hands it back.
+	Sequence *layoutmodel.Sequence
+
+	// Dialect is the compiler-side half of the layout, for [Options.Dialect]'s
+	// reason. It is read to lay each record's copybook out, which is what
+	// answers whether an item a `times` or a `when` names repeats or sits
+	// inside a group that repeats.
+	Dialect copybook.Dialect
+
+	// Records are the record types the expression may name, in the order the
+	// layout defines them.
+	Records []SequencedRecord
+}
+
+// CompileSequence compiles a layout's sequencing expression into the record
+// automaton docs/ir/SPEC.md's "The sequencing automaton" describes.
+//
+// What comes back is states and transitions, the registers the value-reading
+// operators needed, and nothing of the expression they were compiled from. Every
+// transition consumes exactly one record, no transition enters the start state,
+// and a counted run is one register and one guard however wide the count field
+// is.
+//
+// Every fault it finds is reported, joined with [errors.Join] and assertable
+// with [errors.As], rather than the first — with one staging: a `times` or a
+// `when` whose item reference does not resolve stops the compilation there,
+// because the register that reference decides is what every guard, binding and
+// proof after it is about, and a graph built over a register nobody could
+// resolve would report a second fault per transition that reads it.
+//
+// The faults it reports are docs/ir/SPEC.md's and docs/layout/SPEC.md's, and
+// each names what the section asking for it asks to be named rather than
+// reporting a generic ambiguity:
+//
+//   - an item reference naming no item of the record it is rooted at, or more
+//     than one ([SequenceItemError]);
+//   - an item that repeats or sits at any depth inside a group that repeats,
+//     naming the record, the item and the enclosing group
+//     ([SequenceOccurrenceError], #84);
+//   - a `times` whose item does not decode to an integer
+//     ([SequenceCountKindError]);
+//   - a register read where some path reaches the read without an earlier
+//     binding, including the run counted by a field of the record being counted
+//     ([UnboundRegisterError], #88);
+//   - two transitions leaving one state whose guards can hold at the same time
+//     and whose predicates can both match one record, a transition carrying no
+//     predicate included ([SequenceAmbiguityError], #37, #80);
+//   - a state whose acceptance would have to be a disjunction of guard lists,
+//     which is not a shape a state can carry ([SequenceAcceptanceError]).
+//
+// What it does not report is the shapes the algebra cannot spell.
+// docs/ir/SPEC.md's "The automaton counts; it does not compute" asks `resolve`
+// to reject arithmetic on a count, a register compared against another register
+// and a guard comparing a register to a field of the record in front of the
+// consumer. None of the three is writable: docs/layout/SPEC.md closes the
+// operator set at eight and every one of them compares a value against literals
+// the layout wrote. The one member of that list a layout *can* ask for is a
+// dependence on a value in a record the consumer has not read, and that is
+// [UnboundRegisterError] — which names the record and the item, as that section
+// requires, and not an ambiguity.
+func CompileSequence(opts Sequencing) (*Automaton, error) {
+	if opts.Sequence == nil {
+		return nil, ErrNilSequence
+	}
+
+	c := &compiler{
+		opts:    opts,
+		follow:  make(map[int][]entry),
+		byItem:  make(map[string]*Register),
+		layouts: make(map[string]*copybook.Layout),
+	}
+
+	top := c.expression(opts.Sequence.Expression)
+	if c.faults.Failed() {
+		return nil, c.faults.Err()
+	}
+
+	automaton := c.assemble(top)
+
+	c.prove(automaton)
+	c.checkAmbiguity(automaton)
+	if c.faults.Failed() {
+		return nil, c.faults.Err()
+	}
+
+	return automaton, nil
+}
+
+// appearance is one appearance of a record name in the expression, and the state
+// the automaton is in once that appearance has been admitted.
+type appearance struct {
+	// record is the name of the `record` form the appearance names.
+	record string
+
+	// pos is where the name was written, which is what a diagnostic about
+	// this appearance points at.
+	pos layout.Pos
+
+	// predicate is the discriminator of that record, or nil where its
+	// strategy is `single-record-type` and lowers into no predicate.
+	predicate *layoutmodel.Strategy
+}
+
+// entry is one way into a position: the guards a transition into it carries and
+// the bindings it applies.
+type entry struct {
+	at      int
+	guards  []Guard
+	binding []Binding
+}
+
+// exit is one way an expression is complete at a position: the guards under
+// which nothing more of it is outstanding.
+//
+// Those guards become the acceptance guards of the state where the expression is
+// the whole sequence, and the leading half of a transition's guards where
+// something may follow it.
+type exit struct {
+	at     int
+	guards []Guard
+}
+
+// facts are what compiling one node of the expression yields: where it can
+// start, where it can end, and under what conditions it admits no record at all.
+//
+// The three are the position automaton's `first`, `last` and `nullable`, with a
+// guard list on each — which is the whole of what the value-reading operators
+// add to the construction. `null` is nil for an expression that always admits at
+// least one record, and holds one entry per way of admitting none: an
+// unconditional way carries no guards.
+type facts struct {
+	first []entry
+	last  []exit
+	null  [][]Guard
+}
+
+// compiler holds the state one [CompileSequence] accumulates.
+type compiler struct {
+	opts   Sequencing
+	faults diag.List
+
+	// positions are the appearances of record names, in the order the walk
+	// meets them. A state's identifier is its index here plus one, the start
+	// state being zero.
+	positions []appearance
+
+	// follow is the ways into each position from another, keyed by the
+	// position followed.
+	follow map[int][]entry
+
+	// registers are every register allocated, in allocation order.
+	registers []*Register
+
+	// byItem is the bytes register standing for each item a `when` reads,
+	// keyed by the reference's spelling. Nothing writes such a register but
+	// the transitions admitting the record it is read from, so two `when`s
+	// over one item are two guards over one value.
+	byItem map[string]*Register
+
+	// layouts are the copybook layouts, one per record, built on demand: a
+	// layout is what answers whether an item repeats or sits in a group that
+	// does, and building one per reference would build the same one twice.
+	layouts map[string]*copybook.Layout
+}
+
+// expression compiles one node of the expression.
+func (c *compiler) expression(e layoutmodel.Expression) facts {
+	switch e.Kind {
+	case layoutmodel.RecordName:
+		return c.name(e)
+	case layoutmodel.Seq:
+		return c.sequence(c.subexpressions(e))
+	case layoutmodel.Alt:
+		return c.alternation(c.subexpressions(e))
+	case layoutmodel.ZeroOrMore:
+		return c.repeat(c.subexpressions(e), true)
+	case layoutmodel.OneOrMore:
+		return c.repeat(c.subexpressions(e), false)
+	case layoutmodel.Optional:
+		return c.optional(c.subexpressions(e))
+	case layoutmodel.Times:
+		return c.times(e)
+	case layoutmodel.When:
+		return c.when(e)
+	}
+
+	// A value handed back by [layoutmodel.ReadSequence] always names a member
+	// of the closed set, so this is a caller that assembled one by hand. It
+	// admits nothing, which is the reading that cannot invent a record.
+	return facts{}
+}
+
+// subexpressions compiles the subexpressions of an operator, in order.
+func (c *compiler) subexpressions(e layoutmodel.Expression) []facts {
+	parts := make([]facts, 0, len(e.Sub))
+	for _, sub := range e.Sub {
+		parts = append(parts, c.expression(sub))
+	}
+	return parts
+}
+
+// name compiles a bare record name: one position, admitting one record of that
+// type, selected by that record's own discriminator.
+func (c *compiler) name(e layoutmodel.Expression) facts {
+	at := len(c.positions)
+
+	record, known := c.record(e.Record)
+	if !known {
+		// [layoutmodel.ReadSequence] has already refused a name no `record`
+		// form defines, so this is a caller that assembled a sequence by
+		// hand. The appearance is kept with no predicate rather than
+		// dropped, so that the shape of the graph is still the shape the
+		// expression describes.
+		c.positions = append(c.positions, appearance{record: e.Record, pos: e.Pos})
+
+		return facts{first: []entry{{at: at}}, last: []exit{{at: at}}}
+	}
+
+	var predicate *layoutmodel.Strategy
+	if record.Discriminator.Predicate() {
+		selects := record.Discriminator
+		predicate = &selects
+	}
+
+	c.positions = append(c.positions, appearance{record: e.Record, pos: e.Pos, predicate: predicate})
+
+	return facts{first: []entry{{at: at}}, last: []exit{{at: at}}}
+}
+
+// sequence compiles `(seq <e> …)`: each in turn, left to right.
+//
+// It is where the guards a skippable segment leaves behind are composed. A
+// subexpression can be started wherever every subexpression ahead of it admits
+// nothing, under the guards saying so; it can be ended wherever every one behind
+// it does; and one position can be followed by another wherever everything
+// between them does.
+func (c *compiler) sequence(parts []facts) facts {
+	var out facts
+
+	for i := range parts {
+		for _, skipped := range emptyWays(parts[:i]) {
+			for _, in := range parts[i].first {
+				out.first = append(out.first, entry{
+					at:      in.at,
+					guards:  mergeGuards(skipped, in.guards),
+					binding: in.binding,
+				})
+			}
+		}
+
+		for _, skipped := range emptyWays(parts[i+1:]) {
+			for _, done := range parts[i].last {
+				out.last = append(out.last, exit{at: done.at, guards: mergeGuards(done.guards, skipped)})
+			}
+		}
+	}
+
+	for i := range parts {
+		for j := i + 1; j < len(parts); j++ {
+			for _, skipped := range emptyWays(parts[i+1 : j]) {
+				c.link(parts[i].last, parts[j].first, skipped, nil)
+			}
+		}
+	}
+
+	out.null = emptyWays(parts)
+
+	return out
+}
+
+// alternation compiles `(alt <e> …)`: exactly one of them. A state already is a
+// disjunction, so nothing is composed and the ways in, the ways out and the ways
+// of admitting nothing are the union of the branches'.
+func (c *compiler) alternation(parts []facts) facts {
+	var out facts
+
+	for _, part := range parts {
+		out.first = append(out.first, part.first...)
+		out.last = append(out.last, part.last...)
+		out.null = append(out.null, part.null...)
+	}
+
+	return out
+}
+
+// repeat compiles `(* <e>)` and `(+ <e>)`: the body, and a way back from every
+// position it can end at to every position it can start at.
+//
+// The two differ in one thing and it is the one docs/layout/SPEC.md names: an
+// empty file is a `*` accepting and a `+` not.
+func (c *compiler) repeat(parts []facts, empty bool) facts {
+	body := c.sequence(parts)
+
+	c.link(body.last, body.first, nil, nil)
+
+	if empty {
+		body.null = [][]Guard{nil}
+	}
+
+	return body
+}
+
+// optional compiles `(? <e>)`: the body, admitting nothing unconditionally
+// besides.
+func (c *compiler) optional(parts []facts) facts {
+	body := c.sequence(parts)
+	body.null = [][]Guard{nil}
+
+	return body
+}
+
+// times compiles `(times <e> <item-ref>)`: exactly as many of the body as the
+// named item holds.
+//
+// One register and one guard, whatever the count field's width. The transition
+// entering a pass is guarded on the counter being above zero and takes one off
+// it, which is both how the run is bounded and how the counter is kept from
+// running below zero — the only transition that takes one off is the one that
+// guard makes ineligible at zero. The run is left where the counter has reached
+// zero, and a count of zero is the whole expression admitting nothing.
+func (c *compiler) times(e layoutmodel.Expression) facts {
+	body := c.sequence(c.subexpressions(e))
+	register := c.register(e, RegisterInteger)
+
+	more := Guard{Register: register, Test: GuardPositive}
+	done := Guard{
+		Register: register,
+		Test:     GuardEquals,
+		Literals: []layoutmodel.Literal{{Pos: e.Item.Pos, Kind: layoutmodel.NumberLiteral, Number: "0"}},
+	}
+	less := []Binding{{Register: register, Value: BindLessOne}}
+
+	c.link(body.last, body.first, []Guard{more}, less)
+
+	var out facts
+	for _, in := range body.first {
+		out.first = append(out.first, entry{
+			at:      in.at,
+			guards:  mergeGuards([]Guard{more}, in.guards),
+			binding: append(append([]Binding{}, less...), in.binding...),
+		})
+	}
+	for _, end := range body.last {
+		out.last = append(out.last, exit{at: end.at, guards: mergeGuards(end.guards, []Guard{done})})
+	}
+	out.null = [][]Guard{{done}}
+
+	return out
+}
+
+// when compiles `(when <item-ref> <match> <e>)`: the body only where the item
+// holds that value.
+//
+// The guard lands on every way into the body and on nothing else. The path that
+// skips the body carries no guard, because the guard set has no negation and
+// there is no test for *the item does not hold that value* to put there; the
+// package comment above says what that costs and what an adopter writes instead.
+func (c *compiler) when(e layoutmodel.Expression) facts {
+	body := c.sequence(c.subexpressions(e))
+	register := c.register(e, RegisterBytes)
+
+	holds := Guard{Register: register, Test: GuardEquals, Literals: e.Match.Literals}
+	if e.Match.Kind == layoutmodel.OneOf {
+		holds.Test = GuardOneOf
+	}
+
+	var out facts
+	for _, in := range body.first {
+		out.first = append(out.first, entry{
+			at:      in.at,
+			guards:  mergeGuards([]Guard{holds}, in.guards),
+			binding: in.binding,
+		})
+	}
+	out.last = body.last
+	out.null = [][]Guard{nil}
+
+	return out
+}
+
+// link records that every position from may be followed by every position to,
+// under the guards each side carries and the ones between them, applying
+// bindings.
+func (c *compiler) link(from []exit, to []entry, between []Guard, bindings []Binding) {
+	for _, done := range from {
+		for _, in := range to {
+			c.follow[done.at] = append(c.follow[done.at], entry{
+				at:      in.at,
+				guards:  mergeGuards(done.guards, between, in.guards),
+				binding: append(append([]Binding{}, bindings...), in.binding...),
+			})
+		}
+	}
+}
+
+// emptyWays is every way the parts together admit no record at all: the product
+// of each part's own ways, and nothing where any part always admits one.
+//
+// The empty product is one way carrying no guards, which is what makes "nothing
+// stands between these two positions" the same expression as "everything between
+// them can be skipped".
+func emptyWays(parts []facts) [][]Guard {
+	ways := [][]Guard{nil}
+
+	for _, part := range parts {
+		if len(part.null) == 0 {
+			return nil
+		}
+
+		var next [][]Guard
+		for _, way := range ways {
+			for _, empty := range part.null {
+				next = append(next, mergeGuards(way, empty))
+			}
+		}
+		ways = next
+	}
+
+	return ways
+}
+
+// mergeGuards is the conjunction of several guard lists, in order and without
+// repeating a test.
+func mergeGuards(lists ...[]Guard) []Guard {
+	var merged []Guard
+	seen := make(map[string]bool)
+
+	for _, list := range lists {
+		for _, guard := range list {
+			key := guard.key()
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			merged = append(merged, guard)
+		}
+	}
+
+	return merged
+}
+
+// register is the register one value-reading operator needs, allocating it where
+// this is the first operator to need it.
+//
+// A `times` register is one per operator and a `when` register one per item; the
+// package comment above says why the two are keyed differently.
+func (c *compiler) register(e layoutmodel.Expression, kind RegisterKind) *Register {
+	if kind == RegisterBytes {
+		if already, ok := c.byItem[e.Item.String()]; ok {
+			return already
+		}
+	}
+
+	register := &Register{ID: len(c.registers) + 1, Kind: kind, Source: e.Item, Field: c.field(e)}
+	c.registers = append(c.registers, register)
+
+	if kind == RegisterBytes {
+		c.byItem[e.Item.String()] = register
+	}
+
+	return register
+}

--- a/internal/resolve/automaton_errors.go
+++ b/internal/resolve/automaton_errors.go
@@ -1,0 +1,421 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package resolve
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/Zaba505/cobol-go/copybook"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+	"github.com/Zaba505/cpybkc/internal/layoutmodel"
+)
+
+// The faults compiling a sequencing expression reports.
+//
+// Every one names what docs/ir/SPEC.md and docs/layout/SPEC.md ask it to name —
+// the record, the item, the enclosing group that repeats, the two records a
+// state cannot tell apart — because the generic version of each has been
+// observed to send a reader to the wrong file. "The automaton counts; it does
+// not compute" says it in as many words: a layout needing what the register
+// machinery does not do is told so, *rather than being told its discriminators
+// overlap*.
+//
+// Most of them carry two spans, which is docs/layout/SPEC.md's "Every diagnostic
+// carries a span, and some carry two": the layout is where the operator was
+// written and the copybook is where the item it names is, and a message naming
+// only one leaves the reader to find the other by hand.
+
+// ErrNilSequence is returned by [CompileSequence] when it is handed no sequence.
+var ErrNilSequence = errors.New("resolve: nil sequence")
+
+// SequenceItemError is a `times` or a `when` whose item reference does not
+// resolve to exactly one item of the record it is rooted at.
+//
+// The reference's own spelling is `layoutmodel`'s and has already been checked;
+// what needs the copybook is whether the path names an item at all. A complete
+// path that still names two is a reference nothing can resolve — duplicate data
+// names are legal COBOL — and is reported rather than resolved to the first,
+// because choosing would bind a register from bytes the adopter did not name.
+type SequenceItemError struct {
+	// Pos is the item reference in the layout.
+	Pos diag.Span
+
+	// Copybook is the copybook the record is bound to, where there is one to
+	// point into.
+	Copybook diag.Span
+
+	// Operator is the operator the reference stands under, as a layout
+	// spells it: `times` or `when`.
+	Operator string
+
+	// Item is the reference as the layout wrote it.
+	Item layoutmodel.ItemRef
+
+	// Record is the record it is rooted at.
+	Record string
+
+	// Found is what is wrong with it, in the message's own words.
+	Found string
+}
+
+// Error implements the error interface.
+func (e *SequenceItemError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *SequenceItemError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf("the %s reads %s, and %s", e.Operator, e.Item, e.Found),
+		Spans:   spans(e.Pos, e.Copybook, "the record "+e.Record+" is bound to this copybook"),
+	}
+}
+
+// SequenceOccurrenceError is a `times` or a `when` naming an item that repeats,
+// or one contained at any depth in a group that repeats.
+//
+// docs/ir/SPEC.md's "A reference names a field, not an occurrence of one" is the
+// rule and this is one of the positions it binds: a binding names a field, no
+// node carries an occurrence number, and an item with a value per occurrence is
+// therefore a value the automaton has no way to name. Which occurrence of a
+// header's table said how many details follow is not a question the IR has a
+// spelling for, and answering it with the first is the reading that looks right
+// and reads data belonging to the table rather than to the record (#76, #84).
+type SequenceOccurrenceError struct {
+	// Pos is the item reference in the layout.
+	Pos diag.Span
+
+	// Copybook is the item's entry in the copybook.
+	Copybook diag.Span
+
+	// Operator is the operator the reference stands under.
+	Operator string
+
+	// Record is the record the reference is rooted at, and Item the item it
+	// names.
+	Record string
+	Item   string
+
+	// Group is the innermost repeating group the item sits in, empty where
+	// the item is itself the thing that repeats.
+	Group string
+}
+
+// Error implements the error interface.
+func (e *SequenceOccurrenceError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *SequenceOccurrenceError) Diagnostic() diag.Diagnostic {
+	repeats := e.Item + " repeats"
+	if e.Group != "" {
+		repeats = e.Item + " sits in the repeating group " + e.Group
+	}
+
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"the %s reads %s of record %s, and %s: a register is bound from a field and nothing names an "+
+				"occurrence of one, so there is no saying which occurrence the value would come from",
+			e.Operator, e.Item, e.Record, repeats),
+		Spans: spans(e.Pos, e.Copybook, "declared here"),
+	}
+}
+
+// SequenceCountKindError is a `times` whose item is not one whose value decodes
+// to an integer.
+//
+// docs/layout/SPEC.md requires it of the operator, and docs/ir/SPEC.md requires
+// it of the register: an integer register holds a number decoded from its source
+// field by that field's own encoding axes, and a producer must not bind a field
+// whose value does not decode to the register's kind. A count that is a group,
+// an alphanumeric item or a number with digits after the point has no reading
+// that makes it a number of records.
+type SequenceCountKindError struct {
+	// Pos is the item reference in the layout.
+	Pos diag.Span
+
+	// Copybook is the item's entry in the copybook.
+	Copybook diag.Span
+
+	// Record is the record the reference is rooted at, and Item the item it
+	// names.
+	Record string
+	Item   string
+
+	// Found is what the item is instead, in the message's own words.
+	Found string
+}
+
+// Error implements the error interface.
+func (e *SequenceCountKindError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *SequenceCountKindError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"the times counts records by %s of record %s, and %s is %s: a count is held in a register as a "+
+				"number, so the item it is read from has to be one",
+			e.Item, e.Record, e.Item, e.Found),
+		Spans: spans(e.Pos, e.Copybook, "declared here"),
+	}
+}
+
+// UnboundRegisterError is a register read on some path that has not bound it.
+//
+// docs/ir/SPEC.md's "A register is read only where it has been written" requires
+// every path from the start state to a read to pass through a binding on a
+// transition taken **strictly earlier** than the reading one, and "A value the
+// automaton has not read yet" is the exclusion it keeps: a consumer reads a
+// stream forward, and one that could not decide a transition until a later
+// record arrived would have to buffer an unbounded stretch of a file whose whole
+// premise is that it does not fit in memory.
+//
+// Two layouts land here and the message tells them apart, because they send an
+// adopter to different places. One reads a value out of a record that some path
+// reaches the operator without having admitted — a trailer's count governing the
+// records in front of it, or a header that may or may not have appeared. The
+// other counts a run by a field of the record being counted, which
+// [UnboundRegisterError.OnAdmitting] reports: the transition admitting the
+// record binds the register at step 7 of the read loop, and both the guard that
+// would read it and the extent it decides are wanted before then, so on the
+// first admission the register holds nothing and on every later one it holds the
+// previous record's value (#88).
+type UnboundRegisterError struct {
+	// Pos is the item reference in the layout.
+	Pos diag.Span
+
+	// Item is the reference as the layout wrote it, which is what names the
+	// register: a register declares its kind and nothing else, so the value
+	// it was to hold is what an adopter recognises it by.
+	Item layoutmodel.ItemRef
+
+	// Register is the record the value would have been read out of.
+	Register string
+
+	// Reader is the record admitted by the transition that reads it, empty
+	// where what reads it is a state's acceptance rather than a transition.
+	Reader string
+
+	// State is the identifier of the state the read is at.
+	State int
+
+	// OnAdmitting reports that the reading transition is itself the one that
+	// binds the register, out of the record it admits.
+	OnAdmitting bool
+
+	// register is the register's identifier, which is what makes one
+	// operator one fault: an unbound count is read by every transition of
+	// the run it bounds and by the acceptance of every state leaving it, and
+	// four messages about one misspelled reference is three too many.
+	//
+	// It is unexported because a register's identifier is this package's
+	// bookkeeping and not something a caller asserting on the fault has any
+	// use for: what names the register to an adopter is
+	// [UnboundRegisterError.Item].
+	register int
+}
+
+// Error implements the error interface.
+func (e *UnboundRegisterError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *UnboundRegisterError) Diagnostic() diag.Diagnostic {
+	read := "state " + strconv.Itoa(e.State) + " accepts on"
+	if e.Reader != "" {
+		read = "admitting " + e.Reader + " reads"
+	}
+
+	if e.OnAdmitting {
+		return diag.Diagnostic{
+			Message: fmt.Sprintf(
+				"%s is read out of %s, and the only record that binds it is the one the transition %s it: "+
+					"a binding applies after the record is admitted, so the value is wanted before there is one",
+				e.Item, e.Register, read),
+			Spans: []diag.Span{e.Pos},
+		}
+	}
+
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"%s is read out of %s, and there is a path to where the transition %s it on which no %s has been "+
+				"admitted: a value the automaton has not read yet governs nothing",
+			e.Item, e.Register, read, e.Register),
+		Spans: []diag.Span{e.Pos},
+	}
+}
+
+// SequenceAmbiguityError is two transitions leaving one state that can be
+// eligible together and are selected by predicates that can both match one
+// record.
+//
+// docs/ir/SPEC.md's "When two match, and when none does" refuses the pair rather
+// than settling it, so that the question docs/layout/SPEC.md defers — what
+// happens when two discriminators match — does not arise: such an IR is never
+// produced.
+//
+// [SequenceAmbiguityError.Unguarded] is the case #80 folds into the same rule. A
+// transition carrying no predicate matches every record, so it overlaps every
+// transition leaving its state whose guards can hold at the same time as its
+// own, and guards are then the only thing that can separate the two. The message
+// says which of the two shapes it is, because the fixes differ: one is a
+// discriminator to narrow and the other is a record type that offers nothing to
+// tell it apart by.
+type SequenceAmbiguityError struct {
+	// Pos is where the second of the two record names was written, and First
+	// where the first was.
+	//
+	// Two spans into one file, which is the shape a fault about a *pair*
+	// takes: what is ambiguous is the point where two appearances meet, and
+	// neither of them alone is the fault.
+	Pos   diag.Span
+	First diag.Span
+
+	// State is the identifier of the state offering both.
+	State int
+
+	// Records are the records the two transitions admit.
+	Records [2]string
+
+	// Unguarded reports that one of the two carries no predicate at all.
+	Unguarded bool
+
+	// Guards reports that at least one of the two carries guards, so that the
+	// message can say the guards do not separate them rather than leaving an
+	// adopter to wonder whether they were read.
+	Guards bool
+}
+
+// Error implements the error interface.
+func (e *SequenceAmbiguityError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *SequenceAmbiguityError) Diagnostic() diag.Diagnostic {
+	why := "their discriminators can both match one record"
+	if e.Unguarded {
+		why = "one of them carries no discriminator, so it matches every record"
+	}
+
+	separated := ""
+	if e.Guards {
+		separated = ", and their guards can hold at the same time"
+	}
+
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"at state %d the sequence admits %s and %s, and %s%s: a consumer reaching that point has no way "+
+				"to tell which record is in front of it",
+			e.State, e.Records[0], e.Records[1], why, separated),
+		Spans: spans(e.Pos, e.First, "the other is admitted here"),
+	}
+}
+
+// SequenceAcceptanceError is a point in the expression that would accept end of
+// input under either of two different sets of guards.
+//
+// A state carries one list of acceptance guards and a list is a conjunction, so
+// a disjunction of two conditions has nowhere to go. docs/ir/SPEC.md puts
+// disjunction in the state — a second transition leaving it — and a state's
+// acceptance is not a transition, so this is the one place the shape has no
+// second half.
+//
+// It is reported rather than narrowed to one of the two. Taking the first would
+// report a complete file as truncated whenever the other condition was the one
+// that held, and dropping the guards would accept a file that stops short — and
+// a file wrongly called complete is the failure guarded acceptance exists to
+// prevent.
+type SequenceAcceptanceError struct {
+	// Pos is the `sequence` form in the layout.
+	Pos diag.Span
+
+	// What is the record whose state it is, or "the file" for the start
+	// state.
+	What string
+
+	// Ways is how many conditions the point would accept under.
+	Ways int
+
+	// Guard is one of them, rendered, so that the message names something an
+	// adopter can find in the expression.
+	Guard string
+}
+
+// Error implements the error interface.
+func (e *SequenceAcceptanceError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *SequenceAcceptanceError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"after %s the sequence is complete under %d different sets of guards, one of them %s: a state "+
+				"accepts under one set of guards, and there is nowhere to write the second",
+			e.What, e.Ways, e.Guard),
+		Spans: []diag.Span{e.Pos},
+	}
+}
+
+// spans is a fault's places: where it is, and the copybook it implicates where
+// there is one to point into.
+func spans(at, copybook diag.Span, note string) []diag.Span {
+	if !copybook.Stated() {
+		return []diag.Span{at}
+	}
+
+	copybook.Note = note
+
+	return []diag.Span{at, copybook}
+}
+
+// copybookSpan is where in a record's copybook a field is, and the copybook
+// itself where the fault is about no field in particular.
+//
+// It is [resolver.span]'s counterpart for a fault about a record the sequencing
+// layer named: the path comes from that record's `record` form rather than from
+// one set of [Options].
+func copybookSpan(record SequencedRecord, field *copybook.Field) diag.Span {
+	span := diag.Span{File: record.Copybook}
+	if field != nil {
+		span.Line, span.Column = field.Pos.Line, field.Pos.Column
+	}
+	return span
+}
+
+// renderGuards draws a guard list the way a message quotes one.
+func renderGuards(guards []Guard) string {
+	if len(guards) == 0 {
+		return "no guard at all"
+	}
+
+	rendered := make([]string, 0, len(guards))
+	for _, guard := range guards {
+		rendered = append(rendered, renderGuard(guard))
+	}
+
+	return strings.Join(rendered, " and ")
+}
+
+// renderGuard draws one guard.
+func renderGuard(guard Guard) string {
+	switch guard.Test {
+	case GuardPositive:
+		return guard.Register.String() + " above zero"
+	case GuardOneOf:
+		literals := make([]string, 0, len(guard.Literals))
+		for _, literal := range guard.Literals {
+			literals = append(literals, literal.String())
+		}
+
+		return guard.Register.String() + " one of " + strings.Join(literals, ", ")
+	case GuardEquals:
+		if len(guard.Literals) == 0 {
+			return guard.Register.String() + " equal to nothing"
+		}
+
+		return guard.Register.String() + " equal to " + guard.Literals[0].String()
+	}
+
+	return guard.Register.String() + " tested by nothing"
+}

--- a/internal/resolve/automaton_errors.go
+++ b/internal/resolve/automaton_errors.go
@@ -8,7 +8,6 @@ package resolve
 import (
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/Zaba505/cobol-go/copybook"
@@ -224,15 +223,19 @@ func (e *UnboundRegisterError) Error() string { return e.Diagnostic().String() }
 
 // Diagnostic is what the error says, and where.
 func (e *UnboundRegisterError) Diagnostic() diag.Diagnostic {
-	read := "state " + strconv.Itoa(e.State) + " accepts on"
+	// The whole clause and not a fragment of one, because the two reads are
+	// not the same part of speech: a transition reads a register and a state's
+	// acceptance does too, and a sentence built to fit the first describes the
+	// second as a transition that is not there.
+	read := fmt.Sprintf("state %d's acceptance", e.State)
 	if e.Reader != "" {
-		read = "admitting " + e.Reader + " reads"
+		read = "the transition admitting " + e.Reader
 	}
 
 	if e.OnAdmitting {
 		return diag.Diagnostic{
 			Message: fmt.Sprintf(
-				"%s is read out of %s, and the only record that binds it is the one the transition %s it: "+
+				"%s is read out of %s, and what reads it is %s, which is the only thing that binds it: "+
 					"a binding applies after the record is admitted, so the value is wanted before there is one",
 				e.Item, e.Register, read),
 			Spans: []diag.Span{e.Pos},
@@ -241,8 +244,8 @@ func (e *UnboundRegisterError) Diagnostic() diag.Diagnostic {
 
 	return diag.Diagnostic{
 		Message: fmt.Sprintf(
-			"%s is read out of %s, and there is a path to where the transition %s it on which no %s has been "+
-				"admitted: a value the automaton has not read yet governs nothing",
+			"%s is read out of %s, and there is a path to %s on which no %s has been admitted: "+
+				"a value the automaton has not read yet governs nothing",
 			e.Item, e.Register, read, e.Register),
 		Spans: []diag.Span{e.Pos},
 	}

--- a/internal/resolve/automaton_test.go
+++ b/internal/resolve/automaton_test.go
@@ -1,0 +1,1057 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package resolve
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cobol-go/copybook"
+
+	"github.com/Zaba505/cpybkc/internal/layout"
+	"github.com/Zaba505/cpybkc/internal/layoutmodel"
+)
+
+// Sequencing reaches a generator compiled, and these hold the compilation to
+// docs/ir/SPEC.md's "The sequencing automaton": states and transitions and no
+// expression, every transition consuming exactly one record, a start state no
+// transition re-enters, and a counted run that is one register and one guard
+// however wide the count is.
+//
+// Every test here drives the real layout parser and the real copybook reader, so
+// that no test asserts a graph compiled out of a model the readers would never
+// have produced. What a test writes is a layout and one copybook per record, and
+// what it asserts is the whole graph rendered — one line per state and one per
+// transition — because what has to be right is not one guard but which state
+// carries it.
+
+// header, detail and summary are the three copybooks of docs/ir/SPEC.md's
+// "A counted run, as nodes": a header carrying a detail count and a flag, the
+// details the count governs, and the summary the flag governs. Each carries its
+// type code at its own first byte, which is what a consumer tells them apart by.
+const (
+	header = `01 HDR-REC.
+   05 HDR-TYPE PIC X(1).
+   05 DTL-COUNT PIC 9(2).
+   05 SUM-FLAG PIC X(1).
+`
+
+	detail = `01 DTL-REC.
+   05 DTL-TYPE PIC X(1).
+   05 DTL-BODY PIC X(20).
+`
+
+	summary = `01 SUM-REC.
+   05 SUM-TYPE PIC X(1).
+   05 SUM-TOTAL PIC 9(7).
+`
+)
+
+// countedRun is the layout of that appendix: the records, what tells each apart,
+// and the expression saying any number of counted groups make a file.
+const countedRun = `(record HEADER (copybook "hdr.cpy" HDR-REC))
+(record DETAIL (copybook "dtl.cpy" DTL-REC))
+(record SUMMARY (copybook "sum.cpy" SUM-REC))
+(discriminate HEADER (equals (item HEADER HDR-TYPE) "H"))
+(discriminate DETAIL (equals (item DETAIL DTL-TYPE) "D"))
+(discriminate SUMMARY (equals (item SUMMARY SUM-TYPE) "S"))
+(sequence
+  (+ (seq HEADER
+          (times DETAIL (item HEADER DTL-COUNT))
+          (when (item HEADER SUM-FLAG) "Y" SUMMARY))))`
+
+// countedRunCopybooks binds those three record names to those three copybooks.
+func countedRunCopybooks() map[string]string {
+	return map[string]string{"HEADER": header, "DETAIL": detail, "SUMMARY": summary}
+}
+
+// compileLayout is the whole pipeline a caller runs: parse the layout, read the
+// two layers the automaton is compiled out of, resolve each record name to the
+// copybook the test gave it, and compile.
+//
+// It reports what compilation said rather than failing on it, because half of
+// these tests are about the fault.
+func compileLayout(t *testing.T, source string, copybooks map[string]string) (*Automaton, error) {
+	t.Helper()
+
+	file, err := layout.Parse("layout.sexpr", strings.NewReader(source))
+	if err != nil {
+		t.Fatalf("parsing the layout: %v", err)
+	}
+
+	sequence, err := layoutmodel.ReadSequence(file)
+	if err != nil {
+		t.Fatalf("reading the sequencing layer: %v", err)
+	}
+
+	discrimination, err := layoutmodel.ReadDiscrimination(file)
+	if err != nil {
+		t.Fatalf("reading the discrimination layer: %v", err)
+	}
+
+	opts := Sequencing{Sequence: sequence, Dialect: copybook.IBMEnterprise()}
+	for _, discriminator := range discrimination.Records {
+		src, bound := copybooks[discriminator.Record]
+		if !bound {
+			t.Fatalf("the test binds no copybook to record %s", discriminator.Record)
+		}
+
+		opts.Records = append(opts.Records, SequencedRecord{
+			Name:          discriminator.Record,
+			Copybook:      strings.ToLower(discriminator.Record) + ".cpy",
+			Item:          recordOf(t, src),
+			Discriminator: discriminator.Strategy,
+		})
+	}
+
+	return CompileSequence(opts)
+}
+
+// compiled is a layout the caller expects to compile.
+func compiled(t *testing.T, source string, copybooks map[string]string) *Automaton {
+	t.Helper()
+
+	automaton, err := compileLayout(t, source, copybooks)
+	if err != nil {
+		t.Fatalf("compiling the sequence: %v", err)
+	}
+
+	return automaton
+}
+
+// refused is a layout the caller expects to be rejected.
+func refused(t *testing.T, source string, copybooks map[string]string) error {
+	t.Helper()
+
+	automaton, err := compileLayout(t, source, copybooks)
+	if err == nil {
+		t.Fatalf("the sequence compiled, want a fault:\n%s", renderAutomaton(automaton))
+	}
+
+	return err
+}
+
+// renderAutomaton draws the whole graph: the registers, then one line per state
+// and one indented line per transition leaving it.
+//
+// A rendering rather than a struct literal for [renderSequence]'s reason: what
+// has to be right is every guard *and* the state carrying it, and a rendering
+// carrying both fails with the whole graph in the message.
+func renderAutomaton(a *Automaton) string {
+	lines := make([]string, 0, len(a.Registers)+len(a.States))
+
+	for _, register := range a.Registers {
+		lines = append(lines, fmt.Sprintf("register %d %s from %s", register.ID, register.Kind, register.Source))
+	}
+
+	for _, state := range a.States {
+		head := fmt.Sprintf("state %d", state.ID)
+		switch {
+		case state.Accepts && len(state.Acceptance) > 0:
+			head += " accepts when " + renderGuards(state.Acceptance)
+		case state.Accepts:
+			head += " accepts"
+		}
+
+		lines = append(lines, head)
+		for _, transition := range state.Transitions {
+			lines = append(lines, "  "+renderTransition(transition))
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// renderTransition draws one edge in the order a consumer evaluates it: the
+// guards that make it eligible, the predicate that selects it, the record it
+// admits, the bindings it applies and the state it moves to.
+func renderTransition(t *Transition) string {
+	parts := make([]string, 0, 5)
+
+	if len(t.Guards) > 0 {
+		parts = append(parts, "when "+renderGuards(t.Guards))
+	}
+
+	if t.Predicate == nil {
+		parts = append(parts, "on no predicate")
+	} else {
+		parts = append(parts, "on "+renderStrategy(*t.Predicate))
+	}
+
+	parts = append(parts, "admit "+t.Record)
+
+	for _, binding := range t.Bindings {
+		if binding.Value == BindLessOne {
+			parts = append(parts, "take one off "+binding.Register.String())
+
+			continue
+		}
+
+		parts = append(parts, "bind "+binding.Register.String())
+	}
+
+	return strings.Join(parts, ", ") + fmt.Sprintf(", go to %d", t.To.ID)
+}
+
+// renderStrategy draws a discriminator the way a layout writes one.
+func renderStrategy(s layoutmodel.Strategy) string {
+	literals := make([]string, 0, len(s.Literals))
+	for _, literal := range s.Literals {
+		literals = append(literals, literal.String())
+	}
+
+	return "(" + string(s.Kind) + " " + s.Item.String() + " " + strings.Join(literals, " ") + ")"
+}
+
+// assertRendering fails with the whole graph where it is not the one wanted.
+func assertRendering(t *testing.T, a *Automaton, want string) {
+	t.Helper()
+
+	if got := renderAutomaton(a); got != strings.TrimSpace(want) {
+		t.Errorf("the automaton is\n%s\n\nwant\n%s", got, strings.TrimSpace(want))
+	}
+}
+
+// TestTheCountedRunOfTheAppendix compiles docs/ir/SPEC.md's "A counted run, as
+// nodes" and asserts the graph against it.
+//
+// The appendix names three states and this graph has four, because a position
+// automaton gives every appearance of a record name its own state and the
+// appendix merges the two that behave alike. State 1 and state 2 are the
+// appendix's single `group`: one is where a header has just been admitted and
+// the other where a detail has, and every transition leaving them agrees. States
+// carry identifiers and no names, so which of the two a consumer is in is not a
+// thing anything downstream can ask.
+//
+// The one difference in substance is the flag guard the appendix carries on
+// `group`'s acceptance and on its third transition. This compiles `(when flag
+// "Y" SUMMARY)` into a guard on the transition admitting the summary and into
+// nothing on the paths that skip it, because the guard set has no negation and
+// the complement of `Y` is not a set a compiler can know. What that costs is one
+// of the appendix's four detections, and [TestTheFailuresACountedRunDetects] is
+// where each of them is asserted.
+func TestTheCountedRunOfTheAppendix(t *testing.T) {
+	t.Parallel()
+
+	assertRendering(t, compiled(t, countedRun, countedRunCopybooks()), `
+register 1 integer from (item HEADER DTL-COUNT)
+register 2 bytes from (item HEADER SUM-FLAG)
+state 0
+  on (equals (item HEADER HDR-TYPE) "H"), admit HEADER, bind (item HEADER DTL-COUNT), bind (item HEADER SUM-FLAG), go to 1
+state 1 accepts when (item HEADER DTL-COUNT) equal to 0
+  when (item HEADER DTL-COUNT) above zero, on (equals (item DETAIL DTL-TYPE) "D"), admit DETAIL, take one off (item HEADER DTL-COUNT), go to 2
+  when (item HEADER DTL-COUNT) equal to 0 and (item HEADER SUM-FLAG) equal to "Y", on (equals (item SUMMARY SUM-TYPE) "S"), admit SUMMARY, go to 3
+  when (item HEADER DTL-COUNT) equal to 0, on (equals (item HEADER HDR-TYPE) "H"), admit HEADER, bind (item HEADER DTL-COUNT), bind (item HEADER SUM-FLAG), go to 1
+state 2 accepts when (item HEADER DTL-COUNT) equal to 0
+  when (item HEADER DTL-COUNT) above zero, on (equals (item DETAIL DTL-TYPE) "D"), admit DETAIL, take one off (item HEADER DTL-COUNT), go to 2
+  when (item HEADER DTL-COUNT) equal to 0 and (item HEADER SUM-FLAG) equal to "Y", on (equals (item SUMMARY SUM-TYPE) "S"), admit SUMMARY, go to 3
+  when (item HEADER DTL-COUNT) equal to 0, on (equals (item HEADER HDR-TYPE) "H"), admit HEADER, bind (item HEADER DTL-COUNT), bind (item HEADER SUM-FLAG), go to 1
+state 3 accepts
+  on (equals (item HEADER HDR-TYPE) "H"), admit HEADER, bind (item HEADER DTL-COUNT), bind (item HEADER SUM-FLAG), go to 1
+`)
+}
+
+// TestTheFailuresACountedRunDetects walks the four things docs/ir/SPEC.md's
+// appendix says its automaton catches that a memoryless graph could not, and
+// asserts of each that the compiled graph carries what catches it.
+//
+// The second is the one a compiled `when` cannot carry, and it is asserted as
+// what it is rather than skipped: the acceptance guard is the counter and not
+// the flag, so a file whose summary is missing where the flag said `Y` is
+// accepted. The sub-test after it is the layout an adopter writes instead, where
+// the summary is counted rather than flagged and the detection comes back —
+// because zero is a test the guard set has and *not `Y`* is not.
+func TestTheFailuresACountedRunDetects(t *testing.T) {
+	t.Parallel()
+
+	automaton := compiled(t, countedRun, countedRunCopybooks())
+
+	t.Run("a file ending two details short", func(t *testing.T) {
+		// End of input in the group with the counter above zero: the
+		// acceptance guard does not hold, so the file is truncated rather
+		// than complete.
+		for _, state := range automaton.States[1:3] {
+			if !state.Accepts || len(state.Acceptance) != 1 {
+				t.Fatalf("state %d accepts %v under %d guards, want one", state.ID, state.Accepts, len(state.Acceptance))
+			}
+
+			if guard := state.Acceptance[0]; guard.Test != GuardEquals || guard.Register.Kind != RegisterInteger {
+				t.Errorf("state %d accepts under %s, want the counter equal to zero", state.ID, renderGuard(guard))
+			}
+		}
+	})
+
+	t.Run("a missing summary where the flag says Y", func(t *testing.T) {
+		// The appendix's second detection, and the one a compiled `when`
+		// gives up. Its accepting states are guarded on the counter alone,
+		// so end of input with the flag at `Y` and no summary read is a
+		// complete file here and a truncated one there.
+		for _, state := range automaton.States[1:3] {
+			for _, guard := range state.Acceptance {
+				if guard.Register.Kind == RegisterBytes {
+					t.Errorf("state %d accepts under %s: a compiled `when` has no negation to put there",
+						state.ID, renderGuard(guard))
+				}
+			}
+		}
+	})
+
+	t.Run("a missing summary where a count says one", func(t *testing.T) {
+		// What an adopter writes to buy that detection back: the summary is
+		// counted rather than flagged, and acceptance is guarded on the
+		// count reaching zero like every other counted run.
+		counted := strings.Replace(countedRun,
+			`(when (item HEADER SUM-FLAG) "Y" SUMMARY)`,
+			`(times SUMMARY (item HEADER SUM-COUNT))`, 1)
+		copybooks := countedRunCopybooks()
+		copybooks["HEADER"] = strings.Replace(header, "SUM-FLAG PIC X(1)", "SUM-COUNT PIC 9(1)", 1)
+
+		guarded := compiled(t, counted, copybooks)
+		for _, state := range guarded.States[1:] {
+			if !state.Accepts {
+				continue
+			}
+
+			if len(state.Acceptance) == 0 {
+				t.Errorf("state %d accepts unguarded, want the summary count to qualify it", state.ID)
+			}
+		}
+	})
+
+	t.Run("a sixth detail where the header said five", func(t *testing.T) {
+		// In the group with the counter at zero the detail transition is
+		// ineligible, and the two transitions that are eligible are selected
+		// by predicates a detail record does not match. So the record is
+		// reported rather than admitted.
+		detail := transitionAdmitting(t, automaton.States[1], "DETAIL")
+		if len(detail.Guards) != 1 || detail.Guards[0].Test != GuardPositive {
+			t.Fatalf("the detail transition is guarded by %s, want the counter above zero", renderGuards(detail.Guards))
+		}
+
+		for _, other := range automaton.States[1].Transitions {
+			if other == detail {
+				continue
+			}
+
+			if satisfiable(mergeGuards(detail.Guards, other.Guards)) {
+				t.Errorf("admitting %s is eligible at the same time as the detail, so a sixth detail has "+
+					"somewhere to go", other.Record)
+			}
+		}
+	})
+
+	t.Run("a summary where the flag says N", func(t *testing.T) {
+		// The transition admitting the summary carries the flag guard, so
+		// with the flag anything but `Y` it is ineligible and a summary
+		// record matches nothing the state offers.
+		summary := transitionAdmitting(t, automaton.States[1], "SUMMARY")
+
+		var flag *Guard
+		for i, guard := range summary.Guards {
+			if guard.Register.Kind == RegisterBytes {
+				flag = &summary.Guards[i]
+			}
+		}
+
+		if flag == nil {
+			t.Fatalf("the summary transition is guarded by %s, want the flag among them", renderGuards(summary.Guards))
+		}
+
+		if flag.Test != GuardEquals || len(flag.Literals) != 1 || flag.Literals[0].Text != "Y" {
+			t.Errorf("the flag guard is %s, want it equal to \"Y\"", renderGuard(*flag))
+		}
+	})
+}
+
+// transitionAdmitting is the one transition of a state that admits a record.
+func transitionAdmitting(t *testing.T, state *State, record string) *Transition {
+	t.Helper()
+
+	for _, transition := range state.Transitions {
+		if transition.Record == record {
+			return transition
+		}
+	}
+
+	t.Fatalf("state %d offers no transition admitting %s", state.ID, record)
+
+	return nil
+}
+
+// TestTheStartStateIsNothingsTarget is docs/layout/SPEC.md's "The first record
+// of a file is the first thing the expression admits, and nothing is written to
+// say so".
+//
+// A state is the only thing the automaton knows about position and there is no
+// predicate for *first* to lower into, so what makes the first record
+// expressible is a state no transition re-enters — even where the file is any
+// number of repeats of the same group and every other state is re-entered (#80).
+func TestTheStartStateIsNothingsTarget(t *testing.T) {
+	t.Parallel()
+
+	automaton := compiled(t, countedRun, countedRunCopybooks())
+
+	if automaton.Start != automaton.States[0] || automaton.Start.ID != 0 {
+		t.Fatalf("the start state is %d, want the first state", automaton.Start.ID)
+	}
+
+	for _, state := range automaton.States {
+		for _, transition := range state.Transitions {
+			if transition.To == automaton.Start {
+				t.Errorf("state %d re-enters the start state admitting %s", state.ID, transition.Record)
+			}
+		}
+	}
+
+	// And the first record of the file is the only thing it offers.
+	if len(automaton.Start.Transitions) != 1 || automaton.Start.Transitions[0].Record != "HEADER" {
+		t.Errorf("the start state offers %d transitions, want one admitting HEADER", len(automaton.Start.Transitions))
+	}
+}
+
+// TestEveryTransitionConsumesExactlyOneRecord is docs/ir/SPEC.md's "No epsilon
+// transitions, and what the graph pays instead": there is no transition that
+// moves without reading, which is what keeps a generated reader a loop over one
+// record at a time.
+func TestEveryTransitionConsumesExactlyOneRecord(t *testing.T) {
+	t.Parallel()
+
+	automaton := compiled(t, countedRun, countedRunCopybooks())
+
+	for _, state := range automaton.States {
+		for _, transition := range state.Transitions {
+			if transition.Record == "" {
+				t.Errorf("state %d carries a transition admitting no record", state.ID)
+			}
+		}
+	}
+}
+
+// TestACountedRunIsOneRegisterAndOneGuard is what the register file is bought
+// with: a graph whose size follows the layout instead of the data.
+//
+// A `PIC 9(4)` count admits ten thousand different files and the graph is the
+// same size for all of them — one register, one guard and no state per possible
+// count, which is what docs/ir/SPEC.md means by a counted run compiled without
+// unrolling.
+func TestACountedRunIsOneRegisterAndOneGuard(t *testing.T) {
+	t.Parallel()
+
+	copybooks := countedRunCopybooks()
+	copybooks["HEADER"] = strings.Replace(header, "DTL-COUNT PIC 9(2)", "DTL-COUNT PIC 9(4)", 1)
+
+	source := `(record HEADER (copybook "hdr.cpy" HDR-REC))
+(record DETAIL (copybook "dtl.cpy" DTL-REC))
+(discriminate HEADER (equals (item HEADER HDR-TYPE) "H"))
+(discriminate DETAIL (equals (item DETAIL DTL-TYPE) "D"))
+(sequence (seq HEADER (times DETAIL (item HEADER DTL-COUNT))))`
+
+	assertRendering(t, compiled(t, source, copybooks), `
+register 1 integer from (item HEADER DTL-COUNT)
+state 0
+  on (equals (item HEADER HDR-TYPE) "H"), admit HEADER, bind (item HEADER DTL-COUNT), go to 1
+state 1 accepts when (item HEADER DTL-COUNT) equal to 0
+  when (item HEADER DTL-COUNT) above zero, on (equals (item DETAIL DTL-TYPE) "D"), admit DETAIL, take one off (item HEADER DTL-COUNT), go to 2
+state 2 accepts when (item HEADER DTL-COUNT) equal to 0
+  when (item HEADER DTL-COUNT) above zero, on (equals (item DETAIL DTL-TYPE) "D"), admit DETAIL, take one off (item HEADER DTL-COUNT), go to 2
+`)
+}
+
+// TestTheCounterCannotRunBelowZero is docs/ir/SPEC.md's requirement on a
+// producer: a transition taking one off a register is guarded so that the
+// register cannot run below zero.
+//
+// One guard does both jobs here, which is why there is no second rule to keep.
+// The transition that takes one off is the transition that enters a pass of the
+// run, and the guard that bounds the run is the guard that keeps the counter
+// non-negative.
+func TestTheCounterCannotRunBelowZero(t *testing.T) {
+	t.Parallel()
+
+	automaton := compiled(t, countedRun, countedRunCopybooks())
+
+	took := 0
+	for _, state := range automaton.States {
+		for _, transition := range state.Transitions {
+			for _, binding := range transition.Bindings {
+				if binding.Value != BindLessOne {
+					continue
+				}
+
+				took++
+
+				guarded := false
+				for _, guard := range transition.Guards {
+					if guard.Register == binding.Register && guard.Test == GuardPositive {
+						guarded = true
+					}
+				}
+
+				if !guarded {
+					t.Errorf("state %d takes one off %s under %s, want it guarded above zero",
+						state.ID, binding.Register, renderGuards(transition.Guards))
+				}
+			}
+		}
+	}
+
+	if took == 0 {
+		t.Error("nothing takes one off a counter, so the graph is not the one this asserts")
+	}
+}
+
+// TestARegisterBoundEarlierAndDecrementedByTheAdmittingTransitionCompiles is
+// what docs/ir/SPEC.md's "A count is in hand before the extent it decides"
+// leaves admissible after #88's rewording: a register bound on an earlier
+// transition and rebound, or decremented, by the transition admitting the record
+// that reads it.
+//
+// Both shapes stand on one transition of the counted run. The transition
+// admitting a detail reads the counter at step 3 and takes one off it at step 7,
+// and the transition admitting the next header reads the counter *and* rebinds
+// it from the record it admits — each read taking the value the register held on
+// entry to the state, which is what makes the two orders different things.
+func TestARegisterBoundEarlierAndDecrementedByTheAdmittingTransitionCompiles(t *testing.T) {
+	t.Parallel()
+
+	automaton := compiled(t, countedRun, countedRunCopybooks())
+	group := automaton.States[1]
+
+	detail := transitionAdmitting(t, group, "DETAIL")
+	if len(detail.Guards) != 1 || len(detail.Bindings) != 1 || detail.Bindings[0].Value != BindLessOne {
+		t.Errorf("the detail transition is %s, want it reading the counter and taking one off it",
+			renderTransition(detail))
+	}
+
+	next := transitionAdmitting(t, group, "HEADER")
+	rebinds := false
+	for _, binding := range next.Bindings {
+		if binding.Value == BindField && binding.Register == next.Guards[0].Register {
+			rebinds = true
+		}
+	}
+
+	if !rebinds {
+		t.Errorf("the transition admitting the next header is %s, want it reading the counter and rebinding it",
+			renderTransition(next))
+	}
+}
+
+// TestARunCountedByTheRecordBeingCountedIsRejected is the shape #88 reworded
+// docs/ir/SPEC.md to refuse: a repetition naming a register that only the
+// transition admitting its own record binds.
+//
+// A binding applies at step 7 of the read loop and the extent it decides is
+// wanted at step 4, so on the first admission the register holds nothing and on
+// every later one it holds the previous record's value. What is asserted here is
+// as much the message as the refusal: the diagnostic names the record and the
+// register rather than reporting a reference that does not resolve, because the
+// reference resolves perfectly and it is the *order* that does not work.
+func TestARunCountedByTheRecordBeingCountedIsRejected(t *testing.T) {
+	t.Parallel()
+
+	source := `(record DETAIL (copybook "dtl.cpy" DTL-REC))
+(discriminate DETAIL (equals (item DETAIL DTL-TYPE) "D"))
+(sequence (times DETAIL (item DETAIL DTL-COUNT)))`
+
+	counted := `01 DTL-REC.
+   05 DTL-TYPE PIC X(1).
+   05 DTL-COUNT PIC 9(2).
+`
+
+	err := refused(t, source, map[string]string{"DETAIL": counted})
+
+	var unbound *UnboundRegisterError
+	if !errors.As(err, &unbound) {
+		t.Fatalf("compiling reported %v, want an unbound register", err)
+	}
+
+	if !unbound.OnAdmitting {
+		t.Error("the fault does not say the only binding is on the admitting transition")
+	}
+
+	for _, want := range []string{"DETAIL", "(item DETAIL DTL-COUNT)", "after the record is admitted"} {
+		if !strings.Contains(unbound.Error(), want) {
+			t.Errorf("the diagnostic is %q, want it to name %q", unbound.Error(), want)
+		}
+	}
+}
+
+// TestAValueInARecordNotYetReadIsRejected is docs/ir/SPEC.md's "A value the
+// automaton has not read yet", and the other half of what
+// [UnboundRegisterError] reports.
+//
+// The header is optional here, so there is a path to the counted run on which no
+// header was admitted and the counter holds nothing. A consumer reading a stream
+// forward has no way to go back for it, and `resolve` proves that before a byte
+// is read rather than leaving it to surprise a reader halfway through a
+// hundred-million-record file.
+func TestAValueInARecordNotYetReadIsRejected(t *testing.T) {
+	t.Parallel()
+
+	source := `(record HEADER (copybook "hdr.cpy" HDR-REC))
+(record DETAIL (copybook "dtl.cpy" DTL-REC))
+(discriminate HEADER (equals (item HEADER HDR-TYPE) "H"))
+(discriminate DETAIL (equals (item DETAIL DTL-TYPE) "D"))
+(sequence (seq (? HEADER) (times DETAIL (item HEADER DTL-COUNT))))`
+
+	err := refused(t, source, countedRunCopybooks())
+
+	var unbound *UnboundRegisterError
+	if !errors.As(err, &unbound) {
+		t.Fatalf("compiling reported %v, want an unbound register", err)
+	}
+
+	if unbound.OnAdmitting {
+		t.Error("the fault says the admitting transition binds it, and no transition here does")
+	}
+
+	for _, want := range []string{"HEADER", "(item HEADER DTL-COUNT)", "not read yet"} {
+		if !strings.Contains(unbound.Error(), want) {
+			t.Errorf("the diagnostic is %q, want it to name %q", unbound.Error(), want)
+		}
+	}
+}
+
+// TestABindingNeverNamesAnItemThatRepeats is docs/ir/SPEC.md's "A reference
+// names a field, not an occurrence of one", applied to the one position this
+// story owns.
+//
+// Nothing carries an occurrence number, so an item with a value per occurrence
+// is a value the automaton has no spelling for. The diagnostic names the record,
+// the item and the enclosing group that repeats, because the generic version
+// sends a reader to look for a misspelling in a reference that is spelled
+// correctly.
+func TestABindingNeverNamesAnItemThatRepeats(t *testing.T) {
+	t.Parallel()
+
+	source := `(record HEADER (copybook "hdr.cpy" HDR-REC))
+(record DETAIL (copybook "dtl.cpy" DTL-REC))
+(discriminate HEADER (equals (item HEADER HDR-TYPE) "H"))
+(discriminate DETAIL (equals (item DETAIL DTL-TYPE) "D"))
+(sequence (seq HEADER (times DETAIL %s)))`
+
+	for _, tc := range []struct {
+		name      string
+		reference string
+		copybook  string
+		item      string
+		group     string
+	}{
+		{
+			name:      "the item itself repeats",
+			reference: "(item HEADER COUNTS)",
+			copybook: `01 HDR-REC.
+   05 HDR-TYPE PIC X(1).
+   05 COUNTS PIC 9(2) OCCURS 3 TIMES.
+`,
+			item: "COUNTS",
+		},
+		{
+			name:      "the item sits in a group that repeats",
+			reference: "(item HEADER TOTALS COUNTS)",
+			copybook: `01 HDR-REC.
+   05 HDR-TYPE PIC X(1).
+   05 TOTALS OCCURS 3 TIMES.
+      10 COUNTS PIC 9(2).
+`,
+			item:  "COUNTS",
+			group: "TOTALS",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			copybooks := countedRunCopybooks()
+			copybooks["HEADER"] = tc.copybook
+
+			err := refused(t, fmt.Sprintf(source, tc.reference), copybooks)
+
+			var repeats *SequenceOccurrenceError
+			if !errors.As(err, &repeats) {
+				t.Fatalf("compiling reported %v, want a repeating reference", err)
+			}
+
+			if repeats.Record != "HEADER" || repeats.Item != tc.item || repeats.Group != tc.group {
+				t.Errorf("the fault names record %q, item %q and group %q, want %q, %q and %q",
+					repeats.Record, repeats.Item, repeats.Group, "HEADER", tc.item, tc.group)
+			}
+		})
+	}
+}
+
+// TestACountThatDoesNotDecodeToAnIntegerIsRejected is docs/layout/SPEC.md's
+// third restriction on `times`, and docs/ir/SPEC.md's rule that a producer must
+// not bind a field whose value does not decode to the register's kind.
+//
+// A `when` carries no such rule and the sub-test says so: a bytes register holds
+// its source field's bytes as they appear, so a guard over one is a byte
+// comparison whatever the item's PICTURE turns out to be.
+func TestACountThatDoesNotDecodeToAnIntegerIsRejected(t *testing.T) {
+	t.Parallel()
+
+	alphanumeric := `01 HDR-REC.
+   05 HDR-TYPE PIC X(1).
+   05 DTL-COUNT PIC X(2).
+   05 SUM-FLAG PIC X(1).
+`
+
+	copybooks := countedRunCopybooks()
+	copybooks["HEADER"] = alphanumeric
+
+	source := `(record HEADER (copybook "hdr.cpy" HDR-REC))
+(record DETAIL (copybook "dtl.cpy" DTL-REC))
+(discriminate HEADER (equals (item HEADER HDR-TYPE) "H"))
+(discriminate DETAIL (equals (item DETAIL DTL-TYPE) "D"))
+(sequence (seq HEADER (times DETAIL (item HEADER DTL-COUNT))))`
+
+	err := refused(t, source, copybooks)
+
+	var kind *SequenceCountKindError
+	if !errors.As(err, &kind) {
+		t.Fatalf("compiling reported %v, want a count of the wrong kind", err)
+	}
+
+	if kind.Record != "HEADER" || kind.Item != "DTL-COUNT" {
+		t.Errorf("the fault names record %q and item %q, want HEADER and DTL-COUNT", kind.Record, kind.Item)
+	}
+
+	t.Run("a when reads the same item without complaint", func(t *testing.T) {
+		flagged := `(record HEADER (copybook "hdr.cpy" HDR-REC))
+(record DETAIL (copybook "dtl.cpy" DTL-REC))
+(discriminate HEADER (equals (item HEADER HDR-TYPE) "H"))
+(discriminate DETAIL (equals (item DETAIL DTL-TYPE) "D"))
+(sequence (seq HEADER (when (item HEADER DTL-COUNT) "01" DETAIL)))`
+
+		automaton := compiled(t, flagged, copybooks)
+		if len(automaton.Registers) != 1 || automaton.Registers[0].Kind != RegisterBytes {
+			t.Errorf("the automaton carries %d registers, want one holding bytes", len(automaton.Registers))
+		}
+	})
+}
+
+// TestAnItemReferenceNamingNoItemIsRejected is the half of the reference rules
+// that needs a copybook, which is why it is here and not in `layoutmodel`.
+func TestAnItemReferenceNamingNoItemIsRejected(t *testing.T) {
+	t.Parallel()
+
+	source := `(record HEADER (copybook "hdr.cpy" HDR-REC))
+(record DETAIL (copybook "dtl.cpy" DTL-REC))
+(discriminate HEADER (equals (item HEADER HDR-TYPE) "H"))
+(discriminate DETAIL (equals (item DETAIL DTL-TYPE) "D"))
+(sequence (seq HEADER (times DETAIL (item HEADER NO-SUCH-COUNT))))`
+
+	err := refused(t, source, countedRunCopybooks())
+
+	var missing *SequenceItemError
+	if !errors.As(err, &missing) {
+		t.Fatalf("compiling reported %v, want an unresolved reference", err)
+	}
+
+	if missing.Operator != "times" || missing.Record != "HEADER" {
+		t.Errorf("the fault names operator %q of record %q, want times of HEADER", missing.Operator, missing.Record)
+	}
+}
+
+// TestAFlagGoverningTheRecordHoldingItBecomesABranch is docs/ir/SPEC.md's "When
+// a value becomes a state, and when it becomes a register", and the SHOULD in
+// it kept rather than restated.
+//
+// Two records told apart by a flag are an `alt` of two names with a
+// discriminator each: the dependence on the value has become the state the
+// automaton is in, and no register is emitted for it. A register the graph does
+// not need is memory every consumer in every language carries for nothing.
+func TestAFlagGoverningTheRecordHoldingItBecomesABranch(t *testing.T) {
+	t.Parallel()
+
+	source := `(record HEADER (copybook "hdr.cpy" HDR-REC))
+(record DETAIL (copybook "dtl.cpy" DTL-REC))
+(discriminate HEADER (equals (item HEADER HDR-TYPE) "H"))
+(discriminate DETAIL (equals (item DETAIL DTL-TYPE) "D"))
+(sequence (alt HEADER DETAIL))`
+
+	automaton := compiled(t, source, countedRunCopybooks())
+
+	if len(automaton.Registers) != 0 {
+		t.Errorf("the automaton carries %d registers, want none", len(automaton.Registers))
+	}
+
+	assertRendering(t, automaton, `
+state 0
+  on (equals (item HEADER HDR-TYPE) "H"), admit HEADER, go to 1
+  on (equals (item DETAIL DTL-TYPE) "D"), admit DETAIL, go to 2
+state 1 accepts
+state 2 accepts
+`)
+}
+
+// TestASingleRecordTypeCompilesToNoPredicate is docs/ir/SPEC.md's "A transition
+// may carry no predicate" and the strategy #28 named for it.
+//
+// A file with one record type has nothing for a predicate to test, and the
+// transition admitting it carries the *absence* of a predicate rather than a
+// member of the set testing nothing.
+func TestASingleRecordTypeCompilesToNoPredicate(t *testing.T) {
+	t.Parallel()
+
+	source := `(record DETAIL (copybook "dtl.cpy" DTL-REC))
+(discriminate DETAIL single-record-type)
+(sequence (* DETAIL))`
+
+	assertRendering(t, compiled(t, source, countedRunCopybooks()), `
+state 0 accepts
+  on no predicate, admit DETAIL, go to 1
+state 1 accepts
+  on no predicate, admit DETAIL, go to 1
+`)
+}
+
+// TestATransitionCarryingNoPredicateBesideAnEligibleSiblingIsRejected is #80
+// folded into the overlap rule rather than beside it.
+//
+// A transition carrying no predicate matches every record, so it overlaps every
+// transition leaving its state whose guards can hold at the same time as its
+// own. Guards are the only thing that can separate two of them, and where
+// nothing does the layout is rejected rather than the ambiguity being settled by
+// evaluation order — a transition carrying no predicate is not a default arm and
+// is not tried last.
+func TestATransitionCarryingNoPredicateBesideAnEligibleSiblingIsRejected(t *testing.T) {
+	t.Parallel()
+
+	source := `(record HEADER (copybook "hdr.cpy" HDR-REC))
+(record DETAIL (copybook "dtl.cpy" DTL-REC))
+(discriminate HEADER (equals (item HEADER HDR-TYPE) "H"))
+(discriminate DETAIL single-record-type)
+(sequence (alt HEADER DETAIL))`
+
+	err := refused(t, source, countedRunCopybooks())
+
+	var ambiguous *SequenceAmbiguityError
+	if !errors.As(err, &ambiguous) {
+		t.Fatalf("compiling reported %v, want an ambiguity", err)
+	}
+
+	if !ambiguous.Unguarded {
+		t.Error("the fault does not say one of the two carries no discriminator")
+	}
+
+	if ambiguous.State != 0 {
+		t.Errorf("the fault is at state %d, want the start state", ambiguous.State)
+	}
+}
+
+// TestTwoRecordsAtOnePointTestingOneRunOfBytesForOneValueAreRejected is
+// docs/ir/SPEC.md's "When two match, and when none does": `resolve` rejects a
+// layout whose discriminators overlap, so that the question of what a consumer
+// does when two match does not arise.
+func TestTwoRecordsAtOnePointTestingOneRunOfBytesForOneValueAreRejected(t *testing.T) {
+	t.Parallel()
+
+	source := `(record HEADER (copybook "hdr.cpy" HDR-REC))
+(record DETAIL (copybook "dtl.cpy" DTL-REC))
+(discriminate HEADER (equals (item HEADER HDR-TYPE) "H"))
+(discriminate DETAIL (equals (item DETAIL DTL-TYPE) "H"))
+(sequence (alt HEADER DETAIL))`
+
+	err := refused(t, source, countedRunCopybooks())
+
+	var ambiguous *SequenceAmbiguityError
+	if !errors.As(err, &ambiguous) {
+		t.Fatalf("compiling reported %v, want an ambiguity", err)
+	}
+
+	if ambiguous.Unguarded {
+		t.Error("the fault says one carries no discriminator, and both carry one")
+	}
+
+	if ambiguous.Records != [2]string{"HEADER", "DETAIL"} {
+		t.Errorf("the fault names %v, want both records", ambiguous.Records)
+	}
+}
+
+// TestTwoDiscriminatorsOverDifferentRunsOfBytesOverlap is the reading
+// docs/ir/SPEC.md insists on: the test is whether one input can satisfy both,
+// not whether the two read the same bytes.
+//
+// A record keyed on its first byte beside one keyed on its second is where the
+// narrower reading lets a real ambiguity through, because a record can carry
+// both values at once.
+func TestTwoDiscriminatorsOverDifferentRunsOfBytesOverlap(t *testing.T) {
+	t.Parallel()
+
+	elsewhere := `01 DTL-REC.
+   05 DTL-LEAD PIC X(1).
+   05 DTL-TYPE PIC X(1).
+   05 DTL-BODY PIC X(20).
+`
+
+	copybooks := countedRunCopybooks()
+	copybooks["DETAIL"] = elsewhere
+
+	source := `(record HEADER (copybook "hdr.cpy" HDR-REC))
+(record DETAIL (copybook "dtl.cpy" DTL-REC))
+(discriminate HEADER (equals (item HEADER HDR-TYPE) "H"))
+(discriminate DETAIL (equals (item DETAIL DTL-TYPE) "D"))
+(sequence (alt HEADER DETAIL))`
+
+	var ambiguous *SequenceAmbiguityError
+	if err := refused(t, source, copybooks); !errors.As(err, &ambiguous) {
+		t.Fatalf("compiling reported %v, want an ambiguity", err)
+	}
+}
+
+// TestGuardsSeparateTransitionsWhosePredicatesOverlap is the narrowing
+// docs/ir/SPEC.md puts on the overlap rule, and the thing that makes a counted
+// run expressible at all.
+//
+// Two transitions whose guards cannot hold at the same time are never both
+// eligible, so their predicates may overlap freely — here they are the very same
+// test on the very same run of bytes, and only the counter separates them.
+func TestGuardsSeparateTransitionsWhosePredicatesOverlap(t *testing.T) {
+	t.Parallel()
+
+	// TAIL is built to the detail's copybook and told apart by the same value
+	// in the same place, so nothing but the counter says which of the two a
+	// record at that point is.
+	source := `(record HEADER (copybook "hdr.cpy" HDR-REC))
+(record DETAIL (copybook "dtl.cpy" DTL-REC))
+(record TAIL (copybook "dtl.cpy" DTL-REC))
+(discriminate HEADER (equals (item HEADER HDR-TYPE) "H"))
+(discriminate DETAIL (equals (item DETAIL DTL-TYPE) "D"))
+(discriminate TAIL (equals (item TAIL DTL-TYPE) "D"))
+(sequence (seq HEADER (times DETAIL (item HEADER DTL-COUNT)) TAIL))`
+
+	copybooks := countedRunCopybooks()
+	copybooks["TAIL"] = detail
+
+	automaton := compiled(t, source, copybooks)
+
+	group := automaton.States[1]
+	if len(group.Transitions) != 2 {
+		t.Fatalf("the state after the header offers %d transitions, want two", len(group.Transitions))
+	}
+
+	if satisfiable(mergeGuards(group.Transitions[0].Guards, group.Transitions[1].Guards)) {
+		t.Errorf("the two transitions can be eligible together:\n  %s\n  %s",
+			renderTransition(group.Transitions[0]), renderTransition(group.Transitions[1]))
+	}
+}
+
+// TestANestedWhenIsTheConjunctionTheAlgebraDoesNotCarry is
+// docs/layout/SPEC.md's "What the algebra deliberately cannot say", from the
+// compiler's side: there is no conjunction on one operator, and a nested `when`
+// is the shape that already works. Both guards land on the transition the pair
+// governs.
+func TestANestedWhenIsTheConjunctionTheAlgebraDoesNotCarry(t *testing.T) {
+	t.Parallel()
+
+	source := `(record HEADER (copybook "hdr.cpy" HDR-REC))
+(record SUMMARY (copybook "sum.cpy" SUM-REC))
+(discriminate HEADER (equals (item HEADER HDR-TYPE) "H"))
+(discriminate SUMMARY (equals (item SUMMARY SUM-TYPE) "S"))
+(sequence
+  (seq HEADER
+       (when (item HEADER SUM-FLAG) "Y"
+             (when (item HEADER HDR-TYPE) (one-of "H" "h") SUMMARY))))`
+
+	automaton := compiled(t, source, countedRunCopybooks())
+
+	summary := transitionAdmitting(t, automaton.States[1], "SUMMARY")
+	if len(summary.Guards) != 2 {
+		t.Fatalf("the summary transition carries %s, want both tests", renderGuards(summary.Guards))
+	}
+
+	if summary.Guards[0].Test != GuardEquals || summary.Guards[1].Test != GuardOneOf {
+		t.Errorf("the summary transition carries %s, want an equals and a one-of", renderGuards(summary.Guards))
+	}
+}
+
+// TestAPointAcceptingUnderTwoSetsOfGuardsIsRejected is the one shape of the
+// algebra that has nowhere to go in the IR.
+//
+// A state carries one list of acceptance guards and a list is a conjunction.
+// docs/ir/SPEC.md puts disjunction in the state — a second transition leaving it
+// — and acceptance is not a transition, so an `alt` of two counted runs leaves
+// the state ahead of it complete under either counter reaching zero and there is
+// nowhere to write the second condition. It is reported rather than narrowed to
+// one, because either narrowing calls some file the layout admits truncated or
+// some file it forbids complete.
+func TestAPointAcceptingUnderTwoSetsOfGuardsIsRejected(t *testing.T) {
+	t.Parallel()
+
+	source := `(record HEADER (copybook "hdr.cpy" HDR-REC))
+(record DETAIL (copybook "dtl.cpy" DTL-REC))
+(record SUMMARY (copybook "sum.cpy" SUM-REC))
+(discriminate HEADER (equals (item HEADER HDR-TYPE) "H"))
+(discriminate DETAIL (equals (item DETAIL DTL-TYPE) "D"))
+(discriminate SUMMARY (equals (item SUMMARY SUM-TYPE) "S"))
+(sequence
+  (seq HEADER
+       (alt (times DETAIL (item HEADER DTL-COUNT))
+            (times SUMMARY (item HEADER DTL-COUNT)))))`
+
+	err := refused(t, source, countedRunCopybooks())
+
+	var acceptance *SequenceAcceptanceError
+	if !errors.As(err, &acceptance) {
+		t.Fatalf("compiling reported %v, want a disjunctive acceptance", err)
+	}
+
+	if acceptance.What != "HEADER" || acceptance.Ways != 2 {
+		t.Errorf("the fault is about %q under %d sets of guards, want HEADER under two",
+			acceptance.What, acceptance.Ways)
+	}
+}
+
+// TestATransitionNoRegisterFileAdmitsIsNotEmitted is the other half of what
+// makes overlap decidable: a guard list is a flat conjunction of tests against
+// literals and zero, so whether one contradicts itself is a question this
+// compiler can answer.
+//
+// A counted run inside a `*` is the shape that produces one. Restarting the run
+// needs the counter above zero, leaving it needs the counter at zero, and
+// nothing between the two rebinds it — so the edge back into the run is an edge
+// no register file admits. It is dropped rather than emitted, because a consumer
+// would evaluate it against every record forever and a producer would have to
+// explain it.
+func TestATransitionNoRegisterFileAdmitsIsNotEmitted(t *testing.T) {
+	t.Parallel()
+
+	source := `(record HEADER (copybook "hdr.cpy" HDR-REC))
+(record DETAIL (copybook "dtl.cpy" DTL-REC))
+(discriminate HEADER (equals (item HEADER HDR-TYPE) "H"))
+(discriminate DETAIL (equals (item DETAIL DTL-TYPE) "D"))
+(sequence (seq HEADER (* (times DETAIL (item HEADER DTL-COUNT)))))`
+
+	automaton := compiled(t, source, countedRunCopybooks())
+
+	for _, state := range automaton.States {
+		for _, transition := range state.Transitions {
+			if !satisfiable(transition.Guards) {
+				t.Errorf("state %d carries %s, which no register file admits",
+					state.ID, renderTransition(transition))
+			}
+		}
+	}
+
+	// The run itself is still there, entered from the header and continued
+	// from within: what is dropped is only the way back in from its own end.
+	if len(automaton.States) != 3 {
+		t.Errorf("the automaton has %d states, want the header, the detail and the start", len(automaton.States))
+	}
+}
+
+// TestCompileSequenceRefusesNoSequence is the one fault that is not about a
+// layout: a caller handing over nothing at all.
+func TestCompileSequenceRefusesNoSequence(t *testing.T) {
+	t.Parallel()
+
+	if _, err := CompileSequence(Sequencing{}); !errors.Is(err, ErrNilSequence) {
+		t.Errorf("compiling nothing reported %v, want %v", err, ErrNilSequence)
+	}
+}

--- a/internal/resolve/doc.go
+++ b/internal/resolve/doc.go
@@ -3,9 +3,29 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-// Package resolve turns a copybook record into the shape the IR describes: an
+// Package resolve turns a copybook record into the shape the IR describes — an
 // ordered containment of groups, fields, variants and slack, every elementary
-// item carrying the byte width `cobol-go`'s codec/SPEC.md gives it.
+// item carrying the byte width `cobol-go`'s codec/SPEC.md gives it — and a
+// layout's sequencing expression into the record automaton that says in what
+// order those records may appear.
+//
+// [Resolve] is the first and [CompileSequence] the second. They share this
+// package because they spend the same two sources: a copybook read by
+// `cobol-go`, and a layout read by
+// [github.com/Zaba505/cpybkc/internal/layoutmodel]. They share nothing else —
+// what is inside a record and what order records come in are different
+// questions, and the second needs every record at once where the first needs
+// one.
+//
+// # The automaton is compiled here for the reason the offsets are
+//
+// Sequencing reaches a generator as states and transitions and never as the
+// expression they were compiled from (docs/ir/SPEC.md, "The sequencing
+// automaton"). A regex-like algebra implemented independently in four languages
+// is four slightly different algebras, exactly as four independent readings of a
+// PICTURE are four different widths — so the algebra is spent here, once, and
+// [CompileSequence]'s own comment is where the construction and the two proofs
+// over it are argued (#36, #76, #77, #80, #88).
 //
 // # Why the arithmetic is here and nowhere else
 //
@@ -116,23 +136,22 @@
 // # What this package leaves to the stories after it
 //
 // Compiling a layout's discriminator strategies into predicate nodes is #37's,
-// binding a count that lives in an earlier record into a register is #36's, and
-// assembling nodes into a
+// and assembling nodes into a
 // [github.com/Zaba505/cpybkc/irpb.Descriptor] with identifiers on them is #38's.
 // A [Repetition] here therefore names a [github.com/Zaba505/cobol-go/copybook.Field]
-// rather than an identifier, and an [Arm] carries the
+// rather than an identifier, an [Arm] carries the
 // [github.com/Zaba505/cpybkc/internal/layoutmodel.Strategy] a layout wrote
-// rather than a compiled predicate.
+// rather than a compiled predicate, and a [Transition] carries one too.
 //
-// A count that lives in another record never reaches here at all, and that is
-// the division rather than a gap: a DEPENDING ON phrase names an item of the
-// copybook record carrying it, so every reference this package resolves is to a
+// A count that lives in another record never reaches [Resolve] at all, and that
+// is the division rather than a gap: a DEPENDING ON phrase names an item of the
+// copybook record carrying it, so every reference that function resolves is to a
 // field of the record being read. Where a layout's count comes from a header
-// admitted earlier, the automaton binds that field into a register as it admits
-// the header and the repetition names the register — which is a node this
-// package does not build, and is why a reference reaching across records is not
-// a shape it has to refuse (docs/ir/SPEC.md, "A variable record is a sum with a
-// variable term", #77).
+// admitted earlier it is written as a `times`, and [CompileSequence] binds that
+// field into a [Register] as the transition admitting the header is taken —
+// which is why a reference reaching across records is not a shape [Resolve] has
+// to refuse (docs/ir/SPEC.md, "A variable record is a sum with a variable term",
+// #77).
 //
 // # Slack, and its four producers
 //

--- a/internal/resolve/node.go
+++ b/internal/resolve/node.go
@@ -15,8 +15,9 @@ import (
 // "The node kinds", admits inside a record.
 //
 // The kinds a record cannot contain — file, record, predicate, state,
-// transition, register, binding, guard — are not here. This package resolves
-// what is inside a record; the automaton is #36's and the descriptor #38's.
+// transition, register, binding, guard — are not here. This is what is inside a
+// record; the automaton's own nodes are [State], [Transition] and [Register],
+// and assembling every kind into one descriptor is #38's.
 type Kind int
 
 const (
@@ -186,9 +187,10 @@ type Repetition struct {
 	// A field of the record being read, at any depth, and never a field of
 	// another record: a DEPENDING ON phrase names an item of the copybook
 	// record carrying it, and a count that comes from an earlier record
-	// arrives as a register the automaton bound rather than as a reference
-	// reaching across records (docs/ir/SPEC.md, #77). A register is #36's
-	// node, so nothing here stands for one.
+	// arrives as a [Register] the automaton bound rather than as a
+	// reference reaching across records (docs/ir/SPEC.md, #77). Which
+	// transitions bind that register, and the proof that one is bound
+	// before it is read, are [CompileSequence]'s.
 	DependingOn *copybook.Field
 }
 

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -294,7 +294,7 @@ func (r *resolver) frame(records []*Record) {
 			// dataset at all has no extent for the check below to be
 			// about.
 			r.faults.Fail(&VariableExtentError{
-				Pos:    framingSpan(framing.Pos),
+				Pos:    layoutSpan(framing.Pos),
 				Item:   r.span(item),
 				Record: r.record.Name,
 				RECFM:  framing.RECFM,
@@ -312,7 +312,7 @@ func (r *resolver) frame(records []*Record) {
 		switch {
 		case extent > lrecl:
 			r.faults.Fail(&LRECLExtentError{
-				Pos:          framingSpan(framing.LRECL.Pos),
+				Pos:          layoutSpan(framing.LRECL.Pos),
 				Item:         r.span(r.record),
 				Record:       r.record.Name,
 				Alternatives: alternativeNames(record),
@@ -743,13 +743,14 @@ func (r *resolver) redefine(field *copybook.Field) *Redefine {
 	return nil
 }
 
-// framingSpan is where in the layout a framing form is.
+// layoutSpan is where in the layout a form is: a framing's `lrecl`, a
+// sequencing operator's item reference, the `sequence` form itself.
 //
-// It is the other file a fault about a record's extent implicates: the number
-// comes from the dataset the adopter wrote down and the extent from a copybook
-// they may not own, so a diagnostic naming only one of the two names the one
-// they cannot change (docs/layout/SPEC.md, "Every diagnostic carries a span").
-func framingSpan(pos layout.Pos) diag.Span {
+// It is the other file a fault about a record implicates: a number comes from
+// the dataset the adopter wrote down and an extent from a copybook they may not
+// own, so a diagnostic naming only one of the two names the one they cannot
+// change (docs/layout/SPEC.md, "Every diagnostic carries a span").
+func layoutSpan(pos layout.Pos) diag.Span {
 	return diag.Span{File: pos.File, Line: pos.Line, Column: pos.Column}
 }
 

--- a/internal/resolve/sequence.go
+++ b/internal/resolve/sequence.go
@@ -1,0 +1,765 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package resolve
+
+import (
+	"slices"
+	"strconv"
+
+	"github.com/Zaba505/cobol-go/copybook"
+	"github.com/Zaba505/cobol-go/picture"
+
+	"github.com/Zaba505/cpybkc/internal/layout"
+	"github.com/Zaba505/cpybkc/internal/layoutmodel"
+)
+
+// This file is the half of the record automaton that needs a copybook: what a
+// value-reading operator's item reference is held to, how the compiled graph is
+// assembled out of the positions the expression walk left behind, and the two
+// things proved over it before a byte of a file is read.
+//
+// The split is the one docs/layout/SPEC.md's "Validation and diagnostics"
+// draws. `layoutmodel` has the layout and nothing else, so it holds a `times`
+// or a `when` to the reference's own spelling and to the record it is rooted at.
+// Everything past that — that the path names an item at all, that the item does
+// not repeat, that a count decodes to a number, and that the record holding it
+// was admitted strictly earlier on every path — needs the copybook and the
+// compiled graph, and lands here (#36, #37, #88).
+
+// record is the sequenced record of that name, and whether the layout defines
+// one.
+func (c *compiler) record(name string) (SequencedRecord, bool) {
+	for _, record := range c.opts.Records {
+		if record.Name == name {
+			return record, true
+		}
+	}
+	return SequencedRecord{}, false
+}
+
+// layoutOf is the copybook layout of one record, built once per record.
+//
+// A layout rather than the field tree, because what is asked of it is whether an
+// item repeats or sits inside a group that does, and an OCCURS clause reaches
+// [github.com/Zaba505/cobol-go/copybook.Item] rather than the field.
+func (c *compiler) layoutOf(record SequencedRecord) *copybook.Layout {
+	if already, ok := c.layouts[record.Name]; ok {
+		return already
+	}
+
+	// A copybook this package cannot lay out is a fault [Resolve] reports
+	// against the record itself, with the widths and the clause that made it
+	// unresolvable. Reporting it a second time here would name the same
+	// copybook line for a second reason, so what happens instead is that the
+	// reference cannot be checked and the operator is reported as naming no
+	// item — which is what a caller compiling a sequence over a record it
+	// never resolved has done.
+	built, err := copybook.NewLayout(record.Item, c.opts.Dialect)
+	if err != nil {
+		built = nil
+	}
+
+	c.layouts[record.Name] = built
+
+	return built
+}
+
+// field resolves the item reference a `times` or a `when` wrote, and holds it to
+// everything docs/ir/SPEC.md requires of a field a binding reads.
+//
+// It reports and returns nil rather than stopping, so that a layout whose two
+// operators are both wrong is told about both.
+func (c *compiler) field(e layoutmodel.Expression) *copybook.Field {
+	record, known := c.record(e.Item.Record)
+	if !known {
+		// As in [compiler.name]: `layoutmodel` has already refused a
+		// reference rooted at a record no `record` form defines.
+		c.faults.Fail(&SequenceItemError{
+			Pos:      layoutSpan(e.Item.Pos),
+			Operator: string(e.Kind),
+			Item:     e.Item,
+			Record:   e.Item.Record,
+			Found:    "the layout defines no such record",
+		})
+
+		return nil
+	}
+
+	built := c.layoutOf(record)
+	if built == nil {
+		c.faults.Fail(&SequenceItemError{
+			Pos:      layoutSpan(e.Item.Pos),
+			Operator: string(e.Kind),
+			Item:     e.Item,
+			Record:   record.Name,
+			Copybook: copybookSpan(record, nil),
+			Found:    "its copybook does not lay out",
+		})
+
+		return nil
+	}
+
+	matched := itemsAt(built.Record, e.Item.Path)
+	if len(matched) != 1 {
+		found := "it names no item of that record"
+		if len(matched) > 1 {
+			found = "it names " + strconv.Itoa(len(matched)) + " items of that record"
+		}
+
+		c.faults.Fail(&SequenceItemError{
+			Pos:      layoutSpan(e.Item.Pos),
+			Operator: string(e.Kind),
+			Item:     e.Item,
+			Record:   record.Name,
+			Copybook: copybookSpan(record, nil),
+			Found:    found,
+		})
+
+		return nil
+	}
+
+	item := matched[0]
+
+	// docs/ir/SPEC.md, "A reference names a field, not an occurrence of one":
+	// a binding names a field and nothing carries an occurrence number, so an
+	// item with a value per occurrence is a value the automaton cannot name
+	// (#76, #84).
+	if group := enclosingTable(item); item.MaxOccurs > 1 || group != nil {
+		c.faults.Fail(&SequenceOccurrenceError{
+			Pos:      layoutSpan(e.Item.Pos),
+			Copybook: copybookSpan(record, item.Field),
+			Operator: string(e.Kind),
+			Record:   record.Name,
+			Item:     itemName(item.Field),
+			Group:    groupName(group),
+		})
+
+		return nil
+	}
+
+	// docs/layout/SPEC.md, "Two operators read a value": under `times` the
+	// item must be one whose value decodes to an integer. A `when` carries no
+	// such rule — a bytes register holds its source field's bytes as they
+	// appear, so a guard over one is a byte comparison whatever the item is.
+	if e.Kind == layoutmodel.Times && !counts(item.Field) {
+		c.faults.Fail(&SequenceCountKindError{
+			Pos:      layoutSpan(e.Item.Pos),
+			Copybook: copybookSpan(record, item.Field),
+			Record:   record.Name,
+			Item:     itemName(item.Field),
+			Found:    describeCategory(item.Field),
+		})
+
+		return nil
+	}
+
+	return item.Field
+}
+
+// itemsAt is every item the path names, walking from the record's top-level item
+// down one name per level, outermost first, with the top-level item's own name
+// not repeated.
+//
+// Every match is returned rather than the first, because duplicate data names
+// are legal COBOL and a complete path that still names two items is a reference
+// nothing can resolve — which is a fault to report and not a choice to make.
+func itemsAt(root *copybook.Item, path []string) []*copybook.Item {
+	found := []*copybook.Item{root}
+
+	for _, name := range path {
+		var next []*copybook.Item
+
+		for _, item := range found {
+			for _, child := range item.Children {
+				if !child.Field.Filler && child.Field.Name == name {
+					next = append(next, child)
+				}
+			}
+		}
+
+		found = next
+	}
+
+	return found
+}
+
+// counts reports whether a field's value decodes to an integer, which is what a
+// `times` needs of the item it counts.
+//
+// A category and a scale, and nothing about USAGE: a count may be zoned, packed
+// or binary and is a number under all three, which is why the register holds a
+// number rather than bytes.
+func counts(field *copybook.Field) bool {
+	return field != nil &&
+		field.Kind != copybook.KindGroup &&
+		field.Picture != nil &&
+		field.Picture.Category == picture.CategoryNumeric &&
+		field.Picture.Scale == 0
+}
+
+// describeCategory names what an item is, for a message about one that cannot be
+// a count.
+func describeCategory(field *copybook.Field) string {
+	switch {
+	case field == nil:
+		return "nothing"
+	case field.Kind == copybook.KindGroup:
+		return "a group"
+	case field.Picture == nil:
+		return "an item with no PICTURE"
+	case field.Picture.Category != picture.CategoryNumeric:
+		return "a " + field.Picture.Category.String() + " item"
+	case field.Picture.Scale != 0:
+		return "a numeric item with " + strconv.Itoa(field.Picture.Scale) + " digits after the decimal point"
+	}
+	return "not a count"
+}
+
+// assemble turns the positions and the follows the walk left behind into the
+// graph a consumer walks.
+//
+// Three things happen here and each is a rule about the whole automaton rather
+// than about one node of the expression. Every transition admitting a record
+// gains the bindings of every register read out of that record, since a register
+// holds what the most recent binding put in it and the nearest preceding record
+// is the one that bound it. Transitions whose own guards contradict each other
+// are dropped, because a guard list that no register file satisfies is an edge
+// nothing can take. And states nothing reaches are dropped with them.
+func (c *compiler) assemble(top facts) *Automaton {
+	states := make([]*State, len(c.positions)+1)
+	for i := range states {
+		states[i] = &State{ID: i}
+	}
+
+	start := states[0]
+	c.edges(start, top.first, states)
+
+	for at := range c.positions {
+		c.edges(states[at+1], c.follow[at], states)
+	}
+
+	c.accept(start, top.null, "the file", c.opts.Sequence.Pos)
+	for at, appeared := range c.positions {
+		c.accept(states[at+1], exitsAt(top.last, at), appeared.record, appeared.pos)
+	}
+
+	automaton := &Automaton{Start: start, Registers: c.registers}
+	for _, state := range reachable(start, states) {
+		automaton.States = append(automaton.States, state)
+	}
+
+	return automaton
+}
+
+// edges builds one state's outgoing transitions out of the ways into the
+// positions that may follow it.
+func (c *compiler) edges(from *State, ways []entry, states []*State) {
+	for _, way := range ways {
+		if !satisfiable(way.guards) {
+			// A way in whose guards contradict each other — a counted run
+			// restarted where its own counter has reached zero, and nothing
+			// between to rebind it — is an edge no register file admits. It
+			// is dropped rather than emitted, because a consumer would
+			// evaluate it on every record forever and a producer would have
+			// to explain it.
+			continue
+		}
+
+		to := states[way.at+1]
+		record := c.positions[way.at]
+
+		from.Transitions = append(from.Transitions, &Transition{
+			Record:    record.record,
+			Predicate: record.predicate,
+			Guards:    way.guards,
+			Bindings:  mergeBindings(way.binding, c.bindings(record.record)),
+			To:        to,
+		})
+	}
+}
+
+// bindings are the register writes every transition admitting record applies:
+// one per register read out of that record.
+func (c *compiler) bindings(record string) []Binding {
+	var applied []Binding
+
+	for _, register := range c.registers {
+		if register.Source.Record != record || register.Field == nil {
+			continue
+		}
+
+		applied = append(applied, Binding{Register: register, Value: BindField, Field: register.Field})
+	}
+
+	return applied
+}
+
+// mergeBindings is the bindings of one transition, without two writes of one
+// register.
+//
+// A transition never legitimately carries two: the only way to reach one is a
+// run counted by a field of the very record being counted, which takes one off
+// the register and rebinds it from the record in the same step. That layout is
+// rejected by [compiler.prove], and dropping the second write here is what keeps
+// the graph well formed long enough to say so.
+func mergeBindings(lists ...[]Binding) []Binding {
+	var merged []Binding
+	written := make(map[int]bool)
+
+	for _, list := range lists {
+		for _, binding := range list {
+			if written[binding.Register.ID] {
+				continue
+			}
+			written[binding.Register.ID] = true
+			merged = append(merged, binding)
+		}
+	}
+
+	return merged
+}
+
+// accept records whether a state accepts end of input, and under what guards.
+//
+// A state carries one guard list and a guard list is a conjunction, so a state
+// that would accept under either of two conditions is a disjunction the IR has
+// nowhere to put. An unconditional way subsumes every other and is taken; two or
+// more conditional ways are reported rather than narrowed to one, since choosing
+// would either refuse a file the layout admits or admit one it does not.
+func (c *compiler) accept(state *State, ways [][]Guard, what string, at layout.Pos) {
+	if len(ways) == 0 {
+		return
+	}
+
+	for _, way := range ways {
+		if len(way) == 0 {
+			state.Accepts = true
+
+			return
+		}
+	}
+
+	if len(ways) > 1 {
+		c.faults.Fail(&SequenceAcceptanceError{
+			Pos:   layoutSpan(at),
+			What:  what,
+			Ways:  len(ways),
+			Guard: renderGuards(ways[0]),
+		})
+	}
+
+	state.Accepts = true
+	state.Acceptance = ways[0]
+}
+
+// exitsAt is the ways an expression is complete at one position, as acceptance
+// guards.
+func exitsAt(exits []exit, at int) [][]Guard {
+	var ways [][]Guard
+
+	for _, done := range exits {
+		if done.at == at {
+			ways = append(ways, done.guards)
+		}
+	}
+
+	return ways
+}
+
+// reachable is the states a walk from the start state reaches, in identifier
+// order.
+//
+// Identifier order rather than walk order because the identifiers already follow
+// the expression, and a state list ordered by anything else would move when an
+// unrelated part of the expression changed.
+func reachable(start *State, states []*State) []*State {
+	seen := map[int]bool{start.ID: true}
+	queue := []*State{start}
+
+	for len(queue) > 0 {
+		state := queue[0]
+		queue = queue[1:]
+
+		for _, transition := range state.Transitions {
+			if seen[transition.To.ID] {
+				continue
+			}
+			seen[transition.To.ID] = true
+			queue = append(queue, transition.To)
+		}
+	}
+
+	var found []*State
+	for _, state := range states {
+		if seen[state.ID] {
+			found = append(found, state)
+		}
+	}
+
+	return found
+}
+
+// prove holds the automaton to docs/ir/SPEC.md's "A register is read only where
+// it has been written": every path from the start state to a read of a register
+// passes through a binding of that register on a transition taken **strictly
+// earlier** than the reading one (#88).
+//
+// Strictly earlier is what the proof is over, and it is why the set a state is
+// checked against is the one bound on the way *in*. A transition's bindings
+// apply at step 7 of the read loop; its guards are evaluated at step 3 and the
+// extent of the record it admits is computed at step 4. So a transition that
+// binds a register it also reads reads the value the binding was about to
+// replace, or nothing at all where no earlier transition bound one, and a
+// producer that emitted it would be emitting the reading a layout's author did
+// not mean.
+// One fault per register and not one per read, because one operator is one
+// mistake: a `times` whose count is not in hand puts an unbound read on the
+// guard of every transition entering the run and on the acceptance of every
+// state leaving it, and reporting each of them would describe one misspelled
+// reference four times. The read reported is the most specific one found — the
+// transition that binds the register it reads, where there is one — so that the
+// message an adopter gets is the one naming the order rather than the path.
+func (c *compiler) prove(a *Automaton) {
+	bound := c.boundOnEntry(a)
+	found := make(map[int]*UnboundRegisterError)
+
+	for _, state := range a.States {
+		for _, guard := range state.Acceptance {
+			keepUnbound(found, unboundRead(bound[state.ID], guard.Register, state, nil))
+		}
+
+		for _, transition := range state.Transitions {
+			for _, guard := range transition.Guards {
+				keepUnbound(found, unboundRead(bound[state.ID], guard.Register, state, transition))
+			}
+
+			// Taking one off a counter reads it too, and reads it at the
+			// same moment a guard does: the value written is the value on
+			// entry to the state, less one.
+			for _, binding := range transition.Bindings {
+				if binding.Value == BindLessOne {
+					keepUnbound(found, unboundRead(bound[state.ID], binding.Register, state, transition))
+				}
+			}
+		}
+	}
+
+	for _, register := range a.Registers {
+		if fault, ok := found[register.ID]; ok {
+			c.faults.Fail(fault)
+		}
+	}
+}
+
+// keepUnbound records one register's fault, preferring the read that says most
+// about it.
+func keepUnbound(found map[int]*UnboundRegisterError, fault *UnboundRegisterError) {
+	if fault == nil {
+		return
+	}
+
+	kept, already := found[fault.register]
+	if already && (kept.OnAdmitting || !fault.OnAdmitting) {
+		return
+	}
+
+	found[fault.register] = fault
+}
+
+// boundOnEntry is, for each state, the registers bound on **every** path from
+// the start state to it, not counting the transition being entered on.
+//
+// It is the greatest fixed point of the intersection: every state but the start
+// begins holding every register and loses the ones some path reaches it without,
+// which is what makes a cycle carrying a binding not prove itself.
+func (c *compiler) boundOnEntry(a *Automaton) map[int]map[int]bool {
+	all := make(map[int]bool, len(a.Registers))
+	for _, register := range a.Registers {
+		all[register.ID] = true
+	}
+
+	bound := make(map[int]map[int]bool, len(a.States))
+	for _, state := range a.States {
+		if state == a.Start {
+			bound[state.ID] = map[int]bool{}
+
+			continue
+		}
+
+		bound[state.ID] = maps(all)
+	}
+
+	for settled := false; !settled; {
+		settled = true
+
+		for _, state := range a.States {
+			for _, transition := range state.Transitions {
+				if transition.To == a.Start {
+					continue
+				}
+
+				after := maps(bound[state.ID])
+				for _, binding := range transition.Bindings {
+					after[binding.Register.ID] = true
+				}
+
+				into := bound[transition.To.ID]
+				for id := range into {
+					if !after[id] {
+						delete(into, id)
+						settled = false
+					}
+				}
+			}
+		}
+	}
+
+	return bound
+}
+
+// maps copies a set, so that a state's own answer is never the one being
+// narrowed.
+func maps(of map[int]bool) map[int]bool {
+	out := make(map[int]bool, len(of))
+	for key, value := range of {
+		out[key] = value
+	}
+	return out
+}
+
+// unboundRead is the fault for a register read where the way in did not bind it,
+// and nil where the way in did.
+//
+// Which of two things it says follows from what the reading transition itself
+// does. Where that transition binds the register out of the record it admits,
+// the layout counted a run by a field of the record being counted — the shape
+// docs/ir/SPEC.md's "A count is in hand before the extent it decides" refuses by
+// name — and the message says so. Where it does not, the value simply belongs to
+// a record some path has not read.
+func unboundRead(bound map[int]bool, register *Register, state *State, on *Transition) *UnboundRegisterError {
+	if register == nil || bound[register.ID] {
+		return nil
+	}
+
+	admits := ""
+	if on != nil {
+		admits = on.Record
+	}
+
+	// The reading transition is the binding one exactly where it admits the
+	// record the register is read out of. That is asked of the record rather
+	// than of the bindings actually on the transition, because the two collide
+	// in this one case: a transition that takes one off a counter and rebinds
+	// it from the record it admits carries two writes of one register, which
+	// [mergeBindings] has already refused to emit.
+	return &UnboundRegisterError{
+		Pos:         layoutSpan(register.Source.Pos),
+		Item:        register.Source,
+		Register:    register.Source.Record,
+		Reader:      admits,
+		State:       state.ID,
+		OnAdmitting: on != nil && register.Field != nil && on.Record == register.Source.Record,
+		register:    register.ID,
+	}
+}
+
+// checkAmbiguity holds every state to docs/ir/SPEC.md's "When two match, and
+// when none does": two transitions leaving one state must not be eligible
+// together and selected by predicates that can both match one record.
+//
+// Guards narrow which pairs the rule is about. Two transitions whose guards
+// cannot hold at the same time are never both eligible, and their predicates may
+// overlap freely — which is what makes a counted run expressible at all, since
+// the transition reading another detail and the one moving past them are
+// selected by the very same test on the very same bytes and only the counter
+// separates them.
+func (c *compiler) checkAmbiguity(a *Automaton) {
+	for _, state := range a.States {
+		for i, first := range state.Transitions {
+			for _, second := range state.Transitions[i+1:] {
+				if !satisfiable(mergeGuards(first.Guards, second.Guards)) {
+					continue
+				}
+
+				if !c.predicatesOverlap(first.Predicate, second.Predicate) {
+					continue
+				}
+
+				c.faults.Fail(&SequenceAmbiguityError{
+					Pos:       layoutSpan(c.positions[second.To.ID-1].pos),
+					First:     layoutSpan(c.positions[first.To.ID-1].pos),
+					State:     state.ID,
+					Records:   [2]string{first.Record, second.Record},
+					Unguarded: first.Predicate == nil || second.Predicate == nil,
+					Guards:    len(first.Guards) > 0 || len(second.Guards) > 0,
+				})
+			}
+		}
+	}
+}
+
+// predicatesOverlap reports whether one record can satisfy both predicates.
+//
+// The test is whether one input can satisfy both, not whether the two read the
+// same bytes, and docs/ir/SPEC.md says where the difference lands: "a state
+// offering a transition keyed on a record's first field beside one keyed on its
+// tenth is where the narrower reading lets a real ambiguity through, and
+// predicates reading different fields at different positions overlap just as
+// thoroughly as two reading one". So the question is asked of *positions* and
+// not of items. Two predicates over one run of bytes are told apart by their
+// literals; two over different runs are not told apart at all, because a record
+// can carry an `S` at byte zero and an `X` at byte ten at the same time.
+//
+// It is a run of bytes rather than the copybook item because two records built
+// to different copybooks is the ordinary case, and it is exactly the case
+// docs/ir/SPEC.md's "A counted run, as nodes" is written in: a header, a detail
+// and a summary each carry their own type code at their own copybook's first
+// byte, and a rule keyed on the item would call three type codes at one offset
+// an ambiguity.
+//
+// A transition carrying no predicate matches every record, so it overlaps
+// everything (#80).
+//
+// Two literals are the same value where their spellings are, which is
+// [layoutmodel.Literal.Identity]'s reading and is decidable from the layout
+// alone. Resolving a literal to the bytes a consumer compares — through the
+// item's charset, PICTURE and width — is #37's, and the comparison becomes one
+// over bytes when it lands.
+func (c *compiler) predicatesOverlap(a, b *layoutmodel.Strategy) bool {
+	if a == nil || b == nil {
+		return true
+	}
+
+	over, ok := c.target(a)
+	against, againstOK := c.target(b)
+
+	switch {
+	case !ok || !againstOK:
+		// A discriminator whose reference does not resolve is #37's fault to
+		// report, and an ambiguity decided on one would name a pair of
+		// records where the fault is a misspelled item.
+		return false
+	case over != against:
+		return true
+	}
+
+	return slices.ContainsFunc(a.Literals, func(one layoutmodel.Literal) bool {
+		return slices.ContainsFunc(b.Literals, func(other layoutmodel.Literal) bool {
+			return one.Identity() == other.Identity()
+		})
+	})
+}
+
+// stretch is a run of a record's bytes: what a predicate tests.
+type stretch struct{ at, width int }
+
+// target is the run of bytes a predicate tests, and whether its reference
+// resolves to exactly one item.
+//
+// The offsets are the ones the record's static layout gives, which is the
+// declared maximum of every table in it. That a predicate's target sits at a
+// constant position — so that the run is the same run in every record of that
+// type — is #37's to hold a discriminator to.
+func (c *compiler) target(s *layoutmodel.Strategy) (stretch, bool) {
+	record, known := c.record(s.Item.Record)
+	if !known {
+		return stretch{}, false
+	}
+
+	built := c.layoutOf(record)
+	if built == nil {
+		return stretch{}, false
+	}
+
+	matched := itemsAt(built.Record, s.Item.Path)
+	if len(matched) != 1 {
+		return stretch{}, false
+	}
+
+	return stretch{at: matched[0].Offset, width: matched[0].Length}, true
+}
+
+// satisfiable reports whether some register file satisfies every guard in the
+// list at once.
+//
+// It is the whole of what keeps overlap decidable, and it stays a question about
+// literals and zero because of what a guard is not: a flat conjunction of three
+// tests over a fixed set of declared registers, with no arithmetic in it beyond
+// taking one off a counter and no comparison of one register against another
+// (docs/ir/SPEC.md, "The automaton counts; it does not compute").
+//
+// One list at a time is enough for both callers. A transition's own guards
+// contradicting each other is an edge nothing can take, and two transitions'
+// guards contradicting each other is the pair the overlap rule is not about, and
+// they are the same question asked of the concatenation.
+func satisfiable(guards []Guard) bool {
+	byRegister := make(map[int][]Guard)
+	for _, guard := range guards {
+		byRegister[guard.Register.ID] = append(byRegister[guard.Register.ID], guard)
+	}
+
+	for _, over := range byRegister {
+		if !holdsTogether(over) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// holdsTogether reports whether every guard over one register can hold at once.
+//
+// The values a register may hold are narrowed test by test: `equals` and
+// `one-of` narrow to a set of literals, and `positive` drops the ones that are
+// not numbers above zero. A literal this cannot read as a number survives
+// `positive`, because a guard over a bytes register never carries one and a
+// count literal that will not parse is a fault for whoever wrote it rather than
+// a reason to call a state ambiguous.
+func holdsTogether(guards []Guard) bool {
+	var narrowed []layoutmodel.Literal
+	bounded := false
+
+	for _, guard := range guards {
+		if guard.Test == GuardPositive {
+			continue
+		}
+
+		if !bounded {
+			narrowed, bounded = guard.Literals, true
+
+			continue
+		}
+
+		narrowed = slices.DeleteFunc(slices.Clone(narrowed), func(one layoutmodel.Literal) bool {
+			return !slices.ContainsFunc(guard.Literals, func(other layoutmodel.Literal) bool {
+				return one.Identity() == other.Identity()
+			})
+		})
+	}
+
+	if !slices.ContainsFunc(guards, func(g Guard) bool { return g.Test == GuardPositive }) {
+		return !bounded || len(narrowed) > 0
+	}
+
+	if !bounded {
+		return true
+	}
+
+	return slices.ContainsFunc(narrowed, above(0))
+}
+
+// above is a literal that reads as a number greater than n.
+func above(n int) func(layoutmodel.Literal) bool {
+	return func(literal layoutmodel.Literal) bool {
+		if literal.Kind != layoutmodel.NumberLiteral {
+			return true
+		}
+
+		value, err := strconv.Atoi(literal.Number)
+
+		return err != nil || value > n
+	}
+}


### PR DESCRIPTION
Closes #36

Sequencing reaches a generator compiled. `CompileSequence` turns a layout's
sequencing expression into the state, transition and register nodes
`docs/ir/SPEC.md`'s *The sequencing automaton* describes, and carries none of the
expression they were compiled from — so no plugin author implements a regex-like
algebra, which is the whole reason the IR carries the graph.

## How it is built

A **position automaton**: one state per appearance of a record name, plus a start
state that stands for no appearance. Two of the spec's requirements then fall out
of the construction rather than being enforced over it — every transition
consumes exactly one record (*No epsilon transitions*), and no transition
re-enters the start state, which is what makes `layout/SPEC.md`'s *the first
record of a file* expressible with no operator for it.

`first`, `last` and `nullable` each carry a guard list, and that is the whole of
what the value-reading operators add. `times` allocates an integer register, puts
`> 0` and the take-one-off binding on the transition entering a pass, and leaves
the run where the counter reaches zero — one register and one guard whether the
count is `PIC 9(2)` or `PIC 9(9)`. `when` allocates a bytes register and puts its
test on the transitions entering the subexpression. A record's own discriminator
becomes the transition's predicate and never a register, which keeps the SHOULD
in *When a value becomes a state, and when it becomes a register*.

## Acceptance criteria

- [x] Grammar compiled to explicit states and transitions in the IR
- [x] Ambiguous grammars detected and rejected, including pairs of transitions leaving one state whose guards can hold at the same time and whose predicates overlap — `SequenceAmbiguityError`
- [x] Accepting states identified, with acceptance guards where a count qualifies accepting
- [x] Transition labels reference discriminator predicates, not bare record names; a transition nothing about the record selects carries **no** predicate (#80)
- [x] A transition carrying no predicate rejected beside any sibling whose guards can hold at the same time (#80)
- [x] A layout naming the *first* record compiled to a start state no transition re-enters (#80)
- [x] A value governing another record compiled to a register, a binding on the transition admitting the record holding it, and guards on the transitions it gates
- [x] A value tested only on the transition admitting the record that holds it compiled to a branch — `TestAFlagGoverningTheRecordHoldingItBecomesABranch` asserts zero registers
- [x] Every read of a register proved to be preceded on every path by a binding on a transition taken **strictly earlier** — `UnboundRegisterError` (#88)
- [x] A repetition naming a register only the admitting transition binds rejected, naming the record and the register — `UnboundRegisterError.OnAdmitting`, not a generic reference error (#88)
- [x] A register bound earlier and rebound or decremented by the admitting transition compiled without complaint, each read taking the value on entry to the state
- [x] Counted runs compiled without epsilon transitions and without unrolling — `TestACountedRunIsOneRegisterAndOneGuard` compiles a `PIC 9(4)` count into three states
- [x] A transition taking one off a counter guarded so the counter cannot run below zero
- [x] A binding never names a field that repeats or one in a group that repeats — `SequenceOccurrenceError` names the record, the field and the enclosing group
- [x] A dependence on a value in a record not yet read rejected naming the record and the field, never as a generic ambiguity error (see the judgment call below for the other two members of that list)
- [x] Tests assert the automaton for representative shapes, including `ir/SPEC.md`'s *A counted run, as nodes* and the failures it detects

## Judgment calls

**`when` has no negation, and one of the appendix's four detections is lost.**
The guard set is three positive tests and *Three tests, and no fourth* closes it,
so `(when flag "Y" SUMMARY)` compiles into a guard on the transition admitting
the summary and into nothing on the path that skips it — the complement of `Y` is
not a set a compiler can know. Three of the appendix's four detections survive
(truncated run, a sixth detail, a summary where the flag says `N`); the fourth, a
*missing* summary where the flag says `Y`, does not, because it needs `flag one-of
N or space` on the accepting state. `TestTheFailuresACountedRunDetects` asserts
all four explicitly, including that one as the documented cost, and asserts the
layout an adopter writes to buy it back: count the summary rather than flagging
it, because zero is a test the set has.

**Overlap is decided over runs of bytes, not over items.** *When two match* says
predicates at different positions overlap "just as thoroughly" as two reading one
field — so the question is asked of the target's offset and width in its own
record. Keyed on the copybook item instead, the appendix's own file would be
rejected: a header, a detail and a summary each carry a type code at their own
copybook's first byte, and those are three different items over one run.

**Two of *The automaton counts; it does not compute*'s three shapes cannot be
written.** The algebra has no arithmetic and no comparison of two registers, so
there is nothing to reject and no unreachable diagnostic invented for it; the
member a layout *can* ask for — a value in a record not yet read — is
`UnboundRegisterError`, which names the record and the item as that section
requires. `CompileSequence`'s doc comment says this in as many words.

**`layoutmodel.Literal.identity` is exported as `Identity`.** Guard
satisfiability and predicate overlap decide the same question the arm-overlap
check already decides, and a second reading of what makes two literals equal is a
second answer for them to disagree about.

**A `times` register is per operator; a `when` register is per item.** A pass of a
run takes one off its counter, so two counted runs naming one item are two
counts; a `when` register is only ever written by the transitions admitting the
record it is read from, so two `when`s over one item are two guards over one
value.

## Verified

`dagger call ci` — green.

One note on the tooling rather than the code: the local Dagger engine returned
`missing shared result` for the `lint` and `ir-ci` stages from a stale cached
File handle. Restarting the engine container cleared it and `dagger call ci`
then ran the whole pipeline and passed; nothing in the tree was changed for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)