### PR TITLE
story(plugin): read the cpybkc.json project manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,63 @@ schema](docs/layout/SPEC.md#the-published-schema) is what it is and what it
 deliberately leaves to the reader; `schema/layout.sexpr` is the same file in
 this repository.
 
+## The project manifest
+
+A project is driven by a `cpybkc.json` checked in beside the files it names, so
+that generator selection and options are diffable, reviewable and the same on a
+laptop as in CI:
+
+```json
+{
+  "inputs": ["cpy/orders.cpy"],
+  "layout": "orders.sexpr",
+  "generators": [
+    {
+      "name": "go",
+      "out": "gen",
+      "inputs": ["cpy/orders-go.cpy"],
+      "options": {"package_name": "orders", "receiver": "o"}
+    },
+    {
+      "name": "json-schema",
+      "out": "schema"
+    }
+  ]
+}
+```
+
+| Field | Scope | Required | What it is |
+|---|---|---|---|
+| `inputs` | top-level | no | The copybooks every generator reads. |
+| `layout` | top-level | yes | The [layout file](docs/layout/SPEC.md) the run resolves against. There is one of it: a project resolving against two layouts is two runs. |
+| `generators` | top-level | yes | The generators to run, in order, at least one of them. |
+| `name` | generator | yes | Resolves to the `cpybkc-gen-<name>` executable on `PATH`. It is the whole of how a generator is identified — there is no `source` and no `version` beside it. |
+| `out` | generator | yes | The directory this generator's output lands in. |
+| `inputs` | generator | no | Copybooks this generator reads **in addition to** the top-level `inputs`; a path named in both is read once. |
+| `options` | generator | no | The generator's own options, each handed to it as one `--opt k=v`, **in the order this object writes them**. A key carries no `=`; a value is text, and may be empty. |
+
+Four rules are worth knowing before a manifest is written, because each of them
+is a fault rather than something cpybkc works around:
+
+- **An unknown field is reported, never ignored.** A manifest is a file a person
+  wrote, so a misspelled field is a typo they want told about rather than a line
+  that reads as configuration and silently does nothing. The same goes for a
+  field written twice, a copybook named twice in one list, and an empty string
+  where a path or a name belongs.
+- **A path is used as written.** cpybkc resolves nothing against anything on
+  your behalf; a relative path is relative to the manifest.
+- **Every fault is reported at once**, each with the line and column in
+  `cpybkc.json` it is at — a manifest with three things wrong with it is one run,
+  not three.
+- **Malformed JSON stops the read**, since there is no way to know where the
+  value that failed to parse was meant to end.
+
+The manifest is deliberately **not** one of the four specs above: a plugin never
+reads one, and receives the options it selected already resolved on its command
+line. [The `cpybkc.json` project
+manifest](docs/plugin/SPEC.md#the-cpybkcjson-project-manifest) is where the
+plugin contract says so, and why.
+
 ## Contributing
 
 `dagger call ci` runs fmt, vet, lint and `go test -race` — the same call CI

--- a/internal/manifest/doc.go
+++ b/internal/manifest/doc.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Package manifest reads the cpybkc.json a project is driven by.
+//
+// A manifest names the layout a project resolves against, the copybooks a run
+// reads, and the generators to run over them. It is checked in beside them, so
+// that generator selection and options are diffable, reviewable and the same on
+// a laptop and in CI — which is the whole reason the file exists rather than the
+// flags it would otherwise be:
+//
+//	{
+//	  "inputs": ["cpy/orders.cpy"],
+//	  "layout": "orders.sexpr",
+//	  "generators": [
+//	    {
+//	      "name": "go",
+//	      "out": "gen",
+//	      "options": {"package_name": "orders"}
+//	    }
+//	  ]
+//	}
+//
+// # Why this is not a spec
+//
+// docs/plugin/SPEC.md's "The `cpybkc.json` project manifest" excludes it by
+// name, on the grounds of a different audience: the manifest is what a *user*
+// writes to drive the CLI, and a plugin never reads one — it receives the
+// options the manifest selected, already resolved, on its command line. So the
+// schema below is documented for the person who writes the file, in the
+// README, and stays free to change without touching an interface a third party
+// builds against.
+//
+// # What a manifest carries
+//
+// Three fields at the top level. `layout` names the layout file, is required,
+// and there is one of it: docs/layout/SPEC.md is what the records of a run are
+// framed by, and a project resolving against two of them is two runs.
+// `generators` is the list of generators to run and carries at least one entry,
+// because a manifest declaring none asks for nothing to happen. `inputs` is the
+// copybooks the run reads and is optional.
+//
+// A generator entry carries `name` and `out`, both required, and `inputs` and
+// `options`, both optional. `name` is the whole of how a generator is
+// identified — it resolves to the `cpybkc-gen-<name>` executable on PATH (#41)
+// — so there is no source and no version beside it, and nothing in this package
+// looks for the executable. `out` is where that generator's output lands, and
+// what happens between a generator's scratch directory and that directory is
+// #43's, #44's and #45's.
+//
+// A path is kept exactly as it was written. Resolving one — against the
+// manifest's own directory, against a copybook search path, into the absolute
+// path a plugin is handed (docs/plugin/SPEC.md, "Invocation") — belongs to the
+// stage that opens the file, and a reader that resolved paths would put a
+// second answer beside it.
+//
+// # Why the options are a list and not a map
+//
+// docs/plugin/SPEC.md requires cpybkc to pass a generator's options "in the
+// order the manifest declares them, so that the vector is a function of the
+// manifest rather than of a map iteration". A Go map cannot hold that order, so
+// [Generator.Options] is a slice in the order the file writes them, and the
+// manifest is walked as a token stream rather than unmarshalled into a struct
+// to keep it.
+//
+// An option value is text. An option reaches a generator as `k=v` on a command
+// line, so the manifest writes the value the generator will actually see;
+// accepting `80` and handing over `80` would make this package the place that
+// decides how a number is spelled, which is a decision a generator's own
+// vocabulary owns.
+//
+// # Why an unknown field is a fault
+//
+// A manifest is a file a **person** wrote, and an unknown field in one is a
+// typo they want reported: a line that reads as configuration and does nothing
+// is found by noticing that the output never changed. So every object here
+// admits a closed set of fields and reports anything else by name, along with
+// the fields it does admit.
+//
+// The contrast worth keeping in view is the IR descriptor, which takes the
+// opposite rule — an unknown protobuf field is ignored (#17) — because that is a
+// message a **program** wrote, where an unknown field is a newer producer. Same
+// CLI, opposite rules, and the author is the reason.
+//
+// The same argument covers a field written twice, an input named twice in one
+// list, and an empty string where a path or a name belongs: each is something
+// the author did not mean, and none of them has a reading this package could
+// choose on their behalf.
+//
+// # Why faults accumulate, and where they stop
+//
+// [Read] reports every fault it found rather than the first, joined with
+// [errors.Join] through [github.com/Zaba505/cpybkc/internal/diag.List], because
+// a manifest is wrong in the same way in several places at once and a reader
+// that reports one fault per run is a reader run once per fault. Each carries a
+// [github.com/Zaba505/cpybkc/internal/diag.Span] into the manifest, so a
+// diagnostic points at the line and column an editor can open.
+//
+// Malformed JSON is the exception, and it stops the walk: there is no way to
+// know where the value that failed to parse was meant to end, so everything
+// after it would be a fault invented by the parser rather than found in the
+// file. What was already collected is reported beside it.
+package manifest

--- a/internal/manifest/errors.go
+++ b/internal/manifest/errors.go
@@ -1,0 +1,344 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package manifest
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+)
+
+// Every fault here names a field by the path it is written at —
+// `generators[1].options` — rather than by a description of where it is. A
+// manifest is JSON and JSON has one way of saying where in a document something
+// is; a message that invented a second one would make the adopter translate
+// between them while holding the file open.
+//
+// All of them carry a [diag.Span] into the manifest, so a fault reads the same
+// as one out of the layout reader and lands somewhere an editor can open.
+
+// NotFoundError is a manifest that is not there.
+//
+// It is separated from every other reason a file will not open because it is the
+// one an adopter meets by running cpybkc somewhere else, and what they need to
+// be told is what the file is for rather than what errno was.
+type NotFoundError struct {
+	// Path is where the manifest was looked for.
+	Path string
+}
+
+// Error implements the error interface.
+func (e *NotFoundError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *NotFoundError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: "there is no manifest here; a project is driven by a " + Name +
+			" naming its layout, the copybooks it reads and the generators to run",
+		Spans: []diag.Span{{File: e.Path}},
+	}
+}
+
+// SyntaxError is a manifest [encoding/json] would not read.
+//
+// It is the one fault that ends the walk: there is no way to know where the
+// value that failed to parse was meant to end, so every fault after it would be
+// invented by the parser rather than found in the file. Whatever had already
+// been collected is reported beside it.
+type SyntaxError struct {
+	// Span is where the JSON stopped making sense.
+	Span diag.Span
+
+	// Fault is the sentence the message is, because the four ways a manifest
+	// can fail to be JSON — malformed, truncated, empty, more than one value —
+	// are four things to say rather than one wording with a hole in it.
+	Fault string
+
+	// Err is what [encoding/json] returned, where there was one. It is kept and
+	// reachable with [errors.As] so that a caller can tell a truncated file
+	// from a malformed one without reading the sentence.
+	Err error
+}
+
+// Error implements the error interface.
+func (e *SyntaxError) Error() string { return e.Diagnostic().String() }
+
+// Unwrap gives up the error [encoding/json] returned.
+func (e *SyntaxError) Unwrap() error { return e.Err }
+
+// Diagnostic is what the error says, and where.
+func (e *SyntaxError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{Message: e.Fault, Spans: []diag.Span{e.Span}}
+}
+
+// TypeError is a value written as the wrong kind of JSON.
+//
+// It says what the field is before saying what was found, because a manifest is
+// written by hand and the useful half is what belongs there — `"inputs": "a.cpy"`
+// is one path where a list of them belongs, and the fix is a pair of brackets
+// rather than a different path.
+type TypeError struct {
+	// Span is the value.
+	Span diag.Span
+
+	// Field is the path it is written at.
+	Field string
+
+	// Want is what the field is, in the words the message uses.
+	Want string
+
+	// Found names the JSON that was written instead.
+	Found string
+}
+
+// Error implements the error interface.
+func (e *TypeError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *TypeError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf("%s is %s, and this one is %s", e.Field, e.Want, e.Found),
+		Spans:   []diag.Span{e.Span},
+	}
+}
+
+// UnknownFieldError is a field no object of a manifest has.
+//
+// The message names the fields the object does admit, because every one of these
+// is a spelling question the adopter can answer from the list: a plural written
+// singular, a field of a generator entry written at the top level, a field that
+// belongs to some other tool's manifest.
+type UnknownFieldError struct {
+	// Span is the field name.
+	Span diag.Span
+
+	// Field is what was written.
+	Field string
+
+	// In names the object it was written in.
+	In string
+
+	// Known are the fields that object admits, in the order a manifest writes
+	// them.
+	Known []string
+}
+
+// Error implements the error interface.
+func (e *UnknownFieldError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *UnknownFieldError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf("%s has no field named %s; it carries %s", e.In, quote(e.Field), list(e.Known)),
+		Spans:   []diag.Span{e.Span},
+	}
+}
+
+// RepeatedFieldError is one field written twice in one object.
+//
+// It carries both positions, because the fault is the pair: either line is a
+// perfectly good statement of the field on its own, and what the adopter has to
+// decide is which of the two they meant. JSON's own answer — the last one wins —
+// is not one this package takes, since it would silently discard something they
+// wrote.
+type RepeatedFieldError struct {
+	// Span is the second statement.
+	Span diag.Span
+
+	// First is the one before it.
+	First diag.Span
+
+	// Field is the name written twice.
+	Field string
+
+	// In names the object carrying both.
+	In string
+}
+
+// Error implements the error interface.
+func (e *RepeatedFieldError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *RepeatedFieldError) Diagnostic() diag.Diagnostic {
+	first := e.First
+	first.Note = "the first one is here"
+
+	return diag.Diagnostic{
+		Message: fmt.Sprintf("%s carries %s twice", e.In, quote(e.Field)),
+		Spans:   []diag.Span{e.Span, first},
+	}
+}
+
+// MissingFieldError is a required field an object does not carry.
+//
+// The span is the object rather than a position the field would have had,
+// because that is where the adopter has to write it — a field a manifest is
+// missing has no place of its own.
+type MissingFieldError struct {
+	// Span is the object that should have carried it.
+	Span diag.Span
+
+	// Field is the one nobody wrote.
+	Field string
+
+	// In names the object.
+	In string
+
+	// Fault is why the field is required, in the words the message closes with.
+	Fault string
+}
+
+// Error implements the error interface.
+func (e *MissingFieldError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *MissingFieldError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf("%s carries no %s; %s", e.In, e.Field, e.Fault),
+		Spans:   []diag.Span{e.Span},
+	}
+}
+
+// EmptyValueError is a field written with nothing in it.
+//
+// It is a fault of its own rather than a missing field, because `"layout": ""`
+// is a line the adopter wrote and meant something by: reporting it as absent
+// would send them to write a field the file visibly already has.
+type EmptyValueError struct {
+	// Span is the empty value.
+	Span diag.Span
+
+	// Field is the path it is written at.
+	Field string
+
+	// Fault is why something is required there, in the words the message closes
+	// with.
+	Fault string
+}
+
+// Error implements the error interface.
+func (e *EmptyValueError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *EmptyValueError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf("%s is empty; %s", e.Field, e.Fault),
+		Spans:   []diag.Span{e.Span},
+	}
+}
+
+// RepeatedInputError is one copybook named twice in one list.
+//
+// Reading a copybook twice is not reading two copybooks, so the second mention
+// does nothing — and a line in a checked-in manifest that does nothing is the
+// same fault as an unknown field, met from the other side. A path that appears
+// in both the manifest's inputs and a generator's is a different thing and is
+// not this: there the shared list and the specific one each state it once, and
+// [Manifest.InputsFor] keeps it once.
+type RepeatedInputError struct {
+	// Span is the second mention.
+	Span diag.Span
+
+	// First is the one before it.
+	First diag.Span
+
+	// Path is what was named twice.
+	Path string
+
+	// Field is the list carrying both.
+	Field string
+}
+
+// Error implements the error interface.
+func (e *RepeatedInputError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *RepeatedInputError) Diagnostic() diag.Diagnostic {
+	first := e.First
+	first.Note = "the first one is here"
+
+	return diag.Diagnostic{
+		Message: fmt.Sprintf("%s names %s twice", e.Field, quote(e.Path)),
+		Spans:   []diag.Span{e.Span, first},
+	}
+}
+
+// GeneratorNameError is a generator name that cannot be a filename component.
+//
+// docs/plugin/SPEC.md: a name **MUST** be non-empty and **MUST NOT** contain a
+// `/`, because the name is the suffix of the `cpybkc-gen-<name>` file that is
+// searched for on PATH. The rest of what that section says about a name is a
+// **SHOULD** and is not enforced here: this package reports what an adopter has
+// to fix, and it has no channel for advice they may take or leave.
+type GeneratorNameError struct {
+	// Span is the name.
+	Span diag.Span
+
+	// Name is what was written.
+	Name string
+}
+
+// Error implements the error interface.
+func (e *GeneratorNameError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *GeneratorNameError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"a generator name is the suffix of the cpybkc-gen-<name> executable it resolves to, and %s contains a /",
+			quote(e.Name)),
+		Spans: []diag.Span{e.Span},
+	}
+}
+
+// OptionKeyError is an option key a generator could not be handed.
+//
+// docs/plugin/SPEC.md: an option reaches a generator as a single `--opt k=v`
+// argument, everything before the first `=` is the key, and a key **MUST NOT**
+// be empty or contain an `=`. Both are reported here rather than by the plugin
+// that would receive them, because the manifest is where such a key is written
+// and a plugin handed one cannot tell which half the adopter meant.
+type OptionKeyError struct {
+	// Span is the key.
+	Span diag.Span
+
+	// Key is what was written.
+	Key string
+}
+
+// Error implements the error interface.
+func (e *OptionKeyError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *OptionKeyError) Diagnostic() diag.Diagnostic {
+	message := fmt.Sprintf("an option key contains no =, and %s does", quote(e.Key))
+	if e.Key == "" {
+		message = "an option key is empty, and a generator is handed each option as k=v"
+	}
+
+	return diag.Diagnostic{Message: message, Spans: []diag.Span{e.Span}}
+}
+
+// quote renders a name the way a message names one, so that an empty one and a
+// name with a space in it are both visible as what they are.
+func quote(name string) string { return strconv.Quote(name) }
+
+// list joins names the way a message does, so that the fields an object admits
+// read as a sentence rather than as a slice.
+func list(names []string) string {
+	switch len(names) {
+	case 0:
+		return ""
+	case 1:
+		return names[0]
+	case 2:
+		return names[0] + " and " + names[1]
+	default:
+		return strings.Join(names[:len(names)-1], ", ") + " and " + names[len(names)-1]
+	}
+}

