### PR TITLE
story(resolve): assemble and emit the resolved IR

### DIFF
--- a/docs/ir/SPEC.md
+++ b/docs/ir/SPEC.md
@@ -3615,7 +3615,7 @@ records offer them.
 
 | Section | Implemented by |
 |---|---|
-| [Structure](#structure) | #17, #80, #90 `ir` |
+| [Structure](#structure) | #17, #80, #90 `ir`, #38 `resolve` |
 | [Offsets and widths](#offsets-and-widths) | #32, #34, #35 `resolve`, #77, #82, #84, #87, #88, #89, #90 `ir` |
 | [Physical framing](#physical-framing) | #78, #88, #92, #94 `ir`, #26 `layout`, #52 `gen-go` |
 | [The encoding profile, applied](#the-encoding-profile-applied) | #33 `resolve` |
@@ -3630,5 +3630,6 @@ records offer them.
 | The schema itself | #17 `ir` — [`proto/cpybkc/ir/v1/ir.proto`](../../proto/cpybkc/ir/v1/ir.proto) |
 | The schema, as Go | #18 `ir` — [`irpb/`](../../irpb), a module of its own |
 | The published artifacts | #19 `ir` — [`irpb/descriptor_set.go`](../../irpb/descriptor_set.go) computes the set, [`internal/tools/`](../../internal/tools) writes both files, `.dagger/main.go` builds them and `.github/workflows/release.yaml` attaches them |
+| Assembling the IR | #38 `resolve` — [`internal/assemble/`](../../internal/assemble) turns a framing, a compiled automaton and one resolved record type per `record` form into one descriptor, assigning the identifiers by the traversal [Identity, ordering and determinism](#identity-ordering-and-determinism) asks for, and holds the result to a completeness pass before any generator is invoked |
 | Emitting the IR | #20, #21 `ir` — [`internal/emit/`](../../internal/emit) encodes a descriptor deterministically, in either form, and writes it where `--emit-ir` names, a path or `-` for standard output |
 | Conventions this document follows | #15 `setup` |

--- a/internal/assemble/assemble.go
+++ b/internal/assemble/assemble.go
@@ -1,0 +1,487 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package assemble
+
+import (
+	"math"
+
+	"github.com/Zaba505/cobol-go/copybook"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+	"github.com/Zaba505/cpybkc/internal/layoutmodel"
+	"github.com/Zaba505/cpybkc/internal/resolve"
+	"github.com/Zaba505/cpybkc/irpb"
+)
+
+// Options are the resolved layout: everything a descriptor is assembled out of,
+// and nothing that still needs resolving.
+//
+// Every member arrives already resolved against its copybook, for the reason
+// [github.com/Zaba505/cpybkc/internal/resolve.Redefine] does: reading a layout
+// is one step and resolving a copybook against it is another, and a package
+// doing both would read a layout's spelling of an item in two places.
+type Options struct {
+	// Framing is the layout's physical framing, and is required: the file
+	// node carries one member of a closed set of four, and there is no member
+	// standing for a framing nobody stated.
+	Framing *layoutmodel.Framing
+
+	// Automaton is the compiled sequencing expression, and is required: the
+	// file node names its start state.
+	Automaton *resolve.Automaton
+
+	// Records are the record types the automaton's transitions admit, in the
+	// order their record nodes are to be assigned identifiers.
+	//
+	// One entry per record type and not per `record` form. A copybook holding
+	// a REDEFINES outside a repeating group resolves to one
+	// [github.com/Zaba505/cpybkc/internal/resolve.Record] per combination of
+	// alternatives, each of which is its own record type with its own
+	// discriminator (docs/ir/SPEC.md, "Members never overlap, and `REDEFINES`
+	// is resolved away"), and which of them a given transition admits is a
+	// question about the layout rather than about the resolved records. So the
+	// pairing arrives made: a caller hands over one entry per name a
+	// transition may admit, and this package neither splits nor merges them.
+	Records []Record
+
+	// Renames are the renames the layout wrote, resolved to the copybook items
+	// they name.
+	//
+	// A rename substitutes a name and keeps the original, so what one
+	// contributes is the override beside the name the copybook gave the item
+	// (docs/ir/SPEC.md, "Names"). It reaches every node standing for that item,
+	// in every record type that holds it: a rename is a name, and a name is per
+	// item rather than per record.
+	Renames []Rename
+}
+
+// Record is one record type of the descriptor.
+type Record struct {
+	// Name is the name a transition admits this record type by: the name the
+	// layout's `record` form defines, or whatever a caller distinguishing two
+	// alternatives of one copybook chose to call each.
+	//
+	// It does not reach the descriptor. A record node's names are the
+	// copybook's, because docs/ir/SPEC.md's "Names" carries the name a
+	// copybook spells and a layout-side binding is not one.
+	Name string
+
+	// Copybook is the copybook's path as the layout spells it, carried so
+	// that a diagnostic about an item can name the file the fault is in.
+	Copybook string
+
+	// Resolved is the record itself.
+	Resolved *resolve.Record
+}
+
+// Rename is one `rename` form, resolved.
+type Rename struct {
+	// Item is the copybook item renamed.
+	Item *copybook.Field
+
+	// Substitute is the name carried beside the original, exactly as the
+	// layout wrote it. It is language-neutral and is not munged here: casing,
+	// reserved words and what to do about a name that is not an identifier in
+	// some target language are a generator's.
+	Substitute string
+}
+
+// Assemble turns a resolved layout into the descriptor a generator plugin
+// consumes.
+//
+// Identifiers are assigned by the traversal the package documentation states,
+// the node list comes back in ascending identifier order, and identical inputs
+// produce an identical descriptor — which
+// [github.com/Zaba505/cpybkc/internal/emit.Marshal] turns into identical bytes
+// (docs/ir/SPEC.md, "Identity, ordering and determinism", #38).
+//
+// The result is held to [Validate] before it is handed back, so nothing leaves
+// here that a generator would have been the first to find wrong. A descriptor
+// that failed either pass is not returned at all: a half-assembled one is a
+// descriptor a caller can read, and there is no reading of a layout that was
+// rejected.
+//
+// Every fault it finds is reported, joined with [errors.Join] and assertable
+// with [errors.As], rather than the first.
+func Assemble(opts Options) (*irpb.Descriptor, error) {
+	switch {
+	case opts.Framing == nil:
+		return nil, ErrNoFraming
+	case opts.Automaton == nil:
+		return nil, ErrNoAutomaton
+	case len(opts.Records) == 0:
+		return nil, ErrNoRecords
+	}
+
+	a := &assembler{
+		opts:       opts,
+		byName:     make(map[string]*scope, len(opts.Records)),
+		renames:    make(map[*copybook.Field]string, len(opts.Renames)),
+		registers:  make(map[*resolve.Register]uint64),
+		states:     make(map[*resolve.State]uint64),
+		predicates: make(map[predicateKey]uint64),
+	}
+
+	for _, rename := range opts.Renames {
+		if rename.Item != nil {
+			a.renames[rename.Item] = rename.Substitute
+		}
+	}
+
+	descriptor := a.assemble()
+	if a.faults.Failed() {
+		return nil, a.faults.Err()
+	}
+
+	if err := Validate(descriptor); err != nil {
+		return nil, err
+	}
+
+	return descriptor, nil
+}
+
+// assembler holds the state one [Assemble] accumulates.
+type assembler struct {
+	opts   Options
+	faults diag.List
+
+	// nodes is the node list under construction. A node's identifier is its
+	// index in it, which is what makes the list ascending by construction
+	// rather than by a sort this package could forget to run.
+	nodes []*irpb.Node
+
+	// byName is the record types under the name a transition admits each by.
+	byName map[string]*scope
+
+	renames    map[*copybook.Field]string
+	registers  map[*resolve.Register]uint64
+	states     map[*resolve.State]uint64
+	predicates map[predicateKey]uint64
+
+	// pending are the predicate nodes whose bodies are filled once every
+	// record's field nodes have identifiers. A predicate names a field of the
+	// record it reads, and an arm's predicate is met while that record is
+	// still being walked.
+	pending []pendingPredicate
+}
+
+// scope is one record type while it is being assembled: the identifiers its
+// nodes were given, and the copybook item each field node stands for.
+//
+// A field lookup is per record type and never across the descriptor, because
+// two record types resolved from one copybook hold two field nodes for one
+// copybook item — which is the duplication docs/ir/SPEC.md's "Members never
+// overlap" accepts, seen from the side that has to resolve a reference through
+// it.
+type scope struct {
+	name     string
+	copybook string
+
+	// record is the identifier of the record node itself, which is what a
+	// transition admitting this record type points at.
+	record uint64
+
+	// nodes maps each resolved node to the identifier it was given, and
+	// fields maps the copybook item behind each *field* node to the same.
+	// Only field nodes are in fields: every reference that names an item
+	// names an elementary one.
+	nodes  map[*resolve.Node]uint64
+	fields map[*copybook.Field]uint64
+}
+
+// predicateKey is what makes two references to one predicate the same node: the
+// record whose bytes it reads, and the compiled predicate itself.
+//
+// The record is half of the key rather than the predicate alone, because a
+// predicate names a field and a field node belongs to one record type. `resolve`
+// compiles a record's discriminator once and hands the same node to every
+// appearance of that record in the sequencing expression, so within one record
+// the pointer is identity; across two it would be a reference into the wrong
+// record's fields.
+type predicateKey struct {
+	record    *scope
+	predicate *resolve.Predicate
+}
+
+// pendingPredicate is a predicate node awaiting its body.
+type pendingPredicate struct {
+	scope     *scope
+	predicate *resolve.Predicate
+	node      *irpb.Node
+}
+
+// reserve appends a node with the next identifier and returns it. The body is
+// set by whoever reserved it, which is what lets a reference point forward.
+func (a *assembler) reserve() *irpb.Node {
+	node := &irpb.Node{Id: uint64(len(a.nodes))}
+	a.nodes = append(a.nodes, node)
+
+	return node
+}
+
+// assemble runs the traversal the package documentation states.
+func (a *assembler) assemble() *irpb.Descriptor {
+	file := a.reserve()
+
+	for _, record := range a.opts.Records {
+		a.record(record)
+	}
+
+	a.allocateRegisters()
+	a.allocateStates()
+	a.fillStates()
+	a.fillPredicates()
+
+	file.Kind = &irpb.Node_File{File: fileOf(a.opts.Framing, a.states[a.opts.Automaton.Start])}
+
+	return &irpb.Descriptor{Version: irpb.IrVersion_IR_VERSION_1, Nodes: a.nodes}
+}
+
+// record assembles one record type: the record node, then its tree.
+//
+// The tree is walked twice. The first walk hands out identifiers and records
+// which copybook item each field node stands for; the second fills the bodies,
+// by which time every reference into the record has an identifier to state. Two
+// walks rather than one because a reference need not point backwards: an
+// `OCCURS DEPENDING ON` count lies ahead of the table it sizes, but nothing in
+// this package should depend on that being true, and the rule that makes it
+// true is stated somewhere else entirely (docs/ir/SPEC.md, "A count is in hand
+// before the extent it decides").
+func (a *assembler) record(record Record) {
+	if record.Resolved == nil || record.Resolved.Root == nil {
+		a.faults.Fail(&UnknownRecordError{Record: record.Name, Defined: a.recordNames()})
+
+		return
+	}
+
+	if _, already := a.byName[record.Name]; already {
+		a.faults.Fail(&DuplicateRecordError{Record: record.Name, Copybook: record.Copybook})
+
+		return
+	}
+
+	node := a.reserve()
+	s := &scope{
+		name:     record.Name,
+		copybook: record.Copybook,
+		record:   node.Id,
+		nodes:    make(map[*resolve.Node]uint64),
+		fields:   make(map[*copybook.Field]uint64),
+	}
+	a.byName[record.Name] = s
+
+	a.allocate(s, record.Resolved.Root)
+	a.fill(s, record.Resolved.Root)
+
+	node.Kind = &irpb.Node_Record{Record: &irpb.Record{
+		RootId: s.nodes[record.Resolved.Root],
+		Names:  a.names(record.Resolved.Item),
+	}}
+}
+
+// allocate hands an identifier to every node of a record's tree, in containment
+// order, an arm's predicate ahead of the arm's body.
+func (a *assembler) allocate(s *scope, node *resolve.Node) {
+	s.nodes[node] = a.reserve().Id
+
+	if node.Kind == resolve.KindField && node.Field != nil {
+		s.fields[node.Field] = s.nodes[node]
+	}
+
+	for _, member := range node.Members {
+		a.allocate(s, member)
+	}
+
+	for _, arm := range node.Arms {
+		a.allocatePredicate(s, arm.Predicate)
+
+		if arm.Body != nil {
+			a.allocate(s, arm.Body)
+		}
+	}
+}
+
+// fill sets the body of every node of a record's tree.
+func (a *assembler) fill(s *scope, node *resolve.Node) {
+	at := a.nodes[s.nodes[node]]
+
+	switch node.Kind {
+	case resolve.KindGroup:
+		members := make([]uint64, 0, len(node.Members))
+		for _, member := range node.Members {
+			a.fill(s, member)
+			members = append(members, s.nodes[member])
+		}
+
+		at.Kind = &irpb.Node_Group{Group: &irpb.Group{
+			MemberIds:  members,
+			Names:      a.names(node.Field),
+			Repetition: a.repetition(s, node.Repetition),
+		}}
+	case resolve.KindField:
+		at.Kind = &irpb.Node_Field{Field: &irpb.Field{
+			Width:      width(node.Width()),
+			Encoding:   encodingOf(node.Encoding),
+			Usage:      usageOf(node.Field),
+			Picture:    pictureOf(node.Field),
+			Names:      a.names(node.Field),
+			Repetition: a.repetition(s, node.Repetition),
+		}}
+	case resolve.KindVariant:
+		arms := make([]*irpb.Arm, 0, len(node.Arms))
+		for _, arm := range node.Arms {
+			arms = append(arms, a.arm(s, arm))
+		}
+
+		at.Kind = &irpb.Node_Variant{Variant: &irpb.Variant{Arms: arms}}
+	case resolve.KindSlack:
+		at.Kind = &irpb.Node_Slack{Slack: &irpb.Slack{Width: width(node.Width())}}
+	}
+}
+
+// arm fills one arm of a variant: the predicate that selects it, and the group
+// or field that is its body.
+//
+// The body reference says which of the two kinds it is rather than leaving a
+// consumer to dereference an untyped identifier and find out, which is what the
+// schema's oneof is for.
+func (a *assembler) arm(s *scope, arm resolve.Arm) *irpb.Arm {
+	built := &irpb.Arm{PredicateId: a.allocatePredicate(s, arm.Predicate)}
+
+	if arm.Body == nil {
+		return built
+	}
+
+	a.fill(s, arm.Body)
+
+	id := s.nodes[arm.Body]
+	if arm.Body.Kind == resolve.KindField {
+		built.Body = &irpb.Arm_FieldId{FieldId: id}
+	} else {
+		built.Body = &irpb.Arm_GroupId{GroupId: id}
+	}
+
+	return built
+}
+
+// repetition is what an item that repeats carries, and nil for one that does
+// not.
+//
+// A count that is a reference names a field of the record being read. It never
+// names a register here: a count coming from a record admitted earlier is
+// written `times` in a layout and compiles into the automaton's own memory
+// rather than into a repetition (docs/ir/SPEC.md, "A variable record is a sum
+// with a variable term"), so the register member of the schema's count is one
+// this producer has nothing to put in yet.
+func (a *assembler) repetition(s *scope, repetition *resolve.Repetition) *irpb.Repetition {
+	if repetition == nil {
+		return nil
+	}
+
+	if !repetition.Reference() {
+		return &irpb.Repetition{Count: &irpb.Repetition_Constant{Constant: width(repetition.Count)}}
+	}
+
+	id, found := s.fields[repetition.DependingOn]
+	if !found {
+		a.faults.Fail(&UnresolvedTargetError{
+			Pos:      a.span(s, repetition.DependingOn),
+			Record:   s.name,
+			Item:     itemName(repetition.DependingOn),
+			Position: "the DEPENDING ON count of a table",
+		})
+
+		return nil
+	}
+
+	return &irpb.Repetition{Count: &irpb.Repetition_Variable{Variable: &irpb.VariableCount{
+		Count:          &irpb.VariableCount_FieldId{FieldId: id},
+		MinOccurrences: width(repetition.Min),
+		MaxOccurrences: width(repetition.Max),
+	}}}
+}
+
+// names is what a named node carries: the copybook's own name, and the
+// substitute a rename asked for beside it.
+//
+// A node standing for no copybook item carries none, and neither does one
+// standing for a FILLER: an item COBOL gives no data-name has no original for a
+// substitute to stand beside, and docs/ir/SPEC.md's "Names" makes the original
+// the member that **MUST** be present.
+func (a *assembler) names(field *copybook.Field) *irpb.Names {
+	if field == nil || field.Filler || field.Name == "" {
+		return nil
+	}
+
+	names := &irpb.Names{Original: field.Name}
+	if substitute, renamed := a.renames[field]; renamed {
+		names.OverrideName = proto.String(substitute)
+	}
+
+	return names
+}
+
+// recordNames is every record type handed over, in the order they were, which is
+// what a diagnostic about a name nothing defines lists.
+func (a *assembler) recordNames() []string {
+	found := make([]string, 0, len(a.opts.Records))
+	for _, record := range a.opts.Records {
+		found = append(found, record.Name)
+	}
+
+	return found
+}
+
+// span is where in a record's copybook an item is.
+//
+// A nil item has no line, and what comes back for one is the copybook itself,
+// which diag renders as the file alone rather than as a line zero nothing can
+// jump to.
+func (a *assembler) span(s *scope, field *copybook.Field) diag.Span {
+	span := diag.Span{}
+	if s != nil {
+		span.File = s.copybook
+	}
+
+	if field != nil {
+		span.Line, span.Column = field.Pos.Line, field.Pos.Column
+	}
+
+	return span
+}
+
+// width narrows a count this repository holds as an int to the unsigned width
+// the schema carries it in.
+//
+// Nothing that reaches here is negative or anywhere near four billion — a
+// record's widths are bounded by its `lrecl` and an OCCURS count by the
+// copybook — so both ends are clamped rather than reported: a number outside
+// them is a defect upstream rather than something an adopter wrote, and what
+// comes back is a width [Validate] then refuses on its own terms.
+func width(n int) uint32 {
+	switch {
+	case n < 0:
+		return 0
+	case n > math.MaxUint32:
+		return math.MaxUint32
+	}
+
+	return uint32(n)
+}
+
+// itemName is what a diagnostic calls a copybook item.
+func itemName(field *copybook.Field) string {
+	if field == nil {
+		return "an item that is not there"
+	}
+
+	if field.Filler || field.Name == "" {
+		return "a FILLER item"
+	}
+
+	return field.Name
+}

--- a/internal/assemble/assemble_test.go
+++ b/internal/assemble/assemble_test.go
@@ -1,0 +1,1048 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package assemble
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	cobol "github.com/Zaba505/cobol-go"
+	"github.com/Zaba505/cobol-go/copybook"
+
+	"github.com/Zaba505/cpybkc/internal/emit"
+	"github.com/Zaba505/cpybkc/internal/layout"
+	"github.com/Zaba505/cpybkc/internal/layoutmodel"
+	"github.com/Zaba505/cpybkc/internal/resolve"
+	"github.com/Zaba505/cpybkc/irpb"
+)
+
+// Every test here drives the real layout parser, the real copybook reader and
+// the real resolver, so that no test asserts a descriptor assembled out of a
+// model those readers would never have produced. What a test writes is a layout
+// and one copybook per record, and what it asserts is the whole descriptor
+// rendered — one line per node — because what has to be right is not one member
+// but which node carries it and which identifier it was given.
+
+// The three copybooks of docs/ir/SPEC.md's "A counted run, as nodes": a header
+// carrying a detail count and a flag, the details the count governs, and the
+// summary the flag governs.
+const (
+	header = `01 HDR-REC.
+   05 HDR-TYPE PIC X(1).
+   05 DTL-COUNT PIC 9(2).
+   05 SUM-FLAG PIC X(1).
+`
+
+	detail = `01 DTL-REC.
+   05 DTL-TYPE PIC X(1).
+   05 DTL-BODY PIC X(20).
+`
+
+	summary = `01 SUM-REC.
+   05 SUM-TYPE PIC X(1).
+   05 SUM-TOTAL PIC S9(7).
+`
+)
+
+// countedRun is that appendix's layout: the records, what tells each apart, and
+// the expression saying any number of counted groups make a file.
+const countedRun = `(framing (recfm FB) (lrecl 24))
+(encoding (charset cp037) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))
+(record HEADER (copybook "hdr.cpy" HDR-REC))
+(record DETAIL (copybook "dtl.cpy" DTL-REC))
+(record SUMMARY (copybook "sum.cpy" SUM-REC))
+(discriminate HEADER (equals (item HEADER HDR-TYPE) "H"))
+(discriminate DETAIL (equals (item DETAIL DTL-TYPE) "D"))
+(discriminate SUMMARY (equals (item SUMMARY SUM-TYPE) "S"))
+(sequence
+  (+ (seq HEADER
+          (times DETAIL (item HEADER DTL-COUNT))
+          (when (item HEADER SUM-FLAG) "Y" SUMMARY))))`
+
+// countedRunCopybooks binds those three record names to those three copybooks.
+func countedRunCopybooks() map[string]string {
+	return map[string]string{"HEADER": header, "DETAIL": detail, "SUMMARY": summary}
+}
+
+// recordOf builds the first record of a copybook source, driving `cobol-go`'s
+// real parser so that no test hand-assembles an AST the reader would never
+// produce.
+func recordOf(t *testing.T, src string) *copybook.Field {
+	t.Helper()
+
+	file, err := cobol.Parse(strings.NewReader(src), cobol.WithFragment())
+	if err != nil {
+		t.Fatalf("parsing the copybook: %v", err)
+	}
+	if file.Fragment == nil {
+		t.Fatal("parsing the copybook: no fragment")
+	}
+
+	records, err := copybook.Build(file.Fragment.Entries)
+	if err != nil {
+		t.Fatalf("building the copybook: %v", err)
+	}
+	if len(records) == 0 {
+		t.Fatal("building the copybook: no records")
+	}
+
+	return records[0]
+}
+
+// fieldNamed finds a field of a record by name, for a test naming what a layout
+// would name.
+func fieldNamed(t *testing.T, record *copybook.Field, name string) *copybook.Field {
+	t.Helper()
+
+	var found *copybook.Field
+
+	var walk func(*copybook.Field)
+	walk = func(field *copybook.Field) {
+		if found == nil && !field.Filler && field.Name == name {
+			found = field
+		}
+
+		for _, child := range field.Children {
+			walk(child)
+		}
+	}
+	walk(record)
+
+	if found == nil {
+		t.Fatalf("the copybook declares no %s", name)
+	}
+
+	return found
+}
+
+// options is the whole pipeline in front of this package: parse the layout, read
+// every layer, resolve each record's copybook against them, compile the
+// sequencing expression, and hand the lot over.
+//
+// It is one function rather than a fixture per test because what this package
+// assembles is the *output* of that pipeline, and a fixture would be a second
+// answer to what the pipeline produces.
+func options(t *testing.T, source string, copybooks map[string]string, redefines ...redefiner) Options {
+	t.Helper()
+
+	file, err := layout.Parse("layout.sexpr", strings.NewReader(source))
+	if err != nil {
+		t.Fatalf("parsing the layout: %v", err)
+	}
+
+	framing, err := layoutmodel.ReadFraming(file)
+	if err != nil {
+		t.Fatalf("reading the framing layer: %v", err)
+	}
+
+	profile, err := layoutmodel.ReadProfile(file)
+	if err != nil {
+		t.Fatalf("reading the encoding layer: %v", err)
+	}
+
+	sequence, err := layoutmodel.ReadSequence(file)
+	if err != nil {
+		t.Fatalf("reading the sequencing layer: %v", err)
+	}
+
+	discrimination, err := layoutmodel.ReadDiscrimination(file)
+	if err != nil {
+		t.Fatalf("reading the discrimination layer: %v", err)
+	}
+
+	opts := Options{Framing: framing}
+
+	sequencing := resolve.Sequencing{
+		Sequence: sequence,
+		Dialect:  copybook.IBMEnterprise(),
+		Reading:  layoutmodel.ODOSlide,
+		Encoding: profile.Axes,
+	}
+
+	for _, discriminator := range discrimination.Records {
+		src, bound := copybooks[discriminator.Record]
+		if !bound {
+			t.Fatalf("the test binds no copybook to record %s", discriminator.Record)
+		}
+
+		path := strings.ToLower(discriminator.Record) + ".cpy"
+		record := recordOf(t, src)
+
+		sequencing.Records = append(sequencing.Records, resolve.SequencedRecord{
+			Name:          discriminator.Record,
+			Copybook:      path,
+			Item:          record,
+			Discriminator: discriminator.Strategy,
+		})
+
+		resolved, err := resolve.Resolve(record, resolve.Options{
+			Copybook:  path,
+			Dialect:   copybook.IBMEnterprise(),
+			Framing:   framing,
+			Reading:   layoutmodel.ODOSlide,
+			Encoding:  profile.Axes,
+			Redefines: stated(t, redefines, discriminator.Record, record),
+		})
+		if err != nil {
+			t.Fatalf("resolving %s: %v", discriminator.Record, err)
+		}
+		if len(resolved) != 1 {
+			t.Fatalf("%s resolved to %d record types, want 1", discriminator.Record, len(resolved))
+		}
+
+		opts.Records = append(opts.Records, Record{
+			Name:     discriminator.Record,
+			Copybook: path,
+			Resolved: resolved[0],
+		})
+	}
+
+	automaton, err := resolve.CompileSequence(sequencing)
+	if err != nil {
+		t.Fatalf("compiling the sequence: %v", err)
+	}
+
+	opts.Automaton = automaton
+
+	return opts
+}
+
+// redefiner states a test's redefines against the copybook the pipeline built,
+// rather than against one the test parsed for itself.
+//
+// A [github.com/Zaba505/cpybkc/internal/resolve.Redefine] names a
+// [github.com/Zaba505/cobol-go/copybook.Field], and two reads of one copybook
+// produce two of them, so a test stating one against its own read would state it
+// against a record nobody resolved.
+type redefiner func(t *testing.T, name string, record *copybook.Field) []resolve.Redefine
+
+// stated is what the redefiners a test handed over say about one record.
+func stated(t *testing.T, redefiners []redefiner, name string, record *copybook.Field) []resolve.Redefine {
+	t.Helper()
+
+	var redefines []resolve.Redefine
+
+	for _, state := range redefiners {
+		redefines = append(redefines, state(t, name, record)...)
+	}
+
+	return redefines
+}
+
+// assembled is a layout the caller expects to assemble.
+func assembled(t *testing.T, source string, copybooks map[string]string, redefines ...redefiner) *irpb.Descriptor {
+	t.Helper()
+
+	descriptor, err := Assemble(options(t, source, copybooks, redefines...))
+	if err != nil {
+		t.Fatalf("assembling the descriptor: %v", err)
+	}
+
+	return descriptor
+}
+
+// render draws the whole descriptor: its version, then one line per node.
+//
+// A rendering rather than a struct literal, for the reason the automaton's tests
+// give: what has to be right is every member *and* the identifier carrying it,
+// and a rendering fails with the whole descriptor in the message.
+func render(d *irpb.Descriptor) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "version %d\n", d.GetVersion())
+
+	for _, node := range d.GetNodes() {
+		fmt.Fprintf(&b, "%d %s\n", node.GetId(), renderNode(node))
+	}
+
+	return b.String()
+}
+
+// renderNode draws one node: its kind and every member it carries.
+func renderNode(node *irpb.Node) string {
+	switch body := node.GetKind().(type) {
+	case *irpb.Node_File:
+		return "file " + renderFraming(body.File) + " start=" + id(body.File.GetStartStateId())
+	case *irpb.Node_Record:
+		return "record " + renderNames(body.Record.GetNames()) + " root=" + id(body.Record.GetRootId())
+	case *irpb.Node_Group:
+		return "group " + renderNames(body.Group.GetNames()) +
+			" members=[" + ids(body.Group.GetMemberIds()) + "]" + renderRepetition(body.Group.GetRepetition())
+	case *irpb.Node_Variant:
+		return "variant " + renderArms(body.Variant.GetArms())
+	case *irpb.Node_Field:
+		return "field " + renderNames(body.Field.GetNames()) +
+			" width=" + strconv.Itoa(int(body.Field.GetWidth())) +
+			" " + spell(body.Field.GetUsage(), "USAGE_") +
+			" " + renderEncoding(body.Field.GetEncoding()) +
+			renderPicture(body.Field.GetPicture()) +
+			renderRepetition(body.Field.GetRepetition())
+	case *irpb.Node_Slack:
+		return "slack width=" + strconv.Itoa(int(body.Slack.GetWidth()))
+	case *irpb.Node_Predicate:
+		return "predicate field=" + id(body.Predicate.GetFieldId()) + " " + renderTest(body.Predicate)
+	case *irpb.Node_State:
+		state := "state"
+		if body.State.GetAccepts() {
+			state += " accepts"
+		}
+		if guards := body.State.GetAcceptanceGuardIds(); len(guards) > 0 {
+			state += " when=[" + ids(guards) + "]"
+		}
+
+		return state + " transitions=[" + ids(body.State.GetTransitionIds()) + "]"
+	case *irpb.Node_Transition:
+		line := "transition record=" + id(body.Transition.GetRecordId()) +
+			" to=" + id(body.Transition.GetNextStateId())
+		if body.Transition.PredicateId != nil {
+			line += " predicate=" + id(body.Transition.GetPredicateId())
+		}
+		if guards := body.Transition.GetGuardIds(); len(guards) > 0 {
+			line += " guards=[" + ids(guards) + "]"
+		}
+		if bindings := body.Transition.GetBindingIds(); len(bindings) > 0 {
+			line += " bindings=[" + ids(bindings) + "]"
+		}
+
+		return line
+	case *irpb.Node_Register:
+		return "register " + spell(body.Register.GetKind(), "REGISTER_KIND_")
+	case *irpb.Node_Binding:
+		line := "binding register=" + id(body.Binding.GetRegisterId())
+		if field, reads := body.Binding.GetValue().(*irpb.Binding_FieldId); reads {
+			return line + " field=" + id(field.FieldId)
+		}
+
+		return line + " less-one"
+	case *irpb.Node_Guard:
+		return "guard register=" + id(body.Guard.GetRegisterId()) + " " + renderGuardTest(body.Guard)
+	}
+
+	return "kindless"
+}
+
+func renderFraming(file *irpb.File) string {
+	switch framing := file.GetFraming().(type) {
+	case *irpb.File_Unframed:
+		return "unframed"
+	case *irpb.File_DescriptorWord:
+		return "descriptor-word"
+	case *irpb.File_Segmented:
+		return "segmented max-segment=" + strconv.Itoa(int(framing.Segmented.GetMaxSegmentSize()))
+	case *irpb.File_Delimited:
+		return "delimited delimiter=" + quoteBytes(framing.Delimited.GetDelimiter()) +
+			" " + spell(framing.Delimited.GetPlacement(), "DELIMITER_PLACEMENT_")
+	}
+
+	return "unframed?"
+}
+
+func renderNames(names *irpb.Names) string {
+	if names == nil {
+		return "(unnamed)"
+	}
+
+	if names.OverrideName != nil {
+		return names.GetOriginal() + "->" + names.GetOverrideName()
+	}
+
+	return names.GetOriginal()
+}
+
+func renderEncoding(encoding *irpb.Encoding) string {
+	return spell(encoding.GetCharset(), "CHARSET_") + "/" +
+		spell(encoding.GetSignConvention(), "SIGN_CONVENTION_") + "/" +
+		spell(encoding.GetByteOrder(), "BYTE_ORDER_") + "/" +
+		spell(encoding.GetFloatFormat(), "FLOAT_FORMAT_")
+}
+
+func renderPicture(picture *irpb.Picture) string {
+	if picture == nil {
+		return ""
+	}
+
+	rendered := fmt.Sprintf(" %s(%d,%d)",
+		spell(picture.GetCategory(), "CATEGORY_"), picture.GetDigits(), picture.GetScale())
+
+	if picture.GetSigned() {
+		rendered += " signed " + spell(picture.GetSignPosition(), "SIGN_POSITION_")
+	}
+
+	return rendered
+}
+
+func renderRepetition(repetition *irpb.Repetition) string {
+	switch count := repetition.GetCount().(type) {
+	case *irpb.Repetition_Constant:
+		return " occurs=" + strconv.Itoa(int(count.Constant))
+	case *irpb.Repetition_Variable:
+		where := "?"
+		switch read := count.Variable.GetCount().(type) {
+		case *irpb.VariableCount_FieldId:
+			where = "field=" + id(read.FieldId)
+		case *irpb.VariableCount_RegisterId:
+			where = "register=" + id(read.RegisterId)
+		}
+
+		return fmt.Sprintf(" occurs=%d..%d depending-on %s",
+			count.Variable.GetMinOccurrences(), count.Variable.GetMaxOccurrences(), where)
+	}
+
+	return ""
+}
+
+func renderArms(arms []*irpb.Arm) string {
+	rendered := make([]string, 0, len(arms))
+
+	for _, arm := range arms {
+		body := "?"
+		switch held := arm.GetBody().(type) {
+		case *irpb.Arm_GroupId:
+			body = "group=" + id(held.GroupId)
+		case *irpb.Arm_FieldId:
+			body = "field=" + id(held.FieldId)
+		}
+
+		rendered = append(rendered, "arm(predicate="+id(arm.GetPredicateId())+" "+body+")")
+	}
+
+	return strings.Join(rendered, " ")
+}
+
+func renderTest(predicate *irpb.Predicate) string {
+	switch test := predicate.GetTest().(type) {
+	case *irpb.Predicate_BytesEqual:
+		return "equals " + quoteBytes(test.BytesEqual.GetValue())
+	case *irpb.Predicate_BytesOneOf:
+		values := make([]string, 0, len(test.BytesOneOf.GetValues()))
+		for _, value := range test.BytesOneOf.GetValues() {
+			values = append(values, quoteBytes(value))
+		}
+
+		return "one-of " + strings.Join(values, " ")
+	}
+
+	return "no test"
+}
+
+func renderGuardTest(guard *irpb.Guard) string {
+	switch test := guard.GetTest().(type) {
+	case *irpb.Guard_Equals:
+		return "equals " + renderLiteral(test.Equals)
+	case *irpb.Guard_OneOf:
+		values := make([]string, 0, len(test.OneOf.GetValues()))
+		for _, value := range test.OneOf.GetValues() {
+			values = append(values, renderLiteral(value))
+		}
+
+		return "one-of " + strings.Join(values, " ")
+	case *irpb.Guard_GreaterThanZero:
+		return "greater-than-zero"
+	}
+
+	return "no test"
+}
+
+func renderLiteral(literal *irpb.Literal) string {
+	switch value := literal.GetValue().(type) {
+	case *irpb.Literal_BytesValue:
+		return quoteBytes(value.BytesValue)
+	case *irpb.Literal_Integer:
+		return strconv.FormatInt(value.Integer, 10)
+	}
+
+	return "?"
+}
+
+// spell renders one member of a closed set the way the layout format spells it:
+// the schema's prefix dropped, lower case, and hyphens where protobuf's naming
+// convention puts underscores.
+func spell(value fmt.Stringer, prefix string) string {
+	return strings.ReplaceAll(strings.ToLower(strings.TrimPrefix(value.String(), prefix)), "_", "-")
+}
+
+func id(of uint64) string { return strconv.FormatUint(of, 10) }
+
+func ids(of []uint64) string {
+	rendered := make([]string, 0, len(of))
+	for _, one := range of {
+		rendered = append(rendered, id(one))
+	}
+
+	return strings.Join(rendered, " ")
+}
+
+// equal fails with both renderings where they differ, which is what makes a
+// golden over a whole descriptor debuggable.
+func equal(t *testing.T, got, want string) {
+	t.Helper()
+
+	if strings.TrimSpace(got) == strings.TrimSpace(want) {
+		return
+	}
+
+	t.Errorf("the descriptor is not what was expected.\ngot:\n%s\nwant:\n%s", got, want)
+}
+
+// TestADescriptorCarriesEveryLayerOfTheLayout is the whole of this package in
+// one assertion: three copybooks, a framing, an encoding profile and a
+// sequencing expression, in one message with identifiers on everything.
+//
+// The golden is the whole descriptor because the traversal is what this test is
+// about. Every identifier in it is a position in the node list, and a change to
+// the order nodes are met in moves every number after it — which is exactly the
+// change docs/ir/SPEC.md's "Identity, ordering and determinism" makes a
+// producer state once and keep.
+func TestADescriptorCarriesEveryLayerOfTheLayout(t *testing.T) {
+	descriptor := assembled(t, countedRun, countedRunCopybooks())
+
+	equal(t, render(descriptor), `version 1
+0 file unframed start=19
+1 record HDR-REC root=2
+2 group HDR-REC members=[3 4 5 6]
+3 field HDR-TYPE width=1 display cp037/ebcdic/big-endian/ibm-hfp alphanumeric(0,0)
+4 field DTL-COUNT width=2 display cp037/ebcdic/big-endian/ibm-hfp numeric(2,0)
+5 field SUM-FLAG width=1 display cp037/ebcdic/big-endian/ibm-hfp alphanumeric(0,0)
+6 slack width=20
+7 record DTL-REC root=8
+8 group DTL-REC members=[9 10 11]
+9 field DTL-TYPE width=1 display cp037/ebcdic/big-endian/ibm-hfp alphanumeric(0,0)
+10 field DTL-BODY width=20 display cp037/ebcdic/big-endian/ibm-hfp alphanumeric(0,0)
+11 slack width=3
+12 record SUM-REC root=13
+13 group SUM-REC members=[14 15 16]
+14 field SUM-TYPE width=1 display cp037/ebcdic/big-endian/ibm-hfp alphanumeric(0,0)
+15 field SUM-TOTAL width=7 display cp037/ebcdic/big-endian/ibm-hfp numeric(7,0) signed trailing
+16 slack width=16
+17 register integer
+18 register bytes
+19 state transitions=[23]
+20 state accepts when=[27] transitions=[28 32 36]
+21 state accepts when=[40] transitions=[41 44 47]
+22 state accepts transitions=[51]
+23 transition record=1 to=20 predicate=24 bindings=[25 26]
+24 predicate field=3 equals 0xc8
+25 binding register=17 field=4
+26 binding register=18 field=5
+27 guard register=17 equals 0
+28 transition record=7 to=21 predicate=29 guards=[30] bindings=[31]
+29 predicate field=9 equals 0xc4
+30 guard register=17 greater-than-zero
+31 binding register=17 less-one
+32 transition record=12 to=22 predicate=33 guards=[34 35]
+33 predicate field=14 equals 0xe2
+34 guard register=17 equals 0
+35 guard register=18 equals 0xe8
+36 transition record=1 to=20 predicate=24 guards=[37] bindings=[38 39]
+37 guard register=17 equals 0
+38 binding register=17 field=4
+39 binding register=18 field=5
+40 guard register=17 equals 0
+41 transition record=7 to=21 predicate=29 guards=[42] bindings=[43]
+42 guard register=17 greater-than-zero
+43 binding register=17 less-one
+44 transition record=12 to=22 predicate=33 guards=[45 46]
+45 guard register=17 equals 0
+46 guard register=18 equals 0xe8
+47 transition record=1 to=20 predicate=24 guards=[48] bindings=[49 50]
+48 guard register=17 equals 0
+49 binding register=17 field=4
+50 binding register=18 field=5
+51 transition record=1 to=20 predicate=24 bindings=[52 53]
+52 binding register=17 field=4
+53 binding register=18 field=5
+`)
+}
+
+// TestIdenticalInputsProduceByteIdenticalIR is the promise the whole traversal
+// exists for, run end to end: two independent passes over the same layout, each
+// building its own copybooks, its own resolved records and its own automaton,
+// come out as the same bytes.
+//
+// The two halves are in two places and this is where they meet. The identifiers
+// and the order of the node list are this package's (docs/ir/SPEC.md, "Identity,
+// ordering and determinism"); the encoding is
+// [github.com/Zaba505/cpybkc/internal/emit.Marshal]'s. Asserting over the bytes
+// rather than over the message is what makes it the promise a consumer diffing
+// two emissions actually holds.
+func TestIdenticalInputsProduceByteIdenticalIR(t *testing.T) {
+	first, err := emit.Marshal(assembled(t, countedRun, countedRunCopybooks()))
+	if err != nil {
+		t.Fatalf("encoding the first descriptor: %v", err)
+	}
+
+	second, err := emit.Marshal(assembled(t, countedRun, countedRunCopybooks()))
+	if err != nil {
+		t.Fatalf("encoding the second descriptor: %v", err)
+	}
+
+	if !bytes.Equal(first, second) {
+		t.Errorf("two assemblies of one layout encoded differently:\n%x\n%x", first, second)
+	}
+}
+
+// TestNoDefaultSurvivesIntoTheDescriptor walks every node for a member left at
+// the unspecified zero of its closed set.
+//
+// [Validate] already refuses one, and [Assemble] runs it — so this asserts the
+// property directly rather than through the pass that enforces it, because a
+// pass and the thing it enforces failing together is the one way a green suite
+// says nothing.
+func TestNoDefaultSurvivesIntoTheDescriptor(t *testing.T) {
+	descriptor := assembled(t, countedRun, countedRunCopybooks())
+
+	for _, node := range descriptor.GetNodes() {
+		field := node.GetField()
+		if field == nil {
+			continue
+		}
+
+		if missing := unresolved(field.GetEncoding()); len(missing) > 0 {
+			t.Errorf("field node %d states no %s", node.GetId(), list(missing))
+		}
+
+		if field.GetUsage() == irpb.Usage_USAGE_UNSPECIFIED {
+			t.Errorf("field node %d states no USAGE", node.GetId())
+		}
+
+		if picture := field.GetPicture(); picture != nil &&
+			picture.GetCategory() == irpb.Category_CATEGORY_UNSPECIFIED {
+			t.Errorf("field node %d carries a PICTURE of no category", node.GetId())
+		}
+	}
+
+	for _, node := range descriptor.GetNodes() {
+		if register := node.GetRegister(); register != nil &&
+			register.GetKind() == irpb.RegisterKind_REGISTER_KIND_UNSPECIFIED {
+			t.Errorf("register node %d does not say what it holds", node.GetId())
+		}
+	}
+}
+
+// TestAnOverrideStandsBesideTheOriginal holds a rename to substituting a name
+// and keeping the copybook's, so that generated code can still point back at the
+// copybook it came from.
+func TestAnOverrideStandsBesideTheOriginal(t *testing.T) {
+	opts := options(t, countedRun, countedRunCopybooks())
+
+	item := fieldNamed(t, opts.Records[0].Resolved.Item, "DTL-COUNT")
+	opts.Renames = []Rename{{Item: item, Substitute: "detail_count"}}
+
+	descriptor, err := Assemble(opts)
+	if err != nil {
+		t.Fatalf("assembling the descriptor: %v", err)
+	}
+
+	names := namesOf(t, descriptor, "DTL-COUNT")
+	if names.GetOriginal() != "DTL-COUNT" {
+		t.Errorf("the original name is %q, want DTL-COUNT", names.GetOriginal())
+	}
+
+	if names.GetOverrideName() != "detail_count" {
+		t.Errorf("the override is %q, want detail_count", names.GetOverrideName())
+	}
+}
+
+// TestARenameReachesOneItemAndNoOther holds a rename to being about the item it
+// names, which is what makes it safe for it to be keyed on the copybook item
+// rather than on a record.
+func TestARenameReachesOneItemAndNoOther(t *testing.T) {
+	opts := options(t, countedRun, countedRunCopybooks())
+	opts.Renames = []Rename{{
+		Item:       fieldNamed(t, opts.Records[0].Resolved.Item, "HDR-TYPE"),
+		Substitute: "kind",
+	}}
+
+	descriptor, err := Assemble(opts)
+	if err != nil {
+		t.Fatalf("assembling the descriptor: %v", err)
+	}
+
+	for _, name := range []string{"DTL-TYPE", "SUM-TYPE", "DTL-COUNT"} {
+		if names := namesOf(t, descriptor, name); names.OverrideName != nil {
+			t.Errorf("%s carries the override %q, and the rename named HDR-TYPE", name, names.GetOverrideName())
+		}
+	}
+}
+
+// namesOf finds the names of the one field node standing for a copybook item.
+func namesOf(t *testing.T, d *irpb.Descriptor, original string) *irpb.Names {
+	t.Helper()
+
+	var found *irpb.Names
+
+	for _, node := range d.GetNodes() {
+		names := node.GetField().GetNames()
+		if names.GetOriginal() != original {
+			continue
+		}
+
+		if found != nil {
+			t.Fatalf("two field nodes are named %s", original)
+		}
+
+		found = names
+	}
+
+	if found == nil {
+		t.Fatalf("no field node is named %s", original)
+	}
+
+	return found
+}
+
+// TestAFramingReachesTheFileNode holds each of the layout's record formats to
+// the physical shape docs/ir/SPEC.md's "Four framings, and none of them is a
+// RECFM" maps it to, and holds what a framing carries beside the shape to
+// reaching the node with it.
+func TestAFramingReachesTheFileNode(t *testing.T) {
+	tests := []struct {
+		name    string
+		framing string
+		want    string
+	}{
+		{
+			name:    "F is unframed",
+			framing: `(framing (recfm F) (lrecl 24))`,
+			want:    "unframed",
+		},
+		{
+			name:    "V is a descriptor word",
+			framing: `(framing (recfm V) (lrecl 24))`,
+			want:    "descriptor-word",
+		},
+		{
+			name:    "VBS is segmented, and carries the one size a framing carries",
+			framing: `(framing (recfm VBS) (lrecl 24) (blksize 512) (max-segment 200))`,
+			want:    "segmented max-segment=200",
+		},
+		{
+			name:    "line sequential is delimited, and carries the delimiter as bytes",
+			framing: `(framing (recfm line-sequential) (delimiter (bytes "0A")) (placement separator))`,
+			want:    "delimited delimiter=0x0a separator",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := strings.Replace(countedRun, `(framing (recfm FB) (lrecl 24))`, test.framing, 1)
+
+			descriptor := assembled(t, source, countedRunCopybooks())
+
+			if got := renderFraming(descriptor.GetNodes()[0].GetFile()); got != test.want {
+				t.Errorf("the file node states %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+// TestATableCarriesItsCountAsAReference holds an OCCURS DEPENDING ON to
+// resolving into a repetition whose count is the identifier of the field the
+// clause names, with the copybook's own bounds beside it.
+func TestATableCarriesItsCountAsAReference(t *testing.T) {
+	const orders = `01 ORD-REC.
+   05 ORD-TYPE PIC X(1).
+   05 ORD-COUNT PIC 9(2).
+   05 ORD-LINE OCCURS 1 TO 5 TIMES DEPENDING ON ORD-COUNT.
+      10 ORD-SKU PIC X(4).
+`
+
+	const source = `(framing (recfm V) (lrecl 100))
+(encoding (charset cp037) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))
+(copybook-reading (occurs-depending-on odoslide))
+(record ORDER (copybook "ord.cpy" ORD-REC))
+(discriminate ORDER (equals (item ORDER ORD-TYPE) "O"))
+(sequence (+ ORDER))`
+
+	descriptor := assembled(t, source, map[string]string{"ORDER": orders})
+
+	equal(t, render(descriptor), `version 1
+0 file descriptor-word start=7
+1 record ORD-REC root=2
+2 group ORD-REC members=[3 4 5]
+3 field ORD-TYPE width=1 display cp037/ebcdic/big-endian/ibm-hfp alphanumeric(0,0)
+4 field ORD-COUNT width=2 display cp037/ebcdic/big-endian/ibm-hfp numeric(2,0)
+5 group ORD-LINE members=[6] occurs=1..5 depending-on field=4
+6 field ORD-SKU width=4 display cp037/ebcdic/big-endian/ibm-hfp alphanumeric(0,0)
+7 state transitions=[9]
+8 state accepts transitions=[11]
+9 transition record=1 to=8 predicate=10
+10 predicate field=3 equals 0xd6
+11 transition record=1 to=8 predicate=10
+`)
+}
+
+// TestAVariantBecomesArmsAndPredicates holds a REDEFINES inside a repeating
+// group to reaching the descriptor as the one alternation resolution does not
+// split into record types: an ordered list of arms, each naming the predicate
+// that selects it and the item that is its body.
+func TestAVariantBecomesArmsAndPredicates(t *testing.T) {
+	const entries = `01 ENT-REC.
+   05 ENT-TYPE PIC X(1).
+   05 ENT-LINE OCCURS 3 TIMES.
+      10 ENT-KIND PIC X(1).
+      10 ENT-CASH PIC 9(4).
+      10 ENT-NOTE REDEFINES ENT-CASH PIC X(4).
+`
+
+	const source = `(framing (recfm V) (lrecl 100))
+(encoding (charset cp037) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))
+(record ENTRY (copybook "ent.cpy" ENT-REC))
+(discriminate ENTRY (equals (item ENTRY ENT-TYPE) "E"))
+(sequence (+ ENTRY))`
+
+	descriptor := assembled(t, source, map[string]string{"ENTRY": entries},
+		func(t *testing.T, name string, record *copybook.Field) []resolve.Redefine {
+			t.Helper()
+
+			return []resolve.Redefine{{
+				Item: fieldNamed(t, record, "ENT-CASH"),
+				Alternatives: []resolve.Alternative{
+					{Name: "ENT-CASH", Predicate: selects("C", "ENT-LINE", "ENT-KIND")},
+					{Name: "ENT-NOTE", Predicate: selects("N", "ENT-LINE", "ENT-KIND")},
+				},
+			}}
+		})
+
+	equal(t, render(descriptor), `version 1
+0 file descriptor-word start=11
+1 record ENT-REC root=2
+2 group ENT-REC members=[3 4]
+3 field ENT-TYPE width=1 display cp037/ebcdic/big-endian/ibm-hfp alphanumeric(0,0)
+4 group ENT-LINE members=[5 6] occurs=3
+5 field ENT-KIND width=1 display cp037/ebcdic/big-endian/ibm-hfp alphanumeric(0,0)
+6 variant arm(predicate=7 field=8) arm(predicate=9 field=10)
+7 predicate field=5 equals 0xc3
+8 field ENT-CASH width=4 display cp037/ebcdic/big-endian/ibm-hfp numeric(4,0)
+9 predicate field=5 equals 0xd5
+10 field ENT-NOTE width=4 display cp037/ebcdic/big-endian/ibm-hfp alphanumeric(0,0)
+11 state transitions=[13]
+12 state accepts transitions=[15]
+13 transition record=1 to=12 predicate=14
+14 predicate field=3 equals 0xc5
+15 transition record=1 to=12 predicate=14
+`)
+}
+
+// selects is an `equals` strategy over an item of a record, for a test that
+// needs an arm selected by something rather than by a particular thing.
+func selects(value string, path ...string) layoutmodel.Strategy {
+	return layoutmodel.Strategy{
+		Kind:     layoutmodel.Equals,
+		Item:     layoutmodel.ItemRef{Path: path},
+		Literals: []layoutmodel.Literal{{Kind: layoutmodel.TextLiteral, Text: value}},
+	}
+}
+
+// TestARecordNothingAdmitsIsRefused holds the descriptor to every record type
+// hanging off the file node.
+func TestARecordNothingAdmitsIsRefused(t *testing.T) {
+	opts := options(t, countedRun, countedRunCopybooks())
+	opts.Records = append(opts.Records, Record{
+		Name:     "ORPHAN",
+		Copybook: "orphan.cpy",
+		Resolved: opts.Records[0].Resolved,
+	})
+
+	_, err := Assemble(opts)
+	if err == nil {
+		t.Fatal("the descriptor assembled, want a fault")
+	}
+
+	var fault *NodeError
+	if !errors.As(err, &fault) {
+		t.Fatalf("the fault is %v, want a NodeError about an unreachable node", err)
+	}
+
+	if !strings.Contains(err.Error(), "not reachable from the file node") {
+		t.Errorf("the fault reads %q, and does not say what is wrong", err)
+	}
+}
+
+// TestTwoRecordTypesUnderOneNameAreRefused holds a name to being what a
+// transition says which record it admits by.
+func TestTwoRecordTypesUnderOneNameAreRefused(t *testing.T) {
+	opts := options(t, countedRun, countedRunCopybooks())
+	opts.Records = append(opts.Records, Record{
+		Name:     "HEADER",
+		Copybook: "twice.cpy",
+		Resolved: opts.Records[1].Resolved,
+	})
+
+	_, err := Assemble(opts)
+
+	var fault *DuplicateRecordError
+	if !errors.As(err, &fault) {
+		t.Fatalf("the fault is %v, want a DuplicateRecordError", err)
+	}
+
+	if fault.Record != "HEADER" || fault.Copybook != "twice.cpy" {
+		t.Errorf("the fault names %s in %s, want HEADER in twice.cpy", fault.Record, fault.Copybook)
+	}
+}
+
+// TestATransitionAdmittingAnUnknownRecordIsRefused holds every transition to
+// admitting a record type the descriptor carries.
+func TestATransitionAdmittingAnUnknownRecordIsRefused(t *testing.T) {
+	opts := options(t, countedRun, countedRunCopybooks())
+	opts.Records = slices.Delete(opts.Records, 2, 3)
+
+	_, err := Assemble(opts)
+
+	var fault *UnknownRecordError
+	if !errors.As(err, &fault) {
+		t.Fatalf("the fault is %v, want an UnknownRecordError", err)
+	}
+
+	if fault.Record != "SUMMARY" {
+		t.Errorf("the fault names %s, want SUMMARY", fault.Record)
+	}
+
+	if !slices.Equal(fault.Defined, []string{"HEADER", "DETAIL"}) {
+		t.Errorf("the fault lists %v, want the two record types that were handed over", fault.Defined)
+	}
+}
+
+// TestAnIncompleteLayoutIsRefusedBeforeAnythingIsAssembled holds the three
+// members a descriptor cannot be built without to being required rather than
+// defaulted.
+func TestAnIncompleteLayoutIsRefusedBeforeAnythingIsAssembled(t *testing.T) {
+	tests := []struct {
+		name  string
+		spoil func(Options) Options
+		want  error
+	}{
+		{
+			name:  "no framing",
+			spoil: func(opts Options) Options { opts.Framing = nil; return opts },
+			want:  ErrNoFraming,
+		},
+		{
+			name:  "no automaton",
+			spoil: func(opts Options) Options { opts.Automaton = nil; return opts },
+			want:  ErrNoAutomaton,
+		},
+		{
+			name:  "no record types",
+			spoil: func(opts Options) Options { opts.Records = nil; return opts },
+			want:  ErrNoRecords,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := Assemble(test.spoil(options(t, countedRun, countedRunCopybooks())))
+			if !errors.Is(err, test.want) {
+				t.Errorf("the fault is %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+// TestASignedDisplayItemCarriesWhereItsSignIs holds the SIGN clause to reaching
+// the descriptor, inherited the way USAGE is, and to being unspecified where the
+// question does not arise.
+func TestASignedDisplayItemCarriesWhereItsSignIs(t *testing.T) {
+	const signs = `01 SGN-REC.
+   05 SGN-TYPE PIC X(1).
+   05 SGN-GROUP SIGN IS LEADING SEPARATE CHARACTER.
+      10 SGN-ONE PIC S9(3).
+      10 SGN-TWO PIC S9(3) SIGN IS TRAILING.
+   05 SGN-PLAIN PIC S9(3).
+   05 SGN-COMP PIC S9(4) COMP-3.
+   05 SGN-CHAR PIC X(2).
+`
+
+	const source = `(framing (recfm V) (lrecl 100))
+(encoding (charset cp037) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))
+(record SIGNS (copybook "sgn.cpy" SGN-REC))
+(discriminate SIGNS (equals (item SIGNS SGN-TYPE) "S"))
+(sequence (+ SIGNS))`
+
+	descriptor := assembled(t, source, map[string]string{"SIGNS": signs})
+
+	want := map[string]string{
+		"SGN-ONE":   "leading-separate",
+		"SGN-TWO":   "trailing",
+		"SGN-PLAIN": "trailing",
+		"SGN-COMP":  "unspecified",
+		"SGN-CHAR":  "unspecified",
+	}
+
+	for name, position := range want {
+		picture := fieldNodeNamed(t, descriptor, name).GetPicture()
+
+		if got := spell(picture.GetSignPosition(), "SIGN_POSITION_"); got != position {
+			t.Errorf("%s holds its sign %s, want %s", name, got, position)
+		}
+	}
+}
+
+// TestAnAliasedUsageResolvesToTheRepresentationItsBytesAreIn holds COMP, COMP-4
+// and BINARY to reaching a generator as one representation, and COMP-3 and
+// PACKED-DECIMAL likewise.
+func TestAnAliasedUsageResolvesToTheRepresentationItsBytesAreIn(t *testing.T) {
+	const usages = `01 USE-REC.
+   05 USE-TYPE PIC X(1).
+   05 USE-COMP PIC S9(4) COMP.
+   05 USE-COMP4 PIC S9(4) COMP-4.
+   05 USE-BINARY PIC S9(4) BINARY.
+   05 USE-COMP3 PIC S9(4) COMP-3.
+   05 USE-PACKED PIC S9(4) PACKED-DECIMAL.
+   05 USE-COMP5 PIC S9(4) COMP-5.
+   05 USE-FLOAT COMP-1.
+`
+
+	const source = `(framing (recfm V) (lrecl 100))
+(encoding (charset cp037) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))
+(record USAGES (copybook "use.cpy" USE-REC))
+(discriminate USAGES (equals (item USAGES USE-TYPE) "U"))
+(sequence (+ USAGES))`
+
+	descriptor := assembled(t, source, map[string]string{"USAGES": usages})
+
+	want := map[string]irpb.Usage{
+		"USE-COMP":   irpb.Usage_USAGE_BINARY,
+		"USE-COMP4":  irpb.Usage_USAGE_BINARY,
+		"USE-BINARY": irpb.Usage_USAGE_BINARY,
+		"USE-COMP3":  irpb.Usage_USAGE_PACKED_DECIMAL,
+		"USE-PACKED": irpb.Usage_USAGE_PACKED_DECIMAL,
+		"USE-COMP5":  irpb.Usage_USAGE_COMP_5,
+		"USE-FLOAT":  irpb.Usage_USAGE_COMP_1,
+	}
+
+	for name, usage := range want {
+		if got := fieldNodeNamed(t, descriptor, name).GetUsage(); got != usage {
+			t.Errorf("%s is %s, want %s", name, got, usage)
+		}
+	}
+
+	// COMP-1 permits no PICTURE, and what a field with none carries is no
+	// picture message rather than an empty one.
+	if picture := fieldNodeNamed(t, descriptor, "USE-FLOAT").GetPicture(); picture != nil {
+		t.Errorf("USE-FLOAT carries the picture %v, and COMP-1 permits none", picture)
+	}
+}
+
+// fieldNodeNamed finds the one field node standing for a copybook item.
+func fieldNodeNamed(t *testing.T, d *irpb.Descriptor, original string) *irpb.Field {
+	t.Helper()
+
+	for _, node := range d.GetNodes() {
+		if field := node.GetField(); field.GetNames().GetOriginal() == original {
+			return field
+		}
+	}
+
+	t.Fatalf("no field node is named %s", original)
+
+	return nil
+}

--- a/internal/assemble/attributes.go
+++ b/internal/assemble/attributes.go
@@ -1,0 +1,308 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package assemble
+
+import (
+	cobol "github.com/Zaba505/cobol-go"
+	"github.com/Zaba505/cobol-go/copybook"
+	"github.com/Zaba505/cobol-go/picture"
+
+	"github.com/Zaba505/cpybkc/internal/layoutmodel"
+	"github.com/Zaba505/cpybkc/internal/resolve"
+	"github.com/Zaba505/cpybkc/irpb"
+)
+
+// This file is the spelling: each resolved value written into the member the
+// schema gives it. Nothing here decides anything — `resolve` settled the axes, a
+// layout settled the framing, and `cobol-go` parsed the PICTURE and inherited
+// the USAGE — and every function is a total map from one closed set onto
+// another.
+//
+// A value outside the set it maps from comes back as that member's unspecified
+// zero rather than as a guess, and [Validate] refuses a descriptor carrying one.
+// That is the only shape a mapping failure can take: a producer that quietly
+// picked a neighbouring code page would be exactly the silent failure the four
+// axes exist to prevent.
+
+// fileOf is the dataset node: its physical framing, as one member of the closed
+// set of four, and the state the read begins in.
+//
+// The layout's RECFM is mapped rather than carried, because docs/ir/SPEC.md's
+// "Four framings, and none of them is a RECFM" keeps the adopter's spelling on
+// the layout side and hands a consumer the four physical shapes: `F` and `FB`
+// are one shape, `V` and `VB` another, and a consumer implementing RECFM would
+// be implementing a JCL vocabulary it has no other use for.
+//
+// It carries no `lrecl`, no block size and no descriptor-word width. Each is
+// absent for a reason docs/ir/SPEC.md's "Lengths the file node does not carry"
+// gives, and the shortest of them is that a consumer takes a record's end from
+// its extent — so a length here is a value a consumer would have to ignore. The
+// one size any framing carries is a segmented dataset's largest segment, which
+// is a bound on a *writer* rather than a length anything is read against.
+//
+// The framing is set rather than returned because the member set of a oneof is
+// an unexported interface of the generated package: the four members are
+// exported and each can be assigned, and naming their common type outside irpb
+// is not something Go admits.
+func fileOf(framing *layoutmodel.Framing, startState uint64) *irpb.File {
+	file := &irpb.File{StartStateId: startState}
+
+	switch framing.Kind() {
+	case layoutmodel.Unframed:
+		file.Framing = &irpb.File_Unframed{Unframed: &irpb.Unframed{}}
+	case layoutmodel.DescriptorWord:
+		file.Framing = &irpb.File_DescriptorWord{DescriptorWord: &irpb.DescriptorWord{}}
+	case layoutmodel.Segmented:
+		file.Framing = &irpb.File_Segmented{Segmented: &irpb.Segmented{
+			MaxSegmentSize: width(int(framing.MaxSegment.Value)),
+		}}
+	case layoutmodel.Delimited:
+		file.Framing = &irpb.File_Delimited{Delimited: &irpb.Delimited{
+			Delimiter: framing.Delimiter.Bytes,
+			Placement: placementOf(framing.Placement),
+		}}
+	}
+
+	return file
+}
+
+// placementOf is where a delimited file's delimiter stands relative to the
+// records it separates.
+func placementOf(placement layoutmodel.Placement) irpb.DelimiterPlacement {
+	switch placement {
+	case layoutmodel.Terminator:
+		return irpb.DelimiterPlacement_DELIMITER_PLACEMENT_TERMINATOR
+	case layoutmodel.Separator:
+		return irpb.DelimiterPlacement_DELIMITER_PLACEMENT_SEPARATOR
+	case layoutmodel.OptionalTerminator:
+		return irpb.DelimiterPlacement_DELIMITER_PLACEMENT_OPTIONAL_TERMINATOR
+	}
+
+	return irpb.DelimiterPlacement_DELIMITER_PLACEMENT_UNSPECIFIED
+}
+
+// encodingOf is the four resolved axes, on the field they govern.
+//
+// All four, on every field, with no profile node for one to inherit from: the
+// pair a layout writes — one profile and per-item overrides over it — was
+// applied by `resolve`, and what a field carries is the result
+// (docs/ir/SPEC.md, "The encoding profile, applied").
+func encodingOf(axes layoutmodel.Axes) *irpb.Encoding {
+	return &irpb.Encoding{
+		Charset:        charsetOf(axes.Charset),
+		SignConvention: signConventionOf(axes.SignConvention),
+		ByteOrder:      byteOrderOf(axes.ByteOrder),
+		FloatFormat:    floatFormatOf(axes.FloatFormat),
+	}
+}
+
+// charsetOf is the code page governing alphanumeric data, the digit zone of
+// zoned decimal, and the byte values of a separate sign.
+func charsetOf(charset layoutmodel.Charset) irpb.Charset {
+	switch charset {
+	case layoutmodel.CP037:
+		return irpb.Charset_CHARSET_CP037
+	case layoutmodel.CP500:
+		return irpb.Charset_CHARSET_CP500
+	case layoutmodel.CP1047:
+		return irpb.Charset_CHARSET_CP1047
+	case layoutmodel.CP1140:
+		return irpb.Charset_CHARSET_CP1140
+	case layoutmodel.ASCII:
+		return irpb.Charset_CHARSET_ASCII
+	}
+
+	return irpb.Charset_CHARSET_UNSPECIFIED
+}
+
+// signConventionOf is how an overpunched sign is spelled in a zoned decimal
+// byte.
+func signConventionOf(convention layoutmodel.SignConvention) irpb.SignConvention {
+	switch convention {
+	case layoutmodel.SignEBCDIC:
+		return irpb.SignConvention_SIGN_CONVENTION_EBCDIC
+	case layoutmodel.SignASCIIZone37:
+		return irpb.SignConvention_SIGN_CONVENTION_ASCII_ZONE37
+	case layoutmodel.SignTranslatedEBCDIC:
+		return irpb.SignConvention_SIGN_CONVENTION_TRANSLATED_EBCDIC
+	case layoutmodel.SignRealia:
+		return irpb.SignConvention_SIGN_CONVENTION_REALIA
+	}
+
+	return irpb.SignConvention_SIGN_CONVENTION_UNSPECIFIED
+}
+
+// byteOrderOf is the order of the bytes in a binary integer.
+func byteOrderOf(order layoutmodel.ByteOrder) irpb.ByteOrder {
+	switch order {
+	case layoutmodel.BigEndian:
+		return irpb.ByteOrder_BYTE_ORDER_BIG_ENDIAN
+	case layoutmodel.LittleEndian:
+		return irpb.ByteOrder_BYTE_ORDER_LITTLE_ENDIAN
+	}
+
+	return irpb.ByteOrder_BYTE_ORDER_UNSPECIFIED
+}
+
+// floatFormatOf is the representation of a floating point item.
+func floatFormatOf(format layoutmodel.FloatFormat) irpb.FloatFormat {
+	switch format {
+	case layoutmodel.IEEE754:
+		return irpb.FloatFormat_FLOAT_FORMAT_IEEE754
+	case layoutmodel.HFP:
+		return irpb.FloatFormat_FLOAT_FORMAT_IBM_HFP
+	}
+
+	return irpb.FloatFormat_FLOAT_FORMAT_UNSPECIFIED
+}
+
+// usageOf is the item's USAGE, resolved to the one its bytes are in rather than
+// to the alias the copybook spelled.
+//
+// `cobol-go` keeps every spelling the grammar admits distinct, because which
+// representation a spelling selects is a property of the dialect and belongs
+// beside the codec rather than in the record tree. The IR takes the other side
+// deliberately: a generator switches over representations, and COMP, COMP-4 and
+// BINARY are one representation under every dialect this project supports. So
+// the aliases collapse here, which is the last place they can without a
+// generator author having to know that they are aliases.
+func usageOf(field *copybook.Field) irpb.Usage {
+	if field == nil {
+		return irpb.Usage_USAGE_UNSPECIFIED
+	}
+
+	switch field.Usage {
+	case copybook.UsageDisplay:
+		return irpb.Usage_USAGE_DISPLAY
+	case copybook.UsagePackedDecimal, copybook.UsageComp3:
+		return irpb.Usage_USAGE_PACKED_DECIMAL
+	case copybook.UsageBinary, copybook.UsageComp, copybook.UsageComp4:
+		return irpb.Usage_USAGE_BINARY
+	case copybook.UsageComp5:
+		return irpb.Usage_USAGE_COMP_5
+	case copybook.UsageComp1:
+		return irpb.Usage_USAGE_COMP_1
+	case copybook.UsageComp2:
+		return irpb.Usage_USAGE_COMP_2
+	case copybook.UsageIndex:
+		return irpb.Usage_USAGE_INDEX
+	case copybook.UsagePointer:
+		return irpb.Usage_USAGE_POINTER
+	}
+
+	return irpb.Usage_USAGE_UNSPECIFIED
+}
+
+// pictureOf is what the PICTURE character-string and the SIGN clause resolved
+// to, and nil where the item has no PICTURE at all.
+//
+// Nothing is derived here. `cobol-go` parsed the character-string into its
+// category, its digit count, its scale and whether it carries an operational
+// sign, and reading it a second time would be a second answer to a question
+// codec/SPEC.md's "From PICTURE to Attributes" has already settled. What this
+// adds is the one attribute that is not the picture's — where the sign sits,
+// which the SIGN clause says and which is inherited exactly as USAGE is.
+func pictureOf(field *copybook.Field) *irpb.Picture {
+	if field == nil || field.Picture == nil {
+		return nil
+	}
+
+	return &irpb.Picture{
+		Category:     categoryOf(field.Picture.Category),
+		Digits:       width(field.Picture.Digits),
+		Scale:        int32(field.Picture.Scale),
+		Signed:       field.Picture.Signed,
+		SignPosition: signPositionOf(field),
+	}
+}
+
+// categoryOf is the category the set of symbols in the picture fixes.
+func categoryOf(category picture.Category) irpb.Category {
+	switch category {
+	case picture.CategoryNumeric:
+		return irpb.Category_CATEGORY_NUMERIC
+	case picture.CategoryAlphabetic:
+		return irpb.Category_CATEGORY_ALPHABETIC
+	case picture.CategoryAlphanumeric:
+		return irpb.Category_CATEGORY_ALPHANUMERIC
+	case picture.CategoryNumericEdited:
+		return irpb.Category_CATEGORY_NUMERIC_EDITED
+	case picture.CategoryAlphanumericEdited:
+		return irpb.Category_CATEGORY_ALPHANUMERIC_EDITED
+	}
+
+	return irpb.Category_CATEGORY_UNSPECIFIED
+}
+
+// signPositionOf is where an operational sign is held, and unspecified where the
+// question does not arise.
+//
+// It does not arise for an unsigned item, and it does not arise for a USAGE the
+// SIGN clause has no effect on — which is every usage other than DISPLAY, since
+// packed and binary items hold their sign where their representation puts it.
+// An absent clause is TRAILING, non-separate: that is COBOL's default and it is
+// the one the item's width already reflects, because a separate sign costs a
+// byte and `cobol-go` counted it.
+func signPositionOf(field *copybook.Field) irpb.SignPosition {
+	if !field.Picture.Signed || field.Usage != copybook.UsageDisplay {
+		return irpb.SignPosition_SIGN_POSITION_UNSPECIFIED
+	}
+
+	clause := inheritedSign(field)
+	if clause == nil {
+		return irpb.SignPosition_SIGN_POSITION_TRAILING
+	}
+
+	if clause.Position == "LEADING" {
+		if clause.Separate {
+			return irpb.SignPosition_SIGN_POSITION_LEADING_SEPARATE
+		}
+
+		return irpb.SignPosition_SIGN_POSITION_LEADING
+	}
+
+	if clause.Separate {
+		return irpb.SignPosition_SIGN_POSITION_TRAILING_SEPARATE
+	}
+
+	return irpb.SignPosition_SIGN_POSITION_TRAILING
+}
+
+// inheritedSign is the SIGN clause governing a field: its own, or the nearest
+// one on a group above it, and nil where neither states one.
+//
+// The clause may be written on the item or on any group above it, applying to
+// every signed numeric DISPLAY item subordinate to it, so the nearest one wins —
+// the same inheritance USAGE follows, which `cobol-go` has already run for
+// USAGE and does not expose for this.
+func inheritedSign(field *copybook.Field) *cobol.SignClause {
+	for item := field; item != nil; item = item.Parent {
+		if item.Entry == nil {
+			continue
+		}
+
+		for _, clause := range item.Entry.Clauses {
+			if sign, ok := clause.(*cobol.SignClause); ok {
+				return sign
+			}
+		}
+	}
+
+	return nil
+}
+
+// registerKindOf is what a register holds: the source field's bytes as they
+// appear in the record, or a number decoded from it by that field's own axes.
+func registerKindOf(kind resolve.RegisterKind) irpb.RegisterKind {
+	switch kind {
+	case resolve.RegisterBytes:
+		return irpb.RegisterKind_REGISTER_KIND_BYTES
+	case resolve.RegisterInteger:
+		return irpb.RegisterKind_REGISTER_KIND_INTEGER
+	}
+
+	return irpb.RegisterKind_REGISTER_KIND_UNSPECIFIED
+}

--- a/internal/assemble/automaton.go
+++ b/internal/assemble/automaton.go
@@ -1,0 +1,269 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package assemble
+
+import (
+	"strconv"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/Zaba505/cpybkc/internal/resolve"
+	"github.com/Zaba505/cpybkc/irpb"
+)
+
+// This file is the automaton's half of the traversal: the registers, the
+// states, and everything a transition hangs off.
+//
+// It is a separate half because the two halves resolve references differently.
+// Inside a record every reference is to a node of that record, and the record
+// is the scope. On the automaton side a reference is to a register, to a state,
+// or *into* the record the transition admits — which is why a transition is the
+// place the record scope is picked up, and why nothing here looks a field up
+// without one.
+
+// allocateRegisters gives every register a node, in the order the automaton
+// allocated them.
+//
+// A register declares the kind of value it holds and nothing more. What
+// `resolve` carries beside it — the item reference the layout wrote, the
+// copybook field it resolved to — is read by the bindings and never reaches the
+// node: a binding names where a value came from, so a register naming it too
+// would be one fact stated twice.
+func (a *assembler) allocateRegisters() {
+	for _, register := range a.opts.Automaton.Registers {
+		node := a.reserve()
+		a.registers[register] = node.Id
+
+		node.Kind = &irpb.Node_Register{Register: &irpb.Register{Kind: registerKindOf(register.Kind)}}
+	}
+}
+
+// allocateStates gives every state a node, in the automaton's own order, before
+// any transition is built.
+//
+// Before, because a transition names the state it moves to and a cycle there is
+// ordinary — a header followed by any number of details is one — so there is no
+// order in which every state's identifier is already known when its transitions
+// are filled.
+func (a *assembler) allocateStates() {
+	for _, state := range a.opts.Automaton.States {
+		a.states[state] = a.reserve().Id
+	}
+}
+
+// fillStates fills every state, and builds the guards, transitions, predicates
+// and bindings that hang off it.
+func (a *assembler) fillStates() {
+	for _, state := range a.opts.Automaton.States {
+		node := a.nodes[a.states[state]]
+
+		built := &irpb.State{Accepts: state.Accepts}
+		for _, guard := range state.Acceptance {
+			built.AcceptanceGuardIds = append(built.AcceptanceGuardIds, a.guard(guard))
+		}
+
+		for _, transition := range state.Transitions {
+			built.TransitionIds = append(built.TransitionIds, a.transition(transition))
+		}
+
+		node.Kind = &irpb.Node_State{State: built}
+	}
+}
+
+// transition builds one edge: the record it admits, the state it moves to, the
+// predicate that selects it where it carries one, its guards and its bindings.
+//
+// The record's scope is picked up here and handed down, because everything this
+// transition names in a record — its predicate's target, its bindings' sources —
+// is a field of the record it admits and of no other.
+func (a *assembler) transition(transition *resolve.Transition) uint64 {
+	node := a.reserve()
+
+	scope, admitted := a.byName[transition.Record]
+	if !admitted {
+		a.faults.Fail(&UnknownRecordError{Record: transition.Record, Defined: a.recordNames()})
+
+		return node.Id
+	}
+
+	built := &irpb.Transition{
+		RecordId:    scope.record,
+		NextStateId: a.states[transition.To],
+	}
+
+	// A transition **MAY** carry no predicate, and the absence is the absent
+	// reference rather than a member of the set testing nothing. Zero is an
+	// ordinary identifier, which is why the schema spells this one `optional`
+	// and why nothing here writes a sentinel (docs/ir/SPEC.md, "A transition
+	// may carry no predicate").
+	if transition.Predicate != nil {
+		built.PredicateId = proto.Uint64(a.allocatePredicate(scope, transition.Predicate))
+	}
+
+	for _, guard := range transition.Guards {
+		built.GuardIds = append(built.GuardIds, a.guard(guard))
+	}
+
+	for _, binding := range transition.Bindings {
+		built.BindingIds = append(built.BindingIds, a.binding(scope, binding))
+	}
+
+	node.Kind = &irpb.Node_Transition{Transition: built}
+
+	return node.Id
+}
+
+// guard builds one guard node: the register it reads and the test.
+//
+// Two transitions carrying the same test carry two guard nodes. Nothing in a
+// descriptor reads the identity of a guard — a transition's guards **MUST** all
+// hold, so their order and their sharing say nothing — and a producer that
+// merged them would be asserting a sameness no consumer can act on.
+func (a *assembler) guard(guard resolve.Guard) uint64 {
+	node := a.reserve()
+
+	built := &irpb.Guard{RegisterId: a.registers[guard.Register]}
+
+	switch guard.Test {
+	case resolve.GuardEquals:
+		if len(guard.Values) > 0 {
+			built.Test = &irpb.Guard_Equals{Equals: literalOf(guard.Register, guard.Values[0])}
+		}
+	case resolve.GuardOneOf:
+		set := &irpb.LiteralSet{Values: make([]*irpb.Literal, 0, len(guard.Values))}
+		for _, value := range guard.Values {
+			set.Values = append(set.Values, literalOf(guard.Register, value))
+		}
+
+		built.Test = &irpb.Guard_OneOf{OneOf: set}
+	case resolve.GuardPositive:
+		built.Test = &irpb.Guard_GreaterThanZero{GreaterThanZero: &irpb.GreaterThanZero{}}
+	}
+
+	node.Kind = &irpb.Node_Guard{Guard: built}
+
+	return node.Id
+}
+
+// literalOf is what a guard compares a register against.
+//
+// Which member is set follows the register's kind rather than what the value
+// happens to carry, because the schema requires the two to match: a bytes
+// register is compared as bytes and an integer register as a number, and a
+// literal that disagreed with its register would be a comparison no consumer
+// could run.
+func literalOf(register *resolve.Register, value resolve.Value) *irpb.Literal {
+	if register != nil && register.Kind == resolve.RegisterInteger {
+		return &irpb.Literal{Value: &irpb.Literal_Integer{Integer: value.Number}}
+	}
+
+	return &irpb.Literal{Value: &irpb.Literal_BytesValue{BytesValue: value.Bytes}}
+}
+
+// binding builds one binding node: the register written, and the value written.
+func (a *assembler) binding(s *scope, binding resolve.Binding) uint64 {
+	node := a.reserve()
+
+	built := &irpb.Binding{RegisterId: a.registers[binding.Register]}
+
+	switch binding.Value {
+	case resolve.BindField:
+		id, found := s.fields[binding.Field]
+		if !found {
+			a.faults.Fail(&UnresolvedTargetError{
+				Pos:      a.span(s, binding.Field),
+				Record:   s.name,
+				Item:     itemName(binding.Field),
+				Position: "the binding of register " + strconv.Itoa(registerNumber(binding.Register)),
+			})
+
+			break
+		}
+
+		built.Value = &irpb.Binding_FieldId{FieldId: id}
+	case resolve.BindLessOne:
+		built.Value = &irpb.Binding_Decrement{Decrement: &irpb.Decrement{}}
+	}
+
+	node.Kind = &irpb.Node_Binding{Binding: built}
+
+	return node.Id
+}
+
+// registerNumber is the register's own number, which is what a diagnostic about
+// one quotes when the layout's spelling of it is not what went wrong.
+func registerNumber(register *resolve.Register) int {
+	if register == nil {
+		return 0
+	}
+
+	return register.ID
+}
+
+// allocatePredicate gives a predicate a node, once per record type that reads
+// it, and returns the identifier.
+//
+// The body is filled later. A predicate names a field, an arm's predicate is met
+// while its record is still being walked, and a transition's is met after every
+// record has been — so filling on sight would work for one of the two and not
+// the other.
+func (a *assembler) allocatePredicate(s *scope, predicate *resolve.Predicate) uint64 {
+	if predicate == nil || s == nil {
+		return 0
+	}
+
+	key := predicateKey{record: s, predicate: predicate}
+	if id, already := a.predicates[key]; already {
+		return id
+	}
+
+	node := a.reserve()
+	a.predicates[key] = node.Id
+	a.pending = append(a.pending, pendingPredicate{scope: s, predicate: predicate, node: node})
+
+	return node.Id
+}
+
+// fillPredicates fills every predicate node, in the order the nodes were
+// allocated.
+//
+// The order matters for the diagnostics and for nothing else: the identifiers
+// were handed out during the traversal, so what happens here cannot move one.
+func (a *assembler) fillPredicates() {
+	for _, waiting := range a.pending {
+		built := &irpb.Predicate{}
+
+		id, found := waiting.scope.fields[waiting.predicate.Target]
+		if !found {
+			a.faults.Fail(&UnresolvedTargetError{
+				Pos:      a.span(waiting.scope, waiting.predicate.Target),
+				Record:   waiting.scope.name,
+				Item:     itemName(waiting.predicate.Target),
+				Position: "the predicate selecting it",
+			})
+		}
+
+		built.FieldId = id
+
+		switch waiting.predicate.Test {
+		case resolve.BytesEqual:
+			if len(waiting.predicate.Values) > 0 {
+				built.Test = &irpb.Predicate_BytesEqual{
+					BytesEqual: &irpb.BytesEqual{Value: waiting.predicate.Values[0].Bytes},
+				}
+			}
+		case resolve.BytesOneOf:
+			values := make([][]byte, 0, len(waiting.predicate.Values))
+			for _, value := range waiting.predicate.Values {
+				values = append(values, value.Bytes)
+			}
+
+			built.Test = &irpb.Predicate_BytesOneOf{BytesOneOf: &irpb.BytesOneOf{Values: values}}
+		}
+
+		waiting.node.Kind = &irpb.Node_Predicate{Predicate: built}
+	}
+}

--- a/internal/assemble/doc.go
+++ b/internal/assemble/doc.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Package assemble turns everything a resolved layout consists of — the
+// framing, the record automaton, one resolved record type per `record` form,
+// and the renames over them — into the single
+// [github.com/Zaba505/cpybkc/irpb.Descriptor] a generator plugin consumes.
+//
+// [Assemble] is the whole of the interface. What reaches it is already
+// resolved: [github.com/Zaba505/cpybkc/internal/resolve] has spent the COBOL
+// and the algebra, and this package spends neither. It assigns the identifiers,
+// spells each resolved value into the member the schema gives it, and holds the
+// result to [Validate] before handing it back.
+//
+// # Why the identifiers are assigned here and nowhere else
+//
+// A [github.com/Zaba505/cpybkc/internal/resolve.Node] names a
+// [github.com/Zaba505/cobol-go/copybook.Field] and never an identifier, and so
+// does a [github.com/Zaba505/cpybkc/internal/resolve.Predicate], a
+// [github.com/Zaba505/cpybkc/internal/resolve.Repetition] and a
+// [github.com/Zaba505/cpybkc/internal/resolve.Binding]. That is deliberate:
+// resolving a copybook is one question and numbering the result is another, and
+// a package doing both would have to know, while it was laying out a record,
+// which record node the automaton would eventually point at.
+//
+// So the numbering is one traversal, here, and it is the traversal
+// docs/ir/SPEC.md's "Identity, ordering and determinism" asks a producer for.
+// Identifiers are positions in the node list: a node's identifier is its index,
+// the list is therefore in ascending identifier order by construction, and
+// neither property is a sort this package could forget to run.
+//
+// # The traversal, and why identical inputs produce identical bytes
+//
+// The order is fixed and reads down the descriptor:
+//
+//  1. the file node, which is therefore identifier zero;
+//  2. each record type in the order [Options.Records] gives them, and inside
+//     one, its record node, then its top level, then its members in record
+//     order, an arm's predicate ahead of the arm's body;
+//  3. the registers, in the order the automaton allocated them;
+//  4. every state, in the automaton's own order;
+//  5. then, state by state in that same order, the guards qualifying its
+//     acceptance, and each of its transitions with its predicate, its guards
+//     and its bindings.
+//
+// The states are numbered before anything hanging off them because a transition
+// names the state it moves to and a cycle there is ordinary — a header followed
+// by any number of details is one — so there is no order in which every state's
+// identifier is already known when its transitions are built.
+//
+// Nothing in that walk reads a Go map, which is what makes the whole of it a
+// function of the input rather than of the run. Two assemblies of one layout
+// produce identical descriptors, and
+// [github.com/Zaba505/cpybkc/internal/emit.Marshal] turns identical descriptors
+// into identical bytes — the two halves docs/ir/SPEC.md asks for, met in the
+// two places that can meet them (#38).
+//
+// A predicate is shared by every transition admitting one record, because
+// `resolve` compiles a record's discriminator once and hands the same node to
+// each appearance. It is shared *within* a record type and never across one:
+// the field a predicate names is looked up in the record whose bytes the
+// predicate reads, and two record types that resolved from one copybook have
+// two field nodes for one copybook item. Guards and bindings are not shared at
+// all — two transitions carrying the same test carry two guard nodes, because
+// the identity of a guard is not something any consumer reads.
+//
+// # No default survives, and the validation pass says so
+//
+// [Validate] is the completeness pass, and [Assemble] runs it over its own
+// output before returning: nothing leaves this package unvalidated, so the
+// obligation is met wherever a descriptor comes from rather than wherever a
+// generator is invoked.
+//
+// What it checks is the shape of the message rather than the COBOL behind it —
+// every reference resolves to a node of a kind its position admits, every node
+// is reachable from the file node, every closed set carries a member rather
+// than its unspecified zero, and every field states all four encoding axes.
+// The last is the one docs/ir/SPEC.md phrases as a requirement on the producer
+// twice over, because each of the four fails silently when it is wrong: a
+// charset yields a plausible string and a byte order a plausible number, with
+// nothing in the file to disagree.
+//
+// The pass exists because the failures it catches are otherwise invisible until
+// a generator reads the descriptor, and a generator reading one is entitled to
+// assume it conforms. A descriptor that reached a plugin with an axis unset is
+// a bug in this repository being reported by somebody else's code.
+//
+// # Faults are diagnostics, not a first error
+//
+// Every fault is a [github.com/Zaba505/cpybkc/internal/diag.Error] carrying the
+// span of whatever the fault is about — the layout's framing form, the
+// copybook entry behind a node — joined with [errors.Join] and assertable with
+// [errors.As], exactly as the readers and `resolve` report theirs. One
+// descriptor is wrong in the same way in many places at once, and a pass
+// reporting one fault per run is a pass run once per fault.
+package assemble

--- a/internal/assemble/errors.go
+++ b/internal/assemble/errors.go
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package assemble
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+)
+
+// The faults this package reports fall into two halves, and the halves carry
+// different things because they are about different objects.
+//
+// A fault [Assemble] finds is about something an adopter wrote — a record the
+// automaton admits and no `record` form defines, a discriminator naming an item
+// the record it selects does not hold — so it carries a span into the copybook
+// or the layout, exactly as `resolve`'s do.
+//
+// A fault [Validate] finds is about the descriptor, and a descriptor carries no
+// positions: no node holds a line, a column or a file, for the reason none holds
+// an offset. So what identifies one is the node's identifier and a sentence, and
+// there are two types rather than a dozen because the identifier and the
+// sentence are the whole of what a caller can act on. A malformed descriptor is
+// a bug in this repository in any case, and what makes one findable is which
+// node and what about it, not which struct it came back in.
+
+// ErrNoFraming is returned by [Assemble] when it is handed no framing.
+//
+// A descriptor's file node carries the dataset's framing as one member of a
+// closed set of four, and a layout **MUST** carry exactly one `framing` form
+// (docs/layout/SPEC.md, "Physical framing"). There is no fifth member standing
+// for a framing nobody stated, and inventing one here would be a default
+// surviving into the one form of the layout that exists to carry none.
+var ErrNoFraming = errors.New("assemble: the layout states no framing, and a file node carries one")
+
+// ErrNoAutomaton is returned by [Assemble] when it is handed no automaton.
+//
+// The file node names the start state, so a descriptor without an automaton has
+// no root for anything else to hang off.
+var ErrNoAutomaton = errors.New("assemble: the layout states no sequencing, and a file node names a start state")
+
+// ErrNoRecords is returned by [Assemble] when it is handed no record types.
+//
+// Every transition admits one, so a descriptor with no record node is a
+// descriptor whose automaton cannot take a single step.
+var ErrNoRecords = errors.New("assemble: the layout defines no record types")
+
+// DuplicateRecordError is two record types handed over under one name.
+//
+// A name is how a transition says which record it admits, so two of them make
+// every transition admitting that name ambiguous. It is the layout reader that
+// ordinarily refuses a duplicate record name (docs/layout/SPEC.md, "Validation
+// and diagnostics"); this catches the pair that reached here by another road,
+// because assembling either one silently would put a record type in the
+// descriptor that nothing in the layout asked for.
+type DuplicateRecordError struct {
+	// Record is the name given twice.
+	Record string
+
+	// Copybook is the second entry's copybook, which is the file the caller
+	// would look in to tell the two apart.
+	Copybook string
+}
+
+// Error implements the error interface.
+func (e *DuplicateRecordError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *DuplicateRecordError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"two record types are named %s, so no transition can say which of them it admits", e.Record),
+		Spans: []diag.Span{{File: e.Copybook}},
+	}
+}
+
+// UnknownRecordError is a transition admitting a record type nothing defines.
+//
+// The automaton names the records its transitions admit, and every one of them
+// **MUST** resolve to a record node in the same message (docs/ir/SPEC.md,
+// "Identity, ordering and determinism"). A transition pointing nowhere is the
+// one shape a consumer cannot recover from: it has bytes in front of it and no
+// record type to read them as.
+//
+// A [Record] handed over carrying no resolved record reports the same fault,
+// because it is the same one seen a step earlier: the name is in the list and
+// nothing resolved to it.
+type UnknownRecordError struct {
+	// Record is the name the transition admits.
+	Record string
+
+	// Defined are the record types that were handed over, in the order they
+	// were, which is what tells a caller whether the name is misspelled or
+	// missing.
+	Defined []string
+}
+
+// Error implements the error interface.
+func (e *UnknownRecordError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *UnknownRecordError) Diagnostic() diag.Diagnostic {
+	message := fmt.Sprintf("a transition admits record %s, which no record type resolved to", e.Record)
+	if len(e.Defined) > 0 {
+		message += ": the record types are " + list(e.Defined)
+	}
+
+	return diag.Diagnostic{Message: message}
+}
+
+// UnresolvedTargetError is a reference naming a copybook item the record it
+// reads has no field node for.
+//
+// Three positions name a field of the record a transition admits — a
+// discriminator predicate, a register binding, and an `OCCURS DEPENDING ON`
+// count — and each is a reference the descriptor states by identifier. An item
+// that laid out as no elementary node of that record has no identifier to state,
+// which is what this reports rather than emitting a reference to nothing.
+type UnresolvedTargetError struct {
+	// Pos is the copybook entry the item was declared at.
+	Pos diag.Span
+
+	// Record is the record type the reference reads.
+	Record string
+
+	// Item is the item named.
+	Item string
+
+	// Position is what named it, in the message's own words — "the predicate
+	// selecting it", "a binding of register 0".
+	Position string
+}
+
+// Error implements the error interface.
+func (e *UnresolvedTargetError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *UnresolvedTargetError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"%s names %s, which is no field of record %s", e.Position, e.Item, e.Record),
+		Spans: []diag.Span{e.Pos},
+	}
+}
+
+// DescriptorError is one thing wrong with an assembled descriptor as a whole:
+// its version, how many roots it has, or the order of its node list.
+//
+// It carries no span, because a descriptor has none. See the note at the top of
+// this file.
+type DescriptorError struct {
+	// Fault is what is wrong, as a sentence.
+	Fault string
+}
+
+// Error implements the error interface.
+func (e *DescriptorError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *DescriptorError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{Message: "the assembled descriptor " + e.Fault}
+}
+
+// NodeError is one thing wrong with one node of an assembled descriptor.
+type NodeError struct {
+	// ID is the node's identifier.
+	ID uint64
+
+	// Kind is what the node is — "field", "transition" — or "no kind" for a
+	// node whose body was never set.
+	Kind string
+
+	// Fault is what is wrong with it, as a sentence.
+	Fault string
+}
+
+// Error implements the error interface.
+func (e *NodeError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *NodeError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf("node %d, a %s node, %s", e.ID, e.Kind, e.Fault),
+	}
+}
+
+// list joins names the way a message does, so that a list of what a caller could
+// have meant reads as a sentence rather than as a slice.
+func list(names []string) string {
+	switch len(names) {
+	case 0:
+		return ""
+	case 1:
+		return names[0]
+	case 2:
+		return names[0] + " and " + names[1]
+	}
+
+	return strings.Join(names[:len(names)-1], ", ") + " and " + names[len(names)-1]
+}

--- a/internal/assemble/validate.go
+++ b/internal/assemble/validate.go
@@ -1,0 +1,650 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package assemble
+
+import (
+	"encoding/hex"
+	"fmt"
+	"slices"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+	"github.com/Zaba505/cpybkc/irpb"
+)
+
+// Validate holds a descriptor to what docs/ir/SPEC.md requires of one before a
+// generator is invoked, and reports everything it finds wrong.
+//
+// [Assemble] runs it over its own output, so a descriptor this repository
+// produced has already passed. It is exported for the other caller: a command
+// about to hand a descriptor to a plugin, which is where "before any generator
+// is invoked" is a statement about a process rather than about a function (#38).
+//
+// # What it checks
+//
+// Everything a consumer is entitled to assume and cannot check for itself
+// without failing halfway through a walk:
+//
+//   - The version is set, and names a release. A descriptor whose version is
+//     zero is a descriptor whose producer did not set one.
+//   - Exactly one file node exists, identifiers are unique, and the node list is
+//     in ascending identifier order.
+//   - Every reference resolves to a node in the same message, of a kind the
+//     referring position admits.
+//   - Every node is reachable from the file node, and every item is named by
+//     exactly one member list, one arm, or one record's top level — which is
+//     also what makes containment acyclic.
+//   - No closed set carries its unspecified zero: not an encoding axis, not a
+//     USAGE, not a register's kind, not a delimiter's placement.
+//   - Every field states all four encoding axes. docs/ir/SPEC.md makes this a
+//     requirement on the producer and a refusal on the consumer, because each
+//     of the four fails silently when wrong: a charset yields a plausible
+//     string and a byte order a plausible number, with nothing in the file to
+//     disagree.
+//
+// # What it does not check
+//
+// Anything that is arithmetic on the message rather than a property of it. A
+// group's width, a field's position, whether two arms of a variant come to the
+// same extent: a consumer computes each of those from what it was handed, and a
+// second computation here would be a second answer to a question the descriptor
+// states once (docs/ir/SPEC.md, "Dereferencing is not recomputation").
+//
+// It also does not check the COBOL. Whether a width follows from a PICTURE and
+// whether an automaton follows from a sequencing expression are `resolve`'s, and
+// a pass re-deriving either would be the second reading of that knowledge the
+// whole project exists to avoid.
+//
+// Every fault is reported, joined with [errors.Join] and assertable with
+// [errors.As], rather than the first: a descriptor assembled wrong is wrong in
+// the same way in many places at once.
+func Validate(d *irpb.Descriptor) error {
+	if d == nil {
+		return &DescriptorError{Fault: "is not there"}
+	}
+
+	v := &validator{nodes: make(map[uint64]*irpb.Node, len(d.GetNodes()))}
+
+	v.version(d)
+	v.index(d)
+	v.bodies()
+	v.containment()
+
+	// Reachability is a statement about a descriptor whose references all
+	// resolve. Over one whose references do not, every node the broken
+	// reference stood in front of is unreachable *because* of it, and
+	// reporting a dozen consequences beside the cause buries the cause. So it
+	// runs last and only over a descriptor nothing else was wrong with.
+	if !v.faults.Failed() {
+		v.reachability()
+	}
+
+	return v.faults.Err()
+}
+
+// validator holds the state one [Validate] accumulates.
+type validator struct {
+	faults diag.List
+
+	// nodes is the node list indexed by identifier, which is the index every
+	// consumer builds before it can walk anything.
+	nodes map[uint64]*irpb.Node
+
+	// order is the identifiers in the order the list carried them, so that
+	// every pass runs in a fixed order and reports its faults in one.
+	order []uint64
+
+	// root is the file node's identifier, and rooted whether there is exactly
+	// one to have.
+	root   uint64
+	rooted bool
+
+	// edges are the references out of each node, which is what reachability
+	// walks. contained counts the references that are *containment* — a member
+	// list, an arm's body, a record's top level — which is a stricter rule.
+	edges     map[uint64][]uint64
+	contained map[uint64]int
+}
+
+// version holds the descriptor to a version a release names.
+func (v *validator) version(d *irpb.Descriptor) {
+	version := d.GetVersion()
+	if version == irpb.IrVersion_IR_VERSION_UNSPECIFIED {
+		v.faults.Fail(&DescriptorError{Fault: "states no version, so nothing says which contract it was written against"})
+
+		return
+	}
+
+	if _, named := irpb.IrVersion_name[int32(version)]; !named {
+		v.faults.Fail(&DescriptorError{
+			Fault: fmt.Sprintf("states version %d, which no release of the IR names", version),
+		})
+	}
+}
+
+// index builds the identifier index, and holds the node list to being unique,
+// ascending, and rooted at exactly one file node.
+func (v *validator) index(d *irpb.Descriptor) {
+	v.edges = make(map[uint64][]uint64, len(d.GetNodes()))
+	v.contained = make(map[uint64]int, len(d.GetNodes()))
+
+	var previous uint64
+	var files []uint64
+
+	for at, node := range d.GetNodes() {
+		if node == nil {
+			v.faults.Fail(&DescriptorError{Fault: fmt.Sprintf("carries nothing at position %d of its node list", at)})
+
+			continue
+		}
+
+		if _, already := v.nodes[node.GetId()]; already {
+			v.faults.Fail(&NodeError{
+				ID:    node.GetId(),
+				Kind:  kindOf(node),
+				Fault: "shares its identifier with another node, and an identifier is identity",
+			})
+
+			continue
+		}
+
+		if at > 0 && node.GetId() <= previous {
+			v.faults.Fail(&NodeError{
+				ID:   node.GetId(),
+				Kind: kindOf(node),
+				Fault: fmt.Sprintf(
+					"stands behind node %d in the node list, which docs/ir/SPEC.md requires to be in ascending identifier order",
+					previous),
+			})
+		}
+
+		previous = node.GetId()
+		v.nodes[node.GetId()] = node
+		v.order = append(v.order, node.GetId())
+
+		if node.GetFile() != nil {
+			files = append(files, node.GetId())
+		}
+	}
+
+	switch len(files) {
+	case 1:
+		v.root, v.rooted = files[0], true
+	case 0:
+		v.faults.Fail(&DescriptorError{Fault: "carries no file node, and the file node is the root everything hangs off"})
+	default:
+		v.faults.Fail(&DescriptorError{
+			Fault: fmt.Sprintf("carries %d file nodes, and exactly one exists", len(files)),
+		})
+	}
+}
+
+// bodies holds every node to what its own kind requires of it.
+func (v *validator) bodies() {
+	for _, id := range v.order {
+		node := v.nodes[id]
+
+		switch body := node.GetKind().(type) {
+		case *irpb.Node_File:
+			v.file(id, body.File)
+		case *irpb.Node_Record:
+			v.record(id, body.Record)
+		case *irpb.Node_Group:
+			v.group(id, body.Group)
+		case *irpb.Node_Variant:
+			v.variant(id, body.Variant)
+		case *irpb.Node_Field:
+			v.field(id, body.Field)
+		case *irpb.Node_Slack:
+			v.slack(id, body.Slack)
+		case *irpb.Node_Predicate:
+			v.predicate(id, body.Predicate)
+		case *irpb.Node_State:
+			v.state(id, body.State)
+		case *irpb.Node_Transition:
+			v.transition(id, body.Transition)
+		case *irpb.Node_Register:
+			v.register(id, body.Register)
+		case *irpb.Node_Binding:
+			v.binding(id, body.Binding)
+		case *irpb.Node_Guard:
+			v.guard(id, body.Guard)
+		default:
+			v.faults.Fail(&NodeError{
+				ID:    id,
+				Kind:  "kindless",
+				Fault: "carries no body, and every node is one member of the closed set of twelve kinds",
+			})
+		}
+	}
+}
+
+// reference resolves one reference and records the edge, faulting where it names
+// no node or a node of a kind the position does not admit.
+func (v *validator) reference(from uint64, position string, to uint64, admits ...string) {
+	v.edges[from] = append(v.edges[from], to)
+
+	target, found := v.nodes[to]
+	if !found {
+		v.fault(from, "%s names node %d, which is not in this descriptor", position, to)
+
+		return
+	}
+
+	if kind := kindOf(target); !slices.Contains(admits, kind) {
+		v.fault(from, "%s names node %d, a %s node, and admits only %s", position, to, kind, list(admits))
+	}
+}
+
+// contain records a reference that is also containment, which is under the
+// stricter rule: exactly one member list, arm or record top level names an item.
+func (v *validator) contain(from uint64, position string, to uint64, admits ...string) {
+	v.reference(from, position, to, admits...)
+	v.contained[to]++
+}
+
+// fault records one thing wrong with one node.
+func (v *validator) fault(id uint64, format string, args ...any) {
+	kind := "kindless"
+	if node, found := v.nodes[id]; found {
+		kind = kindOf(node)
+	}
+
+	v.faults.Fail(&NodeError{ID: id, Kind: kind, Fault: fmt.Sprintf(format, args...)})
+}
+
+func (v *validator) file(id uint64, file *irpb.File) {
+	switch framing := file.GetFraming().(type) {
+	case *irpb.File_Delimited:
+		if len(framing.Delimited.GetDelimiter()) == 0 {
+			v.fault(id, "states a delimited dataset whose delimiter is no bytes at all")
+		}
+
+		if framing.Delimited.GetPlacement() == irpb.DelimiterPlacement_DELIMITER_PLACEMENT_UNSPECIFIED {
+			v.fault(id, "states a delimited dataset and does not say where the delimiter stands")
+		}
+	case nil:
+		v.fault(id, "states no framing, and a framing is one member of a closed set of four")
+	}
+
+	v.reference(id, "the start state", file.GetStartStateId(), "state")
+}
+
+func (v *validator) record(id uint64, record *irpb.Record) {
+	v.names(id, record.GetNames(), true)
+	v.contain(id, "the record's top level", record.GetRootId(), "group")
+
+	if top, found := v.nodes[record.GetRootId()]; found && len(top.GetGroup().GetMemberIds()) == 0 {
+		v.fault(id, "holds no items, and no transition may admit a record whose extent is zero")
+	}
+}
+
+func (v *validator) group(id uint64, group *irpb.Group) {
+	v.names(id, group.GetNames(), false)
+
+	for at, member := range group.GetMemberIds() {
+		v.contain(id, fmt.Sprintf("member %d", at+1), member, "group", "variant", "field", "slack")
+	}
+
+	v.repetition(id, group.GetRepetition())
+}
+
+func (v *validator) variant(id uint64, variant *irpb.Variant) {
+	if len(variant.GetArms()) == 0 {
+		v.fault(id, "carries no arms, and an alternation over nothing is not a choice a consumer can make")
+	}
+
+	for at, arm := range variant.GetArms() {
+		where := fmt.Sprintf("arm %d", at+1)
+
+		v.reference(id, where+"'s predicate", arm.GetPredicateId(), "predicate")
+
+		switch body := arm.GetBody().(type) {
+		case *irpb.Arm_GroupId:
+			v.contain(id, where+"'s body", body.GroupId, "group")
+		case *irpb.Arm_FieldId:
+			v.contain(id, where+"'s body", body.FieldId, "field")
+		case nil:
+			v.fault(id, "%s names no body", where)
+		}
+	}
+}
+
+func (v *validator) field(id uint64, field *irpb.Field) {
+	v.names(id, field.GetNames(), false)
+
+	if field.GetWidth() == 0 {
+		v.fault(id, "occupies no bytes, and an elementary item occupies at least one")
+	}
+
+	if missing := unresolved(field.GetEncoding()); len(missing) > 0 {
+		v.fault(id, "states no %s, and all four encoding axes are stated on every field", list(missing))
+	}
+
+	if field.GetUsage() == irpb.Usage_USAGE_UNSPECIFIED {
+		v.fault(id, "states no USAGE")
+	}
+
+	if picture := field.GetPicture(); picture != nil && picture.GetCategory() == irpb.Category_CATEGORY_UNSPECIFIED {
+		v.fault(id, "carries a PICTURE of no category")
+	}
+
+	v.repetition(id, field.GetRepetition())
+}
+
+func (v *validator) slack(id uint64, slack *irpb.Slack) {
+	if slack.GetWidth() == 0 {
+		v.fault(id, "covers no bytes, and slack is one node per maximal run of them")
+	}
+}
+
+func (v *validator) predicate(id uint64, predicate *irpb.Predicate) {
+	v.reference(id, "the field it tests", predicate.GetFieldId(), "field")
+
+	switch test := predicate.GetTest().(type) {
+	case *irpb.Predicate_BytesEqual:
+		if len(test.BytesEqual.GetValue()) == 0 {
+			v.fault(id, "compares against no bytes at all")
+		}
+	case *irpb.Predicate_BytesOneOf:
+		values := test.BytesOneOf.GetValues()
+		if len(values) < 2 {
+			v.fault(id, "offers %d literals, and a one-of test carries at least two", len(values))
+		}
+
+		if duplicate, twice := repeated(values); twice {
+			v.fault(id, "carries the literal %s twice, which is a value tested twice", quoteBytes(duplicate))
+		}
+	case nil:
+		v.fault(id, "carries no test, and a predicate testing nothing is the absence of one")
+	}
+}
+
+func (v *validator) state(id uint64, state *irpb.State) {
+	if !state.GetAccepts() && len(state.GetAcceptanceGuardIds()) > 0 {
+		v.fault(id, "does not accept and still qualifies its acceptance with guards")
+	}
+
+	for at, guard := range state.GetAcceptanceGuardIds() {
+		v.reference(id, fmt.Sprintf("acceptance guard %d", at+1), guard, "guard")
+	}
+
+	for at, transition := range state.GetTransitionIds() {
+		v.reference(id, fmt.Sprintf("transition %d", at+1), transition, "transition")
+	}
+}
+
+func (v *validator) transition(id uint64, transition *irpb.Transition) {
+	v.reference(id, "the record it admits", transition.GetRecordId(), "record")
+	v.reference(id, "the state it moves to", transition.GetNextStateId(), "state")
+
+	if transition.PredicateId != nil {
+		v.reference(id, "the predicate selecting it", transition.GetPredicateId(), "predicate")
+	}
+
+	for at, guard := range transition.GetGuardIds() {
+		v.reference(id, fmt.Sprintf("guard %d", at+1), guard, "guard")
+	}
+
+	var written []uint64
+
+	for at, binding := range transition.GetBindingIds() {
+		v.reference(id, fmt.Sprintf("binding %d", at+1), binding, "binding")
+
+		node, found := v.nodes[binding]
+		if !found || node.GetBinding() == nil {
+			continue
+		}
+
+		register := node.GetBinding().GetRegisterId()
+		if slices.Contains(written, register) {
+			v.fault(id, "applies two bindings writing register node %d, and nothing orders them", register)
+		}
+
+		written = append(written, register)
+	}
+}
+
+func (v *validator) register(id uint64, register *irpb.Register) {
+	if register.GetKind() == irpb.RegisterKind_REGISTER_KIND_UNSPECIFIED {
+		v.fault(id, "does not say what it holds")
+	}
+}
+
+func (v *validator) binding(id uint64, binding *irpb.Binding) {
+	v.reference(id, "the register it writes", binding.GetRegisterId(), "register")
+
+	switch value := binding.GetValue().(type) {
+	case *irpb.Binding_FieldId:
+		v.reference(id, "the field it reads", value.FieldId, "field")
+	case nil:
+		v.fault(id, "writes no value, and every value in a register was put there by a binding naming where it came from")
+	}
+}
+
+func (v *validator) guard(id uint64, guard *irpb.Guard) {
+	v.reference(id, "the register it tests", guard.GetRegisterId(), "register")
+
+	switch test := guard.GetTest().(type) {
+	case *irpb.Guard_Equals:
+		v.literal(id, "the literal it compares against", test.Equals)
+	case *irpb.Guard_OneOf:
+		values := test.OneOf.GetValues()
+		if len(values) == 0 {
+			v.fault(id, "compares against an empty set")
+		}
+
+		for at, value := range values {
+			v.literal(id, fmt.Sprintf("literal %d", at+1), value)
+		}
+	case nil:
+		v.fault(id, "carries no test, and the set of three has no member testing nothing")
+	}
+}
+
+// literal holds a guard's literal to carrying a value at all.
+//
+// Which of the two members it carries **MUST** match the kind of the register
+// tested, and that is checked here rather than left to a consumer: a bytes
+// literal against an integer register is a comparison nothing can run.
+func (v *validator) literal(id uint64, position string, literal *irpb.Literal) {
+	switch literal.GetValue().(type) {
+	case *irpb.Literal_BytesValue, *irpb.Literal_Integer:
+	default:
+		v.fault(id, "%s carries no value", position)
+	}
+}
+
+// repetition holds an item's repetition to naming a count.
+func (v *validator) repetition(id uint64, repetition *irpb.Repetition) {
+	if repetition == nil {
+		return
+	}
+
+	switch count := repetition.GetCount().(type) {
+	case *irpb.Repetition_Constant:
+		if count.Constant == 0 {
+			v.fault(id, "repeats zero times, and an item that does not repeat carries no repetition")
+		}
+	case *irpb.Repetition_Variable:
+		variable := count.Variable
+
+		switch where := variable.GetCount().(type) {
+		case *irpb.VariableCount_FieldId:
+			v.reference(id, "the count of its occurrences", where.FieldId, "field")
+		case *irpb.VariableCount_RegisterId:
+			v.reference(id, "the count of its occurrences", where.RegisterId, "register")
+		case nil:
+			v.fault(id, "repeats a variable number of times and does not say where the count is read from")
+		}
+
+		if variable.GetMaxOccurrences() < variable.GetMinOccurrences() {
+			v.fault(id, "declares between %d and %d occurrences, which is no range at all",
+				variable.GetMinOccurrences(), variable.GetMaxOccurrences())
+		}
+
+		if variable.GetMaxOccurrences() == 0 {
+			v.fault(id, "declares a maximum of zero occurrences, which no count can satisfy")
+		}
+	case nil:
+		v.fault(id, "carries a repetition that states no count")
+	}
+}
+
+// names holds a named node's names to carrying an original.
+//
+// The original **MUST** be present even where an override is: a rename
+// substitutes a name, and the substitute is carried beside the original rather
+// than in place of it, so that generated code can still point back at the
+// copybook it came from. A node with no names at all is a node COBOL gave no
+// data-name — a FILLER, or one this producer introduced — except on a record,
+// where the copybook's top-level item always has one.
+func (v *validator) names(id uint64, names *irpb.Names, required bool) {
+	if names == nil {
+		if required {
+			v.fault(id, "carries no names, and a record node carries the copybook's own")
+		}
+
+		return
+	}
+
+	if names.GetOriginal() == "" {
+		v.fault(id, "carries an override and no original name for it to stand beside")
+	}
+}
+
+// containment holds every item to being named exactly once.
+//
+// Exactly one member list, one arm or one record's top level names it. Two would
+// put one run of bytes in two places, none makes it unreachable, and the rule
+// together with reachability is what makes containment acyclic without a walk
+// looking for a cycle: every cycle either leaves a node named twice or leaves
+// the whole of it unreachable.
+func (v *validator) containment() {
+	for _, id := range v.order {
+		kind := kindOf(v.nodes[id])
+		if !slices.Contains([]string{"group", "variant", "field", "slack"}, kind) {
+			continue
+		}
+
+		switch v.contained[id] {
+		case 1:
+		case 0:
+			v.fault(id, "is contained by nothing, and every item is named by one member list, one arm or one record")
+		default:
+			v.fault(id, "is contained %d times, and no two members of a group may occupy the same bytes", v.contained[id])
+		}
+	}
+}
+
+// reachability holds every node to hanging off the file node.
+//
+// Everything hangs off the one node of kind file, which the message does not
+// separately point at. A node nothing reaches is a node no consumer will ever
+// index its way to, and a producer that emitted one has emitted a record type,
+// a state or a register that the layout does not actually describe.
+func (v *validator) reachability() {
+	if !v.rooted {
+		return
+	}
+
+	seen := map[uint64]bool{v.root: true}
+	queue := []uint64{v.root}
+
+	for len(queue) > 0 {
+		at := queue[0]
+		queue = queue[1:]
+
+		for _, to := range v.edges[at] {
+			if seen[to] {
+				continue
+			}
+
+			seen[to] = true
+			queue = append(queue, to)
+		}
+	}
+
+	for _, id := range v.order {
+		if !seen[id] {
+			v.fault(id, "is not reachable from the file node, so nothing in the descriptor describes it")
+		}
+	}
+}
+
+// unresolved is the encoding axes a field left unstated, in the order
+// docs/layout/SPEC.md names them.
+func unresolved(encoding *irpb.Encoding) []string {
+	var missing []string
+
+	if encoding.GetCharset() == irpb.Charset_CHARSET_UNSPECIFIED {
+		missing = append(missing, "charset")
+	}
+
+	if encoding.GetSignConvention() == irpb.SignConvention_SIGN_CONVENTION_UNSPECIFIED {
+		missing = append(missing, "sign convention")
+	}
+
+	if encoding.GetByteOrder() == irpb.ByteOrder_BYTE_ORDER_UNSPECIFIED {
+		missing = append(missing, "byte order")
+	}
+
+	if encoding.GetFloatFormat() == irpb.FloatFormat_FLOAT_FORMAT_UNSPECIFIED {
+		missing = append(missing, "float format")
+	}
+
+	return missing
+}
+
+// repeated reports the first literal a one-of test carries twice.
+func repeated(values [][]byte) ([]byte, bool) {
+	for at, value := range values {
+		for _, against := range values[at+1:] {
+			if slices.Equal(value, against) {
+				return value, true
+			}
+		}
+	}
+
+	return nil, false
+}
+
+// quoteBytes renders a literal the way a dump prints one, which is the only
+// rendering that is right whatever charset the file is in.
+func quoteBytes(value []byte) string {
+	return "0x" + hex.EncodeToString(value)
+}
+
+// kindOf is what a node is, in the words docs/ir/SPEC.md's table uses.
+func kindOf(node *irpb.Node) string {
+	switch node.GetKind().(type) {
+	case *irpb.Node_File:
+		return "file"
+	case *irpb.Node_Record:
+		return "record"
+	case *irpb.Node_Group:
+		return "group"
+	case *irpb.Node_Variant:
+		return "variant"
+	case *irpb.Node_Field:
+		return "field"
+	case *irpb.Node_Slack:
+		return "slack"
+	case *irpb.Node_Predicate:
+		return "predicate"
+	case *irpb.Node_State:
+		return "state"
+	case *irpb.Node_Transition:
+		return "transition"
+	case *irpb.Node_Register:
+		return "register"
+	case *irpb.Node_Binding:
+		return "binding"
+	case *irpb.Node_Guard:
+		return "guard"
+	}
+
+	return "kindless"
+}

--- a/internal/assemble/validate.go
+++ b/internal/assemble/validate.go
@@ -276,7 +276,12 @@ func (v *validator) record(id uint64, record *irpb.Record) {
 	v.names(id, record.GetNames(), true)
 	v.contain(id, "the record's top level", record.GetRootId(), "group")
 
-	if top, found := v.nodes[record.GetRootId()]; found && len(top.GetGroup().GetMemberIds()) == 0 {
+	// Only where the top level really is a group. A root naming some other
+	// kind is already reported by the reference above, and an empty member
+	// list read off a node that has none would report that fault a second time
+	// under a description that is not what is wrong with it.
+	if top, found := v.nodes[record.GetRootId()]; found && top.GetGroup() != nil &&
+		len(top.GetGroup().GetMemberIds()) == 0 {
 		v.fault(id, "holds no items, and no transition may admit a record whose extent is zero")
 	}
 }
@@ -424,12 +429,29 @@ func (v *validator) binding(id uint64, binding *irpb.Binding) {
 	}
 }
 
+// guard holds a guard to reading a register the descriptor carries, and to a
+// test that agrees with what that register holds.
+//
+// The agreement is checked here rather than left to a consumer, because a
+// mismatch is a comparison nothing can run: a bytes literal against a register
+// holding a number has no reading at all, and *greater than zero* has none
+// against a register holding bytes.
 func (v *validator) guard(id uint64, guard *irpb.Guard) {
 	v.reference(id, "the register it tests", guard.GetRegisterId(), "register")
 
+	// The unspecified kind stands for "not known here", which covers the
+	// register naming no node and the register that does not say what it
+	// holds. Both are already reported against the node they are wrong on, and
+	// a second fault about the literals that read them would be that fault
+	// again under a description of something else.
+	held := irpb.RegisterKind_REGISTER_KIND_UNSPECIFIED
+	if register, found := v.nodes[guard.GetRegisterId()]; found {
+		held = register.GetRegister().GetKind()
+	}
+
 	switch test := guard.GetTest().(type) {
 	case *irpb.Guard_Equals:
-		v.literal(id, "the literal it compares against", test.Equals)
+		v.literal(id, "the literal it compares against", test.Equals, held)
 	case *irpb.Guard_OneOf:
 		values := test.OneOf.GetValues()
 		if len(values) == 0 {
@@ -437,21 +459,29 @@ func (v *validator) guard(id uint64, guard *irpb.Guard) {
 		}
 
 		for at, value := range values {
-			v.literal(id, fmt.Sprintf("literal %d", at+1), value)
+			v.literal(id, fmt.Sprintf("literal %d", at+1), value, held)
+		}
+	case *irpb.Guard_GreaterThanZero:
+		if held == irpb.RegisterKind_REGISTER_KIND_BYTES {
+			v.fault(id, "tests a register holding bytes for being greater than zero, and only an integer is a number")
 		}
 	case nil:
 		v.fault(id, "carries no test, and the set of three has no member testing nothing")
 	}
 }
 
-// literal holds a guard's literal to carrying a value at all.
-//
-// Which of the two members it carries **MUST** match the kind of the register
-// tested, and that is checked here rather than left to a consumer: a bytes
-// literal against an integer register is a comparison nothing can run.
-func (v *validator) literal(id uint64, position string, literal *irpb.Literal) {
+// literal holds a guard's literal to carrying a value, and to carrying the one
+// the register it is compared against holds.
+func (v *validator) literal(id uint64, position string, literal *irpb.Literal, held irpb.RegisterKind) {
 	switch literal.GetValue().(type) {
-	case *irpb.Literal_BytesValue, *irpb.Literal_Integer:
+	case *irpb.Literal_BytesValue:
+		if held == irpb.RegisterKind_REGISTER_KIND_INTEGER {
+			v.fault(id, "%s carries bytes, and the register it is compared against holds an integer", position)
+		}
+	case *irpb.Literal_Integer:
+		if held == irpb.RegisterKind_REGISTER_KIND_BYTES {
+			v.fault(id, "%s carries a number, and the register it is compared against holds bytes", position)
+		}
 	default:
 		v.fault(id, "%s carries no value", position)
 	}

--- a/internal/assemble/validate_test.go
+++ b/internal/assemble/validate_test.go
@@ -1,0 +1,576 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package assemble
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+	"github.com/Zaba505/cpybkc/irpb"
+)
+
+// [Assemble] cannot produce most of what these test, which is the point: the
+// pass exists for the descriptor a later change to this package, or a caller
+// building one some other way, gets wrong. So each test spoils one member of a
+// descriptor that passes and asserts what the pass then says, rather than
+// looking for a layout that provokes it.
+//
+// The descriptor spoiled is the smallest one that conforms — one record type of
+// one field, one state, one transition — because a fault reported against six
+// nodes is a fault a reader can check by hand.
+
+// valid is the smallest conforming descriptor: a fixed-length dataset of one
+// record type, read by a state that admits it and accepts.
+func valid() *irpb.Descriptor {
+	return &irpb.Descriptor{
+		Version: irpb.IrVersion_IR_VERSION_1,
+		Nodes: []*irpb.Node{
+			{Id: 0, Kind: &irpb.Node_File{File: &irpb.File{
+				Framing:      &irpb.File_Unframed{Unframed: &irpb.Unframed{}},
+				StartStateId: 4,
+			}}},
+			{Id: 1, Kind: &irpb.Node_Record{Record: &irpb.Record{
+				RootId: 2,
+				Names:  &irpb.Names{Original: "REC"},
+			}}},
+			{Id: 2, Kind: &irpb.Node_Group{Group: &irpb.Group{
+				MemberIds: []uint64{3},
+				Names:     &irpb.Names{Original: "REC"},
+			}}},
+			{Id: 3, Kind: &irpb.Node_Field{Field: &irpb.Field{
+				Width: 1,
+				Encoding: &irpb.Encoding{
+					Charset:        irpb.Charset_CHARSET_CP037,
+					SignConvention: irpb.SignConvention_SIGN_CONVENTION_EBCDIC,
+					ByteOrder:      irpb.ByteOrder_BYTE_ORDER_BIG_ENDIAN,
+					FloatFormat:    irpb.FloatFormat_FLOAT_FORMAT_IBM_HFP,
+				},
+				Usage: irpb.Usage_USAGE_DISPLAY,
+				Names: &irpb.Names{Original: "REC-TYPE"},
+			}}},
+			{Id: 4, Kind: &irpb.Node_State{State: &irpb.State{
+				Accepts:       true,
+				TransitionIds: []uint64{5},
+			}}},
+			{Id: 5, Kind: &irpb.Node_Transition{Transition: &irpb.Transition{
+				RecordId:    1,
+				NextStateId: 4,
+			}}},
+		},
+	}
+}
+
+// node is one node of a descriptor, by identifier, for a test about to spoil it.
+func node(t *testing.T, d *irpb.Descriptor, id uint64) *irpb.Node {
+	t.Helper()
+
+	for _, found := range d.GetNodes() {
+		if found.GetId() == id {
+			return found
+		}
+	}
+
+	t.Fatalf("the descriptor carries no node %d", id)
+
+	return nil
+}
+
+// refused holds a spoiled descriptor to being refused, and to saying what is
+// wrong in words a reader can act on.
+func refused(t *testing.T, d *irpb.Descriptor, says string) {
+	t.Helper()
+
+	err := Validate(d)
+	if err == nil {
+		t.Fatalf("the descriptor validated, want a fault saying it %q", says)
+	}
+
+	if !strings.Contains(diag.Render(err), says) {
+		t.Errorf("the fault reads:\n%s\nand does not say %q", diag.Render(err), says)
+	}
+}
+
+// TestTheSmallestConformingDescriptorPasses keeps every test below honest: a
+// pass that refuses everything proves nothing about the descriptor it refuses.
+func TestTheSmallestConformingDescriptorPasses(t *testing.T) {
+	if err := Validate(valid()); err != nil {
+		t.Fatalf("the smallest conforming descriptor was refused: %v", diag.Render(err))
+	}
+}
+
+// TestAnAssembledDescriptorPasses holds the whole pipeline's output to the same
+// pass, which is what [Assemble] running it means.
+func TestAnAssembledDescriptorPasses(t *testing.T) {
+	if err := Validate(assembled(t, countedRun, countedRunCopybooks())); err != nil {
+		t.Fatalf("an assembled descriptor was refused: %v", diag.Render(err))
+	}
+}
+
+// TestADescriptorMustSayWhichContractItWasWrittenAgainst holds the version to
+// being set, because a consumer's first obligation is to read it.
+func TestADescriptorMustSayWhichContractItWasWrittenAgainst(t *testing.T) {
+	t.Run("nothing at all", func(t *testing.T) {
+		var fault *DescriptorError
+		if err := Validate(nil); !errors.As(err, &fault) {
+			t.Fatalf("the fault is %v, want a DescriptorError", err)
+		}
+	})
+
+	t.Run("no version", func(t *testing.T) {
+		d := valid()
+		d.Version = irpb.IrVersion_IR_VERSION_UNSPECIFIED
+
+		refused(t, d, "states no version")
+
+		var fault *DescriptorError
+		if err := Validate(d); !errors.As(err, &fault) {
+			t.Errorf("the fault is %v, want a DescriptorError", err)
+		}
+	})
+
+	t.Run("a version no release names", func(t *testing.T) {
+		d := valid()
+		d.Version = irpb.IrVersion(97)
+
+		refused(t, d, "which no release of the IR names")
+	})
+}
+
+// TestExactlyOneFileNodeIsTheRoot holds the descriptor to having one root, since
+// nothing points at it and a second would leave two graphs in one message.
+func TestExactlyOneFileNodeIsTheRoot(t *testing.T) {
+	t.Run("none", func(t *testing.T) {
+		d := valid()
+		d.Nodes = d.GetNodes()[1:]
+
+		refused(t, d, "carries no file node")
+	})
+
+	t.Run("two", func(t *testing.T) {
+		d := valid()
+		d.Nodes = append(d.GetNodes(), &irpb.Node{Id: 6, Kind: &irpb.Node_File{File: &irpb.File{
+			Framing:      &irpb.File_Unframed{Unframed: &irpb.Unframed{}},
+			StartStateId: 4,
+		}}})
+
+		refused(t, d, "carries 2 file nodes")
+	})
+}
+
+// TestTheNodeListIsAscendingAndItsIdentifiersUnique holds the ordering the
+// determinism promise is built on: a producer assigns identifiers by a
+// deterministic traversal and emits the list in ascending order.
+func TestTheNodeListIsAscendingAndItsIdentifiersUnique(t *testing.T) {
+	t.Run("out of order", func(t *testing.T) {
+		d := valid()
+		d.Nodes[4], d.Nodes[5] = d.GetNodes()[5], d.GetNodes()[4]
+
+		refused(t, d, "ascending identifier order")
+	})
+
+	t.Run("shared", func(t *testing.T) {
+		d := valid()
+		node(t, d, 5).Id = 4
+
+		refused(t, d, "shares its identifier with another node")
+	})
+}
+
+// TestEveryReferenceResolvesToAKindItsPositionAdmits is the rule a node set
+// stands on: a consumer indexes by identifier, and a reference that resolves to
+// nothing or to the wrong kind is a walk that fails halfway.
+func TestEveryReferenceResolvesToAKindItsPositionAdmits(t *testing.T) {
+	t.Run("nothing", func(t *testing.T) {
+		d := valid()
+		node(t, d, 5).GetTransition().RecordId = 97
+
+		refused(t, d, "names node 97, which is not in this descriptor")
+	})
+
+	t.Run("the wrong kind", func(t *testing.T) {
+		d := valid()
+		node(t, d, 5).GetTransition().RecordId = 3
+
+		refused(t, d, "a field node, and admits only record")
+	})
+
+	t.Run("a node with no body at all", func(t *testing.T) {
+		d := valid()
+		node(t, d, 3).Kind = nil
+
+		refused(t, d, "carries no body")
+	})
+}
+
+// TestEveryFieldStatesAllFourAxes is the requirement docs/ir/SPEC.md makes of a
+// producer and a consumer both, because every one of the four fails silently
+// when it is wrong.
+func TestEveryFieldStatesAllFourAxes(t *testing.T) {
+	tests := []struct {
+		name  string
+		spoil func(*irpb.Encoding)
+		says  string
+	}{
+		{
+			name:  "charset",
+			spoil: func(e *irpb.Encoding) { e.Charset = irpb.Charset_CHARSET_UNSPECIFIED },
+			says:  "states no charset",
+		},
+		{
+			name:  "sign convention",
+			spoil: func(e *irpb.Encoding) { e.SignConvention = irpb.SignConvention_SIGN_CONVENTION_UNSPECIFIED },
+			says:  "states no sign convention",
+		},
+		{
+			name:  "byte order",
+			spoil: func(e *irpb.Encoding) { e.ByteOrder = irpb.ByteOrder_BYTE_ORDER_UNSPECIFIED },
+			says:  "states no byte order",
+		},
+		{
+			name:  "float format",
+			spoil: func(e *irpb.Encoding) { e.FloatFormat = irpb.FloatFormat_FLOAT_FORMAT_UNSPECIFIED },
+			says:  "states no float format",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			d := valid()
+			test.spoil(node(t, d, 3).GetField().GetEncoding())
+
+			refused(t, d, test.says)
+		})
+	}
+
+	t.Run("all four", func(t *testing.T) {
+		d := valid()
+		node(t, d, 3).GetField().Encoding = nil
+
+		refused(t, d, "states no charset, sign convention, byte order and float format")
+	})
+}
+
+// TestAFieldSaysWhatItsBytesAreAndHowManyOfThem holds the two members a field
+// cannot be read without.
+func TestAFieldSaysWhatItsBytesAreAndHowManyOfThem(t *testing.T) {
+	t.Run("no usage", func(t *testing.T) {
+		d := valid()
+		node(t, d, 3).GetField().Usage = irpb.Usage_USAGE_UNSPECIFIED
+
+		refused(t, d, "states no USAGE")
+	})
+
+	t.Run("no width", func(t *testing.T) {
+		d := valid()
+		node(t, d, 3).GetField().Width = 0
+
+		refused(t, d, "occupies no bytes")
+	})
+
+	t.Run("a picture of no category", func(t *testing.T) {
+		d := valid()
+		node(t, d, 3).GetField().Picture = &irpb.Picture{Digits: 2}
+
+		refused(t, d, "carries a PICTURE of no category")
+	})
+}
+
+// TestAnOverrideWithNoOriginalIsRefused holds the original to being present even
+// where a substitute is, which is what lets generated code point back at the
+// copybook it came from.
+func TestAnOverrideWithNoOriginalIsRefused(t *testing.T) {
+	d := valid()
+	node(t, d, 3).GetField().Names = &irpb.Names{OverrideName: proto.String("kind")}
+
+	refused(t, d, "carries an override and no original name")
+}
+
+// TestEveryNodeHangsOffTheFileNode holds a descriptor to describing everything
+// it carries. A node nothing reaches is one no consumer will index its way to.
+func TestEveryNodeHangsOffTheFileNode(t *testing.T) {
+	d := valid()
+	d.Nodes = append(d.GetNodes(), &irpb.Node{Id: 6, Kind: &irpb.Node_Register{
+		Register: &irpb.Register{Kind: irpb.RegisterKind_REGISTER_KIND_INTEGER},
+	}})
+
+	refused(t, d, "is not reachable from the file node")
+}
+
+// TestEveryItemIsContainedExactlyOnce holds the member lists to being the one
+// statement of where anything is: twice puts one run of bytes in two places, and
+// never leaves it belonging to no record.
+func TestEveryItemIsContainedExactlyOnce(t *testing.T) {
+	t.Run("twice", func(t *testing.T) {
+		d := valid()
+		node(t, d, 2).GetGroup().MemberIds = []uint64{3, 3}
+
+		refused(t, d, "is contained 2 times")
+	})
+
+	t.Run("never", func(t *testing.T) {
+		d := valid()
+		d.Nodes = append(d.GetNodes(), &irpb.Node{Id: 6, Kind: &irpb.Node_Slack{
+			Slack: &irpb.Slack{Width: 4},
+		}})
+
+		refused(t, d, "is contained by nothing")
+	})
+}
+
+// TestARecordWithNoItemsIsRefused holds the rule that no transition may admit a
+// record whose extent is zero, at the one shape a producer can reach it by.
+func TestARecordWithNoItemsIsRefused(t *testing.T) {
+	d := valid()
+	node(t, d, 2).GetGroup().MemberIds = nil
+	node(t, d, 3).Kind = &irpb.Node_Slack{Slack: &irpb.Slack{Width: 1}}
+
+	refused(t, d, "holds no items")
+}
+
+// TestAVariantCarriesArmsAndEachArmCarriesBoth holds the one place an
+// alternation survives resolution to being a choice a consumer can make.
+func TestAVariantCarriesArmsAndEachArmCarriesBoth(t *testing.T) {
+	t.Run("no arms", func(t *testing.T) {
+		d := valid()
+		node(t, d, 3).Kind = &irpb.Node_Variant{Variant: &irpb.Variant{}}
+
+		refused(t, d, "carries no arms")
+	})
+
+	t.Run("an arm with no body", func(t *testing.T) {
+		d := valid()
+		node(t, d, 3).Kind = &irpb.Node_Variant{Variant: &irpb.Variant{
+			Arms: []*irpb.Arm{{PredicateId: 6}},
+		}}
+		d.Nodes = append(d.GetNodes(), &irpb.Node{Id: 6, Kind: &irpb.Node_Predicate{
+			Predicate: &irpb.Predicate{
+				FieldId: 3,
+				Test:    &irpb.Predicate_BytesEqual{BytesEqual: &irpb.BytesEqual{Value: []byte{0xc8}}},
+			},
+		}})
+
+		refused(t, d, "names no body")
+	})
+}
+
+// TestAPredicateCarriesATestOverBytes holds the closed set of two to being
+// stated, and a one-of to carrying a set worth testing.
+func TestAPredicateCarriesATestOverBytes(t *testing.T) {
+	predicated := func(t *testing.T, test *irpb.Predicate) *irpb.Descriptor {
+		t.Helper()
+
+		d := valid()
+		node(t, d, 5).GetTransition().PredicateId = proto.Uint64(6)
+		d.Nodes = append(d.GetNodes(), &irpb.Node{Id: 6, Kind: &irpb.Node_Predicate{Predicate: test}})
+
+		return d
+	}
+
+	t.Run("no test", func(t *testing.T) {
+		refused(t, predicated(t, &irpb.Predicate{FieldId: 3}), "carries no test")
+	})
+
+	t.Run("no bytes to compare", func(t *testing.T) {
+		refused(t, predicated(t, &irpb.Predicate{
+			FieldId: 3,
+			Test:    &irpb.Predicate_BytesEqual{BytesEqual: &irpb.BytesEqual{}},
+		}), "compares against no bytes at all")
+	})
+
+	t.Run("one literal in a one-of", func(t *testing.T) {
+		refused(t, predicated(t, &irpb.Predicate{
+			FieldId: 3,
+			Test: &irpb.Predicate_BytesOneOf{BytesOneOf: &irpb.BytesOneOf{
+				Values: [][]byte{{0xc8}},
+			}},
+		}), "offers 1 literals, and a one-of test carries at least two")
+	})
+
+	t.Run("one literal twice", func(t *testing.T) {
+		refused(t, predicated(t, &irpb.Predicate{
+			FieldId: 3,
+			Test: &irpb.Predicate_BytesOneOf{BytesOneOf: &irpb.BytesOneOf{
+				Values: [][]byte{{0xc8}, {0xc4}, {0xc8}},
+			}},
+		}), "carries the literal 0xc8 twice")
+	})
+}
+
+// TestTheAutomatonsMemoryIsWellFormed holds the register file's three node kinds
+// to what each cannot be read without.
+func TestTheAutomatonsMemoryIsWellFormed(t *testing.T) {
+	// A register, a guard reading it and a binding writing it, hung off the
+	// one transition the smallest descriptor has.
+	memory := func() *irpb.Descriptor {
+		d := valid()
+		d.Nodes = append(d.GetNodes(),
+			&irpb.Node{Id: 6, Kind: &irpb.Node_Register{Register: &irpb.Register{
+				Kind: irpb.RegisterKind_REGISTER_KIND_INTEGER,
+			}}},
+			&irpb.Node{Id: 7, Kind: &irpb.Node_Guard{Guard: &irpb.Guard{
+				RegisterId: 6,
+				Test:       &irpb.Guard_GreaterThanZero{GreaterThanZero: &irpb.GreaterThanZero{}},
+			}}},
+			&irpb.Node{Id: 8, Kind: &irpb.Node_Binding{Binding: &irpb.Binding{
+				RegisterId: 6,
+				Value:      &irpb.Binding_Decrement{Decrement: &irpb.Decrement{}},
+			}}},
+		)
+
+		transition := node(t, d, 5).GetTransition()
+		transition.GuardIds = []uint64{7}
+		transition.BindingIds = []uint64{8}
+
+		return d
+	}
+
+	t.Run("it passes as it stands", func(t *testing.T) {
+		if err := Validate(memory()); err != nil {
+			t.Fatalf("a descriptor with a register file was refused: %v", diag.Render(err))
+		}
+	})
+
+	t.Run("a register that does not say what it holds", func(t *testing.T) {
+		d := memory()
+		node(t, d, 6).GetRegister().Kind = irpb.RegisterKind_REGISTER_KIND_UNSPECIFIED
+
+		refused(t, d, "does not say what it holds")
+	})
+
+	t.Run("a guard with no test", func(t *testing.T) {
+		d := memory()
+		node(t, d, 7).GetGuard().Test = nil
+
+		refused(t, d, "carries no test")
+	})
+
+	t.Run("a guard whose literal carries no value", func(t *testing.T) {
+		d := memory()
+		node(t, d, 7).GetGuard().Test = &irpb.Guard_Equals{Equals: &irpb.Literal{}}
+
+		refused(t, d, "carries no value")
+	})
+
+	t.Run("a binding that writes nothing", func(t *testing.T) {
+		d := memory()
+		node(t, d, 8).GetBinding().Value = nil
+
+		refused(t, d, "writes no value")
+	})
+
+	t.Run("two bindings writing one register", func(t *testing.T) {
+		d := memory()
+		d.Nodes = append(d.GetNodes(), &irpb.Node{Id: 9, Kind: &irpb.Node_Binding{Binding: &irpb.Binding{
+			RegisterId: 6,
+			Value:      &irpb.Binding_FieldId{FieldId: 3},
+		}}})
+		node(t, d, 5).GetTransition().BindingIds = []uint64{8, 9}
+
+		refused(t, d, "applies two bindings writing register node 6")
+	})
+
+	t.Run("a state that does not accept and guards its acceptance anyway", func(t *testing.T) {
+		d := memory()
+		state := node(t, d, 4).GetState()
+		state.Accepts = false
+		state.AcceptanceGuardIds = []uint64{7}
+
+		refused(t, d, "does not accept and still qualifies its acceptance with guards")
+	})
+}
+
+// TestARepetitionSaysHowManyTimes holds the count to being stated, and a
+// variable one to carrying bounds a decoded count can be held to.
+func TestARepetitionSaysHowManyTimes(t *testing.T) {
+	t.Run("no count", func(t *testing.T) {
+		d := valid()
+		node(t, d, 3).GetField().Repetition = &irpb.Repetition{}
+
+		refused(t, d, "carries a repetition that states no count")
+	})
+
+	t.Run("a constant of zero", func(t *testing.T) {
+		d := valid()
+		node(t, d, 3).GetField().Repetition = &irpb.Repetition{
+			Count: &irpb.Repetition_Constant{Constant: 0},
+		}
+
+		refused(t, d, "repeats zero times")
+	})
+
+	t.Run("a variable count read from nowhere", func(t *testing.T) {
+		d := valid()
+		node(t, d, 3).GetField().Repetition = &irpb.Repetition{
+			Count: &irpb.Repetition_Variable{Variable: &irpb.VariableCount{
+				MinOccurrences: 1,
+				MaxOccurrences: 5,
+			}},
+		}
+
+		refused(t, d, "does not say where the count is read from")
+	})
+
+	t.Run("bounds that are no range", func(t *testing.T) {
+		d := valid()
+		node(t, d, 3).GetField().Repetition = &irpb.Repetition{
+			Count: &irpb.Repetition_Variable{Variable: &irpb.VariableCount{
+				Count:          &irpb.VariableCount_FieldId{FieldId: 3},
+				MinOccurrences: 5,
+				MaxOccurrences: 1,
+			}},
+		}
+
+		refused(t, d, "which is no range at all")
+	})
+}
+
+// TestADelimitedDatasetSaysWhatItsDelimiterIsAndWhereItStands holds the one
+// framing that carries more than its own name.
+func TestADelimitedDatasetSaysWhatItsDelimiterIsAndWhereItStands(t *testing.T) {
+	t.Run("no framing at all", func(t *testing.T) {
+		d := valid()
+		node(t, d, 0).GetFile().Framing = nil
+
+		refused(t, d, "states no framing")
+	})
+
+	t.Run("no delimiter", func(t *testing.T) {
+		d := valid()
+		node(t, d, 0).GetFile().Framing = &irpb.File_Delimited{Delimited: &irpb.Delimited{
+			Placement: irpb.DelimiterPlacement_DELIMITER_PLACEMENT_TERMINATOR,
+		}}
+
+		refused(t, d, "whose delimiter is no bytes at all")
+	})
+
+	t.Run("no placement", func(t *testing.T) {
+		d := valid()
+		node(t, d, 0).GetFile().Framing = &irpb.File_Delimited{Delimited: &irpb.Delimited{
+			Delimiter: []byte{0x0a},
+		}}
+
+		refused(t, d, "does not say where the delimiter stands")
+	})
+}
+
+// TestEveryFaultIsReportedRatherThanTheFirst holds the pass to collecting, since
+// a descriptor assembled wrong is wrong in the same way in many places at once.
+func TestEveryFaultIsReportedRatherThanTheFirst(t *testing.T) {
+	d := valid()
+	node(t, d, 3).GetField().Usage = irpb.Usage_USAGE_UNSPECIFIED
+	node(t, d, 3).GetField().Width = 0
+	node(t, d, 5).GetTransition().RecordId = 97
+
+	err := Validate(d)
+
+	if found := len(diag.Diagnostics(err)); found != 3 {
+		t.Errorf("the pass reported %d faults, want 3:\n%s", found, diag.Render(err))
+	}
+}

--- a/internal/assemble/validate_test.go
+++ b/internal/assemble/validate_test.go
@@ -334,6 +334,27 @@ func TestARecordWithNoItemsIsRefused(t *testing.T) {
 	refused(t, d, "holds no items")
 }
 
+// TestARecordRootedAtTheWrongKindIsOneFault holds the emptiness check to being
+// about a record whose top level really is a group.
+//
+// A root naming some other kind reads as holding no members whatever it is, so
+// reporting both would report the reference fault twice — once as itself and
+// once as a consequence a reader would go looking for separately.
+func TestARecordRootedAtTheWrongKindIsOneFault(t *testing.T) {
+	d := valid()
+	node(t, d, 1).GetRecord().RootId = 3
+
+	refused(t, d, "a field node, and admits only group")
+
+	// The reference, the top level nothing now contains, and the field the
+	// record and its group both name. Every one of those is what the root
+	// being wrong did; a fourth about the record holding no items would be a
+	// consequence a reader would go looking for separately.
+	if rendered := diag.Render(Validate(d)); strings.Contains(rendered, "holds no items") {
+		t.Errorf("the pass also reported the record as holding no items:\n%s", rendered)
+	}
+}
+
 // TestAVariantCarriesArmsAndEachArmCarriesBoth holds the one place an
 // alternation survives resolution to being a choice a consumer can make.
 func TestAVariantCarriesArmsAndEachArmCarriesBoth(t *testing.T) {
@@ -456,6 +477,32 @@ func TestTheAutomatonsMemoryIsWellFormed(t *testing.T) {
 		node(t, d, 7).GetGuard().Test = &irpb.Guard_Equals{Equals: &irpb.Literal{}}
 
 		refused(t, d, "carries no value")
+	})
+
+	t.Run("a literal of the kind the register does not hold", func(t *testing.T) {
+		d := memory()
+		node(t, d, 7).GetGuard().Test = &irpb.Guard_Equals{Equals: &irpb.Literal{
+			Value: &irpb.Literal_BytesValue{BytesValue: []byte{0xe8}},
+		}}
+
+		refused(t, d, "carries bytes, and the register it is compared against holds an integer")
+	})
+
+	t.Run("a number compared against a register holding bytes", func(t *testing.T) {
+		d := memory()
+		node(t, d, 6).GetRegister().Kind = irpb.RegisterKind_REGISTER_KIND_BYTES
+		node(t, d, 7).GetGuard().Test = &irpb.Guard_OneOf{OneOf: &irpb.LiteralSet{
+			Values: []*irpb.Literal{{Value: &irpb.Literal_Integer{Integer: 3}}},
+		}}
+
+		refused(t, d, "carries a number, and the register it is compared against holds bytes")
+	})
+
+	t.Run("a bytes register tested for being greater than zero", func(t *testing.T) {
+		d := memory()
+		node(t, d, 6).GetRegister().Kind = irpb.RegisterKind_REGISTER_KIND_BYTES
+
+		refused(t, d, "for being greater than zero, and only an integer is a number")
 	})
 
 	t.Run("a binding that writes nothing", func(t *testing.T) {

--- a/internal/resolve/doc.go
+++ b/internal/resolve/doc.go
@@ -165,8 +165,9 @@
 // # What this package leaves to the stories after it
 //
 // Assembling nodes into a [github.com/Zaba505/cpybkc/irpb.Descriptor] with
-// identifiers on them is #38's. A [Repetition], a [Binding] and a [Predicate]
-// here therefore name a
+// identifiers on them is #38's, and
+// [github.com/Zaba505/cpybkc/internal/assemble] is where it landed. A
+// [Repetition], a [Binding] and a [Predicate] here therefore name a
 // [github.com/Zaba505/cobol-go/copybook.Field] rather than an identifier.
 //
 // A count that lives in another record never reaches [Resolve] at all, and that


### PR DESCRIPTION
Closes #38

`internal/assemble` is the stage between `resolve` and a generator: it takes
everything a resolved layout consists of — the physical framing, the compiled
record automaton, one resolved record type per `record` form, and the renames
over them — and produces the single `irpb.Descriptor` a plugin consumes.

## Acceptance criteria

- [x] **Copybooks, layout, and encoding profiles resolve into a single IR
  message.** `Assemble` walks the resolved records into record, group, variant,
  field and slack nodes; the automaton into register, state, transition,
  predicate, guard and binding nodes; and the framing into the one file node
  everything hangs off. The encoding profile arrives already applied by
  `resolve`, and lands as the four axes on every field node.
- [x] **The IR contains no unresolved defaults.** Every field carries all four
  encoding axes, its `USAGE` resolved to the representation its bytes are in
  rather than the alias the copybook spelled, and the attributes that follow
  from its PICTURE including where a `SIGN` clause puts the sign. `Validate`
  refuses any closed set left at its unspecified zero.
- [x] **Resolution is deterministic: identical inputs produce byte-identical
  IR.** Identifiers are positions in the node list, handed out by one fixed
  traversal that reads no Go map, so the list is in ascending identifier order
  by construction. `TestIdenticalInputsProduceByteIdenticalIR` runs the whole
  pipeline twice — two parses, two copybook reads, two automata — and asserts
  over `emit.Marshal`'s bytes rather than over the message.
- [x] **A completeness validation pass runs before any generator is invoked.**
  `Validate` is exported for the command that will hand a descriptor to a
  plugin, and `Assemble` runs it over its own output, so nothing leaves this
  package unvalidated. It checks the version, exactly one root, unique ascending
  identifiers, every reference resolving to a kind its position admits, every
  node reachable from the file node, every item contained exactly once, and the
  unset members above.
- [x] **Failures report via the cross-file diagnostic machinery.** Every fault
  is a `diag.Error`, joined with `errors.Join` and assertable with `errors.As`.
  Assembly faults carry a span into the copybook the item was declared in;
  validation faults carry the node identifier instead, because a descriptor
  holds no positions.

## Judgment calls that shaped the public API

- **`Options.Records` is one entry per record type, already paired with the name
  a transition admits it by.** A copybook with a `REDEFINES` outside a repeating
  group resolves to several `resolve.Record`s, and which one a given transition
  admits is a question about the layout rather than about the resolved records.
  Making the caller state the pairing keeps this package from reading a layout's
  spelling of a record a second time — the same division `resolve.Redefine` and
  `resolve.EncodingOverride` already draw.
- **A record node's names are the copybook's, not the layout's.** `Record.Name`
  is used to match transitions and does not reach the descriptor.
- **`USAGE` aliases collapse here.** `cobol-go` keeps `COMP`, `COMP-4` and
  `BINARY` distinct because which representation a spelling selects is a
  property of the dialect; the IR carries the representation, so this is the
  last place they can collapse without a generator author having to know they
  are aliases.
- **A `FILLER` carries no `Names` at all**, rather than an empty original: the
  spec makes the original the member that must be present.
- **Guards and bindings are not shared between transitions; predicates are** —
  and only within one record type, because a predicate names a field and a field
  node belongs to one record.
- **Reachability is reported only over a descriptor whose references all
  resolve**, so one broken reference does not bury itself under a dozen
  consequences.
- **`Validate` computes nothing.** A group's width, a field's position and
  whether two arms come to the same extent are arithmetic a consumer runs; a
  second computation here would be a second answer.

Two documentation changes go with it: `docs/ir/SPEC.md`'s Mapping to Stories
appendix gains a row for the assembly and `#38` on the Structure row, and
`internal/resolve`'s package comment now names the package its forward reference
pointed at.

## Verification

`dagger call ci` — green (gofmt, `go vet`, golangci-lint, `go test -race`, `buf
lint`, the `irpb` module's own standard, and the release artifacts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)