### PR TITLE
story(resolve): compile discriminators into IR predicates

### DIFF
--- a/docs/layout/SPEC.md
+++ b/docs/layout/SPEC.md
@@ -1621,7 +1621,7 @@ computed once by `resolve`.
 | [The encoding profile](#the-encoding-profile) | #25 `layout` |
 | [Physical framing](#physical-framing) | #26 `layout` |
 | [Record definitions](#record-definitions) | #27, #30 `layout`; `copybook-reading` by #35 `resolve` |
-| [Discrimination](#discrimination) | #28 `layout` |
+| [Discrimination](#discrimination) | #28 `layout`; the strategies lowered into IR predicates, the literals resolved to bytes, and the rules on a target that need a copybook, by #37 `resolve` |
 | [Sequencing](#sequencing) | #29 `layout`; the expression compiled to an automaton, and the rules on `times` and `when` that need a copybook, by #36 `resolve` |
 | [The published schema](#the-published-schema) | #23 `layout` |
 | [Validation and diagnostics](#validation-and-diagnostics) | #24, #31 `layout` |

--- a/internal/resolve/armpredicate_test.go
+++ b/internal/resolve/armpredicate_test.go
@@ -1,0 +1,307 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package resolve
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cobol-go/copybook"
+
+	"github.com/Zaba505/cpybkc/internal/layoutmodel"
+)
+
+// An arm of a variant is selected by a predicate of the same kind and the same
+// closed set as a transition's, and these hold that scope to docs/ir/SPEC.md's
+// "A predicate on an arm reads one occurrence": a target inside the occurrence
+// being walked, no constant-position rule, no rule against sitting in a
+// repeating group, and the overlap test a state's transitions get.
+//
+// The rules that reverse are the interesting ones, and each has a test here
+// beside the transition-scope test that asserts its opposite in predicate_test.go.
+
+// nested is a table whose entry carries a redefine inside a redefine: the outer
+// alternation chooses how the entry is shaped and the inner one chooses inside
+// the arm that contains it, which is the one arm an arm's target may sit in
+// besides the occurrence at large.
+const nested = `01 N-REC.
+   05 N-HDR PIC X(3).
+   05 N-ENTRY OCCURS 3 TIMES.
+      10 N-KIND PIC X(1).
+      10 N-OUTER.
+         15 N-INNER-KIND PIC X(1).
+         15 N-INNER PIC X(6).
+         15 N-INNER-ALT REDEFINES N-INNER PIC X(6).
+      10 N-OUTER-ALT REDEFINES N-OUTER PIC X(7).
+      10 N-TAG PIC X(2).
+`
+
+// armsOf is the arms of the one variant in a resolved record.
+func armsOf(t *testing.T, record *Record) []Arm {
+	t.Helper()
+
+	variant := variantIn(record.Root)
+	if variant == nil {
+		t.Fatal("the record holds no variant")
+	}
+
+	return variant.Arms
+}
+
+// TestAnArmIsSelectedByATypeCodeInsideTheEntry is the ordinary shape: a code at
+// the front of an occurrence saying which alternative the rest of it is.
+//
+// The target sits inside the group that repeats, which is the reverse of the
+// rule binding a transition's predicate — and the reason is that rule's own. A
+// reference with no occurrence to be read in is what it refuses, and an arm's
+// predicate is evaluated in the occurrence being walked.
+func TestAnArmIsSelectedByATypeCodeInsideTheEntry(t *testing.T) {
+	t.Parallel()
+
+	records, err := resolveTable(t, tableSource, func(field *copybook.Field) []Redefine {
+		return []Redefine{{
+			Item: fieldNamed(t, field, "BODY"),
+			Alternatives: []Alternative{
+				{Name: "BODY", Predicate: selects("B")},
+				{Name: "SPLIT", Predicate: selects("S")},
+			},
+		}}
+	})
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+
+	arms := armsOf(t, records[0])
+	for _, arm := range arms {
+		if arm.Predicate == nil {
+			t.Fatalf("the arm %s is selected by nothing", arm.Alternative)
+		}
+		if arm.Predicate.Test != BytesEqual {
+			t.Errorf("the arm %s is selected by %s, want the bytes-equal member",
+				arm.Alternative, arm.Predicate.Test)
+		}
+		if arm.Predicate.Target.Name != "CODE" {
+			t.Errorf("the arm %s names %s, want CODE", arm.Alternative, itemName(arm.Predicate.Target))
+		}
+	}
+
+	// cp037's B and S, each one byte because CODE is PIC X.
+	if got := string(arms[0].Predicate.Values[0].Bytes); got != "\xC2" {
+		t.Errorf("the first arm compares % X, want cp037's B", got)
+	}
+	if got := string(arms[1].Predicate.Values[0].Bytes); got != "\xE2" {
+		t.Errorf("the second arm compares % X, want cp037's S", got)
+	}
+}
+
+// TestAnArmTargetMaySitBehindTheVariant, because an arm runs against a record
+// already admitted and every byte of the occurrence is locatable before an arm
+// is chosen — the arms are of one extent, so nothing about where the variant
+// ends depends on which arm was taken.
+func TestAnArmTargetMaySitBehindTheVariant(t *testing.T) {
+	t.Parallel()
+
+	records, err := resolveTable(t, tableSource, func(field *copybook.Field) []Redefine {
+		return []Redefine{{
+			Item: fieldNamed(t, field, "BODY"),
+			Alternatives: []Alternative{
+				{Name: "BODY", Predicate: selects("B", "ENTRY", "TAG")},
+				{Name: "SPLIT", Predicate: selects("S", "ENTRY", "TAG")},
+			},
+		}}
+	})
+	if err != nil {
+		t.Fatalf("resolving an arm selected by a field behind the variant: %v", err)
+	}
+
+	if got := armsOf(t, records[0])[0].Predicate.Target.Name; got != "TAG" {
+		t.Errorf("the arm names %s, want TAG", got)
+	}
+}
+
+// TestANestedVariantsSelectorSitsInTheArmContainingIt is the one arm an arm's
+// target may sit inside: the rule rules out the variant's own arms and any
+// sibling variant's, and admits an arm enclosing it, where a copybook redefines
+// a redefinition.
+func TestANestedVariantsSelectorSitsInTheArmContainingIt(t *testing.T) {
+	t.Parallel()
+
+	records, err := resolveTable(t, nested, func(field *copybook.Field) []Redefine {
+		return []Redefine{
+			{
+				Item: fieldNamed(t, field, "N-OUTER"),
+				Alternatives: []Alternative{
+					{Name: "N-OUTER", Predicate: selects("O", "N-ENTRY", "N-KIND")},
+					{Name: "N-OUTER-ALT", Predicate: selects("A", "N-ENTRY", "N-KIND")},
+				},
+			},
+			{
+				Item: fieldNamed(t, field, "N-INNER"),
+				Alternatives: []Alternative{
+					// The selector sits inside N-OUTER, which is the arm
+					// containing this variant.
+					{Name: "N-INNER", Predicate: selects("I", "N-ENTRY", "N-OUTER", "N-INNER-KIND")},
+					{Name: "N-INNER-ALT", Predicate: selects("J", "N-ENTRY", "N-OUTER", "N-INNER-KIND")},
+				},
+			},
+		}
+	})
+	if err != nil {
+		t.Fatalf("resolving a nested variant: %v", err)
+	}
+
+	variants := 0
+	records[0].Walk(func(node *Node) {
+		if node.Kind != KindVariant {
+			return
+		}
+
+		variants++
+		for _, arm := range node.Arms {
+			if arm.Predicate == nil {
+				t.Errorf("the arm %s is selected by nothing", arm.Alternative)
+			}
+		}
+	})
+
+	if variants != 2 {
+		t.Errorf("the record holds %d variants, want the outer one and the one inside its arm", variants)
+	}
+}
+
+// TestAnArmTargetInsideASiblingArmIsRejected: those bytes exist only where that
+// alternative was selected, so reading them where it was not is reading one
+// alternative's data as another's — the failure this document's whole treatment
+// of REDEFINES is arranged around.
+func TestAnArmTargetInsideASiblingArmIsRejected(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveTable(t, tableSource, func(field *copybook.Field) []Redefine {
+		return []Redefine{{
+			Item: fieldNamed(t, field, "BODY"),
+			Alternatives: []Alternative{
+				{Name: "BODY", Predicate: selects("B", "ENTRY", "SPLIT", "LEFT")},
+				{Name: "SPLIT", Predicate: selects("S", "ENTRY", "CODE")},
+			},
+		}}
+	})
+
+	var scope *ArmTargetScopeError
+	if !errors.As(err, &scope) {
+		t.Fatalf("resolving reported %v, want an ArmTargetScopeError", err)
+	}
+	for _, want := range []string{"R", "ENTRY", "BODY", "SPLIT"} {
+		if !strings.Contains(scope.Error(), want) {
+			t.Errorf("the diagnostic does not name %s: %s", want, scope.Error())
+		}
+	}
+}
+
+// TestAnArmTargetOutsideTheRepeatingGroupIsRejected: it has the same bytes in
+// every occurrence, so it selects the same arm in all of them — which is a
+// choice made once per record, and a record node's rather than a variant's.
+func TestAnArmTargetOutsideTheRepeatingGroupIsRejected(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveTable(t, tableSource, func(field *copybook.Field) []Redefine {
+		return []Redefine{{
+			Item: fieldNamed(t, field, "BODY"),
+			Alternatives: []Alternative{
+				{Name: "BODY", Predicate: selects("B", "HDR")},
+				{Name: "SPLIT", Predicate: selects("S", "HDR")},
+			},
+		}}
+	})
+
+	var scope *ArmTargetScopeError
+	if !errors.As(err, &scope) {
+		t.Fatalf("resolving reported %v, want an ArmTargetScopeError", err)
+	}
+	if !strings.Contains(scope.Error(), "the same bytes in every entry") {
+		t.Errorf("the diagnostic does not say why: %s", scope.Error())
+	}
+}
+
+// TestTwoArmsWhosePredicatesOverlapAreRejected is "When two match, and when none
+// does" at this scope. There are no guards on an arm to exempt a pair, so every
+// pair is inside the rule — and the test is over the resolved bytes, so two
+// spellings of one value are one value here as they are for two transitions.
+func TestTwoArmsWhosePredicatesOverlapAreRejected(t *testing.T) {
+	t.Parallel()
+
+	spelledAsBytes := layoutmodel.Strategy{
+		Kind:     layoutmodel.Equals,
+		Item:     layoutmodel.ItemRef{Record: "R", Path: []string{"ENTRY", "CODE"}},
+		Literals: []layoutmodel.Literal{{Kind: layoutmodel.BytesLiteral, Bytes: layoutmodel.ByteString{Bytes: []byte{0xC2}}}},
+	}
+
+	_, err := resolveTable(t, tableSource, func(field *copybook.Field) []Redefine {
+		return []Redefine{{
+			Item: fieldNamed(t, field, "BODY"),
+			Alternatives: []Alternative{
+				{Name: "BODY", Predicate: selects("B")},
+				{Name: "SPLIT", Predicate: spelledAsBytes},
+			},
+		}}
+	})
+
+	var overlapping *ArmOverlapError
+	if !errors.As(err, &overlapping) {
+		t.Fatalf("resolving reported %v, want an ArmOverlapError", err)
+	}
+	for _, want := range []string{"R", "ENTRY", "BODY", "SPLIT"} {
+		if !strings.Contains(overlapping.Error(), want) {
+			t.Errorf("the diagnostic does not name %s: %s", want, overlapping.Error())
+		}
+	}
+}
+
+// TestAnOccurrenceMatchingNoArmIsReportedDistinctly, because the two failures
+// send an adopter to different places: a record no transition matched is a
+// record type the layout is missing, and an occurrence no arm matched is a
+// record the layout does describe carrying an entry it does not.
+func TestAnOccurrenceMatchingNoArmIsReportedDistinctly(t *testing.T) {
+	t.Parallel()
+
+	records, err := resolveTable(t, tableSource, func(field *copybook.Field) []Redefine {
+		return []Redefine{{
+			Item: fieldNamed(t, field, "BODY"),
+			Alternatives: []Alternative{
+				{Name: "BODY", Predicate: selects("B")},
+				{Name: "SPLIT", Predicate: selects("S")},
+			},
+		}}
+	})
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+
+	variant := variantIn(records[0].Root)
+	if _, err := variant.SelectArm(func(*Predicate) []byte { return []byte("\xE9") }); err == nil {
+		t.Fatal("an occurrence matching no arm selected one, want it reported")
+	} else {
+		var unmatched *UnmatchedOccurrenceError
+		if !errors.As(err, &unmatched) {
+			t.Fatalf("selecting reported %v, want an UnmatchedOccurrenceError", err)
+		}
+
+		var undescribed *UndescribedRecordError
+		if errors.As(err, &undescribed) {
+			t.Error("an unmatched occurrence reads as an undescribed record, and the two are different faults")
+		}
+	}
+
+	// The arms are evaluated in the order the variant carries, and a consumer
+	// may stop at the first that matches.
+	arm, err := variant.SelectArm(func(*Predicate) []byte { return []byte("\xE2") })
+	if err != nil {
+		t.Fatalf("selecting the arm a matching occurrence names: %v", err)
+	}
+	if arm.Alternative != "SPLIT" {
+		t.Errorf("the occurrence selected %s, want SPLIT", arm.Alternative)
+	}
+}

--- a/internal/resolve/automaton.go
+++ b/internal/resolve/automaton.go
@@ -319,7 +319,7 @@ func (g Guard) Holds(held Value) bool {
 		return held.Bytes == nil && held.Number > 0
 	case GuardEquals, GuardOneOf:
 		for _, value := range g.Values {
-			if value.Identity() == held.Identity() {
+			if sameValue(value, held) {
 				return true
 			}
 		}

--- a/internal/resolve/automaton.go
+++ b/internal/resolve/automaton.go
@@ -284,26 +284,48 @@ type Guard struct {
 	// Test is the test.
 	Test GuardTest
 
-	// Literals are what the register is compared against, in the order the
+	// Values are what the register is compared against, in the order the
 	// layout writes them: exactly one under [GuardEquals], at least one under
 	// [GuardOneOf], and none under [GuardPositive].
 	//
-	// They are the layout's literals rather than the bytes a consumer
-	// compares, for the reason [Arm.Predicate] carries a strategy: resolving
-	// a literal to bytes through an item's charset, PICTURE and width is
-	// #37's, and doing it in two places is two answers.
-	Literals []layoutmodel.Literal
+	// They are resolved rather than the layout's own spellings. A guard over a
+	// bytes register compares bytes, so its values are the source field's
+	// width and already padded to it — no consumer decides whether `Y` matches
+	// `Y `, which is the same comparison [Predicate] refuses to leave open. A
+	// guard over an integer register compares a number, and carries one.
+	Values []Value
 }
 
 // key is what makes two guards the same guard, so that composing an expression
 // out of its parts cannot put one test on a transition twice.
 func (g Guard) key() string {
-	parts := make([]string, 0, len(g.Literals)+2)
+	parts := make([]string, 0, len(g.Values)+2)
 	parts = append(parts, strconv.Itoa(g.Register.ID), g.Test.String())
-	for _, literal := range g.Literals {
-		parts = append(parts, literal.Identity())
+	for _, value := range g.Values {
+		parts = append(parts, value.Identity())
 	}
 	return strings.Join(parts, " ")
+}
+
+// Holds reports whether the guard holds of the value the register carries.
+//
+// The register file is the consumer's, so what is handed over is the one value
+// the guard reads rather than the whole of it: a guard is a test of one
+// register, and a consumer evaluating one already has it (docs/ir/SPEC.md, "The
+// automaton remembers, in registers").
+func (g Guard) Holds(held Value) bool {
+	switch g.Test {
+	case GuardPositive:
+		return held.Bytes == nil && held.Number > 0
+	case GuardEquals, GuardOneOf:
+		for _, value := range g.Values {
+			if value.Identity() == held.Identity() {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // Transition is one edge of the automaton: it consumes exactly one record, and
@@ -327,9 +349,13 @@ type Transition struct {
 	// predicate and not a member of the set testing nothing
 	// (docs/ir/SPEC.md, "A transition may carry no predicate", #80).
 	//
-	// It is the layout's strategy rather than a compiled predicate node, for
-	// [Arm.Predicate]'s reason: lowering one is #37's.
-	Predicate *layoutmodel.Strategy
+	// It is carried on every transition admitting a record whose discriminator
+	// names a field, even at a state where the guards alone would select it.
+	// That is docs/ir/SPEC.md's **SHOULD** kept rather than optimised away: a
+	// predicate the automaton does not need in order to choose is the only
+	// detection such a state has, and a group two records short would
+	// otherwise be absorbed by reading the next group's header as a detail.
+	Predicate *Predicate
 
 	// Guards are the tests that make this transition eligible, all of which
 	// must hold. A transition carrying none is always eligible.
@@ -429,6 +455,29 @@ type Sequencing struct {
 	// inside a group that repeats.
 	Dialect copybook.Dialect
 
+	// Reading is which of the two vendor readings of `OCCURS DEPENDING ON` the
+	// layout says its file was written under, for [Options.Reading]'s reason.
+	//
+	// It is read for one rule and nothing else: a discriminator's target must
+	// sit at a constant position within its record, and whether an item ahead
+	// of it has an extent that moves is a question only the reading answers.
+	// Under `noodoslide` the same clause is a fixed table and nothing moves,
+	// so a layout stating no reading is one this half never has to ask.
+	Reading layoutmodel.Reading
+
+	// Encoding is the layout's encoding profile, and EncodingOverrides the
+	// per-item overrides over it: the four axes a literal is resolved to bytes
+	// through.
+	//
+	// They reach the automaton for the reason they reach [Resolve]: a
+	// discriminator's literal and a `when`'s are compared against a field's
+	// bytes, and what those bytes are is the item's charset and width. A
+	// layout stating fewer than four axes is refused while it is being read
+	// and again as a record is resolved, so what arrives here is complete or
+	// the caller never got this far.
+	Encoding          layoutmodel.Axes
+	EncodingOverrides []EncodingOverride
+
 	// Records are the record types the expression may name, in the order the
 	// layout defines them.
 	Records []SequencedRecord
@@ -486,10 +535,11 @@ func CompileSequence(opts Sequencing) (*Automaton, error) {
 	}
 
 	c := &compiler{
-		opts:    opts,
-		follow:  make(map[int][]entry),
-		byItem:  make(map[string]*Register),
-		layouts: make(map[string]*copybook.Layout),
+		opts:       opts,
+		follow:     make(map[int][]entry),
+		byItem:     make(map[string]*Register),
+		predicates: make(map[string]*Predicate),
+		layouts:    make(map[string]*copybook.Layout),
 	}
 
 	top := c.expression(opts.Sequence.Expression)
@@ -500,6 +550,7 @@ func CompileSequence(opts Sequencing) (*Automaton, error) {
 	automaton := c.assemble(top)
 
 	c.prove(automaton)
+	c.checkDiscrimination(automaton)
 	c.checkAmbiguity(automaton)
 	if c.faults.Failed() {
 		return nil, c.faults.Err()
@@ -518,9 +569,9 @@ type appearance struct {
 	// this appearance points at.
 	pos layout.Pos
 
-	// predicate is the discriminator of that record, or nil where its
-	// strategy is `single-record-type` and lowers into no predicate.
-	predicate *layoutmodel.Strategy
+	// predicate is the discriminator of that record, compiled, or nil where
+	// its strategy lowers into no predicate at all.
+	predicate *Predicate
 }
 
 // entry is one way into a position: the guards a transition into it carries and
@@ -578,6 +629,13 @@ type compiler struct {
 	// the transitions admitting the record it is read from, so two `when`s
 	// over one item are two guards over one value.
 	byItem map[string]*Register
+
+	// predicates are the compiled discriminator of each record, keyed by the
+	// record's name and holding nil for a record whose strategy lowers into
+	// none. A record named twice in the expression is compiled once, so a
+	// discriminator that cannot be resolved is one fault and not one per
+	// appearance.
+	predicates map[string]*Predicate
 
 	// layouts are the copybook layouts, one per record, built on demand: a
 	// layout is what answers whether an item repeats or sits in a group that
@@ -638,10 +696,14 @@ func (c *compiler) name(e layoutmodel.Expression) facts {
 		return facts{first: []entry{{at: at}}, last: []exit{{at: at}}}
 	}
 
-	var predicate *layoutmodel.Strategy
-	if record.Discriminator.Predicate() {
-		selects := record.Discriminator
-		predicate = &selects
+	// One appearance of a record name is one position, and every appearance of
+	// one record carries the same predicate: the discriminator is a property
+	// of the record and not of where it stands in the expression. It is
+	// compiled once per record for that reason, and the compiled node shared.
+	predicate, already := c.predicates[e.Record]
+	if !already {
+		predicate = c.discriminator(record)
+		c.predicates[e.Record] = predicate
 	}
 
 	c.positions = append(c.positions, appearance{record: e.Record, pos: e.Pos, predicate: predicate})
@@ -748,7 +810,11 @@ func (c *compiler) times(e layoutmodel.Expression) facts {
 	done := Guard{
 		Register: register,
 		Test:     GuardEquals,
-		Literals: []layoutmodel.Literal{{Pos: e.Item.Pos, Kind: layoutmodel.NumberLiteral, Number: "0"}},
+		Values: []Value{number(layoutmodel.Literal{
+			Pos:    e.Item.Pos,
+			Kind:   layoutmodel.NumberLiteral,
+			Number: "0",
+		})},
 	}
 	less := []Binding{{Register: register, Value: BindLessOne}}
 
@@ -781,7 +847,7 @@ func (c *compiler) when(e layoutmodel.Expression) facts {
 	body := c.sequence(c.subexpressions(e))
 	register := c.register(e, RegisterBytes)
 
-	holds := Guard{Register: register, Test: GuardEquals, Literals: e.Match.Literals}
+	holds := Guard{Register: register, Test: GuardEquals, Values: c.guardValues(e, register)}
 	if e.Match.Kind == layoutmodel.OneOf {
 		holds.Test = GuardOneOf
 	}

--- a/internal/resolve/automaton_errors.go
+++ b/internal/resolve/automaton_errors.go
@@ -406,18 +406,18 @@ func renderGuard(guard Guard) string {
 	case GuardPositive:
 		return guard.Register.String() + " above zero"
 	case GuardOneOf:
-		literals := make([]string, 0, len(guard.Literals))
-		for _, literal := range guard.Literals {
-			literals = append(literals, literal.String())
+		values := make([]string, 0, len(guard.Values))
+		for _, value := range guard.Values {
+			values = append(values, value.String())
 		}
 
-		return guard.Register.String() + " one of " + strings.Join(literals, ", ")
+		return guard.Register.String() + " one of " + strings.Join(values, ", ")
 	case GuardEquals:
-		if len(guard.Literals) == 0 {
+		if len(guard.Values) == 0 {
 			return guard.Register.String() + " equal to nothing"
 		}
 
-		return guard.Register.String() + " equal to " + guard.Literals[0].String()
+		return guard.Register.String() + " equal to " + guard.Values[0].String()
 	}
 
 	return guard.Register.String() + " tested by nothing"

--- a/internal/resolve/automaton_test.go
+++ b/internal/resolve/automaton_test.go
@@ -94,7 +94,12 @@ func compileLayout(t *testing.T, source string, copybooks map[string]string) (*A
 		t.Fatalf("reading the discrimination layer: %v", err)
 	}
 
-	opts := Sequencing{Sequence: sequence, Dialect: copybook.IBMEnterprise()}
+	opts := Sequencing{
+		Sequence: sequence,
+		Dialect:  copybook.IBMEnterprise(),
+		Reading:  layoutmodel.ODOSlide,
+		Encoding: mainframe(),
+	}
 	for _, discriminator := range discrimination.Records {
 		src, bound := copybooks[discriminator.Record]
 		if !bound {
@@ -177,11 +182,7 @@ func renderTransition(t *Transition) string {
 		parts = append(parts, "when "+renderGuards(t.Guards))
 	}
 
-	if t.Predicate == nil {
-		parts = append(parts, "on no predicate")
-	} else {
-		parts = append(parts, "on "+renderStrategy(*t.Predicate))
-	}
+	parts = append(parts, "on "+t.Predicate.String())
 
 	parts = append(parts, "admit "+t.Record)
 
@@ -196,16 +197,6 @@ func renderTransition(t *Transition) string {
 	}
 
 	return strings.Join(parts, ", ") + fmt.Sprintf(", go to %d", t.To.ID)
-}
-
-// renderStrategy draws a discriminator the way a layout writes one.
-func renderStrategy(s layoutmodel.Strategy) string {
-	literals := make([]string, 0, len(s.Literals))
-	for _, literal := range s.Literals {
-		literals = append(literals, literal.String())
-	}
-
-	return "(" + string(s.Kind) + " " + s.Item.String() + " " + strings.Join(literals, " ") + ")"
 }
 
 // assertRendering fails with the whole graph where it is not the one wanted.
@@ -242,17 +233,17 @@ func TestTheCountedRunOfTheAppendix(t *testing.T) {
 register 1 integer from (item HEADER DTL-COUNT)
 register 2 bytes from (item HEADER SUM-FLAG)
 state 0
-  on (equals (item HEADER HDR-TYPE) "H"), admit HEADER, bind (item HEADER DTL-COUNT), bind (item HEADER SUM-FLAG), go to 1
+  on bytes-equal HDR-TYPE "H", admit HEADER, bind (item HEADER DTL-COUNT), bind (item HEADER SUM-FLAG), go to 1
 state 1 accepts when (item HEADER DTL-COUNT) equal to 0
-  when (item HEADER DTL-COUNT) above zero, on (equals (item DETAIL DTL-TYPE) "D"), admit DETAIL, take one off (item HEADER DTL-COUNT), go to 2
-  when (item HEADER DTL-COUNT) equal to 0 and (item HEADER SUM-FLAG) equal to "Y", on (equals (item SUMMARY SUM-TYPE) "S"), admit SUMMARY, go to 3
-  when (item HEADER DTL-COUNT) equal to 0, on (equals (item HEADER HDR-TYPE) "H"), admit HEADER, bind (item HEADER DTL-COUNT), bind (item HEADER SUM-FLAG), go to 1
+  when (item HEADER DTL-COUNT) above zero, on bytes-equal DTL-TYPE "D", admit DETAIL, take one off (item HEADER DTL-COUNT), go to 2
+  when (item HEADER DTL-COUNT) equal to 0 and (item HEADER SUM-FLAG) equal to "Y", on bytes-equal SUM-TYPE "S", admit SUMMARY, go to 3
+  when (item HEADER DTL-COUNT) equal to 0, on bytes-equal HDR-TYPE "H", admit HEADER, bind (item HEADER DTL-COUNT), bind (item HEADER SUM-FLAG), go to 1
 state 2 accepts when (item HEADER DTL-COUNT) equal to 0
-  when (item HEADER DTL-COUNT) above zero, on (equals (item DETAIL DTL-TYPE) "D"), admit DETAIL, take one off (item HEADER DTL-COUNT), go to 2
-  when (item HEADER DTL-COUNT) equal to 0 and (item HEADER SUM-FLAG) equal to "Y", on (equals (item SUMMARY SUM-TYPE) "S"), admit SUMMARY, go to 3
-  when (item HEADER DTL-COUNT) equal to 0, on (equals (item HEADER HDR-TYPE) "H"), admit HEADER, bind (item HEADER DTL-COUNT), bind (item HEADER SUM-FLAG), go to 1
+  when (item HEADER DTL-COUNT) above zero, on bytes-equal DTL-TYPE "D", admit DETAIL, take one off (item HEADER DTL-COUNT), go to 2
+  when (item HEADER DTL-COUNT) equal to 0 and (item HEADER SUM-FLAG) equal to "Y", on bytes-equal SUM-TYPE "S", admit SUMMARY, go to 3
+  when (item HEADER DTL-COUNT) equal to 0, on bytes-equal HDR-TYPE "H", admit HEADER, bind (item HEADER DTL-COUNT), bind (item HEADER SUM-FLAG), go to 1
 state 3 accepts
-  on (equals (item HEADER HDR-TYPE) "H"), admit HEADER, bind (item HEADER DTL-COUNT), bind (item HEADER SUM-FLAG), go to 1
+  on bytes-equal HDR-TYPE "H", admit HEADER, bind (item HEADER DTL-COUNT), bind (item HEADER SUM-FLAG), go to 1
 `)
 }
 
@@ -362,7 +353,7 @@ func TestTheFailuresACountedRunDetects(t *testing.T) {
 			t.Fatalf("the summary transition is guarded by %s, want the flag among them", renderGuards(summary.Guards))
 		}
 
-		if flag.Test != GuardEquals || len(flag.Literals) != 1 || flag.Literals[0].Text != "Y" {
+		if flag.Test != GuardEquals || len(flag.Values) != 1 || flag.Values[0].Literal.Text != "Y" {
 			t.Errorf("the flag guard is %s, want it equal to \"Y\"", renderGuard(*flag))
 		}
 	})
@@ -454,11 +445,11 @@ func TestACountedRunIsOneRegisterAndOneGuard(t *testing.T) {
 	assertRendering(t, compiled(t, source, copybooks), `
 register 1 integer from (item HEADER DTL-COUNT)
 state 0
-  on (equals (item HEADER HDR-TYPE) "H"), admit HEADER, bind (item HEADER DTL-COUNT), go to 1
+  on bytes-equal HDR-TYPE "H", admit HEADER, bind (item HEADER DTL-COUNT), go to 1
 state 1 accepts when (item HEADER DTL-COUNT) equal to 0
-  when (item HEADER DTL-COUNT) above zero, on (equals (item DETAIL DTL-TYPE) "D"), admit DETAIL, take one off (item HEADER DTL-COUNT), go to 2
+  when (item HEADER DTL-COUNT) above zero, on bytes-equal DTL-TYPE "D", admit DETAIL, take one off (item HEADER DTL-COUNT), go to 2
 state 2 accepts when (item HEADER DTL-COUNT) equal to 0
-  when (item HEADER DTL-COUNT) above zero, on (equals (item DETAIL DTL-TYPE) "D"), admit DETAIL, take one off (item HEADER DTL-COUNT), go to 2
+  when (item HEADER DTL-COUNT) above zero, on bytes-equal DTL-TYPE "D", admit DETAIL, take one off (item HEADER DTL-COUNT), go to 2
 `)
 }
 
@@ -783,8 +774,8 @@ func TestAFlagGoverningTheRecordHoldingItBecomesABranch(t *testing.T) {
 
 	assertRendering(t, automaton, `
 state 0
-  on (equals (item HEADER HDR-TYPE) "H"), admit HEADER, go to 1
-  on (equals (item DETAIL DTL-TYPE) "D"), admit DETAIL, go to 2
+  on bytes-equal HDR-TYPE "H", admit HEADER, go to 1
+  on bytes-equal DTL-TYPE "D", admit DETAIL, go to 2
 state 1 accepts
 state 2 accepts
 `)

--- a/internal/resolve/discriminator.go
+++ b/internal/resolve/discriminator.go
@@ -1,0 +1,762 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package resolve
+
+import (
+	"slices"
+
+	"github.com/Zaba505/cobol-go/copybook"
+
+	"github.com/Zaba505/cpybkc/internal/layoutmodel"
+)
+
+// This file is the lowering: a layout's discriminator strategies compiled into
+// the predicate nodes of predicate.go, in the two scopes docs/ir/SPEC.md admits
+// one in.
+//
+// A record's strategy becomes the predicate every transition admitting that
+// record carries, and an arm's becomes the predicate selecting that arm inside
+// one occurrence of a table. The two share the node kind, the closed set and the
+// literal resolution, and they part company over where a target may sit — which
+// is why both halves are here rather than one of them beside the code that calls
+// it. A rule that binds one scope and not the other is a rule an adopter is
+// entitled to see stated beside its opposite.
+//
+// # Two stages, and why the refusals are the later one
+//
+// A fault about the *target* is reported while the expression is being walked,
+// because it needs nothing but the record and its copybook, and a graph built
+// over a discriminator nobody could resolve would report a second fault per
+// transition carrying it.
+//
+// A fault about the *strategy* — a record's length, or where a record sits in
+// the stream — is reported after the graph is assembled, because what
+// docs/ir/SPEC.md asks those diagnostics to name is not in hand before then. A
+// record-length discriminator is refused "naming both records", and which other
+// record it would have had to be told apart from is a property of the states the
+// record appears at. Positional *first* is not refused at all: it lowers into
+// the start state, and what is checked is that the record is admitted there and
+// nowhere else.
+
+// The strategies that name no field, as docs/layout/SPEC.md's "The strategies
+// that are not in the set" spells the two it refuses.
+//
+// A layout has no way to write either — `layoutmodel` closes the set at three
+// and rejects a fourth tag while the file is being read — and they are named
+// here all the same, for [resolver.assertResolved]'s reason. docs/ir/SPEC.md
+// requires `resolve` to reject them by name, the requirement is on what leaves
+// this package rather than on what entered it, and a caller assembling a
+// [Sequencing] by hand reaches this package without passing the layout reader at
+// all. The diagnostic is what an adopter gets either way.
+const (
+	// strategyRecordLength is a record told apart by how long it is.
+	strategyRecordLength layoutmodel.StrategyKind = "record-length"
+
+	// strategyPositional is a record told apart by where it sits in the
+	// stream. Its literal says which end.
+	strategyPositional layoutmodel.StrategyKind = "positional"
+)
+
+// positionalFirst is the literal that makes a positional strategy the file's
+// first record, which is the one reading of it that lowers into something.
+const positionalFirst = "first"
+
+// discriminator lowers one record's strategy into the predicate every transition
+// admitting that record carries, or nil where it lowers into none.
+//
+// Three strategies lower into no predicate and only one of the three is a fault
+// here. `single-record-type` is the absence of a predicate; positional *first*
+// is the start state, which the construction already gives; and a strategy this
+// package refuses outright is left for [compiler.checkDiscrimination], which can
+// name what the refusal has to name.
+func (c *compiler) discriminator(record SequencedRecord) *Predicate {
+	strategy := record.Discriminator
+	if !strategy.Predicate() {
+		return nil
+	}
+
+	// docs/layout/SPEC.md, "What the item reference must satisfy": the item is
+	// contained in the record the strategy is written on. `layoutmodel` checks
+	// the reference's own root and this checks the same thing of a strategy
+	// that reached here by another road, because a predicate naming a field of
+	// another record is the one shape the whole rule exists to refuse.
+	if strategy.Item.Record != record.Name {
+		c.faults.Fail(&PredicateTargetError{
+			Pos:      layoutSpan(strategy.Item.Pos),
+			Copybook: copybookSpan(record, nil),
+			Record:   record.Name,
+			Item:     strategy.Item,
+			Found:    "it is rooted at record " + quote(strategy.Item.Record),
+		})
+
+		return nil
+	}
+
+	built := c.layoutOf(record)
+	if built == nil {
+		c.faults.Fail(&PredicateTargetError{
+			Pos:      layoutSpan(strategy.Item.Pos),
+			Copybook: copybookSpan(record, nil),
+			Record:   record.Name,
+			Item:     strategy.Item,
+			Found:    "its copybook does not lay out",
+		})
+
+		return nil
+	}
+
+	matched := itemsAt(built.Record, strategy.Item.Path)
+	if len(matched) != 1 {
+		found := "it names no item of that record"
+		if len(matched) > 1 {
+			found = "it names " + plural(len(matched), "item") + " of that record"
+		}
+
+		c.faults.Fail(&PredicateTargetError{
+			Pos:      layoutSpan(strategy.Item.Pos),
+			Copybook: copybookSpan(record, nil),
+			Record:   record.Name,
+			Item:     strategy.Item,
+			Found:    found,
+		})
+
+		return nil
+	}
+
+	target := matched[0]
+
+	// docs/ir/SPEC.md, "Discriminator predicates": the target must not repeat
+	// and must not be contained at any depth in a group that repeats, under the
+	// rule "A reference names a field, not an occurrence of one" states for
+	// every position naming a field (#84). An arm's target is outside this rule
+	// and is *required* to sit inside one, which is where a variant is built.
+	if group := enclosingTable(target); target.MaxOccurs > 1 || group != nil {
+		c.faults.Fail(&PredicateOccurrenceError{
+			Pos:      layoutSpan(strategy.Item.Pos),
+			Copybook: copybookSpan(record, target.Field),
+			Record:   record.Name,
+			Item:     itemName(target.Field),
+			Group:    groupName(group),
+		})
+
+		return nil
+	}
+
+	// docs/ir/SPEC.md, "Discriminator predicates", second restriction: the
+	// target's position must be constant within the record its transition would
+	// admit, so no item ahead of it may carry a repetition whose count is a
+	// reference. It is asked under the sliding reading alone, for
+	// [resolver.referenceCount]'s reason: on a non-sliding file the same clause
+	// is a fixed table and there is no variable term to be behind.
+	if c.opts.Reading.Slides() {
+		if ahead := variableAhead(built.Items(), target); ahead != nil {
+			c.faults.Fail(&PredicatePositionError{
+				Pos:      layoutSpan(strategy.Item.Pos),
+				Copybook: copybookSpan(record, target.Field),
+				Record:   record.Name,
+				Item:     itemName(target.Field),
+				Behind:   itemName(ahead.Field),
+				Count:    itemName(ahead.DependingOn.Field),
+			})
+
+			return nil
+		}
+	}
+
+	values := c.values(record, strategy, target)
+	if values == nil {
+		return nil
+	}
+
+	test := BytesEqual
+	if strategy.Kind == layoutmodel.OneOf {
+		test = BytesOneOf
+	}
+
+	return &Predicate{Target: target.Field, Test: test, Values: values}
+}
+
+// values resolves a record discriminator's literals against the item it tests,
+// reporting every one that cannot be resolved and returning nil where any could
+// not.
+//
+// Every literal is resolved even after one has failed, so that a `one-of`
+// carrying three misspellings is three things to fix rather than one to discover
+// on the next run.
+func (c *compiler) values(record SequencedRecord, strategy layoutmodel.Strategy, target *copybook.Item) []Value {
+	resolver := literalResolver{
+		field: target.Field,
+		width: target.Length,
+		axes:  axesOf(c.opts.Encoding, c.opts.EncodingOverrides, target.Field),
+	}
+
+	values := make([]Value, 0, len(strategy.Literals))
+	failed := false
+
+	for _, literal := range strategy.Literals {
+		value, wrong := resolver.resolve(literal)
+		if wrong != "" {
+			failed = true
+
+			c.faults.Fail(&PredicateLiteralError{
+				Pos:      layoutSpan(literal.Pos),
+				Copybook: copybookSpan(record, target.Field),
+				Subject:  "the discriminator for record " + record.Name,
+				Literal:  literal,
+				Item:     itemName(target.Field),
+				Found:    wrong,
+			})
+
+			continue
+		}
+
+		values = append(values, value)
+	}
+
+	if failed {
+		return nil
+	}
+
+	return values
+}
+
+// guardValues resolves the literals a `when` compares its register against.
+//
+// A bytes register holds its source field's bytes as they appear in the record,
+// so a guard over one compares bytes and its literals are resolved exactly as a
+// predicate's are — padded to the item's width, so that a `when` over a
+// `PIC X(4)` flag does not leave a consumer deciding whether `Y` matches `Y `.
+// The register is bytes rather than a decoded value for the same reason a
+// predicate tests bytes: neither needs to know any COBOL.
+//
+// A register whose item did not resolve carries no values. The fault is already
+// reported against the operator, and a second one about its literals would name
+// a line the adopter has one thing to fix on.
+func (c *compiler) guardValues(e layoutmodel.Expression, register *Register) []Value {
+	if register.Field == nil {
+		return nil
+	}
+
+	record, known := c.record(e.Item.Record)
+	if !known {
+		return nil
+	}
+
+	built := c.layoutOf(record)
+	if built == nil {
+		return nil
+	}
+
+	matched := itemsAt(built.Record, e.Item.Path)
+	if len(matched) != 1 {
+		return nil
+	}
+
+	target := matched[0]
+	resolver := literalResolver{
+		field: target.Field,
+		width: target.Length,
+		axes:  axesOf(c.opts.Encoding, c.opts.EncodingOverrides, target.Field),
+	}
+
+	values := make([]Value, 0, len(e.Match.Literals))
+	for _, literal := range e.Match.Literals {
+		value, wrong := resolver.resolve(literal)
+		if wrong != "" {
+			c.faults.Fail(&PredicateLiteralError{
+				Pos:      layoutSpan(literal.Pos),
+				Copybook: copybookSpan(record, target.Field),
+				Subject:  "the when over " + e.Item.String(),
+				Literal:  literal,
+				Item:     itemName(target.Field),
+				Found:    wrong,
+			})
+
+			continue
+		}
+
+		values = append(values, value)
+	}
+
+	return values
+}
+
+// checkDiscrimination holds the assembled graph to the rules about a
+// discriminator that need the graph: the two strategies docs/ir/SPEC.md refuses
+// by name, the one it lowers into the start state, and the two shapes a
+// transition carrying no predicate is refused in.
+func (c *compiler) checkDiscrimination(a *Automaton) {
+	for _, record := range c.opts.Records {
+		c.refuseStrategy(a, record)
+		c.checkFirst(a, record)
+		c.checkExtent(a, record)
+	}
+}
+
+// refuseStrategy reports the strategies that name neither a field nor nothing.
+//
+// Each is refused where docs/ir/SPEC.md refuses it and in the words that section
+// uses, because the generic version — an unknown strategy — sends an adopter
+// looking for a spelling mistake in a strategy they wrote deliberately.
+func (c *compiler) refuseStrategy(a *Automaton, record SequencedRecord) {
+	strategy := record.Discriminator
+	switch {
+	case strategy.Predicate() || strategy.Kind == layoutmodel.SingleRecordType:
+		return
+
+	case strategy.Kind == strategyRecordLength:
+		c.faults.Fail(&RefusedStrategyError{
+			Pos:      layoutSpan(strategy.Pos),
+			Record:   record.Name,
+			Strategy: string(strategy.Kind),
+			Beside:   c.beside(a, record.Name),
+			Found:    "a predicate tests a field's bytes, and a record's length is not one",
+		})
+
+	case strategy.Kind == strategyPositional && !positionalFirstStrategy(strategy):
+		c.faults.Fail(&RefusedStrategyError{
+			Pos:      layoutSpan(strategy.Pos),
+			Record:   record.Name,
+			Strategy: string(strategy.Kind),
+			Beside:   c.beside(a, record.Name),
+			Found:    "a writer does not know which record is last",
+		})
+
+	case strategy.Kind == strategyPositional:
+		return
+
+	default:
+		c.faults.Fail(&RefusedStrategyError{
+			Pos:      layoutSpan(strategy.Pos),
+			Record:   record.Name,
+			Strategy: string(strategy.Kind),
+			Beside:   c.beside(a, record.Name),
+			Found:    "a predicate tests a field's bytes and there is nothing else to select a record on",
+		})
+	}
+}
+
+// positionalFirstStrategy reports whether a positional strategy names the file's
+// first record, which is the reading that lowers into the start state.
+func positionalFirstStrategy(strategy layoutmodel.Strategy) bool {
+	return len(strategy.Literals) == 1 &&
+		strategy.Literals[0].Kind == layoutmodel.TextLiteral &&
+		strategy.Literals[0].Text == positionalFirst
+}
+
+// checkFirst holds a record named as the file's first to being admitted there
+// and nowhere else.
+//
+// docs/ir/SPEC.md's "A predicate always names a field" is the whole of it:
+// position is the automaton's shape and not a test, the start state is what the
+// automaton knows about position, and a state distinguishes position only while
+// it is entered once. The construction already gives a start state no transition
+// re-enters, so what is left to check is the other half — that the record the
+// layout called first is not also admitted somewhere further in, where being
+// first says nothing about it.
+func (c *compiler) checkFirst(a *Automaton, record SequencedRecord) {
+	if record.Discriminator.Kind != strategyPositional || !positionalFirstStrategy(record.Discriminator) {
+		return
+	}
+
+	for _, state := range a.States {
+		if state == a.Start {
+			continue
+		}
+
+		for _, transition := range state.Transitions {
+			if transition.Record != record.Name {
+				continue
+			}
+
+			c.faults.Fail(&RefusedStrategyError{
+				Pos:      layoutSpan(record.Discriminator.Pos),
+				Record:   record.Name,
+				Strategy: string(record.Discriminator.Kind),
+				Beside:   c.beside(a, record.Name),
+				Found: "the file's first record is the one the expression admits first, and this one" +
+					" is admitted after another record besides",
+			})
+
+			return
+		}
+	}
+}
+
+// checkExtent refuses a transition admitting a record whose extent is zero.
+//
+// docs/ir/SPEC.md's "A transition may carry no predicate" states it where it
+// became necessary: before that section every admitted record held at least one
+// field of non-zero width, because a predicate's target had to be one. A
+// zero-extent record on a transition that matches everything is a reader that
+// emits records forever without advancing its read position, which is the
+// unterminating walk "No epsilon transitions" refused at the front door (#80).
+//
+// It cannot fire against a copybook `cobol-go` laid out, and running it anyway
+// is [resolver.assertResolved]'s argument: the only shape that occupies no bytes
+// is a group with no elementary item under it, which that reader refuses by
+// name, so the requirement is asserted over the result rather than assumed from
+// the input. A dialect that grew a zero-width item, or a caller assembling a
+// [SequencedRecord] by hand, would otherwise reach a consumer unchecked.
+func (c *compiler) checkExtent(a *Automaton, record SequencedRecord) {
+	built := c.layoutOf(record)
+	if built == nil || built.Record.Total() > 0 {
+		return
+	}
+
+	if !admitted(a, record.Name) {
+		return
+	}
+
+	c.faults.Fail(&ZeroExtentError{
+		Pos:      layoutSpan(record.Discriminator.Pos),
+		Copybook: copybookSpan(record, record.Item),
+		Record:   record.Name,
+		Item:     itemName(record.Item),
+	})
+}
+
+// admitted reports whether any transition of the graph admits the record.
+func admitted(a *Automaton, record string) bool {
+	for _, state := range a.States {
+		for _, transition := range state.Transitions {
+			if transition.Record == record {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// beside is the records a record has to be told apart from: those admitted by a
+// transition leaving a state it is admitted at, whose guards can hold at the
+// same time as its own.
+//
+// Eligibility at the same time and not merely leaving the same state, which is
+// the pairing every rule about telling two records apart is over
+// (docs/ir/SPEC.md, "When two match, and when none does"). A record with nothing
+// beside it is one nothing has to be told from, and the diagnostics that call
+// this say so rather than naming an ambiguity that does not exist.
+func (c *compiler) beside(a *Automaton, record string) []string {
+	var found []string
+
+	for _, state := range a.States {
+		for _, first := range state.Transitions {
+			if first.Record != record {
+				continue
+			}
+
+			for _, second := range state.Transitions {
+				if second == first || second.Record == record {
+					continue
+				}
+
+				if !satisfiable(mergeGuards(first.Guards, second.Guards)) {
+					continue
+				}
+
+				if !slices.Contains(found, second.Record) {
+					found = append(found, second.Record)
+				}
+			}
+		}
+	}
+
+	return found
+}
+
+// nameable reports whether a record offers a field a predicate may name: an
+// elementary item that neither repeats nor sits at any depth inside a group that
+// does.
+//
+// A record every field of which is inside a table cannot be discriminated, and
+// docs/ir/SPEC.md's "A record with nothing outside a table to name" is why the
+// rule is not softened for it: the first entry of a table is exactly where a
+// discriminator looks right and reads a value belonging to the data rather than
+// to the record's identity.
+func nameable(built *copybook.Layout) bool {
+	if built == nil {
+		return false
+	}
+
+	for _, item := range built.Items() {
+		if item.Field.Kind == copybook.KindGroup {
+			continue
+		}
+
+		if item.MaxOccurs > 1 || enclosingTable(item) != nil {
+			continue
+		}
+
+		return true
+	}
+
+	return false
+}
+
+// stretchOf is the run of a record's bytes a predicate tests.
+//
+// The offsets are the record's own static layout, which is what the target's
+// position being constant makes safe: no item ahead of it carries a repetition
+// whose count is a reference, so the run is the same run in every record of that
+// type, and this is the sum docs/ir/SPEC.md's "Ordering and width" states rather
+// than a number any node carries.
+func (c *compiler) stretchOf(record string, predicate *Predicate) (stretch, bool) {
+	if predicate == nil {
+		return stretch{}, false
+	}
+
+	known, ok := c.record(record)
+	if !ok {
+		return stretch{}, false
+	}
+
+	built := c.layoutOf(known)
+	if built == nil {
+		return stretch{}, false
+	}
+
+	for _, item := range built.Items() {
+		if item.Field == predicate.Target {
+			return stretch{at: item.Offset, width: item.Length}, true
+		}
+	}
+
+	return stretch{}, false
+}
+
+// axesOf is the four encoding axes governing one field's bytes: the profile with
+// every override reaching the field applied over it, outermost first.
+//
+// The same fold [resolver.encoding] runs during the record walk, written as a
+// function over an item's ancestry so that the automaton — which walks no record
+// — reaches the same answer. Two readings of what an override applies to would
+// be two answers about the bytes a literal resolves to.
+func axesOf(profile layoutmodel.Axes, overrides []EncodingOverride, field *copybook.Field) layoutmodel.Axes {
+	var ancestry []*copybook.Field
+	for at := field; at != nil; at = at.Parent {
+		ancestry = append(ancestry, at)
+	}
+
+	slices.Reverse(ancestry)
+
+	axes := profile
+	for _, at := range ancestry {
+		if override := overrideFor(overrides, at); override != nil {
+			axes = override.Axes.Over(axes)
+		}
+	}
+
+	return axes
+}
+
+// overrideFor is the layout's override naming field, or nil where it wrote none.
+//
+// The first entry naming an item wins. `layoutmodel` already refuses a layout
+// that overrides one item twice, so a second entry is a caller that assembled
+// one by hand, and reporting it as the adopter's fault would name a line the
+// adopter wrote correctly.
+func overrideFor(overrides []EncodingOverride, field *copybook.Field) *EncodingOverride {
+	for i := range overrides {
+		if overrides[i].Item == field {
+			return &overrides[i]
+		}
+	}
+
+	return nil
+}
+
+// armPredicate lowers one arm's strategy into the predicate selecting it.
+//
+// Three of the rules a transition's target is held to do not reach here and one
+// of them is reversed, and every difference comes from where the predicate is
+// evaluated: inside one occurrence of a group, with the record already admitted
+// (docs/ir/SPEC.md, "A predicate on an arm reads one occurrence", #90).
+//
+// The target **must** sit at any depth inside the innermost group that repeats
+// and contains the variant — the group one occurrence of which the arm is being
+// chosen for — which is the reverse of the rule refusing a transition's target
+// inside a repeating group. That rule refuses a reference with no occurrence to
+// be read in, and an arm's predicate is evaluated in the occurrence being
+// walked, so nothing is guessed.
+//
+// It **must not** sit inside an arm that does not also contain the variant. A
+// target outside the occurrence has the same bytes in every occurrence and so
+// selects the same arm in all of them, which is a choice made once per record; a
+// target inside a sibling arm has bytes only where that arm was selected.
+//
+// And its position needs no constancy at all: every byte of the occurrence is
+// locatable before an arm is chosen, because the arms are of one extent and the
+// record has already been admitted.
+func (r *resolver) armPredicate(c cluster, table *copybook.Item, alternative Alternative) (*Predicate, *copybook.Item) {
+	redefined := c.members[0]
+	strategy := alternative.Predicate
+
+	fail := func(found string) (*Predicate, *copybook.Item) {
+		r.faults.Fail(&ArmTargetScopeError{
+			Pos:         layoutSpan(strategy.Item.Pos),
+			Copybook:    r.span(redefined.Field),
+			Record:      r.record.Name,
+			Group:       groupName(table),
+			Redefined:   itemName(redefined.Field),
+			Alternative: alternative.Name,
+			Item:        strategy.Item,
+			Found:       found,
+		})
+
+		return nil, nil
+	}
+
+	matched := itemsAt(r.layout.Record, strategy.Item.Path)
+	if len(matched) != 1 {
+		if len(matched) > 1 {
+			return fail("it names " + plural(len(matched), "item") + " of that record")
+		}
+
+		return fail("it names no item of that record")
+	}
+
+	target := matched[0]
+
+	if !within(target, table) {
+		return fail("it sits outside " + groupName(table) + ", so it holds the same bytes in every entry")
+	}
+
+	for _, member := range c.members {
+		if within(target, member) || target == member {
+			return fail("it sits inside " + itemName(member.Field) +
+				", which is an alternative of the variant and has bytes only where it was selected")
+		}
+	}
+
+	resolver := literalResolver{
+		field: target.Field,
+		width: target.Length,
+		axes:  r.axesOf(target),
+	}
+
+	values := make([]Value, 0, len(strategy.Literals))
+	failed := false
+
+	for _, literal := range strategy.Literals {
+		value, wrong := resolver.resolve(literal)
+		if wrong != "" {
+			failed = true
+
+			r.faults.Fail(&PredicateLiteralError{
+				Pos:      layoutSpan(literal.Pos),
+				Copybook: r.span(target.Field),
+				Subject:  "the arm " + alternative.Name + " of " + itemName(redefined.Field),
+				Literal:  literal,
+				Item:     itemName(target.Field),
+				Found:    wrong,
+			})
+
+			continue
+		}
+
+		values = append(values, value)
+	}
+
+	if failed {
+		return nil, nil
+	}
+
+	test := BytesEqual
+	if strategy.Kind == layoutmodel.OneOf {
+		test = BytesOneOf
+	}
+
+	return &Predicate{Target: target.Field, Test: test, Values: values}, target
+}
+
+// checkArmOverlap refuses two arms of one variant that one occurrence can
+// satisfy both of.
+//
+// docs/ir/SPEC.md's "When two match, and when none does" at this scope and for
+// its reasons, with one difference: there are no guards on an arm to exempt a
+// pair, so every pair is inside the rule. The test is the transitions' — whether
+// one input can satisfy both — asked of one occurrence rather than of one
+// record.
+func (r *resolver) checkArmOverlap(c cluster, table *copybook.Item, arms []Arm, targets []*copybook.Item, spec *Redefine) {
+	redefined := c.members[0]
+
+	for i := range arms {
+		for j := i + 1; j < len(arms); j++ {
+			over := stretch{at: targets[i].Offset, width: targets[i].Length}
+			against := stretch{at: targets[j].Offset, width: targets[j].Length}
+
+			if !overlap(arms[i].Predicate, over, arms[j].Predicate, against) {
+				continue
+			}
+
+			r.faults.Fail(&ArmOverlapError{
+				Pos:       layoutSpan(armStrategy(spec, arms[j].Alternative).Pos),
+				First:     layoutSpan(armStrategy(spec, arms[i].Alternative).Pos),
+				Record:    r.record.Name,
+				Group:     groupName(table),
+				Redefined: itemName(redefined.Field),
+				Arms:      [2]string{arms[i].Alternative, arms[j].Alternative},
+				Value:     shared(arms[i].Predicate, arms[j].Predicate),
+			})
+		}
+	}
+}
+
+// armStrategy is the strategy the layout wrote for one alternative, which is
+// what a diagnostic about that arm points at.
+func armStrategy(spec *Redefine, alternative string) layoutmodel.Strategy {
+	for _, candidate := range spec.Alternatives {
+		if candidate.Name == alternative {
+			return candidate.Predicate
+		}
+	}
+
+	return layoutmodel.Strategy{}
+}
+
+// shared is a value two overlapping predicates have in common, or the first of
+// the earlier one where they overlap by reading different runs of bytes.
+func shared(first, second *Predicate) Value {
+	for _, one := range first.Values {
+		for _, other := range second.Values {
+			if one.Identity() == other.Identity() {
+				return one
+			}
+		}
+	}
+
+	if len(first.Values) > 0 {
+		return first.Values[0]
+	}
+
+	return Value{}
+}
+
+// within reports whether item is contained, at any depth, in group.
+func within(item, group *copybook.Item) bool {
+	if group == nil {
+		return false
+	}
+
+	for parent := item.Parent; parent != nil; parent = parent.Parent {
+		if parent == group {
+			return true
+		}
+	}
+
+	return false
+}
+
+// axesOf is the four encoding axes governing one item's bytes, as the record
+// walk would compute them.
+func (r *resolver) axesOf(item *copybook.Item) layoutmodel.Axes {
+	return axesOf(r.opts.Encoding, r.opts.EncodingOverrides, item.Field)
+}
+
+// quote renders a name the way a diagnostic quotes one.
+func quote(name string) string { return "`" + name + "`" }

--- a/internal/resolve/doc.go
+++ b/internal/resolve/doc.go
@@ -133,15 +133,41 @@
 // copybook's items rather than on the resolved nodes, so a copybook with four
 // REDEFINES alternatives reports each fault once rather than four times.
 //
+// # A discriminator is compiled, in two scopes and one closed set
+//
+// Discrimination reaches a generator compiled too, and a [Predicate] is what a
+// layout's strategy becomes: one member of a closed set of two tests, naming the
+// field node it tests and carrying its literals as the bytes a consumer
+// compares. A consumer evaluates one knowing no COBOL and knowing nothing about
+// what the strategy was called in a layout file (#37).
+//
+// Two things select on bytes and they share the node kind and the set. A
+// [Transition] chooses a record, and an [Arm] of a variant chooses an
+// alternative inside one occurrence of a table. What differs is where a target
+// may sit, and every difference follows from when the predicate runs: a
+// transition's runs before its record is admitted, so its target sits outside
+// every repeating group and ahead of every item whose extent moves with a count,
+// while an arm's runs inside an occurrence already located, so its target sits
+// *inside* the repeating group and carries neither restriction (docs/ir/SPEC.md,
+// "Discriminator predicates", "A predicate on an arm reads one occurrence", #84,
+// #90).
+//
+// Three strategies name no field and none of them lowers into a member testing
+// nothing. `single-record-type` is the absence of a predicate, positional
+// *first* is the start state, and a record's length and positional *last* are
+// refused with a diagnostic each (#80).
+//
+// The literals are resolved here and nowhere else. A [Guard] over a bytes
+// register carries the same resolution for the same reason: one reading of what
+// `"01"` is in a file is one answer for a consumer to act on, and two would be
+// two.
+//
 // # What this package leaves to the stories after it
 //
-// Compiling a layout's discriminator strategies into predicate nodes is #37's,
-// and assembling nodes into a
-// [github.com/Zaba505/cpybkc/irpb.Descriptor] with identifiers on them is #38's.
-// A [Repetition] here therefore names a [github.com/Zaba505/cobol-go/copybook.Field]
-// rather than an identifier, an [Arm] carries the
-// [github.com/Zaba505/cpybkc/internal/layoutmodel.Strategy] a layout wrote
-// rather than a compiled predicate, and a [Transition] carries one too.
+// Assembling nodes into a [github.com/Zaba505/cpybkc/irpb.Descriptor] with
+// identifiers on them is #38's. A [Repetition], a [Binding] and a [Predicate]
+// here therefore name a
+// [github.com/Zaba505/cobol-go/copybook.Field] rather than an identifier.
 //
 // A count that lives in another record never reaches [Resolve] at all, and that
 // is the division rather than a gap: a DEPENDING ON phrase names an item of the

--- a/internal/resolve/node.go
+++ b/internal/resolve/node.go
@@ -209,10 +209,17 @@ type Arm struct {
 	// which is what a layout writes in an `arm` form.
 	Alternative string
 
-	// Predicate is the strategy the layout chose for this arm. It is carried
-	// rather than compiled: lowering a strategy into an IR predicate node is
-	// #37's.
-	Predicate layoutmodel.Strategy
+	// Predicate is the predicate that selects this arm, and is never nil.
+	//
+	// The same node kind and the same closed set of tests a transition's
+	// predicate is, and bound by different rules: its target sits inside the
+	// occurrence being walked rather than at a constant position in the
+	// record, because it is evaluated once the record has been admitted
+	// (docs/ir/SPEC.md, "A predicate on an arm reads one occurrence", #90).
+	//
+	// An arm carries exactly one, and there is no default arm: an alternative
+	// selected by nothing is a choice a consumer cannot make.
+	Predicate *Predicate
 
 	// Body is the arm's body, a group or a field node. Where the alternative
 	// occupies fewer bytes than the variant's extent, it is a group holding

--- a/internal/resolve/odo_test.go
+++ b/internal/resolve/odo_test.go
@@ -665,6 +665,7 @@ func TestASlidingTableInsideAnArmIsStillRefused(t *testing.T) {
 	src := `01 R.
    05 N PIC 9(2).
    05 T OCCURS 2 TIMES.
+      10 K PIC X.
       10 A PIC X(12).
       10 B REDEFINES A.
          15 CELL OCCURS 1 TO 3 TIMES DEPENDING ON N PIC X(4).
@@ -680,8 +681,8 @@ func TestASlidingTableInsideAnArmIsStillRefused(t *testing.T) {
 			Redefines: []Redefine{{
 				Item: fieldNamed(t, field, "A"),
 				Alternatives: []Alternative{
-					{Name: "A", Predicate: selects("A")},
-					{Name: "B", Predicate: selects("B")},
+					{Name: "A", Predicate: selects("A", "T", "K")},
+					{Name: "B", Predicate: selects("B", "T", "K")},
 				},
 			}},
 		})

--- a/internal/resolve/predicate.go
+++ b/internal/resolve/predicate.go
@@ -1,0 +1,624 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package resolve
+
+import (
+	"encoding/hex"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/Zaba505/cobol-go/codec"
+	"github.com/Zaba505/cobol-go/copybook"
+	"github.com/Zaba505/cobol-go/picture"
+
+	"github.com/Zaba505/cpybkc/internal/layoutmodel"
+)
+
+// This file is the discriminator, compiled: the closed set of two tests
+// docs/ir/SPEC.md's "Discriminator predicates" admits, the resolution of a
+// layout's literals into the bytes a consumer compares, and the walk a consumer
+// runs over the result.
+//
+// # Two scopes, one node kind and one closed set
+//
+// Two things select on bytes and neither knows what the other is. A transition
+// chooses a record, and an arm of a variant chooses an alternative inside one
+// occurrence of a table. They share this node kind and these two tests, and they
+// differ in the bytes they read and in the rules binding a target — which is
+// docs/ir/SPEC.md's "A predicate on an arm reads one occurrence" (#90).
+//
+// A transition's predicate runs at step 3 of the read loop, before its record is
+// admitted, so its target must sit at a position every record of that type has:
+// outside every group that repeats, and ahead of every item whose extent moves
+// with a count. An arm's runs inside a record already admitted, walking an
+// occurrence that is already located, so both restrictions fall away and the
+// opposite of the first one holds — an arm's target has to be *inside* the
+// repeating group the variant sits in, because that is the occurrence it is
+// evaluated in.
+//
+// # What a predicate never names
+//
+// A predicate names a field and a guard names a register, and neither reaches
+// into the other's half (docs/ir/SPEC.md, "Discriminator predicates"). That is a
+// property of the types here rather than a rule this file enforces: a
+// [Predicate] carries a [github.com/Zaba505/cobol-go/copybook.Field] and has
+// nowhere to put a register, and a [Guard] carries a [Register] and has nowhere
+// to put a field. A layout has no spelling for a register either — the two
+// operators that read one write an item reference and the register is what
+// `resolve` allocates for it — so there is no layout to reject, and the split is
+// kept by there being no way to write it down.
+//
+// The three strategies that name no field do not lower into a predicate at all,
+// and each is refused where its reason is (#80). `single-record-type` is the
+// absence of a predicate; a record's length is not a thing a predicate tests;
+// positional *first* is the start state and positional *last* is refused
+// outright, because a writer does not know which record is last.
+//
+// # No offset reaches a predicate
+//
+// A predicate names the field it tests and nothing else. Where those bytes are
+// is the sum of the widths ahead of the field in the record, which is
+// docs/ir/SPEC.md's "Ordering and width, and no offset" applying here as it
+// applies everywhere: a producer that stated the position a second time could be
+// wrong in a way no consumer can detect. The overlap check below needs a
+// position and computes one from the record's own layout rather than reading one
+// off the node, for exactly that reason.
+//
+// # The literals are bytes before they leave
+//
+// Both members carry their literals as bytes, padded by this package to the
+// target's width, so that no consumer decides whether `Y` matches `Y ` and none
+// applies a COBOL comparison rule of its own. The same resolution runs over a
+// guard's literals for a bytes register, and for the same reason: a `when` over
+// a `PIC X(4)` flag compares four bytes whatever the layout wrote.
+//
+// A literal is spelled three ways and each resolves differently
+// (docs/layout/SPEC.md, "Literals"). `(bytes "F0F1")` is what is in the file and
+// is taken as written; a text literal is translated through the item's charset
+// and padded with that charset's space; a number is the digits of a zoned
+// DISPLAY item, right-aligned and zero-filled. What is *not* resolved is a
+// number against a packed, binary or signed item: those bytes follow from a SIGN
+// clause and a byte order the four axes do not by themselves pin down, and this
+// package refuses to guess bytes rather than emitting plausible ones. The
+// diagnostic sends the adopter to `(bytes …)`, which is the spelling that exists
+// for saying exactly what is in the file.
+
+// PredicateTest is what a predicate tests, one member of the closed set of two
+// docs/ir/SPEC.md's "Discriminator predicates" admits.
+//
+// There is no third and a third is a breaking change. The zero value is not a
+// test: a [Predicate] this package hands back always names one.
+type PredicateTest int
+
+const (
+	// BytesEqual is the target's bytes being the one carried literal.
+	BytesEqual PredicateTest = iota + 1
+
+	// BytesOneOf is the target's bytes being one of the carried literals.
+	//
+	// A member rather than a shorthand a producer expands into several
+	// [BytesEqual] predicates: a transition carries at most one predicate and
+	// an arm exactly one, so a strategy admitting three type codes has
+	// nowhere to put three.
+	BytesOneOf
+)
+
+// String implements the [fmt.Stringer] interface, rendering the test as
+// docs/ir/SPEC.md's table names it.
+func (t PredicateTest) String() string {
+	switch t {
+	case BytesEqual:
+		return "bytes-equal"
+	case BytesOneOf:
+		return "bytes-one-of"
+	}
+	return "unknown"
+}
+
+// Predicate is a discriminator, compiled: the field whose bytes are tested and
+// the test.
+//
+// It carries no position. Where the target's bytes are follows from the ordering
+// and the widths of the record holding it, which is the one statement of
+// position the IR makes (docs/ir/SPEC.md, "Ordering and width, and no offset").
+//
+// The target is a [github.com/Zaba505/cobol-go/copybook.Field] rather than an
+// identifier for [Binding.Field]'s reason: this package resolves what a
+// reference names and #38 assigns the identifiers every reference becomes.
+type Predicate struct {
+	// Target is the field the predicate tests. It is never nil: a member
+	// naming nothing is not in the set, and selecting on nothing at all is the
+	// absence of a predicate.
+	Target *copybook.Field
+
+	// Test is which of the two this is.
+	Test PredicateTest
+
+	// Values are what the target's bytes are compared against, in the order
+	// the layout wrote them: exactly one under [BytesEqual] and at least one
+	// under [BytesOneOf], each already the target's width in bytes.
+	Values []Value
+}
+
+// Matches reports whether target's bytes satisfy the predicate.
+//
+// The bytes are the caller's to fetch, because the position they came from is
+// the caller's to compute — a consumer walking a record already knows where it
+// is standing, and handing this method the record would make it run the sum a
+// second time (docs/ir/SPEC.md, "Dereferencing is not recomputation").
+//
+// A target that is not the width the predicate's values are is not compared
+// against a prefix of one: it does not match. That is the read loop's rule for a
+// target straddling the bound the framing places, arriving here as the one place
+// the comparison happens.
+func (p *Predicate) Matches(target []byte) bool {
+	if p == nil {
+		return true
+	}
+
+	for _, value := range p.Values {
+		if string(value.Bytes) == string(target) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// String renders the predicate the way a diagnostic names one.
+func (p *Predicate) String() string {
+	if p == nil {
+		return "no predicate"
+	}
+
+	rendered := make([]string, 0, len(p.Values))
+	for _, value := range p.Values {
+		rendered = append(rendered, value.String())
+	}
+
+	return p.Test.String() + " " + itemName(p.Target) + " " + strings.Join(rendered, " ")
+}
+
+// Value is one literal a layout wrote, resolved to what a consumer compares.
+//
+// One type over two readings, as [Node] is one type over four kinds: a value
+// compared against bytes carries [Value.Bytes], and one compared against a
+// number — which only an integer register's guard ever is — carries
+// [Value.Number] and no bytes. Which of the two applies follows from what is
+// carrying the value and is never a question about the value itself.
+//
+// The literal the layout wrote is carried beside the resolution, because every
+// diagnostic about a value quotes the adopter's own spelling of it and none of
+// them quotes hex the adopter never typed.
+type Value struct {
+	// Literal is the layout's spelling, which is what a diagnostic quotes.
+	Literal layoutmodel.Literal
+
+	// Bytes are the bytes a consumer compares, already the width of the field
+	// or register they are compared against. It is nil on a value an integer
+	// register's guard carries.
+	Bytes []byte
+
+	// Number is what an integer register is compared against, and is
+	// meaningless where Bytes is set.
+	Number int64
+}
+
+// Identity is what makes two resolved values the same value.
+//
+// It is over the resolution and not over the spelling, which is the whole of
+// what resolving buys the overlap checks: `"01"` written as text and
+// `(bytes "F0F1")` written as bytes are one value on an EBCDIC file, and two
+// transitions carrying them are two transitions one record satisfies both of.
+// [layoutmodel.Literal.Identity] cannot see that and says so — it is the
+// coarsest answer decidable from a layout alone, and this is the answer with a
+// copybook in hand (#36, #37).
+func (v Value) Identity() string {
+	if v.Bytes == nil {
+		return "number " + strconv.FormatInt(v.Number, 10)
+	}
+
+	return "bytes " + hex.EncodeToString(v.Bytes)
+}
+
+// String renders the value as the layout wrote it.
+func (v Value) String() string { return v.Literal.String() }
+
+// number is the value an integer register's guard compares against.
+func number(literal layoutmodel.Literal) Value {
+	parsed, err := strconv.ParseInt(literal.Number, 10, 64)
+	if err != nil {
+		// A count literal that will not parse is a fault for whoever wrote
+		// it, and never a reason to call a state ambiguous: it is carried as
+		// a value nothing equals rather than dropped.
+		return Value{Literal: literal, Number: -1}
+	}
+
+	return Value{Literal: literal, Number: parsed}
+}
+
+// RegisterFile is what the automaton remembers between records: one value per
+// register, keyed by [Register.ID].
+//
+// A register nobody has bound is absent, which is a state [compiler.prove] has
+// already shown no guard can be evaluated in — every read is preceded on every
+// path by a binding on an earlier transition. It is a map rather than a slice so
+// that "absent" and "zero" are different answers, because a counter at zero is
+// the ordinary end of a run and a counter nobody bound is a descriptor fault.
+type RegisterFile map[int]Value
+
+// Eligible reports whether every guard of the transition holds, and the first
+// that does not where one does not.
+//
+// Guards are evaluated against the register file as it stands on entry to the
+// state, before the record in front of the consumer is examined at all, so their
+// order is not significant and a transition never reads what it binds.
+func (t *Transition) Eligible(held RegisterFile) (bool, Guard) {
+	for _, guard := range t.Guards {
+		if !guard.Holds(held[guard.Register.ID]) {
+			return false, guard
+		}
+	}
+
+	return true, Guard{}
+}
+
+// Select is the transition of the state that admits the record in front of a
+// consumer: the first eligible one carrying no predicate, or the first whose
+// predicate matches.
+//
+// bytes hands back the target's bytes for a predicate about to be evaluated.
+// The position they came from is the caller's, because a consumer walking a file
+// already knows where it is standing and the sum that locates a field is
+// arithmetic every consumer runs (docs/ir/SPEC.md, "Dereferencing is not
+// recomputation").
+//
+// The walk is here for [Record.Position]'s reason. It is the walk a generated
+// consumer runs, kept beside the descriptor it walks so that this package's own
+// tests run it — and, more than that, so that the two failures docs/ir/SPEC.md
+// distinguishes are distinguished in one place rather than in every generator.
+// Where nothing matches, this is a record the layout does not describe; where a
+// guard is what excluded the transition that would have matched, it names the
+// register instead, because the two send an adopter to different places. A
+// transition carrying no predicate is never the one named: it would have matched
+// anything, so it says nothing about the bytes in hand.
+func (s *State) Select(held RegisterFile, bytes func(*Predicate) []byte) (*Transition, error) {
+	var excluded *Transition
+	var by Guard
+
+	// A transition carrying no predicate matches every record, and asking the
+	// caller for the bytes of a target that does not exist is not how it says
+	// so: `bytes` is called for a predicate and never for the absence of one.
+	matches := func(predicate *Predicate) bool {
+		return predicate == nil || predicate.Matches(bytes(predicate))
+	}
+
+	for _, transition := range s.Transitions {
+		eligible, failed := transition.Eligible(held)
+		if eligible {
+			if matches(transition.Predicate) {
+				return transition, nil
+			}
+
+			continue
+		}
+
+		if excluded != nil || transition.Predicate == nil {
+			continue
+		}
+
+		if matches(transition.Predicate) {
+			excluded, by = transition, failed
+		}
+	}
+
+	if excluded != nil {
+		return nil, &GuardExcludedError{
+			State:    s.ID,
+			Record:   excluded.Record,
+			Register: by.Register.String(),
+			Guard:    renderGuard(by),
+		}
+	}
+
+	return nil, &UndescribedRecordError{State: s.ID, Records: admits(s)}
+}
+
+// SelectArm is the arm of a variant the occurrence in front of a consumer
+// selects: the first whose predicate matches.
+//
+// There is no default arm and no falling through to the last one. Where no arm
+// matches, that is reported — and reported as its own failure rather than as an
+// undescribed record, because the two send an adopter to different places: a
+// record no transition matched is a record type the layout is missing, while an
+// occurrence no arm matched is a record the layout does describe carrying an
+// entry it does not (docs/ir/SPEC.md, "A predicate on an arm reads one
+// occurrence").
+func (n *Node) SelectArm(bytes func(*Predicate) []byte) (*Arm, error) {
+	for i := range n.Arms {
+		if predicate := n.Arms[i].Predicate; predicate != nil && predicate.Matches(bytes(predicate)) {
+			return &n.Arms[i], nil
+		}
+	}
+
+	return nil, &UnmatchedOccurrenceError{Arms: alternatives(n)}
+}
+
+// admits is the records a state's transitions admit, in evaluation order and
+// without repeating one.
+func admits(state *State) []string {
+	var records []string
+
+	for _, transition := range state.Transitions {
+		if !slices.Contains(records, transition.Record) {
+			records = append(records, transition.Record)
+		}
+	}
+
+	return records
+}
+
+// alternatives is what a variant's arms are called, in evaluation order.
+func alternatives(variant *Node) []string {
+	names := make([]string, 0, len(variant.Arms))
+	for _, arm := range variant.Arms {
+		names = append(names, arm.Alternative)
+	}
+
+	return names
+}
+
+// stretch is a run of a record's bytes: what a predicate tests.
+type stretch struct{ at, width int }
+
+// overlap reports whether one input can satisfy both predicates, each read at
+// the run of bytes given for it.
+//
+// The test is whether one input can satisfy both and not whether the two read
+// the same bytes, which is the distinction docs/ir/SPEC.md's "When two match,
+// and when none does" draws: predicates reading different fields at different
+// positions overlap just as thoroughly as two reading one, because a record can
+// carry an `S` at byte zero and an `X` at byte ten at the same time. So two over
+// different runs always overlap, and two over one run overlap exactly where
+// their value sets intersect.
+//
+// A run of bytes rather than a field, because two records built to different
+// copybooks is the ordinary case and is the case docs/ir/SPEC.md's "A counted
+// run, as nodes" is written in: a header, a detail and a summary each carry
+// their own type code at their own copybook's first byte, and a rule keyed on
+// the field would call three type codes at one offset an ambiguity.
+//
+// A predicate that is absent matches every record, so it overlaps everything
+// (#80).
+func overlap(first *Predicate, at stretch, second *Predicate, against stretch) bool {
+	if first == nil || second == nil {
+		return true
+	}
+
+	if at != against {
+		return true
+	}
+
+	return slices.ContainsFunc(first.Values, func(one Value) bool {
+		return slices.ContainsFunc(second.Values, func(other Value) bool {
+			return one.Identity() == other.Identity()
+		})
+	})
+}
+
+// literals resolves a strategy's literals against the field they are compared
+// with, reporting the first that cannot be resolved.
+//
+// Every literal is resolved even after one has failed, because a strategy
+// carrying three misspelled values is three things to fix rather than one to
+// discover on the next run — the faults are collected by the caller, which knows
+// what the strategy was written for.
+type literalResolver struct {
+	// field is the item the literals are compared against.
+	field *copybook.Field
+
+	// width is the bytes it occupies, which is what every value is padded to.
+	width int
+
+	// axes are the four encoding axes governing that item's bytes.
+	axes layoutmodel.Axes
+}
+
+// resolve turns one literal into the bytes a consumer compares.
+//
+// What is wrong with a literal is returned as prose rather than as an error
+// type, so that the caller can say whether a record's discriminator, an arm's
+// predicate or a `when`'s guard was the thing carrying it — three positions with
+// three different things to tell an adopter about the same misspelling.
+func (r literalResolver) resolve(literal layoutmodel.Literal) (Value, string) {
+	switch literal.Kind {
+	case layoutmodel.BytesLiteral:
+		return r.bytes(literal)
+	case layoutmodel.TextLiteral:
+		return r.text(literal)
+	case layoutmodel.NumberLiteral:
+		return r.digits(literal)
+	}
+
+	return Value{}, "it is not a literal this package can read"
+}
+
+// bytes resolves `(bytes "F0F1")`: exactly what is in the file, with no charset
+// and no padding.
+//
+// It is the one spelling that says what the bytes are rather than what the value
+// is, so a width that does not match the item's is the adopter having counted
+// wrong — padding it would be this package deciding which end the missing bytes
+// belong at.
+func (r literalResolver) bytes(literal layoutmodel.Literal) (Value, string) {
+	written := literal.Bytes.Bytes
+	if len(written) != r.width {
+		return Value{}, "it is " + plural(len(written), "byte") +
+			" and " + itemName(r.field) + " is " + plural(r.width, "byte")
+	}
+
+	return Value{Literal: literal, Bytes: slices.Clone(written)}, ""
+}
+
+// text resolves `"01"`: through the item's charset, padded on the right to the
+// item's width with that charset's space.
+//
+// Padding is the producer's under docs/ir/SPEC.md's "Discriminator predicates",
+// and it is on the right because that is where COBOL leaves an alphanumeric item
+// short of its PICTURE. A literal longer than the item is refused rather than
+// truncated: a comparison against a prefix is the reading that reports a match
+// on bytes the adopter never asked about.
+func (r literalResolver) text(literal layoutmodel.Literal) (Value, string) {
+	charset, exact := charsetOf(r.axes.Charset)
+	if charset == nil {
+		return Value{}, "the charset is not stated on " + itemName(r.field)
+	}
+
+	if len([]rune(literal.Text)) > r.width {
+		return Value{}, "it is " + plural(len([]rune(literal.Text)), "character") +
+			" and " + itemName(r.field) + " is " + plural(r.width, "byte")
+	}
+
+	out := make([]byte, 0, r.width)
+	for _, r0 := range literal.Text {
+		if !exact && !invariant(r0) {
+			return Value{}, "the character " + strconv.QuoteRune(r0) +
+				" is not one every EBCDIC code page spells alike, and `cobol-go`" +
+				" carries no table for " + string(r.axes.Charset) + " yet"
+		}
+
+		encoded, ok := charset.FromUnicode(r0)
+		if !ok {
+			return Value{}, "the character " + strconv.QuoteRune(r0) +
+				" has no byte in " + string(r.axes.Charset)
+		}
+
+		out = append(out, encoded)
+	}
+
+	for len(out) < r.width {
+		out = append(out, charset.Space())
+	}
+
+	return Value{Literal: literal, Bytes: out}, ""
+}
+
+// digits resolves `12`: the digits of a zoned DISPLAY item, right-aligned and
+// zero-filled to the item's width, through the charset's own digit bytes.
+//
+// It resolves for exactly the shape a discriminator has and refuses every other,
+// which is a narrowing worth its diagnostic. The bytes of a number in a packed,
+// binary or signed item follow from a SIGN clause and a byte order that the four
+// encoding axes do not by themselves pin down, and a producer emitting plausible
+// bytes for one would be making the silent-failure mistake this whole project is
+// arranged against. `(bytes …)` is the spelling for saying what is in the file,
+// and the diagnostic says so.
+func (r literalResolver) digits(literal layoutmodel.Literal) (Value, string) {
+	charset, _ := charsetOf(r.axes.Charset)
+	if charset == nil {
+		return Value{}, "the charset is not stated on " + itemName(r.field)
+	}
+
+	if reason := zonedUnsigned(r.field); reason != "" {
+		return Value{}, "a number is resolved through the digits of a zoned item and " +
+			itemName(r.field) + " " + reason + " — write the bytes as (bytes \"…\")"
+	}
+
+	if strings.ContainsAny(literal.Number, ".-") {
+		return Value{}, "it is not a whole number and " + itemName(r.field) +
+			" holds " + plural(r.width, "digit")
+	}
+
+	if len(literal.Number) > r.width {
+		return Value{}, "it is " + plural(len(literal.Number), "digit") +
+			" and " + itemName(r.field) + " holds " + plural(r.width, "digit")
+	}
+
+	out := make([]byte, 0, r.width)
+	for i := len(literal.Number); i < r.width; i++ {
+		encoded, _ := charset.FromUnicode('0')
+		out = append(out, encoded)
+	}
+
+	for _, r0 := range literal.Number {
+		encoded, ok := charset.FromUnicode(r0)
+		if !ok {
+			return Value{}, "the digit " + strconv.QuoteRune(r0) + " has no byte in " +
+				string(r.axes.Charset)
+		}
+
+		out = append(out, encoded)
+	}
+
+	return Value{Literal: literal, Bytes: out}, ""
+}
+
+// zonedUnsigned says what stops a field being an unsigned zoned DISPLAY item, or
+// the empty string where nothing does.
+func zonedUnsigned(field *copybook.Field) string {
+	switch {
+	case field == nil || field.Kind == copybook.KindGroup:
+		return "is not an elementary item"
+	case field.Usage != copybook.UsageDisplay:
+		return "is USAGE " + field.Usage.String()
+	case field.Picture == nil:
+		return "carries no PICTURE"
+	case field.Picture.Category != picture.CategoryNumeric:
+		return "is a " + field.Picture.Category.String() + " item"
+	case field.Picture.Scale != 0:
+		return "carries digits after the decimal point"
+	case field.Picture.Signed:
+		return "carries an operational sign"
+	}
+
+	return ""
+}
+
+// charsetOf is the byte table for one of the code pages a layout may name, and
+// whether that table is the code page's own.
+//
+// `cobol-go` carries a hand-written table per code page and has written two of
+// the five so far, because `codec` is forbidden from depending on
+// golang.org/x/text. What is available for the other three is what
+// `codec/SPEC.md` states normatively about all of them: "the digits `F0`–`F9`,
+// the letters, and the space `40` are identical across all of them". So an
+// EBCDIC code page with no table of its own resolves a literal through cp037's
+// over exactly that subset, and a character outside it is reported rather than
+// guessed — which is the same answer this package gives everywhere a byte is not
+// derivable, and it costs a discriminator nothing, since a type code is digits
+// and letters.
+func charsetOf(charset layoutmodel.Charset) (codec.Charset, bool) {
+	switch charset {
+	case layoutmodel.ASCII:
+		return codec.ASCII(), true
+	case layoutmodel.CP037:
+		return codec.CP037(), true
+	case layoutmodel.CP500, layoutmodel.CP1047, layoutmodel.CP1140:
+		return codec.CP037(), false
+	}
+
+	return nil, false
+}
+
+// invariant reports whether a character has the same byte in every EBCDIC code
+// page the charset axis admits: a digit, a letter, or the space.
+func invariant(r rune) bool {
+	return r == ' ' ||
+		(r >= '0' && r <= '9') ||
+		(r >= 'A' && r <= 'Z') ||
+		(r >= 'a' && r <= 'z')
+}
+
+// plural renders a count and its unit, so that a message says one byte and two
+// bytes rather than 1 byte(s).
+func plural(n int, unit string) string {
+	if n == 1 {
+		return "1 " + unit
+	}
+
+	return strconv.Itoa(n) + " " + unit + "s"
+}

--- a/internal/resolve/predicate.go
+++ b/internal/resolve/predicate.go
@@ -225,6 +225,27 @@ func (v Value) Identity() string {
 	return "bytes " + hex.EncodeToString(v.Bytes)
 }
 
+// sameValue reports what [Value.Identity] equality reports, without building
+// either identity.
+//
+// The two answers agree by construction — a number and a run of bytes are never
+// the same value, two numbers are the same value exactly when the numbers are,
+// and two runs exactly when the bytes are. It exists because the identities are
+// strings: [Guard.Holds] runs inside the consumer's selection loop, and
+// rendering hex there allocates twice on every transition a consumer considers
+// to answer a question about equality alone.
+func sameValue(one, other Value) bool {
+	if (one.Bytes == nil) != (other.Bytes == nil) {
+		return false
+	}
+
+	if one.Bytes == nil {
+		return one.Number == other.Number
+	}
+
+	return slices.Equal(one.Bytes, other.Bytes)
+}
+
 // String renders the value as the layout wrote it.
 func (v Value) String() string { return v.Literal.String() }
 
@@ -405,7 +426,7 @@ func overlap(first *Predicate, at stretch, second *Predicate, against stretch) b
 
 	return slices.ContainsFunc(first.Values, func(one Value) bool {
 		return slices.ContainsFunc(second.Values, func(other Value) bool {
-			return one.Identity() == other.Identity()
+			return sameValue(one, other)
 		})
 	})
 }

--- a/internal/resolve/predicate_errors.go
+++ b/internal/resolve/predicate_errors.go
@@ -1,0 +1,549 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package resolve
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+	"github.com/Zaba505/cpybkc/internal/layoutmodel"
+)
+
+// The faults compiling a discriminator into a predicate reports.
+//
+// Each names what docs/ir/SPEC.md asks it to name and refuses the generic
+// version, because a discriminator goes wrong in five ways that look alike from
+// a distance and send an adopter to five different files. A target in the wrong
+// record is a layout mistake; a target inside a table is a copybook the adopter
+// may not own; a target behind an `OCCURS DEPENDING ON` is a rule about the read
+// loop's order; a literal that will not resolve is a spelling; and a strategy
+// this format refuses is a file shape the IR cannot describe. "rather than
+// reporting a generic reference error" is the spec's own phrase, and it appears
+// against three of these.
+
+// PredicateTargetError is a discriminator whose item reference does not name one
+// item of the record it discriminates.
+//
+// docs/ir/SPEC.md's "Discriminator predicates" requires a producer to ensure the
+// target is contained in the record its transition admits, at any depth, and
+// never to name a field of any other. `layoutmodel` checks the half that needs
+// no copybook — the reference's root — and this is the half that needs one, plus
+// the same root check over a [Sequencing] a caller assembled by hand.
+//
+// A complete path that names two items is reported rather than resolved to the
+// first, for [SequenceItemError]'s reason: duplicate data names are legal COBOL,
+// and choosing would select a record on bytes the adopter did not name.
+type PredicateTargetError struct {
+	// Pos is the item reference in the layout.
+	Pos diag.Span
+
+	// Copybook is the copybook the record is bound to.
+	Copybook diag.Span
+
+	// Record is the record being discriminated, and Item the reference as the
+	// layout wrote it.
+	Record string
+	Item   layoutmodel.ItemRef
+
+	// Found is what is wrong with it, in the message's own words.
+	Found string
+}
+
+// Error implements the error interface.
+func (e *PredicateTargetError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *PredicateTargetError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"the discriminator for record %s tests %s, and %s: a predicate names a field contained in the "+
+				"record its transition admits",
+			e.Record, e.Item, e.Found),
+		Spans: spans(e.Pos, e.Copybook, "the record "+e.Record+" is bound to this copybook"),
+	}
+}
+
+// PredicateOccurrenceError is a record discriminator whose target repeats, or
+// sits at any depth inside a group that repeats.
+//
+// docs/ir/SPEC.md's "A reference names a field, not an occurrence of one" is the
+// rule and a transition's predicate is one of the positions it binds: no node
+// carries an occurrence number, so a target in forty entries carries nothing
+// saying which of the forty, and reading it as the first is a guess at an
+// intention the descriptor cannot express (#84).
+//
+// An arm's predicate is outside this rule and is required to sit inside a
+// repeating group, because it is evaluated in the occurrence being walked and
+// there is nothing left to guess — [ArmTargetScopeError] is that scope's fault
+// (#90).
+type PredicateOccurrenceError struct {
+	// Pos is the item reference in the layout.
+	Pos diag.Span
+
+	// Copybook is the item's entry in the copybook.
+	Copybook diag.Span
+
+	// Record is the record being discriminated, and Item the item the target
+	// names.
+	Record string
+	Item   string
+
+	// Group is the innermost repeating group the target sits in, empty where
+	// the target is itself the thing that repeats.
+	Group string
+}
+
+// Error implements the error interface.
+func (e *PredicateOccurrenceError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *PredicateOccurrenceError) Diagnostic() diag.Diagnostic {
+	repeats := e.Item + " repeats"
+	if e.Group != "" {
+		repeats = e.Item + " sits in the repeating group " + e.Group
+	}
+
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"the discriminator for record %s tests %s, and %s: a predicate names a field and nothing names "+
+				"an occurrence of one, so there is no saying which entry the value would come from",
+			e.Record, e.Item, repeats),
+		Spans: spans(e.Pos, e.Copybook, "declared here"),
+	}
+}
+
+// PredicatePositionError is a record discriminator whose target sits behind an
+// item whose extent moves with a count.
+//
+// docs/ir/SPEC.md's "Discriminator predicates" requires the target's position to
+// be constant within the record its transition would admit, and the reason is
+// the read loop's order: a predicate is evaluated at step 3, before its record
+// has been admitted, so a target whose position depends on a count obliges a
+// consumer to decode that count out of bytes nobody has identified. The bytes
+// may be another record type's, sending the read to an offset the layout never
+// described, or they may not decode at all — and one consumer then condemns a
+// well-formed file while another treats the predicate as not matching and reads
+// it correctly (#84).
+//
+// An arm's predicate carries no such restriction, because it runs against a
+// record already admitted (#90).
+type PredicatePositionError struct {
+	// Pos is the item reference in the layout.
+	Pos diag.Span
+
+	// Copybook is the target's entry in the copybook.
+	Copybook diag.Span
+
+	// Record is the record being discriminated, and Item the target.
+	Record string
+	Item   string
+
+	// Behind is the variable item in front of the target, and Count the field
+	// its occurrence count is read from.
+	Behind string
+	Count  string
+}
+
+// Error implements the error interface.
+func (e *PredicatePositionError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *PredicatePositionError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"the discriminator for record %s tests %s, and %s lies in front of it with as many entries as %s "+
+				"says: a predicate runs before its record has been admitted, so its target has to sit at the "+
+				"same offset in every record of that type",
+			e.Record, e.Item, e.Behind, e.Count),
+		Spans: spans(e.Pos, e.Copybook, "declared here"),
+	}
+}
+
+// PredicateLiteralError is a literal that cannot be resolved to the bytes a
+// consumer compares.
+//
+// docs/ir/SPEC.md requires both members of the predicate set to carry their
+// literals as bytes, already padded to the target's width, so that a consumer
+// compares the whole of the target and never applies a COBOL comparison rule of
+// its own. A literal wider than the item, a character the code page has no byte
+// for, and a number against an item whose bytes do not follow from the encoding
+// axes alone are the three ways that resolution fails, and each is reported
+// rather than resolved to something plausible.
+type PredicateLiteralError struct {
+	// Pos is the literal in the layout.
+	Pos diag.Span
+
+	// Copybook is the item's entry in the copybook.
+	Copybook diag.Span
+
+	// Subject is what carried the literal, as the message names it: a
+	// record's discriminator, an arm of a variant, or a `when`.
+	Subject string
+
+	// Literal is the literal as the layout wrote it, and Item the item it is
+	// compared against.
+	Literal layoutmodel.Literal
+	Item    string
+
+	// Found is why it will not resolve, in the message's own words.
+	Found string
+}
+
+// Error implements the error interface.
+func (e *PredicateLiteralError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *PredicateLiteralError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"%s compares %s against %s, and %s: a literal reaches a consumer as the bytes it compares, "+
+				"padded to the width of the item",
+			e.Subject, e.Item, e.Literal, e.Found),
+		Spans: spans(e.Pos, e.Copybook, "declared here"),
+	}
+}
+
+// RefusedStrategyError is a discriminator asking for something a predicate
+// cannot test.
+//
+// Three strategies were proposed for the layout format and refused, and each is
+// refused on its own terms rather than by an appeal to tidiness. A record's
+// length is a framing byte's value under two framings and is not in the file at
+// all under the other two ("A record told apart only by its length"). Positional
+// *last* is refused because a writer does not know which record is last until
+// its caller says there are no more, which is after that record has been written
+// ("The last record of a stream"). And positional *first* is not refused: it
+// lowers into the start state, and this fires only where the record is admitted
+// somewhere else besides.
+//
+// The rejection is keyed on what the layout asks for, because that is the only
+// thing `resolve` can test. Whether two records are *in fact* told apart by some
+// field is a property of the adopter's data, so a rule keyed on "nothing a field
+// can test" would have a diagnostic that was false whenever it fired.
+type RefusedStrategyError struct {
+	// Pos is the strategy in the layout.
+	Pos diag.Span
+
+	// Record is the record it was written for, and Strategy what it asked
+	// for.
+	Record   string
+	Strategy string
+
+	// Beside are the records this one has to be told apart from: those
+	// admitted by a transition eligible at the same time as one admitting it.
+	// It is empty where nothing has to be told from it.
+	Beside []string
+
+	// Found is why the strategy is refused, in the message's own words.
+	Found string
+}
+
+// Error implements the error interface.
+func (e *RefusedStrategyError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *RefusedStrategyError) Diagnostic() diag.Diagnostic {
+	beside := ""
+	if len(e.Beside) > 0 {
+		beside = ", which has to be told apart from " + list(e.Beside)
+	}
+
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"record %s is discriminated by %s%s, and %s",
+			e.Record, e.Strategy, beside, e.Found),
+		Spans: []diag.Span{e.Pos},
+	}
+}
+
+// UnnameableRecordError is a record every field of which sits inside a group
+// that repeats, standing beside another record a consumer would have to tell it
+// apart from.
+//
+// docs/ir/SPEC.md's "A record with nothing outside a table to name" is the whole
+// of it: two transitions that can be eligible at once have to be told apart by a
+// predicate, a predicate names a field contained in the record it admits, and a
+// target inside a repeating group is refused — so a record with no field outside
+// one leaves nothing to select it with. A variant does not rescue it, because an
+// arm is evaluated only once the record has been admitted.
+//
+// It is narrower than the heading, and deliberately: what is refused is the
+// record standing beside another at one state, not the record. A file of one
+// record type, or a state whose alternatives a guard already separates, admits
+// it under a transition carrying no predicate (#80).
+type UnnameableRecordError struct {
+	// Pos is where the record is admitted in the layout's expression.
+	Pos diag.Span
+
+	// Copybook is the record's entry in its copybook.
+	Copybook diag.Span
+
+	// State is the state offering both transitions.
+	State int
+
+	// Record is the record with nothing to name, and Beside the record it
+	// would have to be told apart from.
+	Record string
+	Beside string
+}
+
+// Error implements the error interface.
+func (e *UnnameableRecordError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *UnnameableRecordError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"at state %d the sequence admits %s and %s, and %s offers no target a predicate may name: every "+
+				"field of it sits inside a group that repeats, and a predicate names a field that does not",
+			e.State, e.Record, e.Beside, e.Record),
+		Spans: spans(e.Pos, e.Copybook, "declared here"),
+	}
+}
+
+// ZeroExtentError is a transition admitting a record whose extent is zero.
+//
+// docs/ir/SPEC.md's "A transition may carry no predicate" states the requirement
+// where it became necessary. Before that section every admitted record held at
+// least one field of non-zero width, because a predicate's target had to be one;
+// once a transition may carry no predicate, nothing else forbids an empty group.
+// Such a transition is a reader that emits records forever without advancing its
+// read position (#80).
+type ZeroExtentError struct {
+	// Pos is the discriminator in the layout, which is the form naming the
+	// record this is about.
+	Pos diag.Span
+
+	// Copybook is the record's entry in its copybook.
+	Copybook diag.Span
+
+	// Record is the record the transition admits, and Item the copybook item
+	// it is bound to.
+	Record string
+	Item   string
+}
+
+// Error implements the error interface.
+func (e *ZeroExtentError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *ZeroExtentError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"the sequence admits record %s and %s occupies no bytes: a transition consumes exactly one "+
+				"record, so one admitting a record of no extent is a reader that never advances",
+			e.Record, e.Item),
+		Spans: spans(e.Pos, e.Copybook, "declared here"),
+	}
+}
+
+// ArmTargetScopeError is an arm's predicate whose target does not stand where an
+// arm's target may stand.
+//
+// docs/ir/SPEC.md's "A predicate on an arm reads one occurrence" binds it two
+// ways, and both are about bytes that may not be there or may not be what they
+// look like. A target outside the occurrence has the same bytes in every
+// occurrence, so it selects the same arm in all of them — a choice made once per
+// record, which is a record node's and not a variant's. A target inside a
+// sibling arm has bytes only where that arm was selected, so reading it where it
+// was not is reading one alternative's data as another's (#90).
+//
+// `layoutmodel` checks the halves that need no copybook — the reference's root,
+// the outermost group, the variant itself and the arm's own name. What needs one
+// is that the group the target shares with the variant is the *innermost
+// repeating* one, which is this.
+type ArmTargetScopeError struct {
+	// Pos is the item reference in the layout.
+	Pos diag.Span
+
+	// Copybook is the redefined item's entry in the copybook.
+	Copybook diag.Span
+
+	// Record is the record being resolved, Group the innermost repeating group
+	// the variant sits in, Redefined the item the arms redefine and
+	// Alternative the arm carrying the predicate.
+	Record      string
+	Group       string
+	Redefined   string
+	Alternative string
+
+	// Item is the target as the layout wrote it.
+	Item layoutmodel.ItemRef
+
+	// Found is what is wrong with it, in the message's own words.
+	Found string
+}
+
+// Error implements the error interface.
+func (e *ArmTargetScopeError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *ArmTargetScopeError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"in record %s the arm %s of %s is selected by a predicate testing %s, and %s: an arm's predicate "+
+				"reads one occurrence of %s, so its target sits inside that occurrence",
+			e.Record, e.Alternative, e.Redefined, e.Item, e.Found, e.Group),
+		Spans: spans(e.Pos, e.Copybook, "the variant is here"),
+	}
+}
+
+// ArmOverlapError is two arms of one variant that one occurrence can satisfy
+// both of.
+//
+// docs/ir/SPEC.md's "A predicate on an arm reads one occurrence" is "When two
+// match, and when none does" at this scope and for its reasons. There are no
+// guards on an arm to exempt a pair — a guard reads a register, a register holds
+// one value for the whole of a record's read, and a value that is the same in
+// every occurrence selects a record rather than an arm — so every pair of arms
+// is inside the rule (#90).
+//
+// `layoutmodel` refuses the smallest version of this without a copybook: two
+// arms testing one item for one spelling of one literal. What needs a copybook
+// is the rest — one literal written as text and another as bytes, or two that
+// resolve to the same bytes under the item's charset and width — and this is it.
+type ArmOverlapError struct {
+	// Pos is the second arm in the layout, and First the arm it overlaps.
+	Pos   diag.Span
+	First diag.Span
+
+	// Record is the record being resolved, Group the innermost repeating group
+	// the variant sits in, and Redefined the item the arms redefine.
+	Record    string
+	Group     string
+	Redefined string
+
+	// Arms are the two alternatives, in the order the layout writes them.
+	Arms [2]string
+
+	// Value is the value one occurrence satisfies both with.
+	Value Value
+}
+
+// Error implements the error interface.
+func (e *ArmOverlapError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *ArmOverlapError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"in record %s the arms %s and %s of %s in %s are both selected by %s: an occurrence satisfying "+
+				"both is one no consumer can choose an alternative for, and there is no default arm",
+			e.Record, e.Arms[0], e.Arms[1], e.Redefined, e.Group, e.Value),
+		Spans: spans(e.Pos, e.First, "the other arm is here"),
+	}
+}
+
+// The two failures a consumer reports while it is reading, which are not faults
+// in a descriptor at all.
+//
+// They are here because docs/ir/SPEC.md requires them to be told apart and the
+// telling apart is worth doing once. An adopter sent to the first for the second
+// spends the day on a record type they already have.
+
+// UndescribedRecordError is a record no transition of the state matched.
+//
+// docs/ir/SPEC.md's "When two match, and when none does" requires a consumer to
+// report it rather than skipping ahead to a transition that matches later or
+// falling through to a default. There is no default, and a file containing an
+// undescribed record is a file the layout is wrong about.
+type UndescribedRecordError struct {
+	// State is the state the consumer was in.
+	State int
+
+	// Records are the records that state admits, in evaluation order, which
+	// is the list an adopter compares their file against.
+	Records []string
+}
+
+// Error implements the error interface.
+func (e *UndescribedRecordError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *UndescribedRecordError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"at state %d the record in front of the consumer is none of %s: the layout does not describe it",
+			e.State, list(e.Records)),
+	}
+}
+
+// GuardExcludedError is a record a transition's predicate matched, on a
+// transition a guard made ineligible.
+//
+// docs/ir/SPEC.md's "When two match, and when none does" asks a consumer to
+// report this instead of an undescribed record, naming the register the guard
+// tested. The two send an adopter to different places: an undescribed record
+// means the layout is missing a record type, while a detail arriving after its
+// counter reached zero means the file and its own header disagree about how many
+// there are. Only the wording differs, and it is the wording that saves a day.
+//
+// A transition carrying no predicate is never reported here. It would have
+// matched anything, so it says nothing about the bytes in hand, and reporting it
+// would displace the undescribed-record diagnostic exactly where that diagnostic
+// is right (#80).
+type GuardExcludedError struct {
+	// State is the state the consumer was in, and Record the record the
+	// excluded transition would have admitted.
+	State  int
+	Record string
+
+	// Register is the register the guard tested, and Guard the test, rendered
+	// as a message quotes one.
+	Register string
+	Guard    string
+}
+
+// Error implements the error interface.
+func (e *GuardExcludedError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *GuardExcludedError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"at state %d the record in front of the consumer is a %s, and the transition admitting one is "+
+				"not eligible: it holds while %s, and %s does not",
+			e.State, e.Record, e.Guard, e.Register),
+	}
+}
+
+// UnmatchedOccurrenceError is an occurrence of a table no arm of its variant
+// selected.
+//
+// docs/ir/SPEC.md's "A predicate on an arm reads one occurrence" requires a
+// consumer to report it and not to fall through to the last arm or leave the
+// occurrence's items unset. There is no default arm and a producer cannot write
+// one; an adopter whose entries carry a code the alternatives do not cover
+// writes an arm for the residue, spelled as the test over the codes it covers.
+type UnmatchedOccurrenceError struct {
+	// Arms are the alternatives the variant offers, in evaluation order.
+	Arms []string
+}
+
+// Error implements the error interface.
+func (e *UnmatchedOccurrenceError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *UnmatchedOccurrenceError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"this entry is none of %s: the layout describes the record it sits in and not this entry of it",
+			list(e.Arms)),
+	}
+}
+
+// list renders several names the way a message names them.
+func list(names []string) string {
+	switch len(names) {
+	case 0:
+		return "nothing"
+	case 1:
+		return names[0]
+	}
+
+	return strings.Join(names[:len(names)-1], ", ") + " and " + names[len(names)-1]
+}

--- a/internal/resolve/predicate_test.go
+++ b/internal/resolve/predicate_test.go
@@ -698,3 +698,45 @@ func TestAGuardExcludedTransitionIsReportedByItsRegister(t *testing.T) {
 		t.Errorf("the diagnostic does not name the register the guard tested: %s", excluded.Error())
 	}
 }