--- a/internal/manifest/errors_test.go
+++ b/internal/manifest/errors_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package manifest
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+)
+
+// somewhere is a position the faults below carry, so that a rendering is
+// asserted with a span in it rather than as a bare sentence.
+var somewhere = diag.Span{File: Name, Line: 3, Column: 7}
+
+// TestEveryFaultReadsTheSameThroughEitherEnd is what
+// [github.com/Zaba505/cpybkc/internal/diag.Error] asks of a typed error: the
+// message a caller prints and the diagnostic a caller inspects are built in one
+// place, so the two cannot say different things.
+//
+// It is a table of every fault this package raises rather than a check applied
+// to the ones a parse happens to produce, because the pairing is a property of
+// each type and a type added without it would go unnoticed until something
+// printed one.
+func TestEveryFaultReadsTheSameThroughEitherEnd(t *testing.T) {
+	faults := []error{
+		&NotFoundError{Path: Name},
+		&SyntaxError{Span: somewhere, Fault: "the manifest is not valid JSON: something"},
+		&TypeError{Span: somewhere, Field: "layout", Want: "text", Found: "a number"},
+		&UnknownFieldError{Span: somewhere, Field: "layoutt", In: manifestObject, Known: manifestFields},
+		&RepeatedFieldError{Span: somewhere, First: somewhere, Field: "layout", In: manifestObject},
+		&MissingFieldError{Span: somewhere, Field: "layout", In: manifestObject, Fault: layoutFault},
+		&EmptyValueError{Span: somewhere, Field: "layout", Fault: layoutFault},
+		&RepeatedInputError{Span: somewhere, First: somewhere, Path: "cpy/orders.cpy", Field: "inputs"},
+		&GeneratorNameError{Span: somewhere, Name: "z5labs/go"},
+		&OptionKeyError{Span: somewhere, Key: "a=b"},
+	}
+
+	for _, fault := range faults {
+		carrier, ok := fault.(diag.Error)
+		if !ok {
+			t.Errorf("%T carries no diagnostic, want it to implement diag.Error", fault)
+
+			continue
+		}
+
+		if got, want := fault.Error(), carrier.Diagnostic().String(); got != want {
+			t.Errorf("%T reads as %q and renders as %q, want one wording", fault, got, want)
+		}
+
+		if got := carrier.Diagnostic().Spans; len(got) == 0 || !got[0].Stated() {
+			t.Errorf("%T points at %v, want a place in the manifest", fault, got)
+		}
+	}
+}
+
+// TestASyntaxFaultGivesUpWhatItWraps is what lets a caller tell one reason a
+// manifest would not parse from another without reading the sentence.
+func TestASyntaxFaultGivesUpWhatItWraps(t *testing.T) {
+	wrapped := errors.New("something")
+
+	if got := errors.Unwrap(&SyntaxError{Span: somewhere, Fault: "x", Err: wrapped}); got != wrapped {
+		t.Errorf("the fault gave up %v, want %v", got, wrapped)
+	}
+
+	// A syntax fault the reader raised itself — an empty manifest — wraps
+	// nothing, and unwrapping it has to say so rather than panic.
+	if got := errors.Unwrap(&SyntaxError{Span: somewhere, Fault: "x"}); got != nil {
+		t.Errorf("a fault wrapping nothing gave up %v, want nothing", got)
+	}
+}
+
+func TestListReadsAsASentence(t *testing.T) {
+	tests := []struct {
+		names []string
+		want  string
+	}{
+		{names: nil, want: ""},
+		{names: []string{"layout"}, want: "layout"},
+		{names: []string{"layout", "generators"}, want: "layout and generators"},
+		{names: manifestFields, want: "inputs, layout and generators"},
+		{names: generatorFields, want: "name, out, inputs and options"},
+	}
+
+	for _, test := range tests {
+		if got := list(test.names); got != test.want {
+			t.Errorf("%q reads as %q, want %q", test.names, got, test.want)
+		}
+	}
+}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -1,0 +1,182 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package manifest
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"slices"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+)
+
+// Name is the file a project keeps its manifest in.
+//
+// It is a constant rather than a string typed out at each call site because the
+// name appears in a diagnostic, in the README and in whatever eventually looks
+// for the file, and a project is driven by exactly one of them.
+const Name = "cpybkc.json"
+
+// Manifest is a project's cpybkc.json, read.
+//
+// Everything in it is what the file said, in the order the file said it. A path
+// is the string that was written and nothing has been resolved against
+// anything; see the package comment for why that is left to whatever opens the
+// file.
+type Manifest struct {
+	// File is the name the manifest was read under, and is what every
+	// diagnostic about it names.
+	File string
+
+	// Inputs are the copybooks every generator reads, in the order they were
+	// written. A manifest that names none is not a fault: which copybooks a
+	// record is in is the layout's to say (docs/layout/SPEC.md, "Binding a
+	// record to a copybook"), and this list is the project's statement of what
+	// a run reads.
+	Inputs []string
+
+	// Layout is the layout file the run resolves against.
+	Layout string
+
+	// Generators are the generators to run, in the order they were declared.
+	Generators []Generator
+}
+
+// InputsFor is every copybook g reads: the manifest's inputs, then g's own, in
+// the order they were written.
+//
+// The two are merged rather than the entry's replacing the manifest's, because
+// the top-level list is what a project shares and an entry's list is what one
+// generator needs beyond it — a generator that had to restate the shared list to
+// add one file would be a list kept in step by hand.
+//
+// A path named in both lists is kept once, at the position the first mention
+// gives it. Reading one copybook twice is not a second copybook, and the
+// duplicate is what a shared list plus a specific one produces honestly; a
+// repeat *within* one list is a different thing and is a fault [Read] reports.
+func (m *Manifest) InputsFor(g Generator) []string {
+	var merged []string
+
+	seen := make(map[string]struct{}, len(m.Inputs)+len(g.Inputs))
+
+	for _, path := range slices.Concat(m.Inputs, g.Inputs) {
+		if _, duplicate := seen[path]; duplicate {
+			continue
+		}
+
+		seen[path] = struct{}{}
+		merged = append(merged, path)
+	}
+
+	return merged
+}
+
+// Generator is one entry of a manifest's generators list.
+type Generator struct {
+	// Span is where the entry was written, so that a fault found about a
+	// generator after the manifest was read — a name that resolves to no
+	// executable (#41), two entries writing the same output file (#44) — can
+	// still point at the line the adopter has to edit.
+	Span diag.Span
+
+	// Name is the generator's name, which resolves to the cpybkc-gen-<Name>
+	// executable on PATH (#41). It is non-empty and contains no `/`; the rest
+	// of docs/plugin/SPEC.md's advice on a name is a SHOULD and is left alone,
+	// because this package reports faults an adopter must fix and has no
+	// channel for one they may.
+	Name string
+
+	// Out is the directory this generator's output lands in.
+	Out string
+
+	// Inputs are the copybooks this generator reads beyond the manifest's.
+	// [Manifest.InputsFor] is the merged list; this is what the entry itself
+	// declared.
+	Inputs []string
+
+	// Options are the generator's options, in the order the manifest declares
+	// them, which is the order docs/plugin/SPEC.md requires them to be passed
+	// in.
+	Options []Option
+}
+
+// Option is one option a generator is invoked with, which reaches it as a
+// single `--opt k=v` argument.
+type Option struct {
+	// Key is the option's name. It is non-empty and contains no `=`, which is
+	// what lets `k=v` be split on its first one.
+	Key string
+
+	// Value is what the manifest wrote for it, and may be empty.
+	Value string
+}
+
+// ReadFile reads the manifest at path.
+//
+// The path is what every diagnostic names, so it is the path an adopter typed
+// or the one a project's root was joined onto rather than one this package
+// invented. Looking for the file — which directory a run starts from, whether a
+// parent is searched — belongs to the caller: a reader that searched would be a
+// second answer to where a project's root is.
+func ReadFile(path string) (*Manifest, error) {
+	src, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, &NotFoundError{Path: path}
+		}
+
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+
+	return parse(path, src)
+}
+
+// Read reads a manifest from r, under the name every diagnostic about it will
+// carry.
+//
+// The whole of it is read before anything is parsed, because a diagnostic
+// carries a line and a column and both are counted over the bytes the manifest
+// is; a manifest is a file a person wrote and is small enough that this costs
+// nothing worth arguing about.
+func Read(name string, r io.Reader) (*Manifest, error) {
+	src, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", name, err)
+	}
+
+	return parse(name, src)
+}
+
+// parse walks src as a manifest, reporting every fault it found.
+func parse(file string, src []byte) (*Manifest, error) {
+	p := newParser(file, src)
+
+	if len(bytes.TrimSpace(src)) == 0 {
+		return nil, &SyntaxError{
+			Span:  p.spanAt(0),
+			Fault: "the manifest is empty; it is a JSON object naming the layout, the copybooks and the generators to run",
+		}
+	}
+
+	m, fatal := p.manifest()
+	if fatal != nil {
+		p.faults.Fail(fatal)
+
+		return nil, p.faults.Err()
+	}
+
+	p.trailing()
+
+	if p.faults.Failed() {
+		return nil, p.faults.Err()
+	}
+
+	return m, nil
+}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -1,0 +1,271 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package manifest
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+)
+
+// read is the whole of what a caller does: hand [Read] a manifest and a name for
+// it. It fails the test on a manifest that will not read, because every test
+// using it is about what a good one becomes.
+func read(t *testing.T, source string) *Manifest {
+	t.Helper()
+
+	m, err := Read(Name, strings.NewReader(source))
+	if err != nil {
+		t.Fatalf("read the manifest:\n%s", diag.Render(err))
+	}
+
+	return m
+}
+
+// worked is a manifest with one of everything in it: shared inputs, a layout,
+// two generators, one of them with inputs and options of its own.
+const worked = `{
+  "inputs": ["cpy/orders.cpy", "cpy/common.cpy"],
+  "layout": "orders.sexpr",
+  "generators": [
+    {
+      "name": "go",
+      "out": "gen",
+      "inputs": ["cpy/orders-go.cpy"],
+      "options": {"package_name": "orders", "receiver": ""}
+    },
+    {
+      "name": "json-schema",
+      "out": "schema"
+    }
+  ]
+}`
+
+func TestReadTakesAManifestApart(t *testing.T) {
+	m := read(t, worked)
+
+	if m.File != Name {
+		t.Errorf("the manifest was read under %q, want %q", m.File, Name)
+	}
+
+	if m.Layout != "orders.sexpr" {
+		t.Errorf("the layout is %q, want %q", m.Layout, "orders.sexpr")
+	}
+
+	wantInputs := []string{"cpy/orders.cpy", "cpy/common.cpy"}
+	if !slices.Equal(m.Inputs, wantInputs) {
+		t.Errorf("the inputs are %q, want %q", m.Inputs, wantInputs)
+	}
+
+	if len(m.Generators) != 2 {
+		t.Fatalf("the manifest declares %d generators, want 2", len(m.Generators))
+	}
+
+	first, second := m.Generators[0], m.Generators[1]
+
+	if first.Name != "go" || first.Out != "gen" {
+		t.Errorf("the first generator is %q into %q, want %q into %q", first.Name, first.Out, "go", "gen")
+	}
+
+	if !slices.Equal(first.Inputs, []string{"cpy/orders-go.cpy"}) {
+		t.Errorf("the first generator reads %q, want %q", first.Inputs, []string{"cpy/orders-go.cpy"})
+	}
+
+	// An option value may be empty; docs/plugin/SPEC.md says so, and a manifest
+	// is where one is written.
+	wantOptions := []Option{{Key: "package_name", Value: "orders"}, {Key: "receiver", Value: ""}}
+	if !slices.Equal(first.Options, wantOptions) {
+		t.Errorf("the first generator's options are %v, want %v", first.Options, wantOptions)
+	}
+
+	// The merge, end to end: what the entry declared, behind what the manifest
+	// shares, in the order both were written.
+	wantMerged := []string{"cpy/orders.cpy", "cpy/common.cpy", "cpy/orders-go.cpy"}
+	if got := m.InputsFor(first); !slices.Equal(got, wantMerged) {
+		t.Errorf("the first generator reads %q in all, want %q", got, wantMerged)
+	}
+
+	if got := m.InputsFor(second); !slices.Equal(got, wantInputs) {
+		t.Errorf("the second generator reads %q in all, want %q", got, wantInputs)
+	}
+
+	if second.Name != "json-schema" || second.Out != "schema" {
+		t.Errorf("the second generator is %q into %q, want %q into %q",
+			second.Name, second.Out, "json-schema", "schema")
+	}
+
+	if second.Inputs != nil || second.Options != nil {
+		t.Errorf("the second generator declares inputs %q and options %v, want neither",
+			second.Inputs, second.Options)
+	}
+}
+
+// TestAGeneratorKnowsWhereItWasWritten is what a fault found after the read —
+// a name that resolves to no executable (#41), two generators writing one file
+// (#44) — points at.
+func TestAGeneratorKnowsWhereItWasWritten(t *testing.T) {
+	m := read(t, worked)
+
+	want := []diag.Span{
+		{File: Name, Line: 5, Column: 5},
+		{File: Name, Line: 11, Column: 5},
+	}
+
+	for i, generator := range m.Generators {
+		if generator.Span != want[i] {
+			t.Errorf("generators[%d] is at %v, want %v", i, generator.Span, want[i])
+		}
+	}
+}
+
+// TestOptionsKeepTheOrderTheManifestDeclaresThem is docs/plugin/SPEC.md's
+// requirement that cpybkc pass the options "in the order the manifest declares
+// them, so that the vector is a function of the manifest rather than of a map
+// iteration". The keys below are in no order a map would reproduce, and a
+// reader that unmarshalled them into one would fail this test most of the time
+// rather than every time — which is why the order is a property of the type and
+// not of a sort applied afterwards.
+func TestOptionsKeepTheOrderTheManifestDeclaresThem(t *testing.T) {
+	m := read(t, `{
+  "layout": "orders.sexpr",
+  "generators": [
+    {
+      "name": "go",
+      "out": "gen",
+      "options": {"z": "1", "a": "2", "m": "3", "b": "4", "y": "5", "c": "6", "n": "7", "d": "8"}
+    }
+  ]
+}`)
+
+	want := []string{"z", "a", "m", "b", "y", "c", "n", "d"}
+
+	var got []string
+	for _, option := range m.Generators[0].Options {
+		got = append(got, option.Key)
+	}
+
+	if !slices.Equal(got, want) {
+		t.Errorf("the options are declared %q, want %q", got, want)
+	}
+}
+
+func TestInputsForMergesTheManifestsInputsWithAGenerators(t *testing.T) {
+	tests := []struct {
+		name      string
+		manifest  []string
+		generator []string
+		want      []string
+	}{
+		{
+			name: "neither states one",
+		},
+		{
+			name:     "the manifest alone",
+			manifest: []string{"cpy/orders.cpy"},
+			want:     []string{"cpy/orders.cpy"},
+		},
+		{
+			name:      "the generator alone",
+			generator: []string{"cpy/orders.cpy"},
+			want:      []string{"cpy/orders.cpy"},
+		},
+		{
+			name:      "the manifest's first, then the generator's",
+			manifest:  []string{"cpy/orders.cpy", "cpy/common.cpy"},
+			generator: []string{"cpy/orders-go.cpy"},
+			want:      []string{"cpy/orders.cpy", "cpy/common.cpy", "cpy/orders-go.cpy"},
+		},
+		{
+			name:      "a copybook both name is read once",
+			manifest:  []string{"cpy/orders.cpy", "cpy/common.cpy"},
+			generator: []string{"cpy/common.cpy", "cpy/orders-go.cpy"},
+			want:      []string{"cpy/orders.cpy", "cpy/common.cpy", "cpy/orders-go.cpy"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := &Manifest{Inputs: test.manifest}
+
+			got := m.InputsFor(Generator{Inputs: test.generator})
+			if !slices.Equal(got, test.want) {
+				t.Errorf("the generator reads %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestReadFileReadsAManifestFromDisk(t *testing.T) {
+	path := filepath.Join("testdata", Name)
+
+	m, err := ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s:\n%s", path, diag.Render(err))
+	}
+
+	if m.File != path {
+		t.Errorf("the manifest was read under %q, want %q", m.File, path)
+	}
+
+	if m.Layout != "orders.sexpr" {
+		t.Errorf("the layout is %q, want %q", m.Layout, "orders.sexpr")
+	}
+
+	if len(m.Generators) != 1 {
+		t.Fatalf("the manifest declares %d generators, want 1", len(m.Generators))
+	}
+}
+
+func TestReadFileReportsAManifestThatIsNotThere(t *testing.T) {
+	path := filepath.Join(t.TempDir(), Name)
+
+	_, err := ReadFile(path)
+
+	var missing *NotFoundError
+	if !errors.As(err, &missing) {
+		t.Fatalf("reading a manifest that is not there gave %v, want a *NotFoundError", err)
+	}
+
+	if missing.Path != path {
+		t.Errorf("the fault names %q, want %q", missing.Path, path)
+	}
+
+	// The message has to say what the file is for, because an adopter meets it
+	// by running cpybkc somewhere a project is not.
+	if got := diag.Render(err); !strings.Contains(got, path) || !strings.Contains(got, "generators to run") {
+		t.Errorf("the fault reads:\n%s\nwant it to name %s and say what a manifest is for", got, path)
+	}
+}
+
+// TestReadFileKeepsAnUnreadableManifestDistinctFromAMissingOne is the other half
+// of the file being unopenable: a directory where the manifest should be is not
+// a project without one, and reporting it as absent would send an adopter to
+// write a file that is in their way.
+func TestReadFileKeepsAnUnreadableManifestDistinctFromAMissingOne(t *testing.T) {
+	path := filepath.Join(t.TempDir(), Name)
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatalf("make a directory where the manifest goes: %v", err)
+	}
+
+	_, err := ReadFile(path)
+	if err == nil {
+		t.Fatal("reading a directory as a manifest succeeded, want a fault")
+	}
+
+	var missing *NotFoundError
+	if errors.As(err, &missing) {
+		t.Errorf("reading a directory gave %v, want something other than a *NotFoundError", err)
+	}
+
+	if !strings.Contains(err.Error(), path) {
+		t.Errorf("the fault reads %q, want it to name %s", err, path)
+	}
+}

--- a/internal/manifest/parse.go
+++ b/internal/manifest/parse.go
@@ -1,0 +1,636 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package manifest
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+)
+
+// The objects a manifest is made of, named the way a message refers to one, and
+// the fields each of them admits.
+//
+// The sets are here rather than beside the code that switches on them because
+// they are what a diagnostic offers an adopter who wrote a field name nobody
+// knows: the switch and the list an unknown field is reported against are the
+// same set, written once.
+const (
+	manifestObject  = "a manifest"
+	generatorObject = "a generator entry"
+	optionObject    = "a generator's option set"
+)
+
+var (
+	manifestFields  = []string{"inputs", "layout", "generators"}
+	generatorFields = []string{"name", "out", "inputs", "options"}
+)
+
+// What a message says a field is for, once, so that the sentence a missing
+// field produces and the sentence an empty one produces cannot drift.
+const (
+	layoutFault     = "a project resolves its records against exactly one"
+	generatorsFault = "there is nothing for a run to do without one"
+	nameFault       = "a generator is found on PATH as cpybkc-gen-<name>"
+	outFault        = "its output lands in the directory out names"
+	inputFault      = "every input names a copybook to read"
+)
+
+// parser walks a manifest as a stream of JSON tokens.
+//
+// [encoding/json] would unmarshal one into a struct in a line, and that is not
+// enough twice over: a struct field cannot keep the order a generator's options
+// were written in, which docs/plugin/SPEC.md requires be preserved, and an
+// unmarshalling error carries a byte offset that has already lost which field
+// it was in. Walking the tokens keeps both — the order because the walk is the
+// file's order, and the position because every token's offset is known as it is
+// read.
+type parser struct {
+	file string
+	src  []byte
+
+	// lines are the byte offsets each line of src starts at, so that turning an
+	// offset into a line and a column is a search rather than a second pass
+	// over the file per fault.
+	lines []int
+
+	dec    *json.Decoder
+	faults diag.List
+}
+
+func newParser(file string, src []byte) *parser {
+	lines := []int{0}
+
+	for offset, b := range src {
+		if b == '\n' {
+			lines = append(lines, offset+1)
+		}
+	}
+
+	return &parser{
+		file:  file,
+		src:   src,
+		lines: lines,
+		dec:   json.NewDecoder(bytes.NewReader(src)),
+	}
+}
+
+// manifest reads the whole file: the top-level object, and every field of it.
+//
+// The error it returns is the fatal one — malformed JSON, which ends the walk.
+// Everything else is recorded in p.faults and reading continues.
+func (p *parser) manifest() (*Manifest, error) {
+	open, span, err := p.token()
+	if err != nil {
+		return nil, err
+	}
+
+	if !isOpen(open, '{') {
+		p.faults.Fail(&TypeError{Span: span, Field: manifestObject, Want: "a JSON object", Found: found(open)})
+
+		return nil, p.discardAfter(open)
+	}
+
+	m := &Manifest{File: p.file}
+	seen := map[string]diag.Span{}
+
+	for p.dec.More() {
+		key, keySpan, err := p.key()
+		if err != nil {
+			return nil, err
+		}
+
+		if first, repeated := seen[key]; repeated {
+			p.faults.Fail(&RepeatedFieldError{Span: keySpan, First: first, Field: key, In: manifestObject})
+
+			if err := p.discard(); err != nil {
+				return nil, err
+			}
+
+			continue
+		}
+
+		seen[key] = keySpan
+
+		switch key {
+		case "inputs":
+			m.Inputs, err = p.paths("inputs")
+		case "layout":
+			m.Layout, _, err = p.requiredText("layout", "the layout file written as text", layoutFault)
+		case "generators":
+			m.Generators, err = p.generators()
+		default:
+			p.faults.Fail(&UnknownFieldError{Span: keySpan, Field: key, In: manifestObject, Known: manifestFields})
+
+			err = p.discard()
+		}
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if _, _, err := p.token(); err != nil {
+		return nil, err
+	}
+
+	p.required(span, seen, manifestObject, [][2]string{
+		{"layout", layoutFault},
+		{"generators", generatorsFault},
+	})
+
+	return m, nil
+}
+
+// generators reads the list of generator entries.
+func (p *parser) generators() ([]Generator, error) {
+	open, span, err := p.token()
+	if err != nil {
+		return nil, err
+	}
+
+	if !isOpen(open, '[') {
+		p.faults.Fail(&TypeError{
+			Span: span, Field: "generators", Want: "a list of generator entries", Found: found(open),
+		})
+
+		return nil, p.discardAfter(open)
+	}
+
+	var (
+		generators []Generator
+		entries    int
+	)
+
+	for ; p.dec.More(); entries++ {
+		generator, ok, err := p.generator(fmt.Sprintf("generators[%d]", entries))
+		if err != nil {
+			return nil, err
+		}
+
+		if ok {
+			generators = append(generators, generator)
+		}
+	}
+
+	if _, _, err := p.token(); err != nil {
+		return nil, err
+	}
+
+	// The count rather than len(generators): a list holding two entries this
+	// package could not read is a list with two things wrong with it, and
+	// reporting it as empty as well would send the adopter to write entries
+	// they have already written.
+	if entries == 0 {
+		p.faults.Fail(&EmptyValueError{Span: span, Field: "generators", Fault: generatorsFault})
+	}
+
+	return generators, nil
+}
+
+// generator reads one entry of the generators list, under the field path a
+// diagnostic about it names — `generators[1]`.
+//
+// The bool is whether there is an entry to keep. An entry that is not an object
+// at all leaves nothing behind; one that is an object with faults in it is kept,
+// because the faults are already recorded and a half-read entry beside them
+// makes the rest of the list's positions read correctly.
+func (p *parser) generator(field string) (Generator, bool, error) {
+	open, span, err := p.token()
+	if err != nil {
+		return Generator{}, false, err
+	}
+
+	if !isOpen(open, '{') {
+		p.faults.Fail(&TypeError{
+			Span: span, Field: field, Want: "a generator entry, which is a JSON object", Found: found(open),
+		})
+
+		return Generator{}, false, p.discardAfter(open)
+	}
+
+	generator := Generator{Span: span}
+	seen := map[string]diag.Span{}
+
+	for p.dec.More() {
+		key, keySpan, err := p.key()
+		if err != nil {
+			return Generator{}, false, err
+		}
+
+		if first, repeated := seen[key]; repeated {
+			p.faults.Fail(&RepeatedFieldError{Span: keySpan, First: first, Field: key, In: generatorObject})
+
+			if err := p.discard(); err != nil {
+				return Generator{}, false, err
+			}
+
+			continue
+		}
+
+		seen[key] = keySpan
+
+		switch key {
+		case "name":
+			var nameSpan diag.Span
+
+			generator.Name, nameSpan, err = p.requiredText(
+				field+".name", "a generator name written as text", nameFault)
+			if strings.Contains(generator.Name, "/") {
+				p.faults.Fail(&GeneratorNameError{Span: nameSpan, Name: generator.Name})
+			}
+		case "out":
+			generator.Out, _, err = p.requiredText(
+				field+".out", "a directory path written as text", outFault)
+		case "inputs":
+			generator.Inputs, err = p.paths(field + ".inputs")
+		case "options":
+			generator.Options, err = p.options(field + ".options")
+		default:
+			p.faults.Fail(&UnknownFieldError{Span: keySpan, Field: key, In: generatorObject, Known: generatorFields})
+
+			err = p.discard()
+		}
+
+		if err != nil {
+			return Generator{}, false, err
+		}
+	}
+
+	if _, _, err := p.token(); err != nil {
+		return Generator{}, false, err
+	}
+
+	p.required(span, seen, generatorObject, [][2]string{
+		{"name", nameFault},
+		{"out", outFault},
+	})
+
+	return generator, true, nil
+}
+
+// options reads a generator's options, keeping the order they were written in.
+func (p *parser) options(field string) ([]Option, error) {
+	open, span, err := p.token()
+	if err != nil {
+		return nil, err
+	}
+
+	if !isOpen(open, '{') {
+		p.faults.Fail(&TypeError{
+			Span: span, Field: field, Want: "an object of generator options", Found: found(open),
+		})
+
+		return nil, p.discardAfter(open)
+	}
+
+	var options []Option
+
+	seen := map[string]diag.Span{}
+
+	for p.dec.More() {
+		key, keySpan, err := p.key()
+		if err != nil {
+			return nil, err
+		}
+
+		repeated := false
+
+		if first, ok := seen[key]; ok {
+			p.faults.Fail(&RepeatedFieldError{Span: keySpan, First: first, Field: key, In: optionObject})
+
+			repeated = true
+		} else {
+			seen[key] = keySpan
+		}
+
+		// docs/plugin/SPEC.md: a key MUST NOT be empty and MUST NOT contain an
+		// `=`, because everything before the first `=` of `--opt k=v` is the
+		// key. A manifest is where such a key is written, so it is where the
+		// fault is reported rather than in the plugin that would be handed an
+		// argument nobody can split.
+		usable := key != "" && !strings.Contains(key, "=")
+		if !usable {
+			p.faults.Fail(&OptionKeyError{Span: keySpan, Key: key})
+		}
+
+		// An option value may be empty — the plugin contract says so — so this
+		// is the plain read rather than the required one.
+		value, _, ok, err := p.text(field+"."+key, "an option value written as text")
+		if err != nil {
+			return nil, err
+		}
+
+		if ok && usable && !repeated {
+			options = append(options, Option{Key: key, Value: value})
+		}
+	}
+
+	if _, _, err := p.token(); err != nil {
+		return nil, err
+	}
+
+	return options, nil
+}
+
+// paths reads a list of copybook paths.
+func (p *parser) paths(field string) ([]string, error) {
+	open, span, err := p.token()
+	if err != nil {
+		return nil, err
+	}
+
+	if !isOpen(open, '[') {
+		p.faults.Fail(&TypeError{
+			Span: span, Field: field, Want: "a list of copybook paths", Found: found(open),
+		})
+
+		return nil, p.discardAfter(open)
+	}
+
+	var paths []string
+
+	seen := map[string]diag.Span{}
+
+	for index := 0; p.dec.More(); index++ {
+		path, pathSpan, err := p.requiredText(
+			fmt.Sprintf("%s[%d]", field, index), "a copybook path written as text", inputFault)
+		if err != nil {
+			return nil, err
+		}
+
+		if path == "" {
+			continue
+		}
+
+		if first, repeated := seen[path]; repeated {
+			p.faults.Fail(&RepeatedInputError{Span: pathSpan, First: first, Path: path, Field: field})
+
+			continue
+		}
+
+		seen[path] = pathSpan
+		paths = append(paths, path)
+	}
+
+	if _, _, err := p.token(); err != nil {
+		return nil, err
+	}
+
+	return paths, nil
+}
+
+// required reports every field of known that the object at span did not carry.
+//
+// The pairs are the field and the clause the message closes with, in the order
+// a manifest writes them, so that an object missing two of them is two things
+// to fix in the order they would be written rather than in a map's.
+func (p *parser) required(span diag.Span, seen map[string]diag.Span, in string, known [][2]string) {
+	for _, field := range known {
+		if _, ok := seen[field[0]]; !ok {
+			p.faults.Fail(&MissingFieldError{Span: span, Field: field[0], In: in, Fault: field[1]})
+		}
+	}
+}
+
+// requiredText reads a string value that has to carry something.
+//
+// An empty one is a fault rather than an absent field: `"layout": ""` is a line
+// the adopter wrote and meant something by, and treating it as unwritten would
+// report it as missing from a manifest it is visibly in.
+func (p *parser) requiredText(field, want, fault string) (string, diag.Span, error) {
+	value, span, ok, err := p.text(field, want)
+	if err != nil || !ok {
+		return "", span, err
+	}
+
+	if value == "" {
+		p.faults.Fail(&EmptyValueError{Span: span, Field: field, Fault: fault})
+	}
+
+	return value, span, nil
+}
+
+// text reads a string value. The bool is whether one was there; anything else is
+// reported and skipped, so that the fields after it are still read.
+func (p *parser) text(field, want string) (string, diag.Span, bool, error) {
+	tok, span, err := p.token()
+	if err != nil {
+		return "", span, false, err
+	}
+
+	value, ok := tok.(string)
+	if !ok {
+		p.faults.Fail(&TypeError{Span: span, Field: field, Want: want, Found: found(tok)})
+
+		return "", span, false, p.discardAfter(tok)
+	}
+
+	return value, span, true, nil
+}
+
+// key reads an object's field name.
+func (p *parser) key() (string, diag.Span, error) {
+	tok, span, err := p.token()
+	if err != nil {
+		return "", span, err
+	}
+
+	key, ok := tok.(string)
+	if !ok {
+		// Unreachable through [encoding/json], which produces a string token
+		// for an object key or an error for anything else. It is here rather
+		// than as a panic because a fault in a file an adopter wrote is
+		// reported to them even when this package cannot explain it.
+		return "", span, &SyntaxError{
+			Span:  span,
+			Fault: "the manifest has " + found(tok) + " where a field name belongs",
+		}
+	}
+
+	return key, span, nil
+}
+
+// trailing reports anything written after the manifest's one top-level object.
+func (p *parser) trailing() {
+	span := p.next()
+
+	tok, err := p.dec.Token()
+
+	switch {
+	case errors.Is(err, io.EOF):
+		return
+	case err != nil:
+		p.faults.Fail(p.syntaxError(span, err))
+	default:
+		p.faults.Fail(&SyntaxError{
+			Span: span,
+			Fault: "the manifest carries " + found(tok) +
+				" after the object it opens with; a manifest is one JSON object and nothing else",
+		})
+	}
+}
+
+// token reads the next JSON token and the place it starts.
+func (p *parser) token() (json.Token, diag.Span, error) {
+	span := p.next()
+
+	tok, err := p.dec.Token()
+	if err != nil {
+		return nil, span, p.syntaxError(span, err)
+	}
+
+	return tok, span, nil
+}
+
+// discard reads the next value and throws it away, whatever it is.
+func (p *parser) discard() error {
+	tok, _, err := p.token()
+	if err != nil {
+		return err
+	}
+
+	return p.discardAfter(tok)
+}
+
+// discardAfter reads whatever is left of the value tok opened.
+//
+// A scalar is already whole and leaves nothing to read; an object or a list is
+// read to its own closing delimiter, counting depth, so that a field this
+// package could not use does not leave the walk standing inside it.
+func (p *parser) discardAfter(tok json.Token) error {
+	delim, ok := tok.(json.Delim)
+	if !ok || (delim != '{' && delim != '[') {
+		return nil
+	}
+
+	for depth := 1; depth > 0; {
+		next, _, err := p.token()
+		if err != nil {
+			return err
+		}
+
+		if d, ok := next.(json.Delim); ok {
+			switch d {
+			case '{', '[':
+				depth++
+			case '}', ']':
+				depth--
+			}
+		}
+	}
+
+	return nil
+}
+
+// next is where the token about to be read starts.
+//
+// [encoding/json] reports the offset it has reached, which is the end of the
+// token before this one; the punctuation and the whitespace between the two are
+// skipped here so that a diagnostic points at the value rather than at the comma
+// in front of it.
+func (p *parser) next() diag.Span {
+	offset := int(p.dec.InputOffset())
+
+	for offset < len(p.src) && isSeparator(p.src[offset]) {
+		offset++
+	}
+
+	return p.spanAt(offset)
+}
+
+// spanAt is the place in the manifest that byte offset names.
+func (p *parser) spanAt(offset int) diag.Span {
+	if offset < 0 {
+		offset = 0
+	}
+
+	if offset > len(p.src) {
+		offset = len(p.src)
+	}
+
+	line := sort.Search(len(p.lines), func(i int) bool { return p.lines[i] > offset }) - 1
+
+	return diag.Span{
+		File: p.file,
+		Line: line + 1,
+
+		// Runes rather than bytes, because the column is for a person looking
+		// at the line in an editor and a copybook path is not always ASCII.
+		Column: utf8.RuneCount(p.src[p.lines[line]:offset]) + 1,
+	}
+}
+
+// syntaxError is what [encoding/json] refused, said where it happened.
+func (p *parser) syntaxError(span diag.Span, err error) error {
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return &SyntaxError{
+			Span:  p.spanAt(len(p.src)),
+			Fault: "the manifest ends before the JSON in it does",
+			Err:   err,
+		}
+	}
+
+	// The span is the walk's own — where the token that would not read starts —
+	// rather than the offset [encoding/json] puts on a *json.SyntaxError. That
+	// offset is counted differently by the two paths a Token call can fail on,
+	// one of them naming the offending byte and the other the byte after it, so
+	// a diagnostic built from it points one column off depending on which of
+	// them raised the fault. Where the reader had reached is exact whichever
+	// path it was, and it is the same place the message is about.
+	return &SyntaxError{Span: span, Fault: "the manifest is not valid JSON: " + err.Error(), Err: err}
+}
+
+// isSeparator reports whether b is punctuation or whitespace between two tokens.
+func isSeparator(b byte) bool {
+	switch b {
+	case ' ', '\t', '\r', '\n', ',', ':':
+		return true
+	default:
+		return false
+	}
+}
+
+// isOpen reports whether tok opens the object or the list want does.
+func isOpen(tok json.Token, want json.Delim) bool {
+	delim, ok := tok.(json.Delim)
+
+	return ok && delim == want
+}
+
+// found names a JSON token the way a message refers to it.
+func found(tok json.Token) string {
+	switch value := tok.(type) {
+	case json.Delim:
+		switch value {
+		case '{':
+			return "an object"
+		case '[':
+			return "a list"
+		case '}':
+			return "the end of an object"
+		case ']':
+			return "the end of a list"
+		}
+	case string:
+		return "text"
+	case float64, json.Number:
+		return "a number"
+	case bool:
+		return "a boolean"
+	case nil:
+		return "null"
+	}
+
+	return "something else"
+}

--- a/internal/manifest/parse_test.go
+++ b/internal/manifest/parse_test.go
@@ -1,0 +1,395 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package manifest
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+)
+
+// refuse hands [Read] a manifest that has something wrong with it and gives back
+// what the faults render as. It fails the test on a manifest that reads cleanly,
+// because a rule nobody enforces passes a test that only ever asserts messages.
+func refuse(t *testing.T, source string) string {
+	t.Helper()
+
+	m, err := Read(Name, strings.NewReader(source))
+	if err == nil {
+		t.Fatalf("the manifest read cleanly as %+v, want a fault", m)
+	}
+
+	if m != nil {
+		t.Errorf("a refused manifest came back as %+v, want nothing", m)
+	}
+
+	return diag.Render(err)
+}
+
+// TestReadRefusesAManifestWithSomethingWrongWithIt is the golden set: one
+// manifest per rule, and the diagnostic it produces in full.
+//
+// The whole rendering is asserted rather than a substring of it, because the
+// position is half of what a diagnostic owes its reader and a message asserted
+// by substring keeps passing while pointing at the wrong line.
+func TestReadRefusesAManifestWithSomethingWrongWithIt(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name: "a field no manifest has",
+			source: `{
+  "layout": "orders.sexpr",
+  "generators": [{"name": "go", "out": "gen"}],
+  "generatorz": []
+}`,
+			want: `cpybkc.json:4:3: a manifest has no field named "generatorz"; it carries inputs, layout and generators`,
+		},
+		{
+			name: "a field no generator entry has",
+			source: `{
+  "layout": "orders.sexpr",
+  "generators": [
+    {"name": "go", "out": "gen", "version": "v1"}
+  ]
+}`,
+			want: `cpybkc.json:4:34: a generator entry has no field named "version"; ` +
+				`it carries name, out, inputs and options`,
+		},
+		{
+			name: "a field written twice",
+			source: `{
+  "layout": "orders.sexpr",
+  "layout": "payments.sexpr",
+  "generators": [{"name": "go", "out": "gen"}]
+}`,
+			want: `cpybkc.json:3:3: a manifest carries "layout" twice
+  cpybkc.json:2:3: the first one is here`,
+		},
+		{
+			name: "an option written twice",
+			source: `{
+  "layout": "orders.sexpr",
+  "generators": [
+    {"name": "go", "out": "gen", "options": {"package_name": "a", "package_name": "b"}}
+  ]
+}`,
+			want: `cpybkc.json:4:67: a generator's option set carries "package_name" twice
+  cpybkc.json:4:46: the first one is here`,
+		},
+		{
+			name: "no layout",
+			source: `{
+  "generators": [{"name": "go", "out": "gen"}]
+}`,
+			want: `cpybkc.json:1:1: a manifest carries no layout; a project resolves its records against exactly one`,
+		},
+		{
+			name:   "no generators",
+			source: `{"layout": "orders.sexpr"}`,
+			want: `cpybkc.json:1:1: a manifest carries no generators; ` +
+				`there is nothing for a run to do without one`,
+		},
+		{
+			name: "generators declared and empty",
+			source: `{
+  "layout": "orders.sexpr",
+  "generators": []
+}`,
+			want: `cpybkc.json:3:17: generators is empty; there is nothing for a run to do without one`,
+		},
+		{
+			name: "a generator with no name and no out",
+			source: `{
+  "layout": "orders.sexpr",
+  "generators": [{"inputs": ["cpy/orders.cpy"]}]
+}`,
+			want: `cpybkc.json:3:18: a generator entry carries no name; a generator is found on PATH as cpybkc-gen-<name>
+cpybkc.json:3:18: a generator entry carries no out; its output lands in the directory out names`,
+		},
+		{
+			name: "an empty layout",
+			source: `{
+  "layout": "",
+  "generators": [{"name": "go", "out": "gen"}]
+}`,
+			want: `cpybkc.json:2:13: layout is empty; a project resolves its records against exactly one`,
+		},
+		{
+			name: "an empty generator name",
+			source: `{
+  "layout": "orders.sexpr",
+  "generators": [{"name": "", "out": "gen"}]
+}`,
+			want: `cpybkc.json:3:27: generators[0].name is empty; a generator is found on PATH as cpybkc-gen-<name>`,
+		},
+		{
+			name: "a generator name that is not a filename component",
+			source: `{
+  "layout": "orders.sexpr",
+  "generators": [{"name": "z5labs/go", "out": "gen"}]
+}`,
+			want: `cpybkc.json:3:27: a generator name is the suffix of the cpybkc-gen-<name> executable ` +
+				`it resolves to, and "z5labs/go" contains a /`,
+		},
+		{
+			name: "one path where a list of them belongs",
+			source: `{
+  "inputs": "cpy/orders.cpy",
+  "layout": "orders.sexpr",
+  "generators": [{"name": "go", "out": "gen"}]
+}`,
+			want: `cpybkc.json:2:13: inputs is a list of copybook paths, and this one is text`,
+		},
+		{
+			name: "a layout written as a number",
+			source: `{
+  "layout": 12,
+  "generators": [{"name": "go", "out": "gen"}]
+}`,
+			want: `cpybkc.json:2:13: layout is the layout file written as text, and this one is a number`,
+		},
+		{
+			name: "a generator entry that is not an object",
+			source: `{
+  "layout": "orders.sexpr",
+  "generators": ["go"]
+}`,
+			want: `cpybkc.json:3:18: generators[0] is a generator entry, which is a JSON object, and this one is text`,
+		},
+		{
+			name: "an option value that is not text",
+			source: `{
+  "layout": "orders.sexpr",
+  "generators": [
+    {"name": "go", "out": "gen", "options": {"width": 80}}
+  ]
+}`,
+			want: `cpybkc.json:4:55: generators[0].options.width is an option value written as text, ` +
+				`and this one is a number`,
+		},
+		{
+			name: "an option key a generator could not be handed",
+			source: `{
+  "layout": "orders.sexpr",
+  "generators": [
+    {"name": "go", "out": "gen", "options": {"package=name": "orders"}}
+  ]
+}`,
+			want: `cpybkc.json:4:46: an option key contains no =, and "package=name" does`,
+		},
+		{
+			name: "an option key with nothing in it",
+			source: `{
+  "layout": "orders.sexpr",
+  "generators": [
+    {"name": "go", "out": "gen", "options": {"": "orders"}}
+  ]
+}`,
+			want: `cpybkc.json:4:46: an option key is empty, and a generator is handed each option as k=v`,
+		},
+		{
+			name: "a copybook named twice in one list",
+			source: `{
+  "inputs": ["cpy/orders.cpy", "cpy/common.cpy", "cpy/orders.cpy"],
+  "layout": "orders.sexpr",
+  "generators": [{"name": "go", "out": "gen"}]
+}`,
+			want: `cpybkc.json:2:50: inputs names "cpy/orders.cpy" twice
+  cpybkc.json:2:14: the first one is here`,
+		},
+		{
+			name: "an input with nothing in it",
+			source: `{
+  "inputs": ["cpy/orders.cpy", ""],
+  "layout": "orders.sexpr",
+  "generators": [{"name": "go", "out": "gen"}]
+}`,
+			want: `cpybkc.json:2:32: inputs[1] is empty; every input names a copybook to read`,
+		},
+		{
+			name: "a layout written as a boolean",
+			source: `{
+  "layout": true,
+  "generators": [{"name": "go", "out": "gen"}]
+}`,
+			want: `cpybkc.json:2:13: layout is the layout file written as text, and this one is a boolean`,
+		},
+		{
+			name: "inputs written as nothing at all",
+			source: `{
+  "inputs": null,
+  "layout": "orders.sexpr",
+  "generators": [{"name": "go", "out": "gen"}]
+}`,
+			want: `cpybkc.json:2:13: inputs is a list of copybook paths, and this one is null`,
+		},
+		{
+			name:   "a manifest that is not an object",
+			source: `["orders.sexpr"]`,
+			want:   `cpybkc.json:1:1: a manifest is a JSON object, and this one is a list`,
+		},
+		{
+			name:   "a manifest that is empty",
+			source: "\n  \n",
+			want: `cpybkc.json:1:1: the manifest is empty; ` +
+				`it is a JSON object naming the layout, the copybooks and the generators to run`,
+		},
+		{
+			name:   "a manifest that is not JSON",
+			source: `{"layout" = "orders.sexpr"}`,
+			want: `cpybkc.json:1:11: the manifest is not valid JSON: ` +
+				`invalid character '=' after object key`,
+		},
+		{
+			name: "a manifest that stops in the middle",
+			source: `{
+  "layout": "orders.sexpr",
+  "generators": [{"name": "go",`,
+			want: `cpybkc.json:3:32: the manifest ends before the JSON in it does`,
+		},
+		{
+			name:   "more than one JSON value",
+			source: `{"layout": "orders.sexpr", "generators": [{"name": "go", "out": "gen"}]} {}`,
+			want: `cpybkc.json:1:74: the manifest carries an object after the object it opens with; ` +
+				`a manifest is one JSON object and nothing else`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := refuse(t, test.source); got != test.want {
+				t.Errorf("the manifest reads:\n%s\nwant:\n%s", got, test.want)
+			}
+		})
+	}
+}
+
+// TestReadStopsWhereverTheJSONDoes is the walk's one fatal fault, met at every
+// depth a manifest has: a file that ends mid-object leaves nothing after it to
+// read, whether it stopped in a list of copybooks, in a generator's options or
+// before the first field of all.
+func TestReadStopsWhereverTheJSONDoes(t *testing.T) {
+	tests := map[string]string{
+		"before the first field":  `{`,
+		"in a list of copybooks":  `{"inputs": ["cpy/orders.cpy",`,
+		"in the generators list":  `{"layout": "orders.sexpr", "generators": [`,
+		"in a generator entry":    `{"layout": "orders.sexpr", "generators": [{`,
+		"in a generator's option": `{"layout": "o.sexpr", "generators": [{"name": "go", "options": {"a":`,
+		"in a field nobody knows": `{"generatorz": [1, [2,`,
+	}
+
+	const want = "the manifest ends before the JSON in it does"
+
+	for name, source := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := refuse(t, source); !strings.HasSuffix(got, want) {
+				t.Errorf("the manifest reads:\n%s\nwant it to end with %q", got, want)
+			}
+		})
+	}
+}
+
+// TestReadReportsEveryFaultRatherThanTheFirst is why the faults accumulate: a
+// manifest is wrong in the same way in several places at once, and a reader
+// reporting one of them per run is a reader run once per fault.
+func TestReadReportsEveryFaultRatherThanTheFirst(t *testing.T) {
+	got := refuse(t, `{
+  "input": ["cpy/orders.cpy"],
+  "layout": "orders.sexpr",
+  "generators": [
+    {"name": "go", "outt": "gen"},
+    {"name": "", "out": "schema"}
+  ]
+}`)
+
+	want := `cpybkc.json:2:3: a manifest has no field named "input"; it carries inputs, layout and generators
+cpybkc.json:5:20: a generator entry has no field named "outt"; it carries name, out, inputs and options
+cpybkc.json:5:5: a generator entry carries no out; its output lands in the directory out names
+cpybkc.json:6:14: generators[1].name is empty; a generator is found on PATH as cpybkc-gen-<name>`
+
+	if got != want {
+		t.Errorf("the manifest reads:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestReadKeepsWhatItFoundBesideAFaultItCannotReadPast is the other half of
+// that: malformed JSON ends the walk, because there is no way to know where the
+// value that failed to parse was meant to end — but the faults already found
+// are still the adopter's to fix.
+func TestReadKeepsWhatItFoundBesideAFaultItCannotReadPast(t *testing.T) {
+	got := refuse(t, `{
+  "layoutt": "orders.sexpr",
+  "generators": [{"name": "go", "out" = "gen"}]
+}`)
+
+	want := `cpybkc.json:2:3: a manifest has no field named "layoutt"; it carries inputs, layout and generators
+cpybkc.json:3:39: the manifest is not valid JSON: invalid character '=' after object key`
+
+	if got != want {
+		t.Errorf("the manifest reads:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestASyntaxFaultKeepsWhatEncodingJSONSaid is what makes a truncated manifest
+// distinguishable from a malformed one without reading the sentence.
+func TestASyntaxFaultKeepsWhatEncodingJSONSaid(t *testing.T) {
+	_, truncated := Read(Name, strings.NewReader(`{"layout": "orders.sexpr"`))
+	if !errors.Is(truncated, io.EOF) {
+		t.Errorf("a truncated manifest gave %v, want it to carry io.EOF", truncated)
+	}
+
+	_, malformed := Read(Name, strings.NewReader(`{"layout" = "orders.sexpr"}`))
+
+	var syntax *json.SyntaxError
+	if !errors.As(malformed, &syntax) {
+		t.Errorf("a malformed manifest gave %v, want it to carry a *json.SyntaxError", malformed)
+	}
+}
+
+// TestAFaultIsAssertableByType is what a caller that wants to act on a fault
+// rather than print it does, and it is why these are types rather than one
+// error with a sentence in it.
+func TestAFaultIsAssertableByType(t *testing.T) {
+	_, err := Read(Name, strings.NewReader(`{
+  "layout": "orders.sexpr",
+  "generators": [{"name": "go", "out": "gen", "options": {"a=b": ""}}]
+}`))
+
+	var key *OptionKeyError
+	if !errors.As(err, &key) {
+		t.Fatalf("the manifest gave %v, want an *OptionKeyError", err)
+	}
+
+	if key.Key != "a=b" {
+		t.Errorf("the fault names the key %q, want %q", key.Key, "a=b")
+	}
+}
+
+// TestReadSkipsPastAFieldItCannotUse is what keeps a manifest with one bad field
+// reporting the fields after it: a value of the wrong shape is read to its end
+// rather than leaving the walk standing inside it.
+func TestReadSkipsPastAFieldItCannotUse(t *testing.T) {
+	got := refuse(t, `{
+  "inputs": {"first": ["cpy/orders.cpy"]},
+  "layout": "orders.sexpr",
+  "generators": [{"name": "go", "out": "gen"}],
+  "generatorz": [[1, 2], {"a": {"b": []}}]
+}`)
+
+	want := `cpybkc.json:2:13: inputs is a list of copybook paths, and this one is an object
+cpybkc.json:5:3: a manifest has no field named "generatorz"; it carries inputs, layout and generators`
+
+	if got != want {
+		t.Errorf("the manifest reads:\n%s\nwant:\n%s", got, want)
+	}
+}

--- a/internal/manifest/testdata/cpybkc.json
+++ b/internal/manifest/testdata/cpybkc.json
@@ -1,0 +1,11 @@
+{
+  "inputs": ["cpy/orders.cpy"],
+  "layout": "orders.sexpr",
+  "generators": [
+    {
+      "name": "go",
+      "out": "gen",
+      "options": {"package_name": "orders"}
+    }
+  ]
+}


### PR DESCRIPTION
Closes #40

`internal/manifest` reads the `cpybkc.json` a project is driven by: the layout
it resolves against, the copybooks a run reads, and the generators to run over
them, with their options.

## Acceptance criteria

- [x] **Manifest declares inputs, the layout file, and a list of generators with `name`, `out`, and `options`** — `Manifest{Inputs, Layout, Generators}` and `Generator{Name, Out, Inputs, Options}`. `layout` and `generators` are required and `generators` carries at least one entry; `name` and `out` are required on each.
- [x] **Per-generator inputs merged with top-level inputs** — `Manifest.InputsFor`: the manifest's list, then the entry's, in the order both were written, with a path named in both kept once. Merged rather than replaced, so a generator adding one copybook does not restate the shared list.
- [x] **Unknown fields rejected rather than ignored** — every object admits a closed set and reports anything else by name, along with the fields it does admit. A field written twice, a copybook named twice in one list, and an empty string where a path or a name belongs are the same argument met from other sides.
- [x] **A missing or malformed manifest produces an actionable error** — `NotFoundError` says what the file is for rather than what errno was; every other fault carries a `diag.Span` with the line and column in `cpybkc.json` it is at, and says what the field is before what was found. Faults accumulate, so a manifest with three things wrong with it is one run rather than three.
- [x] **Manifest schema documented** — [README.md](README.md#the-project-manifest) has the worked example, the field table and the four rules a person writing one meets; the package comment carries the reasoning.

## Judgment calls that shaped the API

- **The options are a slice, not a map.** `docs/plugin/SPEC.md` requires cpybkc to pass a generator's options "in the order the manifest declares them, so that the vector is a function of the manifest rather than of a map iteration". A Go map cannot hold that order, which is why the manifest is walked as a token stream rather than unmarshalled into a struct — the walk is also what gives every fault a position, since an unmarshalling error's byte offset has already lost which field it was in.
- **An option value is text.** An option reaches a generator as `k=v` on a command line, so the manifest writes the value the generator will actually see; accepting `80` would make this package the place that decides how a number is spelled. An empty value is legal, as the plugin contract says.
- **One `layout`, at the top level only.** The criterion says "the layout file", and a per-generator layout is a decision this story was not asked to make. Because unknown fields are reported, a `layout` inside a generator entry is refused by name rather than silently ignored.
- **Only the plugin contract's MUSTs about a name are enforced** — non-empty and no `/`. The lowercase-ASCII advice is a SHOULD, and `diag` has no severities: everything reported through it is something an adopter has to fix.
- **Nothing is resolved.** A path is kept exactly as written; resolving one against the manifest's directory, against a copybook search path, or into the absolute path a plugin is handed belongs to the stage that opens the file (#41–#43).
- **No `SPEC.md`.** `docs/plugin/SPEC.md` excludes the manifest by name, on the grounds that a plugin never reads one — so the schema is documented in the README, for the person who writes the file, and stays free to change.
- **A syntax fault's span is the walk's own position, not `*json.SyntaxError.Offset`.** That offset is counted differently by the two paths a `Token` call can fail on, so a diagnostic built from it lands one column off depending on which raised the fault. The error is still wrapped and reachable with `errors.As`.

## Verification

`dagger call ci` — fmt, vet, lint, `go test -race`, the schema lint and the release artifacts. Green.

The package's own tests are golden diagnostics: one manifest per rule and the fault it produces in full, position included, so a message that keeps passing while pointing at the wrong line fails. Coverage is 90% of statements; what is left is the fatal-error propagation a truncated file cannot reach at every depth at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)