### PR TITLE
story(plugin): invoke plugins with the resolved descriptor

### DIFF
--- a/internal/plugin/doc.go
+++ b/internal/plugin/doc.go
@@ -3,14 +3,48 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-// Package plugin finds the generator executables cpybkc runs.
+// Package plugin finds the generator executables cpybkc runs, and runs them.
 //
 // A generator has a name — the `<name>` a manifest asks for — and that name is
 // the whole of how it is identified. docs/plugin/SPEC.md's "Discovery" is the
 // contract: the executable is named `cpybkc-gen-<name>`, and cpybkc resolves a
 // name to one by searching PATH for exactly that filename. [Resolve] is that
-// search and nothing else; what a discovered executable is then handed, and
-// what it may do with the directory it writes into, is #42's and #43's.
+// search and nothing else.
+//
+// [Runner.Run] is the other half — "Invocation" and "Exit codes and
+// diagnostics": each generator is started once with the descriptor and the
+// directory it writes into, they run concurrently, what they write is surfaced
+// as they write it, and one that fails fails the run. What may be *in* the
+// directory afterwards, and how it reaches the project's output tree, is #43's
+// and #44's; this package hands a generator a path and reads its verdict.
+//
+// # Why running is here rather than beside the caller
+//
+// The argument vector is the contract. A third party implements against
+// docs/plugin/SPEC.md's "Invocation" and nothing else, so the vector is written
+// once, in the package that also spells the executable's name, and there is no
+// second place for a flag to be added to or a path to be left relative in. The
+// same reasoning puts the descriptor's lifetime here: the file's creation, its
+// mode and its removal are three halves of one promise to a plugin author, and
+// a caller holding any of them could keep two.
+//
+// # What a run is a function of
+//
+// A descriptor, a list of invocations, and an environment — and the first two
+// are arguments while the third is a field, for the reason PATH is an argument
+// to [Resolve]. The bytes a generator is handed are
+// [github.com/Zaba505/cpybkc/internal/emit.Marshal]'s, which is the function
+// --emit-ir writes, so "the descriptor a plugin got is the descriptor --emit-ir
+// writes" is true by there being one encoder rather than by two agreeing.
+//
+// # Concurrency, and what it does not buy
+//
+// Generators run at the same time because they are independent processes with
+// disjoint output directories and no reason to queue. What that does not change
+// is the run's answer: every generator is run to completion even after one has
+// failed, and the failures are reported in the order the invocations were
+// declared, so the same inputs fail the same way twice. A run that stopped at
+// the first failure would report whichever generator lost a race.
 //
 // This is not the standard library's plugin package and has nothing to do with
 // it. A cpybkc generator is a process with an argument vector, not a shared
@@ -31,7 +65,10 @@
 // It also reads no environment. The PATH to search is an argument, because a
 // package that read one would be a second place the search could come from,
 // and a test of it would have to move the process's own environment to say
-// anything.
+// anything. [Runner.Env] is the same rule at the other end: docs/plugin/SPEC.md
+// requires cpybkc's own environment to reach a generator unchanged, and the
+// pass-through a nil Env asks for is [os/exec]'s rather than a set of variables
+// read and rebuilt here.
 //
 // # Why not exec.LookPath
 //

--- a/internal/plugin/errors.go
+++ b/internal/plugin/errors.go
@@ -9,17 +9,21 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/Zaba505/cpybkc/internal/diag"
 )
 
-// Neither fault here carries a position in a file, and both are still
+// No fault here carries a position in a file, and every one of them is still
 // [github.com/Zaba505/cpybkc/internal/diag.Error]. A generator that is not on
 // PATH is wrong about the machine rather than about a line: cpybkc.json can name
 // a generator that is perfectly well spelled and simply not installed, so a
 // diagnostic that pointed at the name would be pointing at text that is not the
 // mistake. What these carry instead is every place the search did look, in the
-// order it looked, which is the half an adopter cannot see for themselves.
+// order it looked, which is the half an adopter cannot see for themselves. A
+// generator that ran and failed is the same shape of fault one step later: the
+// mistake is inside an executable this repository did not write, so what the
+// diagnostic can offer is which generator it was and what it did.
 //
 // A caller that does hold a position — the stage that read the manifest — is
 // free to say so around one of these. It is not said here, because a package
@@ -136,6 +140,182 @@ func (e *NotFoundError) Diagnostic() diag.Diagnostic {
 		Message: fmt.Sprintf("there is no generator named %s on PATH; cpybkc looks for an executable named %s",
 			quote(e.Name), e.File),
 		Spans: append(spans, diag.Span{Note: searched}),
+	}
+}
+
+// InvalidOptionError is an option key that cannot be half of a `--opt k=v`.
+//
+// docs/plugin/SPEC.md: everything before the first `=` of the argument is the
+// key, so a key MUST be non-empty and MUST NOT contain one — a key carrying an
+// `=` would reach the generator split somewhere the manifest did not write it,
+// under a name nobody chose, and the generator would refuse a key its author
+// had never heard of.
+//
+// [github.com/Zaba505/cpybkc/internal/manifest] refuses both earlier and with
+// the line in cpybkc.json they were written at. This is the same MUST enforced
+// for the second audience, exactly as [InvalidNameError] is: an option reaches
+// an [Invocation] from wherever the caller had one, and one that arrived by
+// another route would otherwise be passed on as an argument this contract does
+// not define.
+type InvalidOptionError struct {
+	// Name is the generator the option was declared for.
+	Name string
+
+	// Key is what was written for the key.
+	Key string
+}
+
+// Error implements the error interface.
+func (e *InvalidOptionError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *InvalidOptionError) Diagnostic() diag.Diagnostic {
+	opening := "an option key is the k of the --opt k=v the generator " + quote(e.Name) + " is passed, and "
+
+	message := opening + quote(e.Key) + " contains an ="
+	if e.Key == "" {
+		message = opening + "this one is empty"
+	}
+
+	return diag.Diagnostic{Message: message}
+}
+
+// DescriptorError is a descriptor that could not be put where a generator could
+// read it.
+//
+// The generator never ran: docs/plugin/SPEC.md requires the file to be written
+// in full and closed first, so a failure here is one that happened before there
+// was an invocation to fail. It is reported as the generator's all the same,
+// because a run naming no generator leaves a user with several to look at.
+type DescriptorError struct {
+	// Name is the generator whose descriptor it was.
+	Name string
+
+	// Err is what went wrong, from the filesystem.
+	Err error
+}
+
+// Error implements the error interface.
+func (e *DescriptorError) Error() string { return e.Diagnostic().String() }
+
+// Unwrap is the filesystem's error, so that a caller can ask what kind of
+// failure it was.
+func (e *DescriptorError) Unwrap() error { return e.Err }
+
+// Diagnostic is what the error says, and where.
+func (e *DescriptorError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf("the descriptor for the generator %s could not be written, so it was not run: %v",
+			quote(e.Name), e.Err),
+	}
+}
+
+// StartError is a generator that could not be started.
+//
+// It is distinct from a non-zero exit because nothing ran: the executable
+// resolved and then would not execute — an interpreter its `#!` line names and
+// the machine has not got is the usual one, and it is reported by the kernel as
+// a file that is not there, naming a file the adopter can see perfectly well.
+type StartError struct {
+	// Name is the generator that was to be run.
+	Name string
+
+	// File is the executable that was to run it, as [Resolve] spelled it.
+	File string
+
+	// Err is what went wrong, from the operating system.
+	Err error
+}
+
+// Error implements the error interface.
+func (e *StartError) Error() string { return e.Diagnostic().String() }
+
+// Unwrap is the operating system's error.
+func (e *StartError) Unwrap() error { return e.Err }
+
+// Diagnostic is what the error says, and where.
+func (e *StartError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf("the generator %s could not be started: %v", quote(e.Name), e.Err),
+		Spans:   []diag.Span{{}, {File: e.File, Note: "this is the executable that would have run"}},
+	}
+}
+
+// ExitError is a generator that ran and exited non-zero.
+//
+// docs/plugin/SPEC.md: a non-zero exit means the invocation failed, cpybkc MUST
+// fail the run naming the generator, and no meaning beyond failure is attached
+// to the particular value — the small integers are already spoken for by a
+// shell's 126 and 127 and by the 128-plus-signal a shell reports a killed
+// process as. The number is carried because it is what the generator said and
+// an author debugging one wants to see it, not because cpybkc read anything
+// into it.
+//
+// Why the generator's own explanation is not in here: it was on standard error,
+// and it has already reached the user through the log, attributed and at the
+// level the plugin asked for. Holding it back to put it in this message would
+// be surfacing a diagnostic when the process ended rather than when it was
+// written, which is the one thing the contract says not to do with a plugin's
+// stderr.
+type ExitError struct {
+	// Name is the generator that failed.
+	Name string
+
+	// File is the executable that ran, as [Resolve] spelled it.
+	File string
+
+	// Code is the exit status it exited with.
+	Code int
+}
+
+// Error implements the error interface.
+func (e *ExitError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *ExitError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf("the generator %s failed: it exited %d", quote(e.Name), e.Code),
+		Spans:   []diag.Span{{}, {File: e.File, Note: "this is the executable that ran"}},
+	}
+}
+
+// SignalError is a generator that was killed rather than one that failed.
+//
+// docs/plugin/SPEC.md requires the two to be distinguishable, and this type is
+// how: a caller asserts against it rather than reading a number out of an exit
+// status. They need different responses — a non-zero exit is a bug in the
+// generator, a signal is usually the run being cancelled or the machine running
+// out of memory — and a report that flattened them would send the user looking
+// in the wrong place, most often at a generator that did nothing wrong.
+type SignalError struct {
+	// Name is the generator that was killed.
+	Name string
+
+	// File is the executable that was running, as [Resolve] spelled it.
+	File string
+
+	// Signal is the signal that killed it.
+	Signal syscall.Signal
+}
+
+// Error implements the error interface.
+func (e *SignalError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+//
+// The signal is named twice, by number and by the description the runtime gives
+// it, because neither is enough on its own: "killed" does not say which signal
+// and 9 does not say what happened. The name is not spelled SIGKILL, because a
+// table of those in this repository would be a second answer to what a signal
+// is called and would rot the first time a host defined one it did not have.
+func (e *SignalError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf("the generator %s was terminated by signal %d (%s)", quote(e.Name), int(e.Signal), e.Signal),
+		Spans: []diag.Span{
+			{},
+			{File: e.File, Note: "this is the executable that was running"},
+			{Note: "a generator that is killed is usually the run being cancelled or the machine running out of memory, rather than a fault in the generator"},
+		},
 	}
 }
 