+
+// Value equality is asserted in one place because two of them read it. The
+// identity string is what `key` and the diagnostics render, and `sameValue` is
+// what the consumer's selection loop asks so that answering an equality does not
+// build two strings per transition; the two are only trustworthy while they
+// agree, so the agreement is the test rather than either answer alone.
+func TestValueEqualityDoesNotDependOnWhichAnswerIsAsked(t *testing.T) {
+	t.Parallel()
+
+	bytesValue := func(b string) Value { return Value{Bytes: []byte(b)} }
+	numberValue := func(n int64) Value { return Value{Number: n} }
+
+	pairs := []struct {
+		name string
+		one  Value
+		othr Value
+	}{
+		{"the same bytes", bytesValue("\xC8"), bytesValue("\xC8")},
+		{"different bytes", bytesValue("\xC8"), bytesValue("\xC4")},
+		{"bytes of different widths", bytesValue("\xC8"), bytesValue("\xC8\xC8")},
+		{"one run empty", bytesValue(""), bytesValue("\xC8")},
+		{"both runs empty", bytesValue(""), bytesValue("")},
+		{"the same number", numberValue(3), numberValue(3)},
+		{"different numbers", numberValue(3), numberValue(0)},
+		{"a number beside bytes", numberValue(0), bytesValue("\xC8")},
+	}
+
+	for _, pair := range pairs {
+		t.Run(pair.name, func(t *testing.T) {
+			t.Parallel()
+
+			want := pair.one.Identity() == pair.othr.Identity()
+			if got := sameValue(pair.one, pair.othr); got != want {
+				t.Errorf("sameValue says %v and the identities say %v, for %s and %s",
+					got, want, pair.one.Identity(), pair.othr.Identity())
+			}
+			if got := sameValue(pair.othr, pair.one); got != want {
+				t.Errorf("sameValue is not symmetric: %v the other way round, want %v", got, want)
+			}
+		})
+	}
+}

