### PR TITLE
story(plugin): resolve generators to executables on PATH

### DIFF
--- a/internal/plugin/doc.go
+++ b/internal/plugin/doc.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Package plugin finds the generator executables cpybkc runs.
+//
+// A generator has a name — the `<name>` a manifest asks for — and that name is
+// the whole of how it is identified. docs/plugin/SPEC.md's "Discovery" is the
+// contract: the executable is named `cpybkc-gen-<name>`, and cpybkc resolves a
+// name to one by searching PATH for exactly that filename. [Resolve] is that
+// search and nothing else; what a discovered executable is then handed, and
+// what it may do with the directory it writes into, is #42's and #43's.
+//
+// This is not the standard library's plugin package and has nothing to do with
+// it. A cpybkc generator is a process with an argument vector, not a shared
+// object loaded into this one, which is what lets a generator be a shell script
+// and be written in a language that is not Go.
+//
+// # Why PATH is the whole of it
+//
+// docs/plugin/SPEC.md: cpybkc MUST NOT consult anything beyond PATH to find a
+// generator — no registry, no cache directory of its own, no lockfile, no
+// download. That is not a detail of discovery but the project's distribution
+// position: a generator is added by building an image FROM the published one
+// and copying an executable onto a directory already on PATH
+// (docs/container/SPEC.md, #54), and `FROM` plus `COPY` already are a
+// resolution protocol. So this package opens no network connection, writes no
+// state, and reads no file but the ones it stats.
+//
+// It also reads no environment. The PATH to search is an argument, because a
+// package that read one would be a second place the search could come from,
+// and a test of it would have to move the process's own environment to say
+// anything.
+//
+// # Why not exec.LookPath
+//
+// [os/exec.LookPath] is the same search with three differences, and the first
+// of them is a requirement of the contract rather than a preference:
+//
+//   - It treats an empty PATH element as the working directory, which POSIX
+//     permits and docs/plugin/SPEC.md forbids. cpybkc runs generators as a side
+//     effect of a generation command, and a generator picked up from whatever
+//     directory a user happened to be standing in is an execution surface
+//     nobody chose. An empty element is skipped here.
+//   - It asks the kernel whether this process could execute the file, through
+//     eaccess(2). The contract says a candidate is a regular file carrying an
+//     execute bit, which is a question about the file rather than about who is
+//     asking — so [Resolve] reads the mode. The two differ for a file whose
+//     execute bit belongs to another user, and for root, and where they differ
+//     the contract is what a plugin author read.
+//   - It reports a relative resolution as [os/exec.ErrDot], which is a decision
+//     about running a command from an interactive shell's PATH rather than
+//     about this one.
+//
+// # What a candidate is
+//
+// A regular file with an execute bit, and there is no second test — no
+// extension, no magic number, no metadata file beside it. That is what keeps a
+// shell script with `chmod +x` a first-class plugin, and it is why a generator
+// is not asked to describe itself before it is run.
+//
+// A symlink is followed, because [os.Stat] follows one and because a plugin
+// installed by a package manager usually is one. What the mode test sees is the
+// file at the end of the chain, which is the file that would be executed.
+//
+// A file with the right name that fails either test is not a candidate and the
+// search continues past it, exactly as a shell's would. It is still named in
+// the diagnostic when nothing resolves ([NotFoundError]): a missing execute bit
+// is the likeliest single explanation for a generator that is installed and
+// not found, and a message that stayed silent about the file it had just
+// looked at would leave the adopter to find it by hand.
+//
+// # Why the earliest match wins
+//
+// PATH is searched in order and the first match is the answer, exactly as it is
+// for a shell resolving a command name. That rule is what makes a plugin under
+// development shadow an installed one by prepending a directory, which is how
+// an author tests a change; the opposite rule would make that gesture silently
+// do nothing, and the difference is invisible in the output.
+//
+// The search is therefore deterministic in the only sense that matters to a
+// caller: one PATH and one name give one answer, and it changes when the
+// filesystem does rather than when a map is iterated.
+//
+// # What the answer is spelled as
+//
+// The path handed back is the PATH element with the filename joined onto it, as
+// PATH spells it. A relative element resolves to a relative path, against the
+// working directory the search was made from — which is what a shell does with
+// the same PATH, and the reason docs/plugin/SPEC.md says the working directory
+// is searched when it appears in PATH as a written-out path. Making the answer
+// absolute would be this package deciding that a relative element meant
+// somewhere else than it said.
+//
+// # Where the container comes in
+//
+// Nothing here knows about the published image, and that is the point. The
+// image's contribution is a directory on PATH that a derived image copies a
+// generator into (docs/container/SPEC.md, #54); a plugin in it is found by the
+// search below because it is on PATH, under exactly the rules a plugin on a
+// laptop's PATH is found by. There is no container path in this package to keep
+// in step with that document, and a generator behaves the same in both places
+// because only one search exists.
+//
+// # Why the name is checked here as well
+//
+// docs/plugin/SPEC.md requires a name to be non-empty and to contain no `/`,
+// because the name is a filename component. [github.com/Zaba505/cpybkc/internal/manifest]
+// already reports both, with the line in cpybkc.json the name is written at,
+// and this package reports them again with no position at all.
+//
+// That is two enforcements of one MUST for two audiences rather than a
+// duplicated check. A name reaches [Resolve] from wherever a caller had one — a
+// manifest, a flag, a test — and a name with a `/` in it that arrived by some
+// other route would otherwise turn into a path that leaves the directory being
+// searched, which is a search this package is not entitled to make. The
+// manifest reports it earlier and better; this reports it wherever it comes
+// from.
+package plugin