--- a/internal/plugin/invoke.go
+++ b/internal/plugin/invoke.go
@@ -1,0 +1,458 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package plugin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+	"github.com/Zaba505/cpybkc/internal/emit"
+	"github.com/Zaba505/cpybkc/irpb"
+)
+
+// The flags of the argument vector, spelled once.
+//
+// docs/plugin/SPEC.md, "Invocation": the vector is
+// `cpybkc-gen-<name> --descriptor <path> --out <dir> [--opt k=v ...]` and
+// nothing else. They are constants because each name is written by the code
+// that builds the vector and read by the test that pins it, and a vector the
+// tests agree with and a plugin does not is the one failure this contract
+// cannot afford.
+const (
+	descriptorFlag = "--descriptor"
+	outFlag        = "--out"
+	optFlag        = "--opt"
+)
+
+// descriptorFile is what the descriptor is called inside the directory written
+// for one invocation.
+//
+// docs/plugin/SPEC.md: a plugin MUST NOT derive anything from the file's name
+// or its directory, so this name is implementation and not contract. It is
+// spelled to be recognisable in an strace or a `ps` line all the same, because
+// the one reader it is for is whoever is working out what cpybkc handed a
+// generator.
+const descriptorFile = "descriptor.bin"
+
+// descriptorDirPattern is the prefix [os.MkdirTemp] builds the per-invocation
+// directory's name from.
+const descriptorDirPattern = "cpybkc-descriptor-"
+
+// Option is one option a generator is invoked with, which reaches it as a
+// single `--opt k=v` argument.
+//
+// It is this package's own rather than
+// [github.com/Zaba505/cpybkc/internal/manifest.Option], for the reason
+// [Resolve] takes a name rather than a manifest entry: an option reaches an
+// invocation from wherever the caller had one, and a package that ran
+// generators only for callers holding a parsed cpybkc.json could not be driven
+// by a test or by a flag. The manifest is where a project's options are
+// written, and it is the caller that carries them across.
+type Option struct {
+	// Key is the option's name, which docs/plugin/SPEC.md requires to be
+	// non-empty and to contain no `=` — everything before the first `=` of the
+	// argument is the key, so a key carrying one would be split somewhere the
+	// manifest did not write.
+	Key string
+
+	// Value is what is passed for it. It may be empty and may contain further
+	// `=` characters, both of which the contract allows.
+	Value string
+}
+
+// argument is the option as it appears in the vector.
+func (o Option) argument() string { return o.Key + "=" + o.Value }
+
+// Invocation is one generator to run: the executable [Resolve] found, under the
+// name it was asked for, with the directory it writes into and the options it
+// was declared with.
+type Invocation struct {
+	// Name is the generator's name — the `<name>` a manifest asked for. It is
+	// what every diagnostic about this invocation names, and what the lines the
+	// generator writes are attributed to.
+	Name string
+
+	// Path is the executable to run, as [Resolve] spelled it.
+	Path string
+
+	// Out is the directory this generator writes its output into, which
+	// reaches it as `--out`.
+	//
+	// It is the caller's: creating the scratch directory, enforcing that
+	// nothing is written outside it and merging what is left in it are #43's
+	// and #44's, and an invocation that created its own would be a second
+	// answer to where a generator's output goes. What happens here is only that
+	// the path is made absolute, because docs/plugin/SPEC.md requires the
+	// vector to carry one.
+	Out string
+
+	// Options are the options to pass, in the order they are to be passed —
+	// which docs/plugin/SPEC.md fixes as the order the manifest declares them,
+	// so that the vector is a function of the manifest rather than of a map
+	// iteration.
+	Options []Option
+}
+
+// Runner runs generators.
+//
+// The zero value runs them: the process's own environment is passed through,
+// the per-invocation descriptor directories are made wherever the system puts
+// temporary files, and what the generators write is surfaced through
+// [slog.Default].
+type Runner struct {
+	// Log is where a generator's output is surfaced. A nil Log is
+	// [slog.Default] read at the moment of the run, so that a caller that
+	// configures the default logger after building a Runner is still heard.
+	Log *slog.Logger
+
+	// Env is the environment every generator is started with, in
+	// [os/exec.Cmd.Env]'s form. Nil is this process's environment, which is
+	// what docs/plugin/SPEC.md, "The environment", requires: cpybkc passes its
+	// own environment through unchanged, and the propagation of
+	// SOURCE_DATE_EPOCH that determinism rests on (#47) is that pass-through
+	// rather than a variable this package names.
+	//
+	// It is a field rather than something read here so that a test can state an
+	// environment instead of moving the one the test binary runs in; the same
+	// reasoning makes [Resolve] take a PATH.
+	Env []string
+
+	// TempDir is where the directory holding one invocation's descriptor is
+	// created. Empty is the default [os.MkdirTemp] uses.
+	TempDir string
+}
+
+// Run runs every invocation against d, concurrently, and reports every one that
+// failed.
+//
+// docs/plugin/SPEC.md, "Invocation": each generator is started once, with
+// `--descriptor <path> --out <dir>` and one `--opt k=v` per declared option in
+// the declared order, both paths absolute and no other argument. The descriptor
+// is [github.com/Zaba505/cpybkc/internal/emit.Marshal]'s bytes — the same
+// function --emit-ir writes, so that what a plugin is handed and what an author
+// captured for the same inputs are byte-identical by construction rather than
+// by two encoders agreeing.
+//
+// Every generator is run, even after one has failed. Nothing reaches the
+// project's output tree until all of them have succeeded (#43, #44), so
+// stopping early would buy nothing back and would make the set of failures a
+// user is shown depend on which generator lost a race — a run reports what is
+// wrong with it, in the order the invocations were declared, however many
+// things that is.
+//
+// A generator that exits non-zero is an [ExitError] naming it, and one killed
+// by a signal is a [SignalError], which is the distinction docs/plugin/SPEC.md
+// requires: the first is a bug in the generator and the second is usually the
+// run being cancelled or the machine running out of memory. A generator that
+// exits zero after writing an `error:` diagnostic has succeeded — the exit
+// status is the verdict and the diagnostics are the explanation.
+//
+// The context bounds the run: cancelling it kills every generator still
+// running, which surfaces as the signal that killed them.
+func (r *Runner) Run(ctx context.Context, d *irpb.Descriptor, invocations []Invocation) error {
+	if len(invocations) == 0 {
+		return nil
+	}
+
+	// Every invocation is checked before any generator starts. An option key
+	// that cannot be half of `k=v`, or a name that cannot be a filename, is a
+	// fault in what the caller assembled rather than something a generator
+	// could report — and unlike an unrecognised key, which only the plugin
+	// knows about (docs/plugin/SPEC.md, "Options"), it is knowable here.
+	var invalid diag.List
+
+	for _, invocation := range invocations {
+		invalid.Fail(invocation.check())
+	}
+
+	if invalid.Failed() {
+		return invalid.Err()
+	}
+
+	descriptor, err := emit.Marshal(d)
+	if err != nil {
+		return err
+	}
+
+	// Indexed rather than appended to under a lock: the faults are reported in
+	// the order the invocations were declared, and an order that depended on
+	// which generator finished first would make the same failing run read
+	// differently twice.
+	faults := make([]error, len(invocations))
+
+	var running sync.WaitGroup
+
+	for i, invocation := range invocations {
+		running.Add(1)
+
+		go func() {
+			defer running.Done()
+
+			faults[i] = r.invoke(ctx, invocation, descriptor)
+		}()
+	}
+
+	running.Wait()
+
+	var failed diag.List
+
+	for _, fault := range faults {
+		failed.Fail(fault)
+	}
+
+	return failed.Err()
+}
+
+// invoke runs one generator to completion and reports how it ended.
+func (r *Runner) invoke(ctx context.Context, invocation Invocation, descriptor []byte) error {
+	// docs/plugin/SPEC.md, "The descriptor's location and lifetime": the
+	// descriptor goes in a directory cpybkc creates for this one invocation and
+	// nothing else, is never shared between two generators or two runs, and is
+	// removed with its directory once the generator has exited — whether it
+	// exited zero or not. One directory per invocation is what makes the bytes
+	// attributable; the removal is the whole of the file's lifetime.
+	dir, err := os.MkdirTemp(r.TempDir, descriptorDirPattern)
+	if err != nil {
+		return &DescriptorError{Name: invocation.Name, Err: err}
+	}
+
+	defer func() {
+		// The removal is not reported. It happens after the generator has
+		// exited, so there is nothing left to fail, and a run that succeeded
+		// and could not tidy up afterwards has not failed at anything the user
+		// asked for.
+		_ = os.RemoveAll(dir)
+	}()
+
+	path, err := writeDescriptor(dir, descriptor)
+	if err != nil {
+		return &DescriptorError{Name: invocation.Name, Err: err}
+	}
+
+	out, err := filepath.Abs(invocation.Out)
+	if err != nil {
+		return &DescriptorError{Name: invocation.Name, Err: err}
+	}
+
+	return r.run(ctx, invocation, invocation.arguments(path, out))
+}
+
+// outputGrace is how long a generator's output is waited for once there is no
+// generator left to write it.
+//
+// It is [os/exec.Cmd.WaitDelay], and what it bounds is a plugin that started
+// something of its own and exited without waiting for it: the child inherits
+// the pipes, so the read end stays open and a run would otherwise wait for a
+// process it never started and cannot see. It also bounds the same delay after
+// a cancelled run, where the generator has been killed and its own child has
+// not.
+//
+// Five seconds because the delay is only ever reached by a plugin that has
+// already misbehaved, and the cost of reaching it is paid once per such plugin;
+// a shorter grace would start truncating the output of a generator writing a
+// long explanation as it exits.
+const outputGrace = 5 * time.Second
+
+// run starts the generator, surfaces what it writes, and waits for it.
+func (r *Runner) run(ctx context.Context, invocation Invocation, args []string) error {
+	cmd := exec.CommandContext(ctx, invocation.Path, args...)
+	cmd.Env = r.Env
+
+	// Standard input is unused: docs/plugin/SPEC.md gives it a meaning only for
+	// `--descriptor -`, which cpybkc never emits. A nil Stdin is the empty
+	// file, so a generator that reads it anyway sees end of file rather than
+	// whatever cpybkc was started with.
+	cmd.Stdin = nil
+
+	// The streams are pipes of this package's own rather than
+	// [os/exec.Cmd.StdoutPipe]'s, and the difference is what happens when a
+	// generator leaves a child holding its output. Wait is what closes the
+	// pipes it hands out, and it is also what waits for the reads — so reading
+	// those to end of file before calling Wait deadlocks against a grandchild
+	// nobody is going to kill. With a pipe of ours, Wait bounds itself with
+	// [outputGrace], and the reads end when this ends them.
+	out, outWriter := io.Pipe()
+	errs, errWriter := io.Pipe()
+
+	cmd.Stdout = outWriter
+	cmd.Stderr = errWriter
+	cmd.WaitDelay = outputGrace
+
+	log := r.logger().With(slog.String("generator", invocation.Name))
+
+	// Both streams are read as the generator writes them, because
+	// docs/plugin/SPEC.md requires a line to be surfaced when it is written
+	// rather than held back until the process exits.
+	var streams sync.WaitGroup
+
+	streams.Add(2)
+
+	go func() {
+		defer streams.Done()
+
+		surface(ctx, log, stdoutStream, out)
+	}()
+
+	go func() {
+		defer streams.Done()
+
+		surface(ctx, log, stderrStream, errs)
+	}()
+
+	if err := cmd.Start(); err != nil {
+		closeStreams(outWriter, errWriter)
+		streams.Wait()
+
+		return &StartError{Name: invocation.Name, File: invocation.Path, Err: err}
+	}
+
+	waited := cmd.Wait()
+
+	closeStreams(outWriter, errWriter)
+	streams.Wait()
+
+	// The generator exited zero and something it started was still holding the
+	// pipes when the grace ran out. The exit status is the verdict, so that is
+	// not a failed run (docs/plugin/SPEC.md, "Exit codes and diagnostics") —
+	// but the output is short by however much that child had not written, and a
+	// user reading an explanation with the end missing deserves to know which.
+	if errors.Is(waited, exec.ErrWaitDelay) {
+		log.LogAttrs(ctx, slog.LevelWarn,
+			"this generator exited while something it started still held its output open; the rest of that output was not waited for")
+
+		return nil
+	}
+
+	return failure(invocation, waited)
+}
+
+// closeStreams ends the reads, which is what makes the surfacing goroutines
+// return once there is nothing left to write into them.
+func closeStreams(writers ...*io.PipeWriter) {
+	for _, w := range writers {
+		// The only error [io.PipeWriter.Close] reports is that it was already
+		// closed, which it was not.
+		_ = w.Close()
+	}
+}
+
+// failure reads what [os/exec.Cmd.Wait] said as the verdict on an invocation.
+func failure(invocation Invocation, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var exit *exec.ExitError
+	if !errors.As(err, &exit) {
+		// Not the generator's verdict but a failure to collect it — a pipe that
+		// could not be closed, a process that could not be reaped. It is still
+		// a failed invocation and still names the generator, because that is
+		// what the user has to act on.
+		return fmt.Errorf("the generator %s could not be waited for: %w", quote(invocation.Name), err)
+	}
+
+	// docs/plugin/SPEC.md, "Exit codes and diagnostics": a generator terminated
+	// by a signal MUST be reported as terminated by that signal, and
+	// distinguishably from one that exited non-zero. [os/exec.ExitError.ExitCode]
+	// flattens the two into -1, so the wait status is read instead. It is a
+	// POSIX wait status because cpybkc targets POSIX hosts and nothing else;
+	// see docs/plugin/SPEC.md, "Host platform".
+	if status, ok := exit.Sys().(syscall.WaitStatus); ok && status.Signaled() {
+		return &SignalError{Name: invocation.Name, File: invocation.Path, Signal: status.Signal()}
+	}
+
+	return &ExitError{Name: invocation.Name, File: invocation.Path, Code: exit.ExitCode()}
+}
+
+// logger is where this run's output goes.
+func (r *Runner) logger() *slog.Logger {
+	if r.Log != nil {
+		return r.Log
+	}
+
+	return slog.Default()
+}
+
+// writeDescriptor puts the descriptor in dir and hands back the absolute path
+// the generator is passed.
+//
+// docs/plugin/SPEC.md: the file MUST be written in full and closed before the
+// generator is started, so that a plugin never observes a partial descriptor
+// and needs no protocol to find out whether the bytes it can see are all of
+// them. [os.WriteFile] is that, and the mode is the SHOULD beside it — a
+// read-only file does not enforce the prohibition on writing to the descriptor,
+// which a plugin running as the file's owner can undo, but it turns the
+// accidental case into an error where the mistake is rather than into a
+// descriptor quietly different from the one cpybkc wrote.
+func writeDescriptor(dir string, descriptor []byte) (string, error) {
+	path, err := filepath.Abs(filepath.Join(dir, descriptorFile))
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.WriteFile(path, descriptor, 0o444); err != nil {
+		return "", err
+	}
+
+	return path, nil
+}
+
+// arguments is the vector the generator is run with.
+//
+// docs/plugin/SPEC.md: `--descriptor` and `--out` appear exactly once each,
+// `--opt` once per declared option in the declared order, every flag in the
+// separated form, and nothing else at all — no operand, and nothing taken from
+// the environment. The vector is therefore a function of this invocation, which
+// is what makes two runs of the same generator from different directories the
+// same invocation.
+func (inv Invocation) arguments(descriptor, out string) []string {
+	args := make([]string, 0, 4+2*len(inv.Options))
+	args = append(args, descriptorFlag, descriptor, outFlag, out)
+
+	for _, option := range inv.Options {
+		args = append(args, optFlag, option.argument())
+	}
+
+	return args
+}
+
+// check refuses an invocation that cannot be run as written.
+func (inv Invocation) check() error {
+	if err := checkName(inv.Name); err != nil {
+		return err
+	}
+
+	for _, option := range inv.Options {
+		if option.Key == "" || strings.Contains(option.Key, "=") {
+			return &InvalidOptionError{Name: inv.Name, Key: option.Key}
+		}
+	}
+
+	// Neither of these is an adopter's mistake — a manifest cannot express an
+	// invocation with no executable to run or nowhere to write — so they are
+	// plain errors rather than diagnostics. What they are is the caller having
+	// assembled an invocation it never resolved.
+	if inv.Path == "" {
+		return fmt.Errorf("the generator %s has no executable to run; resolve the name first", quote(inv.Name))
+	}
+
+	if inv.Out == "" {
+		return fmt.Errorf("the generator %s has no directory to write into", quote(inv.Name))
+	}
+
+	return nil
+}