--- a/internal/resolve/predicate_test.go
+++ b/internal/resolve/predicate_test.go
@@ -1,0 +1,700 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package resolve
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cobol-go/copybook"
+
+	"github.com/Zaba505/cpybkc/internal/layout"
+	"github.com/Zaba505/cpybkc/internal/layoutmodel"
+)
+
+// Discrimination reaches a generator compiled, and these hold the compilation to
+// docs/ir/SPEC.md's "Discriminator predicates": a closed set of two tests, a
+// target that is a field node and never a name or a position, literals that are
+// already the bytes a consumer compares, and the four shapes `resolve` refuses
+// rather than describing.
+//
+// Every test drives the real layout parser and the real copybook reader, as the
+// automaton's do, so that nothing is asserted about a graph the readers would
+// never have produced. The encoding profile is the mainframe one throughout,
+// because what a literal resolves to is the whole point and cp037 is where `H`
+// is not `0x48`.
+
+// The copybooks these tests discriminate. `typed` carries its type code at its
+// first byte; `prefixed` carries a header every alternative includes and its own
+// code behind it, which is docs/ir/SPEC.md's mid-record discriminator; `tabular`
+// has nothing outside its table to name.
+const (
+	typed = `01 T-REC.
+   05 T-TYPE PIC X(3).
+   05 T-BODY PIC X(10).
+`
+
+	prefixed = `01 P-REC.
+   05 P-HEAD.
+      10 P-KEY PIC X(6).
+      10 P-SEQ PIC 9(2).
+   05 P-TYPE PIC X(1).
+   05 P-BODY PIC X(4).
+`
+
+	tabular = `01 A-REC.
+   05 A-ENTRY OCCURS 5 TIMES.
+      10 A-CODE PIC X(1).
+      10 A-DATA PIC X(9).
+`
+)
+
+// oneRecord is a layout of a single record type, discriminated as the caller
+// says and sequenced as any number of that record.
+func oneRecord(discriminator string) string {
+	return `(record ONLY (copybook "only.cpy" T-REC))
+(discriminate ONLY ` + discriminator + `)
+(sequence (* ONLY))`
+}
+
+// predicateOf is the predicate on the one transition leaving the start state.
+func predicateOf(t *testing.T, a *Automaton) *Predicate {
+	t.Helper()
+
+	if len(a.Start.Transitions) == 0 {
+		t.Fatal("the start state offers no transition")
+	}
+
+	return a.Start.Transitions[0].Predicate
+}
+
+// compileHand compiles a sequence over records a test assembled itself, which is
+// how a strategy the layout format has no spelling for reaches this package.
+//
+// docs/layout/SPEC.md closes the set at three, so `record-length` and
+// `positional` are refused while a layout is being read and never reach
+// `resolve` from a file. `resolve` refuses them all the same, in the words
+// docs/ir/SPEC.md asks for, and this is the road that reaches those words.
+func compileHand(t *testing.T, source string, records []SequencedRecord) (*Automaton, error) {
+	t.Helper()
+
+	file, err := layout.Parse("layout.sexpr", strings.NewReader(source))
+	if err != nil {
+		t.Fatalf("parsing the layout: %v", err)
+	}
+
+	sequence, err := layoutmodel.ReadSequence(file)
+	if err != nil {
+		t.Fatalf("reading the sequencing layer: %v", err)
+	}
+
+	return CompileSequence(Sequencing{
+		Sequence: sequence,
+		Dialect:  copybook.IBMEnterprise(),
+		Reading:  layoutmodel.ODOSlide,
+		Encoding: mainframe(),
+		Records:  records,
+	})
+}
+
+// TestEachStrategyLowersToOneMemberOfTheClosedSet is the whole of the mapping:
+// `equals` and `one-of` are the two members, and `single-record-type` is the
+// absence of a predicate rather than a third member testing nothing.
+func TestEachStrategyLowersToOneMemberOfTheClosedSet(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		strategy string
+		test     PredicateTest
+		values   int
+	}{
+		"equals": {strategy: `(equals (item ONLY T-TYPE) "ABC")`, test: BytesEqual, values: 1},
+		"one-of": {strategy: `(one-of (item ONLY T-TYPE) "ABC" "DEF")`, test: BytesOneOf, values: 2},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			a := compiled(t, oneRecord(test.strategy), map[string]string{"ONLY": typed})
+
+			predicate := predicateOf(t, a)
+			if predicate == nil {
+				t.Fatal("the transition carries no predicate")
+			}
+			if predicate.Test != test.test {
+				t.Errorf("the predicate is %s, want %s", predicate.Test, test.test)
+			}
+			if len(predicate.Values) != test.values {
+				t.Errorf("the predicate carries %d values, want %d", len(predicate.Values), test.values)
+			}
+			if predicate.Target == nil || predicate.Target.Name != "T-TYPE" {
+				t.Errorf("the predicate names %s, want the field node T-TYPE", itemName(predicate.Target))
+			}
+		})
+	}
+
+	t.Run("single-record-type", func(t *testing.T) {
+		t.Parallel()
+
+		a := compiled(t, oneRecord("single-record-type"), map[string]string{"ONLY": typed})
+		if predicate := predicateOf(t, a); predicate != nil {
+			t.Errorf("the transition carries %s, want no predicate at all", predicate)
+		}
+	})
+}
+
+// TestAPredicateCarriesItsLiteralsAsBytesPaddedToTheTarget is the requirement
+// that no consumer decides whether `Y` matches `Y `: the bytes leave here padded
+// to the item's width, in the file's own code page.
+func TestAPredicateCarriesItsLiteralsAsBytesPaddedToTheTarget(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		strategy string
+		want     []byte
+	}{
+		// cp037: `A` is 0xC1, and the two bytes T-TYPE has left over
+		// are the code page's space rather than a NUL or a truncation.
+		"text is translated and padded": {
+			strategy: `(equals (item ONLY T-TYPE) "A")`,
+			want:     []byte{0xC1, 0x40, 0x40},
+		},
+		"a byte string is what is in the file": {
+			strategy: `(equals (item ONLY T-TYPE) (bytes "C1C2C3"))`,
+			want:     []byte{0xC1, 0xC2, 0xC3},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			a := compiled(t, oneRecord(test.strategy), map[string]string{"ONLY": typed})
+
+			predicate := predicateOf(t, a)
+			if got := predicate.Values[0].Bytes; string(got) != string(test.want) {
+				t.Errorf("the literal resolved to % X, want % X", got, test.want)
+			}
+			if !predicate.Matches(test.want) {
+				t.Error("the predicate does not match the bytes it was compiled to")
+			}
+			if predicate.Matches(test.want[:2]) {
+				t.Error("the predicate matches a prefix of its target, want the whole of it")
+			}
+		})
+	}
+
+	t.Run("a number is the digits of a zoned item", func(t *testing.T) {
+		t.Parallel()
+
+		a := compiled(t,
+			`(record ONLY (copybook "only.cpy" P-REC))
+(discriminate ONLY (equals (item ONLY P-HEAD P-SEQ) 7))
+(sequence (* ONLY))`,
+			map[string]string{"ONLY": prefixed})
+
+		want := []byte{0xF0, 0xF7}
+		if got := predicateOf(t, a).Values[0].Bytes; string(got) != string(want) {
+			t.Errorf("the number resolved to % X, want % X", got, want)
+		}
+	})
+}
+
+// TestALiteralThatCannotBeResolvedIsReportedAndNotGuessed, because a producer
+// emitting plausible bytes for a value it could not compute is the silent
+// failure this whole project is arranged against.
+func TestALiteralThatCannotBeResolvedIsReportedAndNotGuessed(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"wider than the item":       `(equals (item ONLY T-TYPE) "ABCD")`,
+		"a byte string mismeasured": `(equals (item ONLY T-TYPE) (bytes "C1C2"))`,
+		"a number against text":     `(equals (item ONLY T-TYPE) 12)`,
+	}
+
+	for name, strategy := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := refused(t, oneRecord(strategy), map[string]string{"ONLY": typed})
+
+			var literal *PredicateLiteralError
+			if !errors.As(err, &literal) {
+				t.Fatalf("compiling reported %v, want a PredicateLiteralError", err)
+			}
+			if !strings.Contains(literal.Error(), "T-TYPE") {
+				t.Errorf("the diagnostic does not name the item: %s", literal.Error())
+			}
+		})
+	}
+}
+
+// TestADiscriminatorTestingAFieldOfAnotherRecordIsRejected, which is the half of
+// docs/ir/SPEC.md's containment rule that needs a copybook, plus the half
+// `layoutmodel` checks, reached by a caller that assembled a strategy itself.
+func TestADiscriminatorTestingAFieldOfAnotherRecordIsRejected(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a path naming no item of the record", func(t *testing.T) {
+		t.Parallel()
+
+		err := refused(t, oneRecord(`(equals (item ONLY T-MISSING) "A")`), map[string]string{"ONLY": typed})
+
+		var target *PredicateTargetError
+		if !errors.As(err, &target) {
+			t.Fatalf("compiling reported %v, want a PredicateTargetError", err)
+		}
+		if !strings.Contains(target.Error(), "names no item") {
+			t.Errorf("the diagnostic does not say the path names nothing: %s", target.Error())
+		}
+	})
+
+	t.Run("a reference rooted at another record", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := compileHand(t,
+			`(record ONLY (copybook "only.cpy" T-REC))
+(sequence (* ONLY))`,
+			[]SequencedRecord{{
+				Name:     "ONLY",
+				Copybook: "only.cpy",
+				Item:     recordOf(t, typed),
+				Discriminator: layoutmodel.Strategy{
+					Kind:     layoutmodel.Equals,
+					Item:     layoutmodel.ItemRef{Record: "OTHER", Path: []string{"T-TYPE"}},
+					Literals: []layoutmodel.Literal{{Kind: layoutmodel.TextLiteral, Text: "A"}},
+				},
+			}})
+
+		var target *PredicateTargetError
+		if !errors.As(err, &target) {
+			t.Fatalf("compiling reported %v, want a PredicateTargetError", err)
+		}
+		if !strings.Contains(target.Error(), "OTHER") {
+			t.Errorf("the diagnostic does not name the other record: %s", target.Error())
+		}
+	})
+}
+
+// TestADiscriminatorTargetInsideARepeatingGroupIsRejected names the record, the
+// field and the enclosing group, and not a generic reference error: which of
+// five entries the value would come from is the question nothing can answer.
+func TestADiscriminatorTargetInsideARepeatingGroupIsRejected(t *testing.T) {
+	t.Parallel()
+
+	err := refused(t,
+		`(record ONLY (copybook "only.cpy" A-REC))
+(discriminate ONLY (equals (item ONLY A-ENTRY A-CODE) "X"))
+(sequence (* ONLY))`,
+		map[string]string{"ONLY": tabular})
+
+	var occurrence *PredicateOccurrenceError
+	if !errors.As(err, &occurrence) {
+		t.Fatalf("compiling reported %v, want a PredicateOccurrenceError", err)
+	}
+	for _, want := range []string{"ONLY", "A-CODE", "A-ENTRY"} {
+		if !strings.Contains(occurrence.Error(), want) {
+			t.Errorf("the diagnostic does not name %s: %s", want, occurrence.Error())
+		}
+	}
+}
+
+// TestADiscriminatorTargetBehindAVariableItemIsRejected is the constant-position
+// restriction, and the diagnostic names the variable item in front of the target
+// because that is the thing the adopter has to move.
+func TestADiscriminatorTargetBehindAVariableItemIsRejected(t *testing.T) {
+	t.Parallel()
+
+	src := `01 V-REC.
+   05 V-N PIC 9(2).
+   05 V-CELL PIC X(4) OCCURS 1 TO 9 TIMES DEPENDING ON V-N.
+   05 V-TYPE PIC X(1).
+`
+
+	err := refused(t,
+		`(record ONLY (copybook "only.cpy" V-REC))
+(discriminate ONLY (equals (item ONLY V-TYPE) "X"))
+(sequence (* ONLY))`,
+		map[string]string{"ONLY": src})
+
+	var position *PredicatePositionError
+	if !errors.As(err, &position) {
+		t.Fatalf("compiling reported %v, want a PredicatePositionError", err)
+	}
+	for _, want := range []string{"ONLY", "V-TYPE", "V-CELL", "V-N"} {
+		if !strings.Contains(position.Error(), want) {
+			t.Errorf("the diagnostic does not name %s: %s", want, position.Error())
+		}
+	}
+}
+
+// TestADiscriminatorBehindASharedPrefixIsAnOrdinaryLayout, because which record
+// the position sum is over is settled before the predicate is evaluated rather
+// than by it: a record whose second half is a set of alternatives is how a
+// mainframe file is usually built.
+func TestADiscriminatorBehindASharedPrefixIsAnOrdinaryLayout(t *testing.T) {
+	t.Parallel()
+
+	a := compiled(t,
+		`(record ONLY (copybook "only.cpy" P-REC))
+(discriminate ONLY (equals (item ONLY P-TYPE) "D"))
+(sequence (* ONLY))`,
+		map[string]string{"ONLY": prefixed})
+
+	predicate := predicateOf(t, a)
+	if predicate == nil || predicate.Target.Name != "P-TYPE" {
+		t.Fatalf("the transition is selected by %s, want the type code behind the shared header", predicate)
+	}
+}
+
+// TestARecordWithNothingOutsideATableToNameIsRejectedBesideASibling is
+// docs/ir/SPEC.md's "A record with nothing outside a table to name", and the
+// diagnostic says so rather than reporting an ambiguity an adopter would try to
+// fix with a different literal.
+func TestARecordWithNothingOutsideATableToNameIsRejectedBesideASibling(t *testing.T) {
+	t.Parallel()
+
+	err := refused(t,
+		`(record TABULAR (copybook "a.cpy" A-REC))
+(record TYPED (copybook "t.cpy" T-REC))
+(discriminate TABULAR single-record-type)
+(discriminate TYPED (equals (item TYPED T-TYPE) "ABC"))
+(sequence (* (alt TABULAR TYPED)))`,
+		map[string]string{"TABULAR": tabular, "TYPED": typed})
+
+	var unnameable *UnnameableRecordError
+	if !errors.As(err, &unnameable) {
+		t.Fatalf("compiling reported %v, want an UnnameableRecordError", err)
+	}
+	if unnameable.Record != "TABULAR" || unnameable.Beside != "TYPED" {
+		t.Errorf("the diagnostic is about %s beside %s, want TABULAR beside TYPED",
+			unnameable.Record, unnameable.Beside)
+	}
+	if !strings.Contains(unnameable.Error(), "offers no target a predicate may name") {
+		t.Errorf("the diagnostic does not say what is missing: %s", unnameable.Error())
+	}
+}
+
+// TestARecordWithNothingOutsideATableToNameIsAdmittedWhereNothingIsBesideIt,
+// which is why the rejection above is narrower than its heading: what is refused
+// is the record standing beside another at one state, and not the record.
+func TestARecordWithNothingOutsideATableToNameIsAdmittedWhereNothingIsBesideIt(t *testing.T) {
+	t.Parallel()
+
+	a := compiled(t,
+		`(record TABULAR (copybook "a.cpy" A-REC))
+(discriminate TABULAR single-record-type)
+(sequence (* TABULAR))`,
+		map[string]string{"TABULAR": tabular})
+
+	if predicate := predicateOf(t, a); predicate != nil {
+		t.Errorf("the transition carries %s, want no predicate at all", predicate)
+	}
+}
+
+// TestARecordOfNoExtentIsRefusedBeforeATransitionCanAdmitOne is the requirement
+// that no transition admits a record whose extent is zero, asserted where the
+// refusal actually lands today.
+//
+// [compiler.checkExtent] states it in the requirement's own terms, and this
+// records why it cannot fire from a copybook: the only shape that would lay out
+// to nothing is a group with no elementary item under it, and `cobol-go` refuses
+// that while it is laying the record out. The check is kept for
+// [resolver.assertResolved]'s reason — the requirement is on what leaves this
+// package rather than on what entered it, and a caller assembling a record by
+// hand reaches this package without passing that reader.
+func TestARecordOfNoExtentIsRefusedBeforeATransitionCanAdmitOne(t *testing.T) {
+	t.Parallel()
+
+	field := recordOf(t, "01 E-REC.\n   05 E-GROUP.\n")
+
+	if _, err := copybook.NewLayout(field, copybook.IBMEnterprise()); err == nil {
+		t.Fatal("a record occupying no bytes laid out, and nothing downstream would have refused it")
+	}
+}
+
+// TestARecordLengthDiscriminatorIsRefusedNamingBothRecords. The rejection is
+// keyed on what the layout asks for, because whether two records are *in fact*
+// told apart by some field is a property of the adopter's data and a rule keyed
+// on that would be false whenever it fired.
+func TestARecordLengthDiscriminatorIsRefusedNamingBothRecords(t *testing.T) {
+	t.Parallel()
+
+	_, err := compileHand(t,
+		`(record LONGER (copybook "p.cpy" P-REC))
+(record SHORTER (copybook "t.cpy" T-REC))
+(sequence (* (alt LONGER SHORTER)))`,
+		[]SequencedRecord{
+			{
+				Name:          "LONGER",
+				Copybook:      "p.cpy",
+				Item:          recordOf(t, prefixed),
+				Discriminator: layoutmodel.Strategy{Kind: strategyRecordLength},
+			},
+			{
+				Name:          "SHORTER",
+				Copybook:      "t.cpy",
+				Item:          recordOf(t, typed),
+				Discriminator: layoutmodel.Strategy{Kind: layoutmodel.SingleRecordType},
+			},
+		})
+
+	var refusal *RefusedStrategyError
+	if !errors.As(err, &refusal) {
+		t.Fatalf("compiling reported %v, want a RefusedStrategyError", err)
+	}
+	for _, want := range []string{"LONGER", "SHORTER", "a record's length is not one"} {
+		if !strings.Contains(refusal.Error(), want) {
+			t.Errorf("the diagnostic does not carry %q: %s", want, refusal.Error())
+		}
+	}
+}
+
+// TestAPositionalLastDiscriminatorIsRefused, and the reason in the message is
+// the writer's rather than the reader's: *last* becomes true only when the
+// caller says there are no more records, which is after the record has been
+// written.
+func TestAPositionalLastDiscriminatorIsRefused(t *testing.T) {
+	t.Parallel()
+
+	_, err := compileHand(t,
+		`(record ONLY (copybook "only.cpy" T-REC))
+(sequence (* ONLY))`,
+		[]SequencedRecord{{
+			Name:     "ONLY",
+			Copybook: "only.cpy",
+			Item:     recordOf(t, typed),
+			Discriminator: layoutmodel.Strategy{
+				Kind:     strategyPositional,
+				Literals: []layoutmodel.Literal{{Kind: layoutmodel.TextLiteral, Text: "last"}},
+			},
+		}})
+
+	var refusal *RefusedStrategyError
+	if !errors.As(err, &refusal) {
+		t.Fatalf("compiling reported %v, want a RefusedStrategyError", err)
+	}
+	if !strings.Contains(refusal.Error(), "a writer does not know which record is last") {
+		t.Errorf("the diagnostic does not give the writer's reason: %s", refusal.Error())
+	}
+}
+
+// TestAPositionalFirstDiscriminatorLowersToTheStartState: nothing is added to
+// express it, because a state is already what the automaton knows about
+// position. What is checked is the other half — that the record is not also
+// admitted somewhere further in, where being first says nothing about it.
+func TestAPositionalFirstDiscriminatorLowersToTheStartState(t *testing.T) {
+	t.Parallel()
+
+	first := func() SequencedRecord {
+		return SequencedRecord{
+			Name:     "HEAD",
+			Copybook: "t.cpy",
+			Item:     recordOf(t, typed),
+			Discriminator: layoutmodel.Strategy{
+				Kind:     strategyPositional,
+				Literals: []layoutmodel.Literal{{Kind: layoutmodel.TextLiteral, Text: "first"}},
+			},
+		}
+	}
+
+	body := SequencedRecord{
+		Name:     "BODY",
+		Copybook: "p.cpy",
+		Item:     recordOf(t, prefixed),
+		Discriminator: layoutmodel.Strategy{
+			Kind:     layoutmodel.Equals,
+			Item:     layoutmodel.ItemRef{Record: "BODY", Path: []string{"P-TYPE"}},
+			Literals: []layoutmodel.Literal{{Kind: layoutmodel.TextLiteral, Text: "D"}},
+		},
+	}
+
+	a, err := compileHand(t,
+		`(record HEAD (copybook "t.cpy" T-REC))
+(record BODY (copybook "p.cpy" P-REC))
+(sequence (seq HEAD (* BODY)))`,
+		[]SequencedRecord{first(), body})
+	if err != nil {
+		t.Fatalf("compiling a first record: %v", err)
+	}
+
+	if predicate := a.Start.Transitions[0].Predicate; predicate != nil {
+		t.Errorf("the first record is selected by %s, want the start state and no predicate", predicate)
+	}
+
+	for _, state := range a.States {
+		if state == a.Start {
+			continue
+		}
+		for _, transition := range state.Transitions {
+			if transition.To == a.Start {
+				t.Errorf("state %d re-enters the start state, which is what makes *first* expressible", state.ID)
+			}
+		}
+	}
+
+	// The same strategy on a record the expression admits twice is refused,
+	// because a state distinguishes position only while it is entered once.
+	_, err = compileHand(t,
+		`(record HEAD (copybook "t.cpy" T-REC))
+(record BODY (copybook "p.cpy" P-REC))
+(sequence (seq HEAD (* BODY) HEAD))`,
+		[]SequencedRecord{first(), body})
+
+	var refusal *RefusedStrategyError
+	if !errors.As(err, &refusal) {
+		t.Fatalf("compiling reported %v, want a RefusedStrategyError", err)
+	}
+}
+
+// TestAPredicateIsCarriedEvenWhereGuardsAloneWouldSelect is docs/ir/SPEC.md's
+// **SHOULD** kept rather than optimised away: a predicate the automaton does not
+// need in order to choose is the only detection such a state has.
+func TestAPredicateIsCarriedEvenWhereGuardsAloneWouldSelect(t *testing.T) {
+	t.Parallel()
+
+	a := compiled(t, countedRun, countedRunCopybooks())
+
+	state := a.States[1]
+	detail := transitionAdmitting(t, state, "DETAIL")
+
+	if len(detail.Guards) == 0 {
+		t.Fatal("the detail transition carries no guard, and this test is about one that does")
+	}
+	if detail.Predicate == nil {
+		t.Error("the detail transition carries no predicate, and its guard alone would have selected it")
+	}
+}
+
+// TestTwoSpellingsOfOneValueOverlap is what resolving the literals buys the
+// overlap check. `layoutmodel` compares spellings and cannot see that `"A"` and
+// `(bytes "C1")` are one value; with a copybook in hand they are, and the two
+// transitions are two a record satisfies both of.
+func TestTwoSpellingsOfOneValueOverlap(t *testing.T) {
+	t.Parallel()
+
+	err := refused(t,
+		`(record FIRST (copybook "t.cpy" T-REC))
+(record SECOND (copybook "u.cpy" T-REC))
+(discriminate FIRST (equals (item FIRST T-TYPE) "A"))
+(discriminate SECOND (equals (item SECOND T-TYPE) (bytes "C14040")))
+(sequence (* (alt FIRST SECOND)))`,
+		map[string]string{"FIRST": typed, "SECOND": typed})
+
+	var ambiguity *SequenceAmbiguityError
+	if !errors.As(err, &ambiguity) {
+		t.Fatalf("compiling reported %v, want a SequenceAmbiguityError", err)
+	}
+}
+
+// TestAGuardOverABytesRegisterCarriesItsLiteralPadded, so that no consumer
+// decides whether `Y` matches `Y `. It is the predicate's rule reached from the
+// other side, and it is why one package resolves both.
+func TestAGuardOverABytesRegisterCarriesItsLiteralPadded(t *testing.T) {
+	t.Parallel()
+
+	a := compiled(t, countedRun, countedRunCopybooks())
+
+	summary := transitionAdmitting(t, a.States[1], "SUMMARY")
+
+	var flag *Guard
+	for i, guard := range summary.Guards {
+		if guard.Register.Kind == RegisterBytes {
+			flag = &summary.Guards[i]
+		}
+	}
+	if flag == nil {
+		t.Fatalf("the summary transition is guarded by %s, want the flag among them", renderGuards(summary.Guards))
+	}
+
+	// SUM-FLAG is PIC X(1), so `Y` is one byte and there is nothing to pad —
+	// what is asserted is that the guard carries bytes at all, and cp037's.
+	if len(flag.Values) != 1 || string(flag.Values[0].Bytes) != "\xE8" {
+		t.Errorf("the flag guard compares % X, want cp037's Y", flag.Values[0].Bytes)
+	}
+}
+
+// TestAWiderFlagPadsItsGuardLiteral is the same rule where there is something to
+// pad: a `PIC X(4)` flag compared against `Y` compares four bytes.
+func TestAWiderFlagPadsItsGuardLiteral(t *testing.T) {
+	t.Parallel()
+
+	wide := `01 W-REC.
+   05 W-TYPE PIC X(1).
+   05 W-FLAG PIC X(4).
+`
+
+	a := compiled(t,
+		`(record HEAD (copybook "w.cpy" W-REC))
+(record BODY (copybook "t.cpy" T-REC))
+(discriminate HEAD (equals (item HEAD W-TYPE) "H"))
+(discriminate BODY (equals (item BODY T-TYPE) "ABC"))
+(sequence (seq HEAD (when (item HEAD W-FLAG) "Y" BODY)))`,
+		map[string]string{"HEAD": wide, "BODY": typed})
+
+	body := transitionAdmitting(t, a.States[1], "BODY")
+	if len(body.Guards) != 1 {
+		t.Fatalf("the body transition carries %d guards, want the flag alone", len(body.Guards))
+	}
+
+	want := "\xE8\x40\x40\x40"
+	if got := string(body.Guards[0].Values[0].Bytes); got != want {
+		t.Errorf("the guard compares % X, want % X", got, want)
+	}
+}
+
+// TestARecordNoTransitionMatchedIsReportedAsUndescribed, rather than skipping
+// ahead to a transition that matches later or falling through to a default:
+// there is no default, and a file containing an undescribed record is a file the
+// layout is wrong about.
+func TestARecordNoTransitionMatchedIsReportedAsUndescribed(t *testing.T) {
+	t.Parallel()
+
+	a := compiled(t, countedRun, countedRunCopybooks())
+
+	_, err := a.Start.Select(RegisterFile{}, func(*Predicate) []byte { return []byte("\xE9") })
+
+	var undescribed *UndescribedRecordError
+	if !errors.As(err, &undescribed) {
+		t.Fatalf("selecting reported %v, want an UndescribedRecordError", err)
+	}
+	if !strings.Contains(undescribed.Error(), "HEADER") {
+		t.Errorf("the diagnostic does not list what the state does admit: %s", undescribed.Error())
+	}
+}
+
+// TestAGuardExcludedTransitionIsReportedByItsRegister, because the two failures
+// send an adopter to different places: an undescribed record means the layout is
+// missing a record type, and a detail arriving after its counter reached zero
+// means the file and its own header disagree about how many there are.
+func TestAGuardExcludedTransitionIsReportedByItsRegister(t *testing.T) {
+	t.Parallel()
+
+	a := compiled(t, countedRun, countedRunCopybooks())
+
+	// The counter has reached zero and the flag says no summary, so the only
+	// eligible transition is the one admitting another header — and the bytes
+	// in front of the consumer are a detail's.
+	held := RegisterFile{
+		1: number(layoutmodel.Literal{Kind: layoutmodel.NumberLiteral, Number: "0"}),
+		2: {Bytes: []byte("\x40")},
+	}
+
+	_, err := a.States[1].Select(held, func(*Predicate) []byte { return []byte("\xC4") })
+
+	var excluded *GuardExcludedError
+	if !errors.As(err, &excluded) {
+		t.Fatalf("selecting reported %v, want a GuardExcludedError", err)
+	}
+	if excluded.Record != "DETAIL" {
+		t.Errorf("the diagnostic is about %s, want DETAIL", excluded.Record)
+	}
+	if !strings.Contains(excluded.Error(), "DTL-COUNT") {
+		t.Errorf("the diagnostic does not name the register the guard tested: %s", excluded.Error())
+	}
+}

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -205,7 +205,7 @@ func Resolve(record *copybook.Field, opts Options) ([]*Record, error) {
 		return nil, err
 	}
 