--- a/internal/plugin/doc.go
+++ b/internal/plugin/doc.go
@@ -107,8 +107,10 @@
 //
 // docs/plugin/SPEC.md requires a name to be non-empty and to contain no `/`,
 // because the name is a filename component. [github.com/Zaba505/cpybkc/internal/manifest]
-// already reports both, with the line in cpybkc.json the name is written at,
-// and this package reports them again with no position at all.
+// already reports both, with the line in cpybkc.json the name is written at —
+// a name carrying a `/` as a fault of its own, and an empty one as the fault
+// every field that has to carry something raises. This package reports them
+// again, as one fault and with no position at all.
 //
 // That is two enforcements of one MUST for two audiences rather than a
 // duplicated check. A name reaches [Resolve] from wherever a caller had one — a

--- a/internal/plugin/errors.go
+++ b/internal/plugin/errors.go
@@ -35,11 +35,15 @@ import (
 // this repository reports what an adopter has to fix and has no channel for
 // advice they may take or leave.
 //
-// The wording deliberately matches
-// [github.com/Zaba505/cpybkc/internal/manifest.GeneratorNameError], which
-// refuses the same two names earlier and with the line in cpybkc.json they were
-// written at. An adopter should not be able to tell from the sentence which of
-// the two stopped them; see the package comment for why both exist.
+// [github.com/Zaba505/cpybkc/internal/manifest] refuses both names earlier, and
+// with the line in cpybkc.json they were written at, but as two faults rather
+// than one: a name carrying a `/` is its
+// [github.com/Zaba505/cpybkc/internal/manifest.GeneratorNameError], and an
+// empty one is the
+// [github.com/Zaba505/cpybkc/internal/manifest.EmptyValueError] every field
+// that has to carry something raises. The wording here deliberately matches the
+// first of those, which is the one whose sentence is about a generator name;
+// see the package comment for why both packages check at all.
 type InvalidNameError struct {
 	// Name is what was asked for.
 	Name string
@@ -89,8 +93,8 @@ type NotFoundError struct {
 	// Name is the generator that was asked for.
 	Name string
 
-	// File is the executable that would have been it, which is
-	// [Filename](Name).
+	// File is the executable that would have been it: Name under [Prefix], as
+	// [Filename] spells it.
 	File string
 
 	// Searched are the PATH elements the search looked in, in order, as PATH

--- a/internal/plugin/errors.go
+++ b/internal/plugin/errors.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package plugin
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+)
+
+// Neither fault here carries a position in a file, and both are still
+// [github.com/Zaba505/cpybkc/internal/diag.Error]. A generator that is not on
+// PATH is wrong about the machine rather than about a line: cpybkc.json can name
+// a generator that is perfectly well spelled and simply not installed, so a
+// diagnostic that pointed at the name would be pointing at text that is not the
+// mistake. What these carry instead is every place the search did look, in the
+// order it looked, which is the half an adopter cannot see for themselves.
+//
+// A caller that does hold a position — the stage that read the manifest — is
+// free to say so around one of these. It is not said here, because a package
+// that invented a span would make the two statements disagree the first time a
+// name arrived from somewhere that is not a manifest.
+
+// InvalidNameError is a generator name that cannot be a filename component.
+//
+// docs/plugin/SPEC.md: a `<name>` MUST be non-empty and MUST NOT contain a `/`,
+// because the name is the suffix of the `cpybkc-gen-<name>` file that is
+// searched for. The rest of what that section says about a name — lowercase
+// ASCII letters, digits and hyphens — is a SHOULD and is not enforced anywhere:
+// this repository reports what an adopter has to fix and has no channel for
+// advice they may take or leave.
+//
+// The wording deliberately matches
+// [github.com/Zaba505/cpybkc/internal/manifest.GeneratorNameError], which
+// refuses the same two names earlier and with the line in cpybkc.json they were
+// written at. An adopter should not be able to tell from the sentence which of
+// the two stopped them; see the package comment for why both exist.
+type InvalidNameError struct {
+	// Name is what was asked for.
+	Name string
+}
+
+// Error implements the error interface.
+func (e *InvalidNameError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *InvalidNameError) Diagnostic() diag.Diagnostic {
+	const opening = "a generator name is the suffix of the " + Prefix + "<name> executable it resolves to, and "
+
+	message := opening + quote(e.Name) + " contains a /"
+	if e.Name == "" {
+		message = opening + "this one is empty"
+	}
+
+	return diag.Diagnostic{Message: message}
+}
+
+// PassedOver is a file with the name of the executable that was being looked
+// for, which was not a candidate for it.
+//
+// docs/plugin/SPEC.md makes a candidate a regular file carrying an execute bit
+// and gives the search no way to report one that is neither: it continues, as a
+// shell's does. Every one of them is kept so that [NotFoundError] can name it,
+// because "the file is there and cpybkc did not take it" is a different problem
+// from "the file is not there" and the fix — usually one chmod — is not one an
+// adopter finds by rereading their PATH.
+type PassedOver struct {
+	// Path is the file, as PATH spells the directory it is in.
+	Path string
+
+	// Fault is why it was not a candidate, in the words the diagnostic shows
+	// beside it.
+	Fault string
+}
+
+// NotFoundError is a generator name that nothing on PATH resolves.
+//
+// It names the executable that was looked for rather than only the generator
+// that was asked for, because those are two strings an adopter has to line up
+// by hand otherwise: the manifest says `"name": "go"` and the file they have to
+// install is called `cpybkc-gen-go`, and the gap between the two is where the
+// mistake usually is.
+type NotFoundError struct {
+	// Name is the generator that was asked for.
+	Name string
+
+	// File is the executable that would have been it, which is
+	// [Filename](Name).
+	File string
+
+	// Searched are the PATH elements the search looked in, in order, as PATH
+	// spelled them. Empty elements are not among them: an empty element names
+	// no directory, and one listed as searched would be reporting a place
+	// nobody wrote.
+	Searched []string
+
+	// PassedOver are the files of that name the search would not take, in the
+	// order it met them.
+	PassedOver []PassedOver
+}
+
+// Error implements the error interface.
+func (e *NotFoundError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+//
+// The first span names nowhere, which is what [diag.Span.Stated] is for: the
+// fault is in the machine and not in a file. Everything after it is somewhere
+// the search looked — each file it passed over, and then the directories
+// themselves, in the order PATH wrote them.
+func (e *NotFoundError) Diagnostic() diag.Diagnostic {
+	spans := []diag.Span{{}}
+
+	for _, passed := range e.PassedOver {
+		spans = append(spans, diag.Span{
+			File: passed.Path,
+			Note: passed.Fault + ", so the search continued past it",
+		})
+	}
+
+	searched := "PATH names no directory to search"
+	if len(e.Searched) > 0 {
+		searched = "PATH was searched in order: " + strings.Join(e.Searched, ", ")
+	}
+
+	return diag.Diagnostic{
+		Message: fmt.Sprintf("there is no generator named %s on PATH; cpybkc looks for an executable named %s",
+			quote(e.Name), e.File),
+		Spans: append(spans, diag.Span{Note: searched}),
+	}
+}
+
+// quote renders a name the way a message names one, so that an empty one and a
+// name with a space in it are both visible as what they are.
+func quote(name string) string { return strconv.Quote(name) }

--- a/internal/plugin/errors_test.go
+++ b/internal/plugin/errors_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package plugin
+
+import (
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+)
+
+// TestEveryFaultReadsTheSameThroughEitherEnd is what
+// [github.com/Zaba505/cpybkc/internal/diag.Error] asks of a typed error: the
+// message a caller prints and the diagnostic a caller inspects are built in one
+// place, so the two cannot say different things.
+//
+// Unlike the manifest reader's faults, neither of these points at a file. A
+// generator that is not installed is wrong about the machine rather than about
+// a line, and a span invented here would send an adopter to edit text that is
+// not the mistake; see the commentary at the top of errors.go.
+func TestEveryFaultReadsTheSameThroughEitherEnd(t *testing.T) {
+	faults := []error{
+		&InvalidNameError{Name: "z5labs/go"},
+		&InvalidNameError{},
+		&NotFoundError{Name: "go", File: Filename("go")},
+		&NotFoundError{
+			Name:       "go",
+			File:       Filename("go"),
+			Searched:   []string{"/home/dev/bin", "/usr/local/bin"},
+			PassedOver: []PassedOver{{Path: "/home/dev/bin/cpybkc-gen-go", Fault: "it carries no execute bit"}},
+		},
+	}
+
+	for _, fault := range faults {
+		carrier, ok := fault.(diag.Error)
+		if !ok {
+			t.Errorf("%T carries no diagnostic, want it to implement diag.Error", fault)
+
+			continue
+		}
+
+		if got, want := fault.Error(), carrier.Diagnostic().String(); got != want {
+			t.Errorf("%T reads as %q and renders as %q, want one wording", fault, got, want)
+		}
+	}
+}
+
+// TestANameThatCannotBeAFilenameSaysWhichWayItCannot keeps the two refusals
+// apart: an empty name and a name with a `/` in it are one MUST met from two
+// sides, and a message that read the same for both would tell an adopter who
+// wrote nothing that what they wrote contains a slash.
+func TestANameThatCannotBeAFilenameSaysWhichWayItCannot(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{
+			name: "",
+			want: "a generator name is the suffix of the cpybkc-gen-<name> executable it resolves to, " +
+				"and this one is empty",
+		},
+		{
+			name: "z5labs/go",
+			want: "a generator name is the suffix of the cpybkc-gen-<name> executable it resolves to, " +
+				`and "z5labs/go" contains a /`,
+		},
+	}
+
+	for _, test := range tests {
+		fault := &InvalidNameError{Name: test.name}
+
+		if got := diag.Render(fault); got != test.want {
+			t.Errorf("%q renders as\n%s\nwant\n%s", test.name, got, test.want)
+		}
+	}
+}
+
+// TestAnUnresolvableNameRendersEverywhereItLooked is the golden the fault is
+// held to. The message names the executable, one indented line per file the
+// search would not take says why it would not, and the last line is the search
+// itself — the half an adopter cannot see for themselves.
+func TestAnUnresolvableNameRendersEverywhereItLooked(t *testing.T) {
+	tests := []struct {
+		about string
+		fault *NotFoundError
+		want  string
+	}{
+		{
+			about: "nothing of that name anywhere",
+			fault: &NotFoundError{
+				Name:     "go",
+				File:     Filename("go"),
+				Searched: []string{"/home/dev/bin", "/usr/local/bin"},
+			},
+			want: `there is no generator named "go" on PATH; cpybkc looks for an executable named cpybkc-gen-go
+  PATH was searched in order: /home/dev/bin, /usr/local/bin`,
+		},
+		{
+			about: "one of them there and not taken",
+			fault: &NotFoundError{
+				Name:     "go",
+				File:     Filename("go"),
+				Searched: []string{"/home/dev/bin", "/usr/local/bin"},
+				PassedOver: []PassedOver{
+					{Path: "/home/dev/bin/cpybkc-gen-go", Fault: "it carries no execute bit"},
+					{Path: "/usr/local/bin/cpybkc-gen-go", Fault: "it is a directory"},
+				},
+			},
+			want: `there is no generator named "go" on PATH; cpybkc looks for an executable named cpybkc-gen-go
+  /home/dev/bin/cpybkc-gen-go: it carries no execute bit, so the search continued past it
+  /usr/local/bin/cpybkc-gen-go: it is a directory, so the search continued past it
+  PATH was searched in order: /home/dev/bin, /usr/local/bin`,
+		},
+		{
+			about: "a PATH with nowhere in it",
+			fault: &NotFoundError{Name: "go", File: Filename("go")},
+			want: `there is no generator named "go" on PATH; cpybkc looks for an executable named cpybkc-gen-go
+  PATH names no directory to search`,
+		},
+	}
+
+	for _, test := range tests {
+		if got := diag.Render(test.fault); got != test.want {
+			t.Errorf("%s renders as\n%s\nwant\n%s", test.about, got, test.want)
+		}
+	}
+}

--- a/internal/plugin/resolve.go
+++ b/internal/plugin/resolve.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package plugin
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Prefix is what the name of every generator executable begins with.
+//
+// docs/plugin/SPEC.md: a generator's executable MUST be named
+// `cpybkc-gen-<name>`, and the suffix of that filename is the generator's name.
+// It is a constant because the same string is the file that is searched for and
+// the file a diagnostic reports missing, and a message naming a filename cpybkc
+// did not look for is worse than no message.
+const Prefix = "cpybkc-gen-"
+
+// Filename is the executable a generator name resolves to.
+//
+// It is the only direction that exists. Nothing inside an executable is
+// consulted to discover its name, and nothing here reads a name back out of a
+// filename: the manifest states the name, and the filename follows from it.
+func Filename(name string) string { return Prefix + name }
+
+// Resolve finds the executable name resolves to by searching searchPath for
+// [Filename](name), and hands back the first one that is a regular file
+// carrying an execute bit.
+//
+// searchPath is a PATH — the value of the environment variable, colon-separated
+// on the POSIX hosts this project targets. It is passed rather than read, so
+// that the search is a function of its arguments; see the package comment.
+//
+// Elements are searched in the order they are written and the earliest match
+// wins. An empty element is skipped rather than treated as the working
+// directory, which docs/plugin/SPEC.md requires; a relative element is searched
+// where it says, against the working directory of the calling process.
+//
+// A name that cannot be a filename component is an [InvalidNameError] and is
+// refused before anything is stat'd. A name nothing resolves is a
+// [NotFoundError] naming the executable that was looked for, every directory it
+// was looked for in, and any file of that name that was passed over.
+func Resolve(name, searchPath string) (string, error) {
+	if err := checkName(name); err != nil {
+		return "", err
+	}
+
+	file := Filename(name)
+	notFound := &NotFoundError{Name: name, File: file}
+
+	for _, dir := range filepath.SplitList(searchPath) {
+		// docs/plugin/SPEC.md: an empty PATH element MUST NOT be treated as the
+		// current working directory, though POSIX permits it to be. It is not
+		// recorded as searched either — a diagnostic listing an empty directory
+		// would be reporting a place nobody named.
+		if dir == "" {
+			continue
+		}
+
+		notFound.Searched = append(notFound.Searched, dir)
+
+		candidate := filepath.Join(dir, file)
+
+		info, err := os.Stat(candidate)
+		if err != nil {
+			// Why the error is dropped: the reasons a stat fails here — the
+			// file is not there, the directory is not searchable, the path is
+			// too long — are one thing to a search that has to carry on either
+			// way, and a shell resolving the same PATH does not distinguish
+			// them either. What the adopter needs is the whole search's answer,
+			// which [NotFoundError] carries.
+			continue
+		}
+
+		if fault := unusable(info); fault != "" {
+			notFound.PassedOver = append(notFound.PassedOver, PassedOver{Path: candidate, Fault: fault})
+
+			continue
+		}
+
+		return candidate, nil
+	}
+
+	return "", notFound
+}
+
+// unusable says why info is not a candidate, or "" if it is one.
+//
+// docs/plugin/SPEC.md: a candidate MUST be a regular file carrying an execute
+// bit, and there is no second test. The wording of each answer is what a
+// diagnostic shows beside the file, so the three cases are three sentences
+// rather than one with a hole in it — a directory named cpybkc-gen-go and a
+// script somebody forgot to chmod are different mistakes with different fixes.
+//
+// The mode is read rather than the kernel asked. See the package comment,
+// "Why not exec.LookPath".
+func unusable(info fs.FileInfo) string {
+	mode := info.Mode()
+
+	switch {
+	case mode.IsDir():
+		return "it is a directory"
+	case !mode.IsRegular():
+		return "it is not a regular file"
+	case mode.Perm()&0o111 == 0:
+		return "it carries no execute bit"
+	default:
+		return ""
+	}
+}
+
+// checkName refuses a name that cannot be a filename component.
+func checkName(name string) error {
+	if name == "" || strings.Contains(name, "/") {
+		return &InvalidNameError{Name: name}
+	}
+
+	return nil
+}

--- a/internal/plugin/resolve.go
+++ b/internal/plugin/resolve.go
@@ -29,8 +29,8 @@ const Prefix = "cpybkc-gen-"
 func Filename(name string) string { return Prefix + name }
 
 // Resolve finds the executable name resolves to by searching searchPath for
-// [Filename](name), and hands back the first one that is a regular file
-// carrying an execute bit.
+// the filename [Filename] spells it, and hands back the first one that is a
+// regular file carrying an execute bit.
 //
 // searchPath is a PATH — the value of the environment variable, colon-separated
 // on the POSIX hosts this project targets. It is passed rather than read, so

--- a/internal/plugin/resolve_test.go
+++ b/internal/plugin/resolve_test.go
@@ -1,0 +1,393 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package plugin
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The tests below build a PATH out of real directories and real files rather
+// than out of a filesystem abstraction, because what is under test is a
+// question about a mode bit and a directory entry — an abstraction would let
+// this package agree with a fake about what an execute bit is. They are POSIX
+// tests for a POSIX contract; docs/plugin/SPEC.md, "Host platform", is where
+// that is decided.
+
+// pathOf spells a PATH the way the host does, so that a test states the
+// directories and not the separator between them.
+func pathOf(dirs ...string) string { return strings.Join(dirs, string(os.PathListSeparator)) }
+
+// executable writes a file that is a candidate: a regular file with an execute
+// bit. It is a shell script because docs/plugin/SPEC.md says one is a
+// first-class plugin, and a test whose fixture was a compiled binary would be
+// testing something the contract does not require.
+func executable(t *testing.T, dir, name string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+
+	return path
+}
+
+// plain writes a file of the right name with no execute bit — the generator
+// somebody built and forgot to chmod.
+func plain(t *testing.T, dir, name string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+
+	return path
+}
+
+func TestFilenameIsTheNameUnderThePrefix(t *testing.T) {
+	if got, want := Filename("go"), "cpybkc-gen-go"; got != want {
+		t.Errorf("a generator named go is %q, want %q", got, want)
+	}
+
+	if got, want := Filename(""), Prefix; got != want {
+		t.Errorf("the empty name is %q, want %q", got, want)
+	}
+}
+
+// TestResolveFindsTheExecutableTheNameSpells is the whole of discovery: a name
+// and a PATH give the file whose name is the name under the prefix.
+func TestResolveFindsTheExecutableTheNameSpells(t *testing.T) {
+	dir := t.TempDir()
+	want := executable(t, dir, "cpybkc-gen-go")
+
+	// A neighbour of the right shape and the wrong name, so that a search that
+	// took whatever it found first would be caught rather than passed.
+	executable(t, dir, "cpybkc-gen-json-schema")
+
+	got, err := Resolve("go", pathOf(dir))
+	if err != nil {
+		t.Fatalf("resolving go on %s: %v", dir, err)
+	}
+
+	if got != want {
+		t.Errorf("go resolved to %s, want %s", got, want)
+	}
+
+	// Determinism, in the sense a caller depends on: one PATH and one name give
+	// one answer, and the answer moves when the filesystem does rather than
+	// between two calls.
+	if again, err := Resolve("go", pathOf(dir)); err != nil || again != got {
+		t.Errorf("resolving go again gave %s, %v; want %s and no error", again, err, got)
+	}
+}
+
+// TestTheEarliestMatchOnPATHWins pins the rule docs/plugin/SPEC.md states as
+// "in order, and the earliest match wins", from the gesture it argues from: a
+// plugin under development shadows an installed one by being in a directory
+// earlier on PATH, and the same two directories in the other order resolve to
+// the other file.
+func TestTheEarliestMatchOnPATHWins(t *testing.T) {
+	installed := t.TempDir()
+	development := t.TempDir()
+
+	installedPlugin := executable(t, installed, "cpybkc-gen-go")
+	developmentPlugin := executable(t, development, "cpybkc-gen-go")
+
+	got, err := Resolve("go", pathOf(development, installed))
+	if err != nil {
+		t.Fatalf("resolving go with the development directory first: %v", err)
+	}
+
+	if got != developmentPlugin {
+		t.Errorf("go resolved to %s, want the shadowing %s", got, developmentPlugin)
+	}
+
+	got, err = Resolve("go", pathOf(installed, development))
+	if err != nil {
+		t.Fatalf("resolving go with the installed directory first: %v", err)
+	}
+
+	if got != installedPlugin {
+		t.Errorf("go resolved to %s, want the installed %s", got, installedPlugin)
+	}
+}
+
+// TestAPathElementIsSearchedWhereItSaysAndSpelledAsItSays covers the relative
+// element, which is the working directory when and only when PATH writes it
+// out. The answer is spelled the way PATH spelled the directory, because making
+// it absolute would be this package deciding a relative element meant somewhere
+// else than it said.
+func TestAPathElementIsSearchedWhereItSaysAndSpelledAsItSays(t *testing.T) {
+	dir := t.TempDir()
+	executable(t, dir, "cpybkc-gen-go")
+
+	t.Chdir(dir)
+
+	got, err := Resolve("go", pathOf("."))
+	if err != nil {
+		t.Fatalf("resolving go on a PATH of .: %v", err)
+	}
+
+	if want := "cpybkc-gen-go"; got != want {
+		t.Errorf("go resolved to %s, want the relative %s", got, want)
+	}
+}
+
+// TestAnEmptyPathElementIsNotTheWorkingDirectory is the one place this search
+// departs from POSIX and from [os/exec.LookPath], and it departs on purpose:
+// docs/plugin/SPEC.md forbids it, because a generator picked up from whatever
+// directory a user happened to be standing in is an execution surface nobody
+// chose.
+func TestAnEmptyPathElementIsNotTheWorkingDirectory(t *testing.T) {
+	dir := t.TempDir()
+	executable(t, dir, "cpybkc-gen-go")
+
+	t.Chdir(dir)
+
+	for _, searchPath := range []string{"", pathOf("", ""), pathOf("", t.TempDir())} {
+		got, err := Resolve("go", searchPath)
+		if got != "" {
+			t.Errorf("go resolved to %s on a PATH of %q, want nothing", got, searchPath)
+		}
+
+		var notFound *NotFoundError
+		if !errors.As(err, &notFound) {
+			t.Fatalf("resolving go on a PATH of %q gave %v, want a NotFoundError", searchPath, err)
+		}
+
+		// An empty element names no directory, so it is not reported as one
+		// that was searched either.
+		for _, searched := range notFound.Searched {
+			if searched == "" || searched == "." {
+				t.Errorf("the search on %q reports looking in %q", searchPath, searched)
+			}
+		}
+	}
+}
+
+// TestOnlyARegularFileWithAnExecuteBitIsACandidate walks past the two files an
+// adopter actually produces — a directory of that name, and a script nobody
+// chmod'd — and takes the one further along PATH, which is what makes the rule
+// a search rule rather than a check on the first hit.
+func TestOnlyARegularFileWithAnExecuteBitIsACandidate(t *testing.T) {
+	first := t.TempDir()
+	second := t.TempDir()
+	third := t.TempDir()
+
+	directory := filepath.Join(first, "cpybkc-gen-go")
+	if err := os.Mkdir(directory, 0o755); err != nil {
+		t.Fatalf("making %s a directory: %v", directory, err)
+	}
+
+	unchmodded := plain(t, second, "cpybkc-gen-go")
+	want := executable(t, third, "cpybkc-gen-go")
+
+	got, err := Resolve("go", pathOf(first, second, third))
+	if err != nil {
+		t.Fatalf("resolving go past two files of the same name: %v", err)
+	}
+
+	if got != want {
+		t.Errorf("go resolved to %s, want %s", got, want)
+	}
+
+	// The same two files with nothing behind them are a fault that names both,
+	// because "it is there and cpybkc would not take it" is not a problem an
+	// adopter solves by rereading their PATH.
+	_, err = Resolve("go", pathOf(first, second))
+
+	var notFound *NotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("resolving go past both gave %v, want a NotFoundError", err)
+	}
+
+	wantPassed := []PassedOver{
+		{Path: directory, Fault: "it is a directory"},
+		{Path: unchmodded, Fault: "it carries no execute bit"},
+	}
+
+	if len(notFound.PassedOver) != len(wantPassed) {
+		t.Fatalf("the fault passed over %v, want %v", notFound.PassedOver, wantPassed)
+	}
+
+	for i, passed := range notFound.PassedOver {
+		if passed != wantPassed[i] {
+			t.Errorf("the fault passed over %v, want %v", passed, wantPassed[i])
+		}
+	}
+}
+
+// TestASymlinkToAnExecutableResolves is how a plugin installed by a package
+// manager usually appears, and the mode test has to see the file at the end of
+// the chain because that is the file that would be executed.
+func TestASymlinkToAnExecutableResolves(t *testing.T) {
+	store := t.TempDir()
+	bin := t.TempDir()
+
+	target := executable(t, store, "cpybkc-gen-go-1.2.3")
+	link := filepath.Join(bin, "cpybkc-gen-go")
+
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("linking %s to %s: %v", link, target, err)
+	}
+
+	got, err := Resolve("go", pathOf(bin))
+	if err != nil {
+		t.Fatalf("resolving go through a symlink: %v", err)
+	}
+
+	if got != link {
+		t.Errorf("go resolved to %s, want the link %s", got, link)
+	}
+}
+
+// TestASymlinkToADirectoryIsPassedOver is the same following, seen from the
+// other side: what a symlink points at is what the rule is applied to.
+func TestASymlinkToADirectoryIsPassedOver(t *testing.T) {
+	bin := t.TempDir()
+	link := filepath.Join(bin, "cpybkc-gen-go")
+
+	if err := os.Symlink(t.TempDir(), link); err != nil {
+		t.Fatalf("linking %s to a directory: %v", link, err)
+	}
+
+	_, err := Resolve("go", pathOf(bin))
+
+	var notFound *NotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("resolving go through a link to a directory gave %v, want a NotFoundError", err)
+	}
+
+	if len(notFound.PassedOver) != 1 || notFound.PassedOver[0].Fault != "it is a directory" {
+		t.Errorf("the fault passed over %v, want the link reported as a directory", notFound.PassedOver)
+	}
+}
+
+// TestAGeneratorInTheImagesPluginDirectoryResolves is the container case
+// (docs/container/SPEC.md, #54), and it is deliberately the same test as every
+// other one here: the image's contribution is a directory on PATH that a
+// derived image copies a generator into, so a plugin in it is found under the
+// rules a plugin on a laptop is found by. There is no container path in this
+// package to keep in step with that document.
+func TestAGeneratorInTheImagesPluginDirectoryResolves(t *testing.T) {
+	plugins := t.TempDir()
+	want := executable(t, plugins, "cpybkc-gen-go")
+
+	// The shape of a PATH inside an image: the system directories, and the one
+	// a derived image's COPY writes into.
+	image := pathOf("/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin", plugins)
+
+	got, err := Resolve("go", image)
+	if err != nil {
+		t.Fatalf("resolving go on an image-shaped PATH: %v", err)
+	}
+
+	if got != want {
+		t.Errorf("go resolved to %s, want %s", got, want)
+	}
+}
+
+// TestAnUnresolvableNameNamesTheExecutableItLookedFor is what the fault owes an
+// adopter: the file they have to install, which is not the string their
+// manifest names, and every directory that was looked in.
+func TestAnUnresolvableNameNamesTheExecutableItLookedFor(t *testing.T) {
+	first := t.TempDir()
+	second := t.TempDir()
+
+	_, err := Resolve("go", pathOf(first, second))
+
+	var notFound *NotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("resolving a generator nobody installed gave %v, want a NotFoundError", err)
+	}
+
+	if notFound.Name != "go" || notFound.File != "cpybkc-gen-go" {
+		t.Errorf("the fault is about %q and %q, want go and cpybkc-gen-go", notFound.Name, notFound.File)
+	}
+
+	if got := notFound.Searched; len(got) != 2 || got[0] != first || got[1] != second {
+		t.Errorf("the fault reports searching %v, want %v then %v", got, first, second)
+	}
+
+	if !strings.Contains(err.Error(), "cpybkc-gen-go") {
+		t.Errorf("the fault reads %q, want the executable named in it", err)
+	}
+}
+
+// TestANameThatCannotBeAFilenameIsRefused enforces docs/plugin/SPEC.md's two
+// MUSTs about a name at the point resolution happens, whatever route the name
+// arrived by. The empty name is refused even though `cpybkc-gen-` is on PATH:
+// what is on PATH is a file whose name carries no generator's name, and taking
+// it would let a manifest with an empty name run something.
+func TestANameThatCannotBeAFilenameIsRefused(t *testing.T) {
+	dir := t.TempDir()
+	executable(t, dir, Prefix)
+	executable(t, dir, "cpybkc-gen-go")
+
+	for _, name := range []string{"", "z5labs/go", "../go", "go/"} {
+		got, err := Resolve(name, pathOf(dir))
+		if got != "" {
+			t.Errorf("%q resolved to %s, want nothing", name, got)
+		}
+
+		var invalid *InvalidNameError
+		if !errors.As(err, &invalid) {
+			t.Errorf("resolving %q gave %v, want an InvalidNameError", name, err)
+
+			continue
+		}
+
+		if invalid.Name != name {
+			t.Errorf("the fault is about %q, want %q", invalid.Name, name)
+		}
+	}
+}
+
+// stat is a file's mode and nothing else, which is all [unusable] reads. It is
+// here because two of the four answers — a device, a socket — are things a test
+// cannot portably make in a temporary directory, and a rule with an untested
+// arm is a rule that has been written down twice rather than checked once.
+type stat struct{ mode fs.FileMode }
+
+func (s stat) Name() string       { return "cpybkc-gen-go" }
+func (s stat) Size() int64        { return 0 }
+func (s stat) Mode() fs.FileMode  { return s.mode }
+func (s stat) ModTime() time.Time { return time.Time{} }
+func (s stat) IsDir() bool        { return s.mode.IsDir() }
+func (s stat) Sys() any           { return nil }
+
+func TestUnusableSaysWhichRuleAFileFails(t *testing.T) {
+	tests := []struct {
+		mode fs.FileMode
+		want string
+	}{
+		{mode: 0o755, want: ""},
+		{mode: 0o700, want: ""},
+		{mode: 0o111, want: ""},
+		{mode: 0o001, want: ""},
+		{mode: 0o644, want: "it carries no execute bit"},
+		{mode: 0o000, want: "it carries no execute bit"},
+		{mode: fs.ModeDir | 0o755, want: "it is a directory"},
+		{mode: fs.ModeSocket | 0o755, want: "it is not a regular file"},
+		{mode: fs.ModeNamedPipe | 0o755, want: "it is not a regular file"},
+		{mode: fs.ModeDevice | 0o755, want: "it is not a regular file"},
+	}
+
+	for _, test := range tests {
+		if got := unusable(stat{mode: test.mode}); got != test.want {
+			t.Errorf("a file of mode %v is rejected as %q, want %q", test.mode, got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #41

`internal/plugin` is where a generator name becomes the executable that runs
it: `Resolve(name, searchPath)` searches `PATH` for `cpybkc-gen-<name>` and
hands back the first regular file carrying an execute bit. It is
[docs/plugin/SPEC.md's *Discovery*](https://github.com/Zaba505/cpybkc/blob/main/docs/plugin/SPEC.md#discovery)
implemented and nothing else — what a discovered executable is handed is #42's.

## Acceptance criteria

- [x] **A generator name resolves to `cpybkc-gen-<name>` on `PATH`** — `Resolve`
  walks the elements of a `PATH` it is given, joins `Filename(name)` onto each,
  and takes the first candidate. `Prefix` and `Filename` are the one place the
  filename is spelled, because the string that is searched for and the string a
  diagnostic reports missing have to be the same one.
- [x] **An unresolvable name errors naming the executable that was expected** —
  `NotFoundError` leads with it: *there is no generator named `"go"` on PATH;
  cpybkc looks for an executable named cpybkc-gen-go*, because the manifest says
  `"name": "go"` and the file to install is called something else. Under it,
  one indented line per file of that name the search would not take and why, and
  a last line naming every directory it looked in, in order:

  ```
  there is no generator named "go" on PATH; cpybkc looks for an executable named cpybkc-gen-go
    /home/dev/bin/cpybkc-gen-go: it carries no execute bit, so the search continued past it
    PATH was searched in order: /home/dev/bin, /usr/local/bin
  ```

- [x] **Resolution order documented and deterministic** — the order is the
  spec's, written by #39 and cited by the package comment rather than restated:
  `PATH` in order, earliest match wins, an empty element skipped rather than
  read as the working directory. Deterministic in the sense a caller depends on:
  one `PATH` and one name give one answer, and it moves when the filesystem does.
  `TestTheEarliestMatchOnPATHWins` pins it from the gesture the spec argues
  from — the same two directories in the other order resolve to the other file.
- [x] **Works inside the published container, where plugins live in the
  documented plugin directory** — by there being nothing in this package that
  knows about the image. The image's contribution is a directory on `PATH`
  (`docs/container/SPEC.md`, #54, which has not chosen the path yet), and a
  plugin in it is found under exactly the rules a plugin on a laptop is found
  by. `TestAGeneratorInTheImagesPluginDirectoryResolves` runs the search over an
  image-shaped `PATH`; it is deliberately the same test as the others, which is
  the property being claimed.

## Judgment calls that shaped the API

- **Not `exec.LookPath`.** It treats an empty `PATH` element as the working
  directory, which the spec forbids by name; it asks the kernel whether *this
  process* could execute the file, where the spec asks whether the file carries
  an execute bit; and it reports a relative resolution as `ErrDot`. The first is
  a conformance difference, so the search is written here.
- **The mode is read, not `eaccess(2)` asked.** The two differ for a file whose
  execute bit belongs to another user, and for root. Where they differ, the
  spec's wording is what a plugin author read; a file that is a candidate and
  cannot be executed fails at exec, which is #42's to report.
- **`PATH` is an argument, not `os.Getenv`.** Nothing here reads the
  environment, so the search is a function of what it was passed and a test of
  it does not move the process's own `PATH`. The caller writes
  `os.Getenv("PATH")` once.
- **The answer is spelled as `PATH` spells it.** A relative element resolves to
  a relative path, against the working directory the search was made from — what
  a shell does with the same `PATH`. Absolutising it would be this package
  deciding a relative element meant somewhere other than it said.
- **A file passed over is kept and reported.** The spec gives the search no way
  to stop at one, and it must not: it continues, as a shell's does. But "it is
  there and cpybkc would not take it" is a different problem from "it is not
  there", and its fix is usually one `chmod` that no amount of rereading a
  `PATH` reveals.
- **The name's two MUSTs are enforced here as well as in
  `internal/manifest`.** A name reaches `Resolve` from wherever a caller had
  one, and a `/` arriving by another route would turn into a search outside the
  directory being searched. The manifest reports it earlier and with the line in
  `cpybkc.json`; the wording is the same on purpose, so an adopter cannot tell
  which of the two stopped them.
- **Neither fault carries a span.** A generator that is not installed is wrong
  about the machine rather than about a line, and a span invented here would
  point at text that is not the mistake. Both still implement `diag.Error`, and
  what they carry instead is every place the search looked.
- **No README section.** `docs/CONVENTIONS.md` says cite rather than restate,
  and unlike the manifest, discovery already has a spec. The README's manifest
  table already points at it.

## Verification

`dagger call ci` — fmt, vet, lint, `go test -race`, the schema lint and the
release artifacts. Green. It failed twice first with
`resolve result: missing shared result`, a stale entry in the local Dagger
engine rather than anything in the tree; restarting the engine container cleared
it and the run above is the one that counts.

The package's tests are 100% of statements. The `PATH` is built out of real
directories and real files, because what is under test is a question about a
mode bit and a directory entry, and an abstraction would let this package agree
with a fake about what an execute bit is. The two file kinds a temporary
directory cannot portably hold — a socket, a device — are covered by a table
over `fs.FileMode` against the rule itself, so no arm of it is written down
without being checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)