--- a/internal/plugin/invoke.go
+++ b/internal/plugin/invoke.go
@@ -219,6 +219,18 @@ func (r *Runner) Run(ctx context.Context, d *irpb.Descriptor, invocations []Invo
 
 // invoke runs one generator to completion and reports how it ended.
 func (r *Runner) invoke(ctx context.Context, invocation Invocation, descriptor []byte) error {
+	// docs/plugin/SPEC.md requires --out to be passed absolute, and this is
+	// where a relative one written in a manifest becomes so. It is resolved
+	// before the descriptor is written rather than after, so that a failure
+	// here is reported as what it is and leaves nothing behind to remove: the
+	// only way it fails is the process having no working directory to resolve
+	// against, which is not something a descriptor could be at fault for.
+	out, err := filepath.Abs(invocation.Out)
+	if err != nil {
+		return fmt.Errorf("the generator %s could not be given an absolute path to %s: %w",
+			quote(invocation.Name), invocation.Out, err)
+	}
+
 	// docs/plugin/SPEC.md, "The descriptor's location and lifetime": the
 	// descriptor goes in a directory cpybkc creates for this one invocation and
 	// nothing else, is never shared between two generators or two runs, and is
@@ -239,11 +251,6 @@ func (r *Runner) invoke(ctx context.Context, invocation Invocation, descriptor [
 	}()
 
 	path, err := writeDescriptor(dir, descriptor)
-	if err != nil {
-		return &DescriptorError{Name: invocation.Name, Err: err}
-	}
-
-	out, err := filepath.Abs(invocation.Out)
 	if err != nil {
 		return &DescriptorError{Name: invocation.Name, Err: err}
 	}

--- a/internal/plugin/invoke_test.go
+++ b/internal/plugin/invoke_test.go
@@ -1,0 +1,645 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/Zaba505/cpybkc/internal/emit"
+	"github.com/Zaba505/cpybkc/irpb"
+)
+
+// The generators below are shell scripts, because docs/plugin/SPEC.md makes one
+// a first-class plugin and because a test whose fixture was a compiled binary
+// would be testing a toolchain rather than a contract. They are real processes
+// against a real filesystem for the reason resolve_test.go gives: what is under
+// test is a question about processes, and an abstraction would let this package
+// agree with a fake about what one is.
+
+// generator writes an executable plugin named for name, running body, and hands
+// back the [Invocation] that runs it into out.
+func generator(t *testing.T, name, body, out string) Invocation {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), Filename(name))
+
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body+"\n"), 0o755); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+
+	return Invocation{Name: name, Path: path, Out: out}
+}
+
+// env is an environment for a generator: PATH, so that a shell script can reach
+// the commands it calls, and whatever else the test is about.
+//
+// PATH is stated rather than inherited because [Runner.Env] is either the whole
+// environment or nothing; a test that left it nil would be asserting against the
+// environment the test binary happened to be started with.
+func env(kv ...string) []string {
+	return append([]string{"PATH=" + os.Getenv("PATH")}, kv...)
+}
+
+// descriptor is the message every run below hands over: a whole descriptor
+// rather than a version field, so that the bytes being compared are bytes a
+// resolved layout would produce.
+func descriptor() *irpb.Descriptor {
+	return &irpb.Descriptor{
+		Version: irpb.IrVersion_IR_VERSION_1,
+		Nodes: []*irpb.Node{
+			{
+				Id: 1,
+				Kind: &irpb.Node_File{File: &irpb.File{
+					Framing:      &irpb.File_Unframed{Unframed: &irpb.Unframed{}},
+					StartStateId: 2,
+				}},
+			},
+			{
+				Id:   2,
+				Kind: &irpb.Node_State{State: &irpb.State{Accepts: true}},
+			},
+		},
+	}
+}
+
+// runner is a runner whose output goes somewhere a test can read but need not.
+func runner(t *testing.T, kv ...string) *Runner {
+	t.Helper()
+
+	log, _ := recorder()
+
+	return &Runner{Log: log, TempDir: t.TempDir(), Env: env(kv...)}
+}
+
+// run runs invocations against [descriptor] and hands back the run's verdict.
+func run(t *testing.T, invocations ...Invocation) error {
+	t.Helper()
+
+	return runner(t).Run(t.Context(), descriptor(), invocations)
+}
+
+// lines is what a plugin recorded, one per line, with the trailing newline
+// dropped.
+func lines(t *testing.T, path string) []string {
+	t.Helper()
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+
+	return strings.Split(strings.TrimSuffix(string(b), "\n"), "\n")
+}
+
+// echoArgv is a generator that records the vector it was handed, one argument
+// per line, so that an assertion is against the arguments and not against a
+// rendering in which a space and a separator look the same.
+const echoArgv = `for arg in "$@"; do echo "$arg" >> "$OUT/argv"; done`
+
+func TestAGeneratorIsRunWithTheVectorTheContractDefines(t *testing.T) {
+	t.Parallel()
+
+	out := t.TempDir()
+
+	invocation := generator(t, "go", echoArgv, out)
+	invocation.Options = []Option{
+		{Key: "package", Value: "orders"},
+		{Key: "module", Value: "example.com/x"},
+	}
+
+	if err := runner(t, "OUT="+out).Run(t.Context(), descriptor(), []Invocation{invocation}); err != nil {
+		t.Fatalf("running the generator: %v", err)
+	}
+
+	argv := lines(t, filepath.Join(out, "argv"))
+
+	// Nothing beyond the four arguments and the two options:
+	// docs/plugin/SPEC.md, "Invocation", forbids cpybkc adding any.
+	if len(argv) != 8 {
+		t.Fatalf("the generator was passed %d arguments, want 8: %q", len(argv), argv)
+	}
+
+	if got, want := argv[0], descriptorFlag; got != want {
+		t.Errorf("argv[0] = %q, want %q", got, want)
+	}
+
+	if got, want := argv[2], outFlag; got != want {
+		t.Errorf("argv[2] = %q, want %q", got, want)
+	}
+
+	if got, want := argv[3], out; got != want {
+		t.Errorf("--out was passed %q, want %q", got, want)
+	}
+
+	// The options are in the order they were declared, which is the order the
+	// manifest declared them; docs/plugin/SPEC.md makes the vector a function
+	// of the manifest rather than of a map iteration.
+	if got, want := argv[4:], []string{optFlag, "package=orders", optFlag, "module=example.com/x"}; !slices.Equal(got, want) {
+		t.Errorf("the options were passed as %q, want %q", got, want)
+	}
+}
+
+func TestAnOptionValueMayBeEmptyOrCarryFurtherEquals(t *testing.T) {
+	t.Parallel()
+
+	out := t.TempDir()
+
+	invocation := generator(t, "go", echoArgv, out)
+	invocation.Options = []Option{
+		{Key: "bare", Value: ""},
+		{Key: "expr", Value: "a=b=c"},
+	}
+
+	if err := runner(t, "OUT="+out).Run(t.Context(), descriptor(), []Invocation{invocation}); err != nil {
+		t.Fatalf("running the generator: %v", err)
+	}
+
+	argv := lines(t, filepath.Join(out, "argv"))
+
+	if got, want := argv[4:], []string{optFlag, "bare=", optFlag, "expr=a=b=c"}; !slices.Equal(got, want) {
+		t.Errorf("the options were passed as %q, want %q", got, want)
+	}
+}
+
+func TestBothPathsArePassedAbsolute(t *testing.T) {
+	t.Parallel()
+
+	out := t.TempDir()
+
+	invocation := generator(t, "go", echoArgv, out)
+
+	// A relative --out is what a manifest can perfectly well write, and
+	// docs/plugin/SPEC.md says the generator is handed an absolute one all the
+	// same: two runs of the same generator from different directories have to
+	// be the same invocation.
+	working, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("reading the working directory: %v", err)
+	}
+
+	relative, err := filepath.Rel(working, out)
+	if err != nil {
+		t.Fatalf("relativising %s: %v", out, err)
+	}
+
+	invocation.Out = relative
+
+	if err := runner(t, "OUT="+out).Run(t.Context(), descriptor(), []Invocation{invocation}); err != nil {
+		t.Fatalf("running the generator: %v", err)
+	}
+
+	argv := lines(t, filepath.Join(out, "argv"))
+
+	for i, flag := range map[int]string{1: descriptorFlag, 3: outFlag} {
+		if !filepath.IsAbs(argv[i]) {
+			t.Errorf("%s was passed %q, which is not absolute", flag, argv[i])
+		}
+	}
+
+	if got, want := argv[3], out; got != want {
+		t.Errorf("--out was passed %q, want the directory it names, %q", got, want)
+	}
+}
+
+func TestTheDescriptorIsTheBytesEmitIRWrites(t *testing.T) {
+	t.Parallel()
+
+	out := t.TempDir()
+
+	invocation := generator(t, "go", `cat "$2" > "$4/descriptor"`, out)
+
+	if err := run(t, invocation); err != nil {
+		t.Fatalf("running the generator: %v", err)
+	}
+
+	handed, err := os.ReadFile(filepath.Join(out, "descriptor"))
+	if err != nil {
+		t.Fatalf("reading what the generator was handed: %v", err)
+	}
+
+	// The comparison is against the function --emit-ir writes with, not against
+	// a second encoding assembled here: the claim is that a plugin and an
+	// author holding a captured descriptor have the same bytes.
+	emitted, err := emit.Marshal(descriptor())
+	if err != nil {
+		t.Fatalf("emitting the descriptor: %v", err)
+	}
+
+	if !bytes.Equal(handed, emitted) {
+		t.Errorf("the generator was handed %d bytes, --emit-ir writes %d, and they differ", len(handed), len(emitted))
+	}
+}
+
+func TestEachGeneratorGetsItsOwnDescriptorFile(t *testing.T) {
+	t.Parallel()
+
+	out := t.TempDir()
+
+	// docs/plugin/SPEC.md: cpybkc MUST NOT share a descriptor file between two
+	// generators, and MUST write it into a directory it creates for that one
+	// invocation and nothing else. One file per invocation is what makes the
+	// bytes attributable.
+	body := `echo "$2" >> "$OUT/paths"`
+
+	first := generator(t, "go", body, out)
+	second := generator(t, "docs", body, out)
+
+	if err := runner(t, "OUT="+out).Run(t.Context(), descriptor(), []Invocation{first, second}); err != nil {
+		t.Fatalf("running the generators: %v", err)
+	}
+
+	paths := lines(t, filepath.Join(out, "paths"))
+
+	if len(paths) != 2 {
+		t.Fatalf("two generators ran and recorded %d descriptors: %q", len(paths), paths)
+	}
+
+	if paths[0] == paths[1] {
+		t.Errorf("both generators were handed %s", paths[0])
+	}
+
+	if filepath.Dir(paths[0]) == filepath.Dir(paths[1]) {
+		t.Errorf("both descriptors were written into %s", filepath.Dir(paths[0]))
+	}
+}
+
+func TestTheDescriptorDoesNotOutliveTheInvocation(t *testing.T) {
+	t.Parallel()
+
+	// docs/plugin/SPEC.md: cpybkc MUST remove the file, and the directory
+	// holding it, once the generator has exited, whether it exited zero or not.
+	for _, status := range []int{0, 1} {
+		t.Run(fmt.Sprintf("exit %d", status), func(t *testing.T) {
+			t.Parallel()
+
+			out := t.TempDir()
+
+			invocation := generator(t, "go", fmt.Sprintf(`echo "$2" > "$4/path"; exit %d`, status), out)
+
+			err := run(t, invocation)
+
+			if (err != nil) != (status != 0) {
+				t.Fatalf("a generator that exited %d reported %v", status, err)
+			}
+
+			path := lines(t, filepath.Join(out, "path"))[0]
+
+			if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+				t.Errorf("the descriptor at %s is still there: %v", path, err)
+			}
+
+			if _, err := os.Stat(filepath.Dir(path)); !errors.Is(err, os.ErrNotExist) {
+				t.Errorf("the directory %s is still there: %v", filepath.Dir(path), err)
+			}
+		})
+	}
+}
+
+func TestTheDescriptorIsWrittenReadOnly(t *testing.T) {
+	t.Parallel()
+
+	// The mode is read here rather than through a plugin because a test that
+	// asked a shell script whether it could write the file would be asking
+	// about the user the tests run as — and as root the answer is yes whatever
+	// the mode says.
+	path, err := writeDescriptor(t.TempDir(), []byte("descriptor"))
+	if err != nil {
+		t.Fatalf("writing the descriptor: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+
+	if got := info.Mode().Perm(); got&0o222 != 0 {
+		t.Errorf("the descriptor was written %#o, which is writable", got)
+	}
+}
+
+// rendezvous is a generator that announces itself and then waits for the other
+// one to announce itself, giving up after a bounded wait.
+//
+// Run at the same time the two meet at once. Run one after the other, the first
+// waits for a file the second cannot write yet, gives up, and exits non-zero —
+// so concurrency is decided by the run's verdict rather than by a duration this
+// test would otherwise have to guess at. The sleep is a whole second because
+// that is the only argument POSIX requires sleep to accept.
+func rendezvous(mine, theirs string) string {
+	return fmt.Sprintf(`
+		touch "$OUT/%s"
+		i=0
+		while [ $i -lt 20 ]; do
+			if [ -e "$OUT/%s" ]; then exit 0; fi
+			sleep 1
+			i=$((i + 1))
+		done
+		exit 1
+	`, mine, theirs)
+}
+
+func TestGeneratorsRunConcurrently(t *testing.T) {
+	t.Parallel()
+
+	out := t.TempDir()
+
+	first := generator(t, "go", rendezvous("go", "docs"), out)
+	second := generator(t, "docs", rendezvous("docs", "go"), out)
+
+	if err := runner(t, "OUT="+out).Run(t.Context(), descriptor(), []Invocation{first, second}); err != nil {
+		t.Fatalf("the two generators did not run at the same time: %v", err)
+	}
+}
+
+func TestANonZeroExitFailsTheRunAndNamesTheGenerator(t *testing.T) {
+	t.Parallel()
+
+	invocation := generator(t, "go", "exit 3", t.TempDir())
+
+	err := run(t, invocation)
+
+	var exit *ExitError
+	if !errors.As(err, &exit) {
+		t.Fatalf("a generator that exited 3 reported %v, want an *ExitError", err)
+	}
+
+	if got, want := exit.Name, "go"; got != want {
+		t.Errorf("the failure names %q, want %q", got, want)
+	}
+
+	if got, want := exit.Code, 3; got != want {
+		t.Errorf("the failure carries exit status %d, want %d", got, want)
+	}
+
+	if got := exit.Error(); !strings.Contains(got, `"go"`) {
+		t.Errorf("the message does not name the generator: %s", got)
+	}
+}
+
+func TestEveryFailingGeneratorIsReported(t *testing.T) {
+	t.Parallel()
+
+	// Nothing is merged until every generator has succeeded (#43, #44), so a
+	// run that stopped at the first failure would buy nothing back and would
+	// report whichever generator lost a race.
+	first := generator(t, "go", "exit 1", t.TempDir())
+	second := generator(t, "docs", "exit 0", t.TempDir())
+	third := generator(t, "sql", "exit 2", t.TempDir())
+
+	err := run(t, first, second, third)
+	if err == nil {
+		t.Fatal("two generators failed and the run reported nothing")
+	}
+
+	rendered := err.Error()
+
+	for _, name := range []string{`"go"`, `"sql"`} {
+		if !strings.Contains(rendered, name) {
+			t.Errorf("the run does not report %s failing: %s", name, rendered)
+		}
+	}
+
+	if strings.Contains(rendered, `"docs"`) {
+		t.Errorf("the run reports the generator that succeeded: %s", rendered)
+	}
+
+	// In the order the invocations were declared, so that the same failing run
+	// reads the same way twice.
+	if strings.Index(rendered, `"go"`) > strings.Index(rendered, `"sql"`) {
+		t.Errorf("the failures are not in the order the generators were declared: %s", rendered)
+	}
+}
+
+func TestAGeneratorKilledBySignalIsReportedAsKilled(t *testing.T) {
+	t.Parallel()
+
+	// docs/plugin/SPEC.md requires this to be distinguishable from a non-zero
+	// exit: the two need different responses, and a shell reports a killed
+	// process as 128 plus the signal, which is a number this must not be read
+	// back out of.
+	invocation := generator(t, "go", `kill -TERM $$; sleep 30`, t.TempDir())
+
+	err := run(t, invocation)
+
+	var signalled *SignalError
+	if !errors.As(err, &signalled) {
+		t.Fatalf("a generator killed by SIGTERM reported %v, want a *SignalError", err)
+	}
+
+	if got, want := signalled.Signal, syscall.SIGTERM; got != want {
+		t.Errorf("the failure names signal %v, want %v", got, want)
+	}
+
+	var exit *ExitError
+	if errors.As(err, &exit) {
+		t.Errorf("a killed generator is also reported as having exited %d", exit.Code)
+	}
+
+	if got := signalled.Error(); !strings.Contains(got, `"go"`) {
+		t.Errorf("the message does not name the generator: %s", got)
+	}
+}
+
+func TestCancellingTheRunStopsTheGenerators(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	out := t.TempDir()
+	invocation := generator(t, "go", `touch "$4/started"; sleep 120`, out)
+
+	done := make(chan error, 1)
+
+	go func() { done <- runner(t, "OUT="+out).Run(ctx, descriptor(), []Invocation{invocation}) }()
+
+	waitFor(t, filepath.Join(out, "started"))
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("a cancelled run reported no failure")
+		}
+	case <-time.After(time.Minute):
+		t.Fatal("the run outlived the context that was cancelled")
+	}
+}
+
+// waitFor blocks until path exists, which is how a test waits for a generator
+// to have started without guessing at how long that takes.
+func waitFor(t *testing.T, path string) {
+	t.Helper()
+
+	deadline := time.Now().Add(time.Minute)
+
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("%s was never written", path)
+}
+
+func TestAGeneratorThatExitsZeroAfterAnErrorDiagnosticSucceeded(t *testing.T) {
+	t.Parallel()
+
+	// docs/plugin/SPEC.md: cpybkc MUST NOT fail a run whose generator exited
+	// zero after printing `error:`, because the exit status is the verdict and
+	// the diagnostics are the explanation.
+	invocation := generator(t, "go", `echo "error: ORDER-DETAIL: something" >&2; exit 0`, t.TempDir())
+
+	if err := run(t, invocation); err != nil {
+		t.Errorf("a generator that exited zero failed the run: %v", err)
+	}
+}
+
+func TestAGeneratorThatLeavesAChildHoldingItsOutputStillFinishes(t *testing.T) {
+	t.Parallel()
+
+	// The generator exits zero, having started something that inherits its
+	// streams and outlives it. The exit status is the verdict, so the run
+	// succeeds — and it succeeds after [outputGrace] rather than after the
+	// child gets round to exiting, which is the whole reason the delay is set.
+	invocation := generator(t, "go", `sleep 120 & echo "note: finished" >&2; exit 0`, t.TempDir())
+
+	log, kept := recorder()
+	r := &Runner{Log: log, TempDir: t.TempDir(), Env: env()}
+
+	done := make(chan error, 1)
+
+	go func() { done <- r.Run(t.Context(), descriptor(), []Invocation{invocation}) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("a generator that exited zero failed the run: %v", err)
+		}
+	case <-time.After(time.Minute):
+		t.Fatal("the run waited for a child the generator left behind")
+	}
+
+	// What the generator itself wrote before exiting is still surfaced.
+	if got := kept.messages(stderrStream); !slices.Contains(got, "finished") {
+		t.Errorf("the generator's own output was not surfaced: %q", got)
+	}
+}
+
+func TestAGeneratorThatCannotBeStartedIsNotAnExit(t *testing.T) {
+	t.Parallel()
+
+	invocation := Invocation{Name: "go", Path: filepath.Join(t.TempDir(), Filename("go")), Out: t.TempDir()}
+
+	err := run(t, invocation)
+
+	var start *StartError
+	if !errors.As(err, &start) {
+		t.Fatalf("a generator that is not there reported %v, want a *StartError", err)
+	}
+
+	if got := start.Error(); !strings.Contains(got, `"go"`) {
+		t.Errorf("the message does not name the generator: %s", got)
+	}
+}
+
+func TestTheEnvironmentReachesTheGeneratorUnchanged(t *testing.T) {
+	t.Parallel()
+
+	out := t.TempDir()
+	invocation := generator(t, "go", `echo "$SOURCE_DATE_EPOCH" > "$4/epoch"`, out)
+
+	if err := runner(t, "SOURCE_DATE_EPOCH=1700000000").Run(t.Context(), descriptor(), []Invocation{invocation}); err != nil {
+		t.Fatalf("running the generator: %v", err)
+	}
+
+	if got, want := lines(t, filepath.Join(out, "epoch"))[0], "1700000000"; got != want {
+		t.Errorf("the generator saw SOURCE_DATE_EPOCH=%q, want %q", got, want)
+	}
+}
+
+func TestAnInvocationThatCannotBeWrittenAsAVectorRunsNothing(t *testing.T) {
+	t.Parallel()
+
+	out := t.TempDir()
+
+	good := generator(t, "go", `touch "$4/ran"`, out)
+
+	bad := generator(t, "docs", "exit 0", t.TempDir())
+	bad.Options = []Option{{Key: "package=orders", Value: "x"}}
+
+	err := run(t, good, bad)
+
+	var invalid *InvalidOptionError
+	if !errors.As(err, &invalid) {
+		t.Fatalf("an option key carrying an = reported %v, want an *InvalidOptionError", err)
+	}
+
+	if got, want := invalid.Key, "package=orders"; got != want {
+		t.Errorf("the failure names the key %q, want %q", got, want)
+	}
+
+	// Checked before anything starts: an invocation the caller assembled wrong
+	// is knowable here, unlike an option key only the plugin knows about.
+	if _, err := os.Stat(filepath.Join(out, "ran")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("a generator ran beside an invocation that could not be written as a vector: %v", err)
+	}
+}
+
+func TestAnEmptyOptionKeyIsRefused(t *testing.T) {
+	t.Parallel()
+
+	invocation := generator(t, "go", "exit 0", t.TempDir())
+	invocation.Options = []Option{{Key: "", Value: "orders"}}
+
+	err := run(t, invocation)
+
+	var invalid *InvalidOptionError
+	if !errors.As(err, &invalid) {
+		t.Fatalf("an empty option key reported %v, want an *InvalidOptionError", err)
+	}
+
+	if got := invalid.Error(); !strings.Contains(got, "empty") {
+		t.Errorf("the message does not say the key is empty: %s", got)
+	}
+}
+
+func TestAnInvocationMissingWhatARunNeedsIsRefused(t *testing.T) {
+	t.Parallel()
+
+	for name, invocation := range map[string]Invocation{
+		"no executable": {Name: "go", Out: t.TempDir()},
+		"no directory":  {Name: "go", Path: "/usr/bin/cpybkc-gen-go"},
+		"no name":       {Path: "/usr/bin/cpybkc-gen-go", Out: t.TempDir()},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if err := run(t, invocation); err == nil {
+				t.Errorf("an invocation with %s was accepted", name)
+			}
+		})
+	}
+}
+
+func TestARunWithNoGeneratorsDoesNothing(t *testing.T) {
+	t.Parallel()
+
+	if err := run(t); err != nil {
+		t.Errorf("a run with no generators reported %v", err)
+	}
+}