-	r := &resolver{opts: opts, record: record}
+	r := &resolver{opts: opts, record: record, layout: layout}
 
 	items := layout.Items()
 	if odo := tables(items); len(odo) > 0 {
@@ -410,6 +410,11 @@ type resolver struct {
 	opts   Options
 	record *copybook.Field
 	faults diag.List
+
+	// layout is the record laid out, which is what an arm's predicate target
+	// is resolved against: a reference names a path of data names and only the
+	// layout says which item that is, at what offset and of what width.
+	layout *copybook.Layout
 }
 
 // option is one resolution of one item: the node it became, and the alternatives
@@ -623,6 +628,8 @@ func (r *resolver) variant(c cluster, in layoutmodel.Axes) run {
 	extent := redefined.Total()
 
 	arms := make([]Arm, 0, len(spec.Alternatives))
+	targets := make([]*copybook.Item, 0, len(spec.Alternatives))
+
 	for _, alternative := range spec.Alternatives {
 		member := c.find(alternative.Name)
 		if member == nil {
@@ -672,11 +679,25 @@ func (r *resolver) variant(c cluster, in layoutmodel.Axes) run {
 			continue
 		}
 
+		// A redefine with one alternative chooses nothing, so its strategy is
+		// ignored rather than compiled: there is no arm for a predicate to
+		// select and a target held to an arm's rules would be held to rules
+		// about a choice nobody is making.
+		var predicate *Predicate
+		var target *copybook.Item
+
+		if len(spec.Alternatives) > 1 {
+			if predicate, target = r.armPredicate(c, table, alternative); predicate == nil {
+				continue
+			}
+		}
+
 		arms = append(arms, Arm{
 			Alternative: alternative.Name,
-			Predicate:   alternative.Predicate,
+			Predicate:   predicate,
 			Body:        armBody(r.first(member, in), extent),
 		})
+		targets = append(targets, target)
 	}
 
 	switch {
@@ -708,6 +729,8 @@ func (r *resolver) variant(c cluster, in layoutmodel.Axes) run {
 		// variant short of them would be a second, less useful one.
 		return r.base(c, in)
 	}
+
+	r.checkArmOverlap(c, table, arms, targets, spec)
 
 	return run{nodes: pad(&Node{Kind: KindVariant, Arms: arms}, c.extent())}
 }

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -116,9 +116,14 @@ func resolveOne(t *testing.T, src string, redefines ...Redefine) *Record {
 // selects is a strategy that lowers into a predicate, for an arm a test needs
 // selected by something rather than by a particular thing. Compiling one into an
 // IR predicate node is #37's, so what it tests is not this package's business.
-func selects(value string) layoutmodel.Strategy {
+func selects(value string, path ...string) layoutmodel.Strategy {
+	if len(path) == 0 {
+		path = []string{"ENTRY", "CODE"}
+	}
+
 	return layoutmodel.Strategy{
 		Kind:     layoutmodel.Equals,
+		Item:     layoutmodel.ItemRef{Record: "R", Path: path},
 		Literals: []layoutmodel.Literal{{Kind: layoutmodel.TextLiteral, Text: value}},
 	}
 }

--- a/internal/resolve/sequence.go
+++ b/internal/resolve/sequence.go
@@ -584,7 +584,19 @@ func (c *compiler) checkAmbiguity(a *Automaton) {
 					continue
 				}
 
-				if !c.predicatesOverlap(first.Predicate, second.Predicate) {
+				if !c.predicatesOverlap(first, second) {
+					continue
+				}
+
+				// A record with nothing outside a table to name is
+				// refused in its own words, because the pair is not a
+				// pair of discriminators an adopter can rewrite: one
+				// of the two records offers no target a predicate may
+				// name, and the answer is a leading item outside the
+				// table rather than a different literal
+				// (docs/ir/SPEC.md, "A record with nothing outside a
+				// table to name", #80, #84).
+				if c.reportUnnameable(state, first, second) {
 					continue
 				}
 
@@ -599,6 +611,39 @@ func (c *compiler) checkAmbiguity(a *Automaton) {
 			}
 		}
 	}
+}
+
+// reportUnnameable reports an overlapping pair one of whose records offers no
+// field a predicate may name, and says whether it did.
+//
+// Only a transition carrying no predicate can be the one: a record every field
+// of which sits inside a table has no target for a discriminator to name, so its
+// strategy is `single-record-type` and its transition carries none. A record
+// that *does* offer a target and carries no predicate anyway is the ordinary
+// ambiguity, and the message for it is the ordinary one.
+func (c *compiler) reportUnnameable(state *State, first, second *Transition) bool {
+	for _, pair := range [][2]*Transition{{first, second}, {second, first}} {
+		if pair[0].Predicate != nil {
+			continue
+		}
+
+		record, known := c.record(pair[0].Record)
+		if !known || nameable(c.layoutOf(record)) {
+			continue
+		}
+
+		c.faults.Fail(&UnnameableRecordError{
+			Pos:      layoutSpan(c.positions[pair[0].To.ID-1].pos),
+			Copybook: copybookSpan(record, record.Item),
+			State:    state.ID,
+			Record:   pair[0].Record,
+			Beside:   pair[1].Record,
+		})
+
+		return true
+	}
+
+	return false
 }
 
 // predicatesOverlap reports whether one record can satisfy both predicates.
@@ -623,63 +668,27 @@ func (c *compiler) checkAmbiguity(a *Automaton) {
 // A transition carrying no predicate matches every record, so it overlaps
 // everything (#80).
 //
-// Two literals are the same value where their spellings are, which is
-// [layoutmodel.Literal.Identity]'s reading and is decidable from the layout
-// alone. Resolving a literal to the bytes a consumer compares — through the
-// item's charset, PICTURE and width — is #37's, and the comparison becomes one
-// over bytes when it lands.
-func (c *compiler) predicatesOverlap(a, b *layoutmodel.Strategy) bool {
-	if a == nil || b == nil {
+// Two values are the same value where the bytes they resolved to are, which is
+// [Value.Identity]'s reading: `"01"` written as text and `(bytes "F0F1")` are
+// one value on an EBCDIC file, and the two transitions carrying them are two a
+// record satisfies both of. That is the answer with a copybook in hand, and it
+// is strictly finer than the one `layoutmodel` reaches from a layout alone.
+func (c *compiler) predicatesOverlap(first, second *Transition) bool {
+	if first.Predicate == nil || second.Predicate == nil {
 		return true
 	}
 
-	over, ok := c.target(a)
-	against, againstOK := c.target(b)
-
-	switch {
-	case !ok || !againstOK:
-		// A discriminator whose reference does not resolve is #37's fault to
-		// report, and an ambiguity decided on one would name a pair of
-		// records where the fault is a misspelled item.
+	over, ok := c.stretchOf(first.Record, first.Predicate)
+	against, againstOK := c.stretchOf(second.Record, second.Predicate)
+	if !ok || !againstOK {
+		// A discriminator whose target this cannot place is one
+		// [compiler.discriminator] has already reported, and an ambiguity
+		// decided on it would name a pair of records where the fault is a
+		// misspelled item.
 		return false
-	case over != against:
-		return true
 	}
 
-	return slices.ContainsFunc(a.Literals, func(one layoutmodel.Literal) bool {
-		return slices.ContainsFunc(b.Literals, func(other layoutmodel.Literal) bool {
-			return one.Identity() == other.Identity()
-		})
-	})
-}
-
-// stretch is a run of a record's bytes: what a predicate tests.
-type stretch struct{ at, width int }
-
-// target is the run of bytes a predicate tests, and whether its reference
-// resolves to exactly one item.
-//
-// The offsets are the ones the record's static layout gives, which is the
-// declared maximum of every table in it. That a predicate's target sits at a
-// constant position — so that the run is the same run in every record of that
-// type — is #37's to hold a discriminator to.
-func (c *compiler) target(s *layoutmodel.Strategy) (stretch, bool) {
-	record, known := c.record(s.Item.Record)
-	if !known {
-		return stretch{}, false
-	}
-
-	built := c.layoutOf(record)
-	if built == nil {
-		return stretch{}, false
-	}
-
-	matched := itemsAt(built.Record, s.Item.Path)
-	if len(matched) != 1 {
-		return stretch{}, false
-	}
-
-	return stretch{at: matched[0].Offset, width: matched[0].Length}, true
+	return overlap(first.Predicate, over, second.Predicate, against)
 }
 
 // satisfiable reports whether some register file satisfies every guard in the
@@ -719,7 +728,7 @@ func satisfiable(guards []Guard) bool {
 // count literal that will not parse is a fault for whoever wrote it rather than
 // a reason to call a state ambiguous.
 func holdsTogether(guards []Guard) bool {
-	var narrowed []layoutmodel.Literal
+	var narrowed []Value
 	bounded := false
 
 	for _, guard := range guards {
@@ -728,13 +737,13 @@ func holdsTogether(guards []Guard) bool {
 		}
 
 		if !bounded {
-			narrowed, bounded = guard.Literals, true
+			narrowed, bounded = guard.Values, true
 
 			continue
 		}
 
-		narrowed = slices.DeleteFunc(slices.Clone(narrowed), func(one layoutmodel.Literal) bool {
-			return !slices.ContainsFunc(guard.Literals, func(other layoutmodel.Literal) bool {
+		narrowed = slices.DeleteFunc(slices.Clone(narrowed), func(one Value) bool {
+			return !slices.ContainsFunc(guard.Values, func(other Value) bool {
 				return one.Identity() == other.Identity()
 			})
 		})
@@ -751,15 +760,12 @@ func holdsTogether(guards []Guard) bool {
 	return slices.ContainsFunc(narrowed, above(0))
 }
 
-// above is a literal that reads as a number greater than n.
-func above(n int) func(layoutmodel.Literal) bool {
-	return func(literal layoutmodel.Literal) bool {
-		if literal.Kind != layoutmodel.NumberLiteral {
-			return true
-		}
-
-		value, err := strconv.Atoi(literal.Number)
-
-		return err != nil || value > n
-	}
+// above is a value that is a number greater than n.
+//
+// A value carrying bytes survives it, because a guard over a bytes register
+// never carries a `positive` test beside an `equals` one — the two are over
+// registers of different kinds — and calling such a pair unsatisfiable would
+// report an ambiguity that is not there.
+func above(n int64) func(Value) bool {
+	return func(value Value) bool { return value.Bytes != nil || value.Number > n }
 }

--- a/internal/resolve/variant_test.go
+++ b/internal/resolve/variant_test.go
@@ -85,7 +85,7 @@ func TestARedefineInsideATableBecomesAVariant(t *testing.T) {
 			variant.Arms[0].Alternative, variant.Arms[1].Alternative)
 	}
 	for _, arm := range variant.Arms {
-		if !arm.Predicate.Predicate() {
+		if arm.Predicate == nil {
 			t.Errorf("the arm %s is selected by nothing", arm.Alternative)
 		}
 		if got := arm.Body.Extent(); got != 8 {
@@ -225,8 +225,8 @@ func TestAShorterArmCarriesTheSlackItsItemsDoNotOccupy(t *testing.T) {
 		return []Redefine{{
 			Item: fieldNamed(t, field, "WIDE"),
 			Alternatives: []Alternative{
-				{Name: "WIDE", Predicate: selects("W")},
-				{Name: "NARROW", Predicate: selects("N")},
+				{Name: "WIDE", Predicate: selects("W", "ENTRY", "TAG")},
+				{Name: "NARROW", Predicate: selects("N", "ENTRY", "TAG")},
 			},
 		}}
 	})
@@ -312,8 +312,8 @@ func TestAVariantIsRejectedWhenItsAlternativesCannotBeMadeToAgree(t *testing.T) 
 		Redefines: []Redefine{{
 			Item: fieldNamed(t, field, "SHORT"),
 			Alternatives: []Alternative{
-				{Name: "SHORT", Predicate: selects("S")},
-				{Name: "LONG", Predicate: selects("L")},
+				{Name: "SHORT", Predicate: selects("S", "ENTRY", "TAG")},
+				{Name: "LONG", Predicate: selects("L", "ENTRY", "TAG")},
 			},
 		}},
 	})
@@ -350,8 +350,8 @@ func TestAVariantIsRejectedWhenAnArmsExtentMovesWithData(t *testing.T) {
 		return []Redefine{{
 			Item: fieldNamed(t, field, "FIXED"),
 			Alternatives: []Alternative{
-				{Name: "FIXED", Predicate: selects("F")},
-				{Name: "VARYING", Predicate: selects("V")},
+				{Name: "FIXED", Predicate: selects("F", "ENTRY", "TAG")},
+				{Name: "VARYING", Predicate: selects("V", "ENTRY", "TAG")},
 			},
 		}}
 	})


### PR DESCRIPTION
Closes #37

Lowers a layout's discriminator strategies into the closed set of IR predicates, in the two scopes `docs/ir/SPEC.md` admits one in — a transition choosing a record, and an arm of a variant choosing an alternative inside one occurrence — and resolves every literal to the bytes a consumer compares.

## What landed

- `internal/resolve/predicate.go` — the `Predicate` node (`bytes-equal`, `bytes-one-of`), `Value` (a literal resolved), the literal→bytes resolution, the overlap test over resolved bytes, and the walk a consumer runs (`State.Select`, `Node.SelectArm`).
- `internal/resolve/discriminator.go` — the lowering for both scopes and the rules on where a target may sit, plus the post-assembly checks that need the graph.
- `internal/resolve/predicate_errors.go` — the diagnostics, each naming what the spec asks it to name.
- `Transition.Predicate` and `Arm.Predicate` are now `*Predicate` rather than the layout's strategy, and `Guard.Literals` is now `Guard.Values` — resolved, so a guard over a bytes register carries its literal padded to the register's width.

## Acceptance criteria

- [x] Each strategy lowered to a closed-set IR predicate — `equals`→`bytes-equal`, `one-of`→`bytes-one-of`, `single-record-type`→no predicate.
- [x] Predicates name a field node identifier, never a field name and never a materialised position — `Predicate.Target` is a `*copybook.Field` (as `Binding.Field` and `Repetition.DependingOn` already are; #38 assigns identifiers), and the node carries no offset. The overlap check computes a position from the record's layout rather than reading one off the node.
- [x] Target contained in the record its transition admits; a target in another record rejected — `PredicateTargetError`. A target that is a register is unrepresentable: a `Predicate` carries a field and a `Guard` carries a register, and a layout has no spelling for a register in a strategy.
- [x] A transition's target that repeats, or sits inside a group that repeats, rejected naming the record, the field and the group — `PredicateOccurrenceError`. An arm's target is outside that rule and required to sit inside one.
- [x] A transition's target whose position is not constant rejected, naming the record, the target and the variable item in front of it — `PredicatePositionError`. An arm's carries no such restriction (test: a target behind the variant).
- [x] A record offering no field outside a repeating group rejected where it stands beside a transition whose guards can hold at the same time — `UnnameableRecordError` — and admitted where nothing has to be told from it.
- [x] `single-record-type` → a transition carrying no predicate; positional *first* → the start state (and refused where the record is also admitted elsewhere, since a state distinguishes position only while entered once).
- [x] A record-length discriminator refused on the key `resolve` can test — the layout *asking* for one — naming both records.
- [x] A transition admitting a record whose extent is zero rejected, naming the record.
- [x] A predicate emitted even where guards alone would select the transition, per the **SHOULD**.
- [x] Positional *last* refused, naming the record and the writer's reason.
- [x] A transition carrying no predicate rejected beside any sibling whose guards can hold at the same time.
- [x] Each variant's arms lowered to predicates of the same set, with the target required inside the innermost repeating group containing the variant and rejected where it sits outside it or inside a sibling arm — `ArmTargetScopeError`.
- [x] Overlapping predicates within one variant rejected on the transitions' test — `ArmOverlapError`.
- [x] An occurrence matching no arm reported distinctly from a record no transition matched — `UnmatchedOccurrenceError` vs `UndescribedRecordError`.
- [x] Arm evaluation order explicit and deterministic, as a state's transition order is.
- [x] Tests: an arm predicate on a type code inside the entry it selects for, a nested variant whose selector sits in the arm containing it, an arm target rejected for sitting in a sibling arm, two arms whose predicates overlap.
- [x] Overlapping predicates within one automaton state rejected on whether one *record* can satisfy both.
- [x] Guard-disjoint transitions exempted, over the closed guard set (`satisfiable`, unchanged and now over resolved values).
- [x] Predicate evaluation order explicit and deterministic.
- [x] A guard's literal for a bytes register padded to the width it is compared against.
- [x] Where no transition is eligible and one would have matched but for a guard, the rejection names the register — and never on the strength of a transition carrying no predicate.
- [x] Tests cover each strategy, the overlap rejection, the guard-disjoint exemption, a discriminator mid-record behind a shared prefix, a target inside a repeating group, and a target behind an `OCCURS DEPENDING ON` group.

## Judgment calls that shaped the public API

**The target is a `*copybook.Field`, not a `*Node`.** A record resolves to one `Record` per combination of `REDEFINES` alternatives outside a repeating group, so there is no single node for a field, while the copybook field is the one answer. This is the convention `Repetition.DependingOn` and `Binding.Field` already set, and `#38` is what turns a field into an identifier.

**A number literal resolves only against an unsigned zoned `DISPLAY` item.** The bytes of a number in a packed, binary or signed item follow from a `SIGN` clause and a byte order the four encoding axes do not by themselves pin down, and emitting plausible bytes is the silent failure this project is arranged against. The diagnostic sends the adopter to `(bytes "…")`, which is the spelling that exists for saying exactly what is in the file.

**cp500, cp1047 and cp1140 resolve through the invariant subset.** `cobol-go`'s `codec` carries hand-written tables for `ascii` and `cp037` only. `codec/SPEC.md` states normatively that the digits, the letters and the space are identical across every EBCDIC code page, so a literal made of those resolves; a character outside that subset is reported rather than guessed. A type code is digits and letters, so this costs a discriminator nothing today, and it becomes an exact table the moment `cobol-go` writes one.

**`State.Select` and `Node.SelectArm` are here.** They are the walk a generated consumer runs, kept beside the descriptor for `Record.Position`'s and `Record.At`'s reason — so this package's own tests run it — and because the two failures `docs/ir/SPEC.md` insists on distinguishing are worth distinguishing in one place rather than in every generator.

**Not in this change:** the bound `docs/ir/SPEC.md`'s *A predicate never reads past the record in front of it* places on a target under **unframed** and **delimited** framing. It is #94's rule, it is not among this issue's acceptance criteria, and it needs the file node's framing, which `Sequencing` does not carry.

## Verified

`dagger call ci` — green, from inside the worktree.