--- a/internal/plugin/stream.go
+++ b/internal/plugin/stream.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package plugin
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+)
+
+// The names the two streams are attributed by, which are the words a plugin
+// author reads in docs/plugin/SPEC.md, "Standard streams".
+const (
+	stdoutStream = "stdout"
+	stderrStream = "stderr"
+)
+
+// The severities of a diagnostic: a closed set of three, matched
+// case-sensitively, and the separator that follows one.
+//
+// docs/plugin/SPEC.md, "The diagnostic format". The separator is a colon and a
+// single space and nothing else, which is what tells a diagnostic from the
+// ordinary output of a program that also writes to standard error.
+const (
+	severityError   = "error"
+	severityWarning = "warning"
+	severityNote    = "note"
+
+	severitySeparator = ": "
+)
+
+// maxLine is how much of one line is read before it is surfaced as a piece of
+// itself rather than held for its newline.
+//
+// A line is not required to be short, and the one that is not is usually the
+// one that matters — a panic, a stack trace, a library that meant to write
+// several lines and wrote no newlines. So the limit is a chunk size and not a
+// ceiling: at it, what has been read is surfaced and reading continues, because
+// docs/plugin/SPEC.md says a line is never discarded and a reader that stopped
+// at the first long one would discard everything after it too.
+const maxLine = 1 << 20
+
+// surface reads everything the generator wrote to one stream and puts it in the
+// log, attributed to the generator, as it arrives.
+//
+// docs/plugin/SPEC.md: cpybkc MUST parse a diagnostic into its structured log
+// at the corresponding level, MUST surface any other line verbatim, and MUST do
+// neither of those things later than the line arrives. Reading concurrently
+// with the process is what makes the last of those true; a generator that
+// writes an explanation and then hangs has still explained itself.
+func surface(ctx context.Context, log *slog.Logger, stream string, r io.Reader) {
+	attr := slog.String("stream", stream)
+
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(nil, maxLine)
+	scanner.Split(splitLines(maxLine))
+
+	for scanner.Scan() {
+		level, message := classify(stream, scanner.Text())
+
+		log.LogAttrs(ctx, level, message, attr)
+	}
+
+	if err := scanner.Err(); err != nil {
+		// The read failed partway. That is not the generator's fault and not a
+		// failed run — the exit status is the verdict — but the output is
+		// incomplete and saying so is cheaper than leaving a user to wonder
+		// where the rest of a message went.
+		log.LogAttrs(ctx, slog.LevelWarn, "the rest of what this generator wrote could not be read: "+err.Error(), attr)
+	}
+}
+
+// classify says at what level a line is recorded, and with what message.
+//
+// docs/plugin/SPEC.md fixes three of the four answers. `error:` records at
+// error, `warning:` at warning and `note:` at info, with the severity stripped
+// because the level now carries it; anything on standard error that is not a
+// diagnostic is recorded **verbatim at warning**, one level above the `note:` a
+// plugin writes deliberately, because info is where a log is ordinarily
+// thresholded and a handler configured a notch above it would drop exactly the
+// panic that rule exists to surface.
+//
+// The fourth answer is this repository's, because the contract says only that
+// standard output MUST be surfaced verbatim and attributed. It is recorded at
+// info: standard output is not the diagnostic channel, so a line on it is not a
+// severity anybody stated, and the argument that puts an unclassified *stderr*
+// line at warning does not reach it — a plugin that leaves `set -x` on is
+// untidy rather than broken, which docs/plugin/SPEC.md says in as many words
+// when it makes writing there a SHOULD NOT rather than a MUST NOT.
+func classify(stream, line string) (slog.Level, string) {
+	if stream != stderrStream {
+		return slog.LevelInfo, line
+	}
+
+	severity, message, found := strings.Cut(line, severitySeparator)
+
+	// A message that is empty, or that is nothing but space, says nothing a
+	// level could be attached to; docs/plugin/SPEC.md puts a bare `error: ` on
+	// the text side of the line along with an `error:something` carrying no
+	// space and a line indented under a stack trace. The first is this test,
+	// the second is Cut finding no separator, and the third is a severity with
+	// leading space, which does not match any of the three.
+	if !found || strings.TrimSpace(message) == "" {
+		return slog.LevelWarn, line
+	}
+
+	switch severity {
+	case severityError:
+		return slog.LevelError, message
+	case severityWarning:
+		return slog.LevelWarn, message
+	case severityNote:
+		return slog.LevelInfo, message
+	default:
+		return slog.LevelWarn, line
+	}
+}
+
+// splitLines is [bufio.ScanLines] with the one difference [maxLine] describes:
+// where ScanLines asks for a bigger buffer and gives up when it cannot have
+// one, this hands back what it has and carries on reading.
+//
+// The only observable difference is on a line longer than max, which arrives as
+// several records instead of one. That is what surfacing everything costs; the
+// alternative — [bufio.ErrTooLong] — ends the scan, and with it every line the
+// generator wrote afterwards.
+func splitLines(max int) bufio.SplitFunc {
+	return func(data []byte, atEOF bool) (int, []byte, error) {
+		if i := bytes.IndexByte(data, '\n'); i >= 0 {
+			return i + 1, dropCR(data[:i]), nil
+		}
+
+		if atEOF {
+			if len(data) == 0 {
+				return 0, nil, nil
+			}
+
+			// The last line of a generator that exited without a final newline
+			// is still a line it wrote.
+			return len(data), dropCR(data), nil
+		}
+
+		if len(data) >= max {
+			return len(data), data, nil
+		}
+
+		return 0, nil, nil
+	}
+}
+
+// dropCR removes a terminating carriage return, exactly as [bufio.ScanLines]
+// does: a plugin written on, or piped through, something that ends its lines
+// with CRLF is writing the same diagnostic as one that does not.
+func dropCR(data []byte) []byte {
+	if len(data) > 0 && data[len(data)-1] == '\r' {
+		return data[:len(data)-1]
+	}
+
+	return data
+}

--- a/internal/plugin/stream_test.go
+++ b/internal/plugin/stream_test.go
@@ -1,0 +1,396 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package plugin
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// record is one line a generator wrote, as it reached the log.
+type record struct {
+	Level     slog.Level
+	Message   string
+	Generator string
+	Stream    string
+}
+
+// recording is what a run said, in the order it said it.
+//
+// A handler of its own rather than a text handler and a parse of its output:
+// the claims under test are that a line arrives at a level and attributed to a
+// generator, and both are structure that a rendering flattens back into a
+// string for the test to guess at again.
+type recording struct {
+	mu      sync.Mutex
+	records []record
+}
+
+// recorder is a logger that keeps everything, at every level.
+func recorder() (*slog.Logger, *recording) {
+	kept := &recording{}
+
+	return slog.New(&handler{recording: kept}), kept
+}
+
+// all is what has been recorded so far.
+func (r *recording) all() []record {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return slices.Clone(r.records)
+}
+
+// on is everything recorded on stream, in order.
+func (r *recording) on(stream string) []record {
+	var found []record
+
+	for _, rec := range r.all() {
+		if rec.Stream == stream {
+			found = append(found, rec)
+		}
+	}
+
+	return found
+}
+
+// messages is every message recorded on stream, in order.
+func (r *recording) messages(stream string) []string {
+	var found []string
+
+	for _, rec := range r.on(stream) {
+		found = append(found, rec.Message)
+	}
+
+	return found
+}
+
+// handler collects records into a [recording].
+type handler struct {
+	recording *recording
+	attrs     []slog.Attr
+}
+
+// Enabled keeps everything: a test that filtered would be testing its own
+// threshold rather than the level a line was recorded at.
+func (h *handler) Enabled(context.Context, slog.Level) bool { return true }
+
+// Handle records one line.
+func (h *handler) Handle(_ context.Context, r slog.Record) error {
+	kept := record{Level: r.Level, Message: r.Message}
+
+	collect := func(a slog.Attr) {
+		switch a.Key {
+		case "generator":
+			kept.Generator = a.Value.String()
+		case "stream":
+			kept.Stream = a.Value.String()
+		}
+	}
+
+	for _, a := range h.attrs {
+		collect(a)
+	}
+
+	r.Attrs(func(a slog.Attr) bool {
+		collect(a)
+
+		return true
+	})
+
+	h.recording.mu.Lock()
+	defer h.recording.mu.Unlock()
+
+	h.recording.records = append(h.recording.records, kept)
+
+	return nil
+}
+
+// WithAttrs is how the generator's name reaches a record: the run attaches it
+// once and every line the generator writes carries it.
+func (h *handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &handler{recording: h.recording, attrs: append(slices.Clone(h.attrs), attrs...)}
+}
+
+// WithGroup is unused, and is the identity rather than a panic so that a caller
+// grouping this repository's logs does not fall over on a test double.
+func (h *handler) WithGroup(string) slog.Handler { return h }
+
+func TestADiagnosticIsRecordedAtItsSeverity(t *testing.T) {
+	t.Parallel()
+
+	// docs/plugin/SPEC.md, "The diagnostic format": `error:` to error,
+	// `warning:` to warning, `note:` to info, with the severity stripped
+	// because the level now carries it.
+	for name, test := range map[string]struct {
+		line    string
+		level   slog.Level
+		message string
+	}{
+		"error": {
+			line:    "error: ORDER-DETAIL.OD-QTY: USAGE COMP-3 is not supported by this generator",
+			level:   slog.LevelError,
+			message: "ORDER-DETAIL.OD-QTY: USAGE COMP-3 is not supported by this generator",
+		},
+		"warning": {
+			line:    "warning: ORDER-DETAIL: two fields render to the same name",
+			level:   slog.LevelWarn,
+			message: "ORDER-DETAIL: two fields render to the same name",
+		},
+		"note": {
+			line:    "note: ORDER-DETAIL.OD-QTY: declared as PIC S9(5)V99",
+			level:   slog.LevelInfo,
+			message: "ORDER-DETAIL.OD-QTY: declared as PIC S9(5)V99",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			level, message := classify(stderrStream, test.line)
+
+			if level != test.level {
+				t.Errorf("%q was recorded at %v, want %v", test.line, level, test.level)
+			}
+
+			if message != test.message {
+				t.Errorf("%q was recorded as %q, want %q", test.line, message, test.message)
+			}
+		})
+	}
+}
+
+func TestALineThatIsNotADiagnosticIsRecordedVerbatimAtWarning(t *testing.T) {
+	t.Parallel()
+
+	// docs/plugin/SPEC.md: an unrecognised line is surfaced verbatim, and at
+	// **warning** rather than at the mildest level available — info is where a
+	// log is ordinarily thresholded, and a line cpybkc could not classify is
+	// usually a panic.
+	for name, line := range map[string]string{
+		"no separator":         "panic: runtime error: index out of range [3]",
+		"no space":             "error:ORDER-DETAIL: something",
+		"indented":             "  error: under a stack trace",
+		"an unknown severity":  "fatal: the generator gave up",
+		"a bare severity":      "error: ",
+		"an empty message":     "error:  ",
+		"a severity by itself": "warning:",
+		"nothing at all":       "",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			level, message := classify(stderrStream, line)
+
+			if level != slog.LevelWarn {
+				t.Errorf("%q was recorded at %v, want %v", line, level, slog.LevelWarn)
+			}
+
+			if message != line {
+				t.Errorf("%q was recorded as %q, want it verbatim", line, message)
+			}
+		})
+	}
+}
+
+func TestStandardOutputIsRecordedVerbatim(t *testing.T) {
+	t.Parallel()
+
+	// Standard output carries nothing the contract defines, so nothing on it is
+	// a diagnostic — a line that looks like one is still just a line, recorded
+	// as it was written.
+	for _, line := range []string{"generated 4 files", "error: this is not a diagnostic"} {
+		level, message := classify(stdoutStream, line)
+
+		if level != slog.LevelInfo {
+			t.Errorf("%q was recorded at %v, want %v", line, level, slog.LevelInfo)
+		}
+
+		if message != line {
+			t.Errorf("%q was recorded as %q, want it verbatim", line, message)
+		}
+	}
+}
+
+func TestBothStreamsAreSurfacedAndAttributed(t *testing.T) {
+	t.Parallel()
+
+	body := `
+		echo "generated 2 files"
+		echo "note: ORDER-DETAIL: one record" >&2
+		echo "panic: nothing is fine" >&2
+	`
+
+	invocation := generator(t, "go", body, t.TempDir())
+
+	log, kept := recorder()
+	r := &Runner{Log: log, TempDir: t.TempDir(), Env: env()}
+
+	if err := r.Run(t.Context(), descriptor(), []Invocation{invocation}); err != nil {
+		t.Fatalf("running the generator: %v", err)
+	}
+
+	// The whole line on standard output, at info; on standard error, the note
+	// stripped of its severity and at info, and the panic verbatim at warning.
+	expected := map[string][]record{
+		stdoutStream: {
+			{Level: slog.LevelInfo, Message: "generated 2 files", Generator: "go", Stream: stdoutStream},
+		},
+		stderrStream: {
+			{Level: slog.LevelInfo, Message: "ORDER-DETAIL: one record", Generator: "go", Stream: stderrStream},
+			{Level: slog.LevelWarn, Message: "panic: nothing is fine", Generator: "go", Stream: stderrStream},
+		},
+	}
+
+	for stream, want := range expected {
+		if got := kept.on(stream); !slices.Equal(got, want) {
+			t.Errorf("%s was surfaced as %+v, want %+v", stream, got, want)
+		}
+	}
+}
+
+func TestEachGeneratorsOutputIsAttributedToIt(t *testing.T) {
+	t.Parallel()
+
+	first := generator(t, "go", `echo "error: from go" >&2`, t.TempDir())
+	second := generator(t, "docs", `echo "error: from docs" >&2`, t.TempDir())
+
+	log, kept := recorder()
+	r := &Runner{Log: log, TempDir: t.TempDir(), Env: env()}
+
+	if err := r.Run(t.Context(), descriptor(), []Invocation{first, second}); err != nil {
+		t.Fatalf("running the generators: %v", err)
+	}
+
+	// The two run at the same time, so the order the lines arrive in is not
+	// this test's to assert; which generator each is attributed to is.
+	said := map[string]string{}
+
+	for _, rec := range kept.all() {
+		said[rec.Generator] = rec.Message
+	}
+
+	for name, want := range map[string]string{"go": "from go", "docs": "from docs"} {
+		if got := said[name]; got != want {
+			t.Errorf("the generator %q is recorded as saying %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestALineIsSurfacedBeforeTheGeneratorExits(t *testing.T) {
+	t.Parallel()
+
+	// docs/plugin/SPEC.md: a line is never held back until the process exits.
+	// The generator writes, waits for this test to have seen it, and only then
+	// exits — so a run that buffered would deadlock rather than pass slowly.
+	out := t.TempDir()
+
+	invocation := generator(t, "go", `
+		echo "error: written before the wait" >&2
+		i=0
+		while [ $i -lt 20 ]; do
+			if [ -e "$OUT/seen" ]; then exit 0; fi
+			sleep 1
+			i=$((i + 1))
+		done
+		exit 1
+	`, out)
+
+	log, kept := recorder()
+	r := &Runner{Log: log, TempDir: t.TempDir(), Env: env("OUT=" + out)}
+
+	done := make(chan error, 1)
+
+	go func() { done <- r.Run(t.Context(), descriptor(), []Invocation{invocation}) }()
+
+	// Nothing here waits on the process: the line has to arrive while it is
+	// still running, and the process only ends because it did.
+	waitForLine(t, kept, "written before the wait")
+
+	if err := os.WriteFile(filepath.Join(out, "seen"), nil, 0o644); err != nil {
+		t.Fatalf("writing the acknowledgement: %v", err)
+	}
+
+	if err := <-done; err != nil {
+		t.Fatalf("the generator did not see the acknowledgement: %v", err)
+	}
+}
+
+// waitForLine blocks until something containing want has been recorded.
+func waitForLine(t *testing.T, kept *recording, want string) {
+	t.Helper()
+
+	deadline := time.Now().Add(time.Minute)
+
+	for time.Now().Before(deadline) {
+		for _, rec := range kept.all() {
+			if strings.Contains(rec.Message, want) {
+				return
+			}
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("%q was never surfaced", want)
+}
+
+func TestALongLineIsSurfacedRatherThanEndingTheStream(t *testing.T) {
+	t.Parallel()
+
+	// A line longer than the buffer arrives as pieces of itself and the lines
+	// after it still arrive, which is what [splitLines] is for: the alternative
+	// ends the scan and discards everything the generator wrote afterwards.
+	long := strings.Repeat("x", 3*maxLine/2)
+
+	log, kept := recorder()
+
+	surface(t.Context(), log, stderrStream, strings.NewReader(long+"\nafter\n"))
+
+	pieces := kept.messages(stderrStream)
+
+	if len(pieces) < 2 {
+		t.Fatalf("a long line was surfaced as %d records, want it split", len(pieces))
+	}
+
+	if got, want := pieces[len(pieces)-1], "after"; got != want {
+		t.Errorf("the line after a long one was surfaced as %q, want %q", got, want)
+	}
+
+	if got, want := len(strings.Join(pieces[:len(pieces)-1], "")), len(long); got != want {
+		t.Errorf("the long line was surfaced as %d bytes, want all %d of them", got, want)
+	}
+}
+
+func TestALastLineWithoutANewlineIsStillSurfaced(t *testing.T) {
+	t.Parallel()
+
+	log, kept := recorder()
+
+	surface(t.Context(), log, stderrStream, strings.NewReader("error: it stopped here"))
+
+	if got, want := kept.messages(stderrStream), []string{"it stopped here"}; !slices.Equal(got, want) {
+		t.Errorf("a final line without a newline was surfaced as %q, want %q", got, want)
+	}
+}
+
+func TestACarriageReturnIsNotPartOfTheLine(t *testing.T) {
+	t.Parallel()
+
+	log, kept := recorder()
+
+	surface(t.Context(), log, stderrStream, strings.NewReader("error: written on a CRLF host\r\n"))
+
+	if got, want := kept.messages(stderrStream), []string{"written on a CRLF host"}; !slices.Equal(got, want) {
+		t.Errorf("a CRLF line was surfaced as %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Closes #42

Runs the generators a project declares. `plugin.Runner.Run` takes a resolved descriptor and a list of `Invocation`s — the executable `Resolve` found, the name it was asked for, the directory it writes into and the options it was declared with — and runs them.

## Acceptance criteria

- [x] **Each plugin invoked with `--descriptor`, `--out`, and its declared options.** The vector is `--descriptor <path> --out <dir> [--opt k=v ...]` and nothing else, in the separated form, both paths absolute, options in the order they were declared. `TestAGeneratorIsRunWithTheVectorTheContractDefines` pins it argument by argument, including that there are exactly eight of them.
- [x] **Plugins run concurrently.** One goroutine per invocation. `TestGeneratorsRunConcurrently` decides it by rendezvous rather than by a duration: each generator announces itself and waits for the other, so sequential execution fails the run instead of passing it slowly.
- [x] **The descriptor handed to a plugin is byte-identical to what `--emit-ir` produces.** It is `internal/emit.Marshal`'s bytes — the same function `--emit-ir` writes with — so the identity holds by there being one encoder rather than by two agreeing. `TestTheDescriptorIsTheBytesEmitIRWrites` compares what a plugin read against what `emit.Marshal` returns.
- [x] **Plugin stdout and stderr surfaced to the user, attributed to the plugin that produced them.** Both streams are read as the generator writes them and go to an `slog.Logger` carrying `generator=<name>` and `stream=stdout|stderr`. `error:`/`warning:`/`note:` are parsed to error/warn/info; anything else on stderr is surfaced verbatim at **warning**, per the spec's argument that an unclassified line is usually a panic and info is where a log gets thresholded.
- [x] **A non-zero plugin exit fails the run and names the plugin.** `ExitError`, carrying the name and the status. A generator killed by a signal is a separate `SignalError`, which is the distinction `docs/plugin/SPEC.md` requires — a shell reports a killed process as 128 plus the signal, and that is a number this must not be read back out of.

Also from the sections the spec's appendix maps to #42: the descriptor lives in a directory created for one invocation and nothing else, is never shared between two generators, is written read-only and in full before the generator starts, and is removed with its directory once the generator has exited whether it exited zero or not.

## Judgment calls that shaped the API

- **`Out` is the caller's, not this package's.** Creating the scratch directory, enforcing that nothing is written outside it and merging what is left in it are #43's and #44's. `Run` makes the path absolute and passes it; it does not create, inspect or clean the directory.
- **Every generator runs to completion, even after one has failed, and failures are reported in the declared order.** Nothing reaches the project's output tree until all of them succeed (#43, #44), so stopping early buys nothing back and would make the reported failure depend on which generator lost a race.
- **`plugin.Option` rather than `manifest.Option`.** An option reaches an invocation from wherever the caller had one — the same reason `Resolve` takes a name rather than a manifest entry. The key is re-checked here for the same reason the name is: a key carrying an `=` that arrived by another route would be split somewhere the manifest did not write it.
- **Standard output is recorded at info.** The spec fixes the three stderr severities and the warning level for an unclassified stderr line, and says only that stdout must be surfaced verbatim and attributed. Info, because stdout is not the diagnostic channel and the spec makes writing there a **SHOULD NOT** rather than a **MUST NOT** — a plugin that left `set -x` on is untidy, not broken.
- **`Cmd.WaitDelay`, five seconds.** Found by the cancellation test: a plugin that leaves a child holding its pipes would otherwise hang the run for as long as that child lives. The delay bounds it, and a generator that exits zero having done so still succeeds — the exit status is the verdict — with a warning saying the tail of its output was not waited for.

## Verified

`dagger call ci` — green, after `dagger core engine local-cache prune`; a stale engine result (`missing shared result`) was failing every call before the code changed and is not related to this branch.