### PR TITLE
story(plugin): give plugins a scratch out-dir and merge atomically

### DIFF
--- a/internal/generate/doc.go
+++ b/internal/generate/doc.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Package generate runs a project's generators and puts what they produce into
+// its output tree.
+//
+// A generator never writes into that tree. It is handed a directory of this
+// package's making — empty, writable, and nobody else's — and what it leaves
+// there reaches the project only once every generator in the run has exited
+// zero (docs/plugin/SPEC.md, "The output directory"). Running the generators is
+// [github.com/Zaba505/cpybkc/internal/plugin]'s; deciding what a run produced
+// and writing it where a person will find it is this package's, and it is the
+// only place anything is written there.
+//
+// # Why a scratch directory
+//
+// A generator writing straight into the project's tree gives up the only
+// guarantee worth having about a failed run. A plugin that dies halfway leaves
+// a tree that is neither the old one nor a new one — and, because generated
+// code usually still compiles with half of it missing, CI goes green on output
+// nobody produced. Interposing a directory costs a copy and buys back the rule
+// docs/plugin/SPEC.md states: a failed run leaves the project tree exactly as
+// it found it.
+//
+// The directory being **empty** is the second half of it, and is what makes
+// "the files this invocation produced" mechanically equal to "the files in the
+// directory afterwards". No marker inside a generated file, no manifest a
+// plugin has to maintain, and no bookkeeping asked of a plugin author at all —
+// which is what lets the contract stay small enough for a generator to be a
+// shell script. Cross-generator collision detection (#44) and stale-file
+// pruning (#45) both rest on that equality; neither is here yet.
+//
+// # Why the merge waits for every generator
+//
+// Not for the one that produced the files. docs/plugin/SPEC.md: nothing reaches
+// the project's tree until every generator in the run has succeeded, so one
+// generator's failure discards another's output too. That is the point rather
+// than a side effect — a half-generated tree is worse than an ungenerated one,
+// because a person then has to work out which half is which — and it is what
+// lets a plugin fail late, on an option key only it could have recognised,
+// without costing anything but the run.
+//
+// It is also what keeps the run's answer the same twice. A merge made as each
+// generator finished would let the first one's files land before the second was
+// known about, so the same unchanged inputs would fail differently depending on
+// which generator lost a race.
+//
+// # What "enforced rather than trusted" can mean
+//
+// docs/plugin/SPEC.md forbids a plugin to write outside the directory it was
+// handed — not through `..`, not through an absolute path, and not through a
+// symlink it created for the purpose — and says cpybkc enforces that rather
+// than trusting it. What can be enforced from here is exact, and worth stating
+// precisely, because a plugin is a separate process and nothing in this package
+// can stop one writing wherever its user could:
+//
+//   - Only what is *beneath* a generator's directory is ever read, so a file
+//     the plugin wrote elsewhere is not output. That is the whole of the `..`
+//     and absolute-path cases: the escape is not blocked, it is simply not
+//     collected, and the run produces the files the contract says it produces.
+//   - A symlink is refused rather than followed, wherever it points, and so is
+//     anything else that is neither a regular file nor a directory. A merge
+//     that followed one would read or write through a link a plugin chose,
+//     which is the escape rather than a variant of it.
+//   - A destination the merge is about to write is removed first rather than
+//     opened, so a symlink already in the project tree — left by a person, or
+//     by a run of something else — is replaced rather than written through.
+//
+// # Modes and ownership, in one place
+//
+// Every file and directory the merge creates gets its mode from this run and
+// not from the plugin: 0666 for a file, 0777 for a directory, 0777 for a file
+// the plugin made executable, each with the run's umask taken out of it. A
+// plugin writes into a scratch directory with whatever umask the process — or
+// the container — it ran in happened to have, so carrying its modes through
+// would make the permissions in a checked-out project depend on where the
+// generator ran.
+//
+// [Runner.Owner] is the same decision for ownership, and exists for one case:
+// cpybkc running as root in a container over a bind mount, where without it a
+// project's generated files come out owned by root and the person who ran the
+// container cannot edit them. Both are applied at one call in merge.go, which
+// is what makes "output ownership is decided in one place" a property of the
+// code rather than a convention.
+//
+// # What a caller supplies
+//
+// [Generator] rather than [github.com/Zaba505/cpybkc/internal/plugin.Invocation],
+// because the two disagree about what an output directory is: an Invocation's
+// is the directory the generator is *handed*, which here is a scratch directory
+// no caller names, while a Generator's is where that directory's contents end
+// up. One field spelling both would let a caller hand a plugin the project's
+// tree by writing the obvious thing, which is exactly the arrangement this
+// package exists to replace.
+package generate

--- a/internal/generate/doc.go
+++ b/internal/generate/doc.go
@@ -67,6 +67,12 @@
 //   - A destination the merge is about to write is removed first rather than
 //     opened, so a symlink already in the project tree — left by a person, or
 //     by a run of something else — is replaced rather than written through.
+//   - A directory the merge has to descend *beneath* the output directory is
+//     examined without following a link, so a symlink standing where a plugin's
+//     path needs a directory fails the merge instead of becoming the way out of
+//     the tree. The output directory itself and everything above it is followed
+//     rather than refused: that path is the one a person wrote in the manifest,
+//     and it routinely runs through a link nobody meant anything by.
 //
 // # Modes and ownership, in one place
 //

--- a/internal/generate/errors.go
+++ b/internal/generate/errors.go
@@ -1,0 +1,196 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package generate
+
+import (
+	"fmt"
+	"io/fs"
+	"strconv"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+)
+
+// No fault here points at a line of anything an adopter wrote, for the reason
+// the plugin package's do not: what went wrong is a generator's doing or the
+// machine's, and a span naming the layout or the manifest would send a reader
+// to edit text that is not the mistake. Neither does one name the scratch
+// directory it happened in — that directory is removed as the run ends, so a
+// path into it is a place the reader cannot go and look. What is named instead
+// is the generator, the path *it* chose for the file, and where in the project
+// that path was to land, which is the whole of what a person needs to find the
+// line of the plugin that wrote it.
+
+// ScratchError is a run that could not be given somewhere for its generators to
+// write.
+//
+// No generator ran, or one of them was about to and had nowhere to put its
+// output. It is separate from a generator that ran and failed because nothing
+// about it is the generator's doing: what failed is this process making a
+// directory, and the fix is a full disk or a TMPDIR that is not writable.
+type ScratchError struct {
+	// Name is the generator whose directory it was, or empty where what could
+	// not be made is the run's own scratch space.
+	Name string
+
+	// Err is what went wrong, from the filesystem.
+	Err error
+}
+
+// Error implements the error interface.
+func (e *ScratchError) Error() string { return e.Diagnostic().String() }
+
+// Unwrap is the filesystem's error, so that a caller can ask what kind of
+// failure it was.
+func (e *ScratchError) Unwrap() error { return e.Err }
+
+// Diagnostic is what the error says, and where.
+func (e *ScratchError) Diagnostic() diag.Diagnostic {
+	if e.Name == "" {
+		return diag.Diagnostic{
+			Message: fmt.Sprintf("this run could not be given anywhere for its generators to write: %v", e.Err),
+		}
+	}
+
+	return diag.Diagnostic{
+		Message: fmt.Sprintf("the generator %s could not be given a directory to write into: %v",
+			strconv.Quote(e.Name), e.Err),
+	}
+}
+
+// UnmergeableError is something a generator left in its directory that cpybkc
+// will not put into a project's tree.
+//
+// docs/plugin/SPEC.md: a plugin's output is the files it writes beneath the
+// directory it was handed, and it MUST NOT write outside that directory —
+// including through a symlink it created for the purpose. cpybkc enforces that
+// rather than trusting it, and this is the enforcement: a symlink is refused
+// wherever it points rather than followed, and so is anything else that is
+// neither a regular file nor a directory.
+//
+// It fails the whole run with nothing merged, so the fault costs the run and
+// never a half-written tree.
+type UnmergeableError struct {
+	// Name is the generator that left it.
+	Name string
+
+	// Path is what the generator called it: the path relative to the directory
+	// the generator was handed, which is the name a plugin author will
+	// recognise. It is `.` where what the generator left is the directory
+	// itself, replaced by something that is not one.
+	Path string
+
+	// Mode is what it turned out to be, as [io/fs.FileMode] renders a type.
+	Mode fs.FileMode
+
+	// Target is where it pointed, for a symlink, as the link was written.
+	// Empty for anything else, and for a link that could not be read.
+	Target string
+}
+
+// Error implements the error interface.
+func (e *UnmergeableError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+//
+// The second span is the rule rather than a second place, because there is no
+// second place: the fault is a decision inside an executable this repository
+// did not write, and what a reader needs is the sentence of the contract that
+// decision broke.
+func (e *UnmergeableError) Diagnostic() diag.Diagnostic {
+	what := kind(e.Mode)
+	note := "a generator's output is the files and the directories it leaves beneath the directory it was handed, and cpybkc merges nothing else"
+
+	if e.Mode&fs.ModeSymlink != 0 {
+		note = "a symlink is how a generator writes outside the directory it was handed, so cpybkc refuses one rather than following it"
+
+		if e.Target != "" {
+			what += " to " + strconv.Quote(e.Target)
+		}
+	}
+
+	where := "at " + strconv.Quote(e.Path)
+	if e.Path == "." {
+		where = "in place of the directory it was handed"
+	}
+
+	return diag.Diagnostic{
+		Message: fmt.Sprintf("the generator %s left %s %s, and its output was not merged",
+			strconv.Quote(e.Name), what, where),
+		Spans: []diag.Span{{}, {Note: note}},
+	}
+}
+
+// kind names what the merge found, in the words a sentence about it uses.
+//
+// [io/fs.FileMode.String] renders a type as the letter `ls -l` prints, which is
+// the right answer in a listing and the wrong one in a sentence: a diagnostic
+// reading `the generator "go" left p---------` names the thing in a notation the
+// reader has to already know. The default is deliberately vague rather than
+// exhaustive — what a reader does about anything in this list is the same, and
+// the list is the operating system's to extend.
+func kind(mode fs.FileMode) string {
+	switch {
+	case mode&fs.ModeSymlink != 0:
+		return "a symlink"
+	case mode&fs.ModeDevice != 0:
+		return "a device"
+	case mode&fs.ModeNamedPipe != 0:
+		return "a named pipe"
+	case mode&fs.ModeSocket != 0:
+		return "a socket"
+	default:
+		return "something that is neither a file nor a directory"
+	}
+}
+
+// MergeError is output that could not be put into the project's tree.
+//
+// Everything the merge refuses of its own accord is an [UnmergeableError] and
+// is reported before anything is written, so this is the filesystem: a full
+// disk, a directory that is not writable, a path in the project's tree where a
+// file stands and a directory has to go. Unlike a refusal, it can be raised
+// with part of the run's output already merged — which is why it names both the
+// generator's own path and where that path was landing, so that a person can
+// see how far the run got.
+type MergeError struct {
+	// Name is the generator whose output it was.
+	Name string
+
+	// Path is what the generator called it, relative to the directory it was
+	// handed. Empty where the fault is about the output directory itself rather
+	// than about anything in it.
+	Path string
+
+	// Dest is where it was to be written, in the project's tree.
+	Dest string
+
+	// Err is what went wrong, from the filesystem.
+	Err error
+}
+
+// Error implements the error interface.
+func (e *MergeError) Error() string { return e.Diagnostic().String() }
+
+// Unwrap is the filesystem's error, so that a caller can ask what kind of
+// failure it was.
+func (e *MergeError) Unwrap() error { return e.Err }
+
+// Diagnostic is what the error says, and where.
+func (e *MergeError) Diagnostic() diag.Diagnostic {
+	if e.Path == "" {
+		return diag.Diagnostic{
+			Message: fmt.Sprintf("the output of the generator %s could not be merged: %v",
+				strconv.Quote(e.Name), e.Err),
+			Spans: []diag.Span{{}, {File: e.Dest, Note: "this is the directory it was landing in"}},
+		}
+	}
+
+	return diag.Diagnostic{
+		Message: fmt.Sprintf("%s, from the generator %s, could not be merged: %v",
+			strconv.Quote(e.Path), strconv.Quote(e.Name), e.Err),
+		Spans: []diag.Span{{}, {File: e.Dest, Note: "this is where it was to be written"}},
+	}
+}

--- a/internal/generate/errors_test.go
+++ b/internal/generate/errors_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package generate
+
+import (
+	"errors"
+	"io/fs"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+)
+
+// TestEveryFaultReadsTheSameThroughEitherEnd is what
+// [github.com/Zaba505/cpybkc/internal/diag.Error] asks of a typed error: the
+// message a caller prints and the diagnostic a caller inspects are built in one
+// place, so the two cannot say different things.
+func TestEveryFaultReadsTheSameThroughEitherEnd(t *testing.T) {
+	t.Parallel()
+
+	faults := []error{
+		&ScratchError{Err: errors.New("no space left on device")},
+		&ScratchError{Name: "go", Err: errors.New("no space left on device")},
+		&UnmergeableError{Name: "go", Path: "orders.go", Mode: fs.ModeSymlink, Target: "/etc/passwd"},
+		&UnmergeableError{Name: "go", Path: "orders.go", Mode: fs.ModeNamedPipe},
+		&UnmergeableError{Name: "go", Path: ".", Mode: fs.ModeSymlink},
+		&MergeError{Name: "go", Dest: "gen", Err: errors.New("permission denied")},
+		&MergeError{Name: "go", Path: "orders.go", Dest: "gen/orders.go", Err: errors.New("permission denied")},
+	}
+
+	for _, fault := range faults {
+		carrier, ok := fault.(diag.Error)
+		if !ok {
+			t.Errorf("%T carries no diagnostic, want it to implement diag.Error", fault)
+
+			continue
+		}
+
+		if got, want := fault.Error(), carrier.Diagnostic().String(); got != want {
+			t.Errorf("%T reads as %q and renders as %q, want one wording", fault, got, want)
+		}
+	}
+}
+
+// TestARefusalSaysWhatWasLeftAndWhyItWasNotMerged is the golden the refusal is
+// held to. A person reading it never sees the scratch directory — it is removed
+// as the run ends — so what the message has to carry is the generator, the path
+// that generator chose, and the rule it broke.
+func TestARefusalSaysWhatWasLeftAndWhyItWasNotMerged(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		about string
+		fault *UnmergeableError
+		want  string
+	}{
+		{
+			about: "a symlink out of the directory",
+			fault: &UnmergeableError{Name: "go", Path: "pkg/orders.go", Mode: fs.ModeSymlink, Target: "/etc/passwd"},
+			want: `the generator "go" left a symlink to "/etc/passwd" at "pkg/orders.go", and its output was not merged
+  a symlink is how a generator writes outside the directory it was handed, so cpybkc refuses one rather than following it`,
+		},
+		{
+			about: "a symlink whose target could not be read",
+			fault: &UnmergeableError{Name: "go", Path: "pkg/orders.go", Mode: fs.ModeSymlink},
+			want: `the generator "go" left a symlink at "pkg/orders.go", and its output was not merged
+  a symlink is how a generator writes outside the directory it was handed, so cpybkc refuses one rather than following it`,
+		},
+		{
+			about: "the directory itself, replaced",
+			fault: &UnmergeableError{Name: "go", Path: ".", Mode: fs.ModeSymlink | 0o777, Target: "/tmp"},
+			want: `the generator "go" left a symlink to "/tmp" in place of the directory it was handed, and its output was not merged
+  a symlink is how a generator writes outside the directory it was handed, so cpybkc refuses one rather than following it`,
+		},
+		{
+			about: "something that is not a file at all",
+			fault: &UnmergeableError{Name: "go", Path: "orders.go", Mode: fs.ModeNamedPipe},
+			want: `the generator "go" left a named pipe at "orders.go", and its output was not merged
+  a generator's output is the files and the directories it leaves beneath the directory it was handed, and cpybkc merges nothing else`,
+		},
+	}
+
+	for _, test := range tests {
+		if got := diag.Render(test.fault); got != test.want {
+			t.Errorf("%s renders as\n%s\nwant\n%s", test.about, got, test.want)
+		}
+	}
+}
+
+// TestAMergeFailureSaysHowFarTheRunGot keeps the two shapes apart: a fault about
+// one file names it and where it was landing, and a fault about the output
+// directory itself has no file to name and must not invent one.
+func TestAMergeFailureSaysHowFarTheRunGot(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		about string
+		fault *MergeError
+		want  string
+	}{
+		{
+			about: "one file",
+			fault: &MergeError{
+				Name: "go",
+				Path: "pkg/orders.go",
+				Dest: "/src/gen/pkg/orders.go",
+				Err:  errors.New("no space left on device"),
+			},
+			want: `"pkg/orders.go", from the generator "go", could not be merged: no space left on device
+  /src/gen/pkg/orders.go: this is where it was to be written`,
+		},
+		{
+			about: "the directory it was landing in",
+			fault: &MergeError{Name: "go", Dest: "/src/gen", Err: errors.New("permission denied")},
+			want: `the output of the generator "go" could not be merged: permission denied
+  /src/gen: this is the directory it was landing in`,
+		},
+	}
+
+	for _, test := range tests {
+		if got := diag.Render(test.fault); got != test.want {
+			t.Errorf("%s renders as\n%s\nwant\n%s", test.about, got, test.want)
+		}
+	}
+}

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -1,0 +1,231 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package generate
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+	"github.com/Zaba505/cpybkc/internal/plugin"
+	"github.com/Zaba505/cpybkc/irpb"
+)
+
+// scratchPattern is the prefix [os.MkdirTemp] builds the name of one run's
+// scratch space from.
+const scratchPattern = "cpybkc-out-"
+
+// scratchMode is the mode a generator's own directory inside that space is
+// created with: this process's and nothing else's.
+//
+// A generator is a child of this process and writes as the same user, so a
+// private directory costs it nothing. What the mode buys is that a run's
+// half-finished output is not readable by everyone on the machine while it is
+// being produced — the project's tree gets [Runner.Umask]'s modes at the merge,
+// and until then the files are nobody's business but the run's.
+const scratchMode = 0o700
+
+// Generator is one generator a run runs: the executable to run, the options to
+// run it with, and the directory of the project's tree its output lands in.
+//
+// It is not a [github.com/Zaba505/cpybkc/internal/plugin.Invocation]; see the
+// package comment for why the two are kept apart.
+type Generator struct {
+	// Name is the generator's name — the `<name>` a manifest asked for (#40).
+	// It is what every diagnostic about this generator names, and what the
+	// lines it writes are attributed to.
+	Name string
+
+	// Path is the executable to run, as
+	// [github.com/Zaba505/cpybkc/internal/plugin.Resolve] spelled it.
+	Path string
+
+	// Out is the directory of the project's tree this generator's output lands
+	// in — the `out` its manifest entry declared (#40). It may be relative, and
+	// is resolved against the working directory the run is made from, exactly
+	// as the path in the argument vector is.
+	//
+	// Two generators may name the same directory, and a project that generates
+	// a package from two of them usually does. What happens when two of them
+	// also produce the same path *within* it is #44's; until that lands they
+	// are merged in the order they were declared, which is at least the same
+	// order twice.
+	Out string
+
+	// Options are the options to pass, in the order they are to be passed —
+	// the order the manifest declared them, which docs/plugin/SPEC.md makes the
+	// order the argument vector carries them in.
+	Options []plugin.Option
+}
+
+// Owner is a user and a group, as chown(2) takes them.
+type Owner struct {
+	// UID is the user every file and directory the merge creates is given.
+	UID int
+
+	// GID is the group it is given.
+	GID int
+}
+
+// Runner runs the generators of one project.
+//
+// The zero value runs them: the generators are run by the zero
+// [github.com/Zaba505/cpybkc/internal/plugin.Runner], the scratch directories
+// are made wherever the system puts temporary files, everything merged is given
+// this process's umask applied to the usual creation modes, and ownership is
+// left as the merging process's.
+type Runner struct {
+	// Plugins runs the generator executables. Nil is the zero
+	// [github.com/Zaba505/cpybkc/internal/plugin.Runner], read at the moment of
+	// the run, so that a caller that configures logging after building a Runner
+	// is still heard.
+	Plugins *plugin.Runner
+
+	// TempDir is where this run's scratch space is created. Empty is the
+	// default [os.MkdirTemp] uses.
+	//
+	// It is worth setting to somewhere beside the project when the two are on
+	// different filesystems: the merge copies rather than renames, so nothing
+	// breaks when they differ, but the run then writes its whole output twice.
+	TempDir string
+
+	// Umask is the file-creation mask taken out of the mode of everything the
+	// merge creates. Nil is this process's own, read once per run.
+	//
+	// It is a field so that a caller — or a test — can state the mask instead
+	// of moving the process's, which is a process-wide setting that every
+	// generator started concurrently would inherit.
+	Umask *fs.FileMode
+
+	// Owner, when set, is the user and group given to every file and directory
+	// the merge creates. Nil leaves them as the merging process's.
+	Owner *Owner
+}
+
+// Run runs every generator against d, each in a private empty directory of its
+// own, and merges what they left there into the project's tree.
+//
+// Nothing is written where a person would find it until every generator has
+// exited zero: a run in which one failed returns that failure with the
+// project's tree exactly as it found it, down to not creating an output
+// directory that was not already there. A generator that fails after writing
+// files has produced nothing, which is what its scratch directory being
+// discarded means.
+//
+// The failure of the run is the plugin package's — a
+// [github.com/Zaba505/cpybkc/internal/plugin.ExitError] for a generator that
+// exited non-zero, a
+// [github.com/Zaba505/cpybkc/internal/plugin.SignalError] for one that was
+// killed, and all of them where more than one failed — because a generator that
+// ran and failed is a fault about that generator and not about the merge that
+// never happened.
+//
+// What the merge itself refuses is [UnmergeableError], reported for every entry
+// it refused rather than for the first: a plugin that emits symlinks emits them
+// by the directory, and a run that named one of them would be run once per
+// symlink.
+//
+// The context bounds the generators, exactly as it bounds
+// [github.com/Zaba505/cpybkc/internal/plugin.Runner.Run]. It does not interrupt
+// the merge, which happens after every generator has already succeeded and is
+// the step whose partial completion the whole arrangement exists to avoid.
+func (r *Runner) Run(ctx context.Context, d *irpb.Descriptor, generators []Generator) error {
+	if len(generators) == 0 {
+		return nil
+	}
+
+	// Checked before anything is created, for the reason the plugin package
+	// checks an invocation before starting a generator: a generator with
+	// nowhere to put its output is a fault in what the caller assembled, and
+	// finding it after a run would mean discovering it once the work was done.
+	var invalid diag.List
+
+	for _, generator := range generators {
+		if generator.Out == "" {
+			invalid.Fail(fmt.Errorf("the generator %s has no directory for its output to land in",
+				strconv.Quote(generator.Name)))
+		}
+	}
+
+	if invalid.Failed() {
+		return invalid.Err()
+	}
+
+	root, err := os.MkdirTemp(r.TempDir, scratchPattern)
+	if err != nil {
+		return &ScratchError{Err: err}
+	}
+
+	// The scratch space is the run's and does not outlive it, whether the run
+	// succeeded or not. It is not reported: by the time it is removed the
+	// generators have all exited and the merge has been made or refused, so
+	// there is nothing left for a failure to spoil.
+	defer func() {
+		_ = os.RemoveAll(root)
+	}()
+
+	// Made absolute so that the diagnostics and the argument vector name the
+	// same directory even when TempDir was written relative.
+	root, err = filepath.Abs(root)
+	if err != nil {
+		return &ScratchError{Err: err}
+	}
+
+	invocations, err := r.scratch(generators, root)
+	if err != nil {
+		return err
+	}
+
+	if err := r.plugins().Run(ctx, d, invocations); err != nil {
+		return err
+	}
+
+	return r.merge(generators, invocations, root)
+}
+
+// scratch gives each generator its own empty directory and hands back the
+// invocations that run them into it.
+//
+// The directory is named for the generator's position and not for the
+// generator, because two entries of one manifest may name the same generator
+// with different options and different output directories, and a directory
+// named for a generator would then be two generators' — which is the one thing
+// docs/plugin/SPEC.md says a scratch directory is not. Nothing reads the name:
+// a plugin is told where to write and is entitled to derive nothing from the
+// path it was told.
+func (r *Runner) scratch(generators []Generator, root string) ([]plugin.Invocation, error) {
+	invocations := make([]plugin.Invocation, len(generators))
+
+	for i, generator := range generators {
+		dir := filepath.Join(root, strconv.Itoa(i))
+
+		if err := os.Mkdir(dir, scratchMode); err != nil {
+			return nil, &ScratchError{Name: generator.Name, Err: err}
+		}
+
+		invocations[i] = plugin.Invocation{
+			Name:    generator.Name,
+			Path:    generator.Path,
+			Out:     dir,
+			Options: generator.Options,
+		}
+	}
+
+	return invocations, nil
+}
+
+// plugins is what runs the generator executables.
+func (r *Runner) plugins() *plugin.Runner {
+	if r.Plugins != nil {
+		return r.Plugins
+	}
+
+	return &plugin.Runner{}
+}

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -1,0 +1,414 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package generate
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"log/slog"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/plugin"
+	"github.com/Zaba505/cpybkc/irpb"
+)
+
+// The generators below are shell scripts, for the reason the plugin package's
+// tests give: docs/plugin/SPEC.md makes one a first-class plugin, and a test
+// whose fixture was a compiled binary would be testing a toolchain rather than
+// a contract. They are real processes writing to a real filesystem, because
+// what is under test here is what is on disk after a run — which is the one
+// thing a fake could agree with this package about and be wrong.
+//
+// A generator's argument vector is `--descriptor <path> --out <dir>`, so `$4`
+// is the directory it was handed. Every script below reads it there rather than
+// from the environment, which is also the assertion that the directory a plugin
+// is handed is the scratch directory and never the project's tree.
+
+// generator writes an executable plugin named for name, running body, and hands
+// back the [Generator] that lands what it writes in out.
+func generator(t *testing.T, name, body, out string) Generator {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), plugin.Filename(name))
+
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body+"\n"), 0o755); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+
+	return Generator{Name: name, Path: path, Out: out}
+}
+
+// descriptor is the message every run below hands over: a whole descriptor
+// rather than a version field, so that what a generator is handed is what a
+// resolved layout would produce.
+func descriptor() *irpb.Descriptor {
+	return &irpb.Descriptor{
+		Version: irpb.IrVersion_IR_VERSION_1,
+		Nodes: []*irpb.Node{
+			{
+				Id: 1,
+				Kind: &irpb.Node_File{File: &irpb.File{
+					Framing:      &irpb.File_Unframed{Unframed: &irpb.Unframed{}},
+					StartStateId: 2,
+				}},
+			},
+			{
+				Id:   2,
+				Kind: &irpb.Node_State{State: &irpb.State{Accepts: true}},
+			},
+		},
+	}
+}
+
+// runner is a runner whose scratch space is the test's own, so that a test can
+// assert against what is left in it, and whose generators' output goes
+// somewhere a test need not read.
+func runner(t *testing.T) *Runner {
+	t.Helper()
+
+	return &Runner{
+		Plugins: &plugin.Runner{
+			Log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+			TempDir: t.TempDir(),
+		},
+		TempDir: t.TempDir(),
+	}
+}
+
+// run runs generators through r against [descriptor].
+func run(t *testing.T, r *Runner, generators ...Generator) error {
+	t.Helper()
+
+	return r.Run(t.Context(), descriptor(), generators)
+}
+
+// tree is every path beneath root, relative and in sorted order, with what is
+// at it: a file's contents, or what kind of thing it is where it is not a file.
+//
+// A whole tree at once rather than one assertion per path, because most of what
+// these tests claim is about what is *not* there as much as what is.
+func tree(t *testing.T, root string) map[string]string {
+	t.Helper()
+
+	found := map[string]string{}
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || path == root {
+			return err
+		}
+
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+
+		switch {
+		case d.IsDir():
+			found[rel] = "<dir>"
+		case !d.Type().IsRegular():
+			found[rel] = "<" + kind(d.Type()) + ">"
+		default:
+			b, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+
+			found[rel] = string(b)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("reading %s: %v", root, err)
+	}
+
+	return found
+}
+
+// same reports whether a tree is the one wanted, and says how it differs when
+// it is not.
+func same(t *testing.T, root string, want map[string]string) {
+	t.Helper()
+
+	got := tree(t, root)
+
+	if maps.Equal(got, want) {
+		return
+	}
+
+	for _, path := range slices.Sorted(maps.Keys(want)) {
+		if got[path] != want[path] {
+			t.Errorf("%s holds %q, want %q", path, got[path], want[path])
+		}
+	}
+
+	for _, path := range slices.Sorted(maps.Keys(got)) {
+		if _, wanted := want[path]; !wanted {
+			t.Errorf("%s holds %q, and nothing was to be there", path, got[path])
+		}
+	}
+}
+
+// exists reports whether there is anything at path at all.
+func exists(t *testing.T, path string) bool {
+	t.Helper()
+
+	_, err := os.Lstat(path)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+
+	return err == nil
+}
+
+// contents is what is in the file at path.
+func contents(t *testing.T, path string) string {
+	t.Helper()
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+
+	return string(b)
+}
+
+// empty reports whether a directory has nothing in it.
+func empty(t *testing.T, dir string) bool {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", dir, err)
+	}
+
+	return len(entries) == 0
+}
+
+// records is a generator that says whether the directory it was handed was
+// empty, and which directory it was.
+const records = `[ -z "$(ls -A "$4")" ] && echo empty > "$4/state" || echo dirty > "$4/state"
+echo "$4" > "$4/where"`
+
+func TestEachGeneratorIsHandedAPrivateEmptyDirectoryOfItsOwn(t *testing.T) {
+	t.Parallel()
+
+	project := t.TempDir()
+	first := filepath.Join(project, "one")
+	second := filepath.Join(project, "two")
+
+	if err := run(t, runner(t),
+		generator(t, "one", records, first),
+		generator(t, "two", records, second),
+	); err != nil {
+		t.Fatalf("running the generators: %v", err)
+	}
+
+	// docs/plugin/SPEC.md: a plugin MAY assume the directory exists, is
+	// writable, and is empty. The last is what makes the files an invocation
+	// produced mechanically equal to the files in the directory afterwards,
+	// which #44 and #45 both rest on.
+	for _, out := range []string{first, second} {
+		if got := contents(t, filepath.Join(out, "state")); got != "empty\n" {
+			t.Errorf("the generator landing in %s found its directory %s, want it empty", out, got)
+		}
+	}
+
+	handed := map[string]string{
+		first:  contents(t, filepath.Join(first, "where")),
+		second: contents(t, filepath.Join(second, "where")),
+	}
+
+	// Private, and never the project's tree: a generator writing where its
+	// output lands is the arrangement this package exists to replace.
+	if handed[first] == handed[second] {
+		t.Errorf("both generators were handed %s, want a directory each", handed[first])
+	}
+
+	for out, dir := range handed {
+		if dir == out+"\n" {
+			t.Errorf("the generator was handed %s, which is where its output lands", out)
+		}
+	}
+}
+
+func TestNothingReachesTheProjectTreeUntilEveryGeneratorHasSucceeded(t *testing.T) {
+	t.Parallel()
+
+	out := filepath.Join(t.TempDir(), "project")
+
+	// docs/plugin/SPEC.md: one generator's failure fails the whole run, and
+	// nothing is merged until every generator has succeeded — so the one that
+	// exited zero has produced nothing either.
+	err := run(t, runner(t),
+		generator(t, "good", `echo A > "$4/orders.go"`, out),
+		generator(t, "bad", `echo B > "$4/broken.go"
+echo "error: OD-QTY: COMP-3 is not supported" >&2
+exit 1`, out),
+	)
+
+	var exit *plugin.ExitError
+	if !errors.As(err, &exit) {
+		t.Fatalf("the run failed with %v, want a plugin.ExitError", err)
+	}
+
+	if exists(t, out) {
+		t.Errorf("%s was created by a failed run, want the tree left as it was found: %v", out, tree(t, out))
+	}
+}
+
+func TestAGeneratorThatFailsAfterWritingFilesLeavesTheTreeAsItFoundIt(t *testing.T) {
+	t.Parallel()
+
+	out := t.TempDir()
+
+	// Something already in the project's tree, so that "untouched" is a claim
+	// about what is there and not only about what is not.
+	if err := os.WriteFile(filepath.Join(out, "orders.go"), []byte("package orders\n"), 0o644); err != nil {
+		t.Fatalf("writing the file that was already there: %v", err)
+	}
+
+	err := run(t, runner(t), generator(t, "go", `echo half > "$4/orders.go"
+mkdir "$4/pkg"
+echo half > "$4/pkg/order.go"
+exit 2`, out))
+
+	var exit *plugin.ExitError
+	if !errors.As(err, &exit) {
+		t.Fatalf("the run failed with %v, want a plugin.ExitError", err)
+	}
+
+	if got, want := exit.Code, 2; got != want {
+		t.Errorf("the generator was reported as exiting %d, want %d", got, want)
+	}
+
+	same(t, out, map[string]string{"orders.go": "package orders\n"})
+}
+
+func TestASuccessfulRunMergesEveryGeneratorsOutput(t *testing.T) {
+	t.Parallel()
+
+	out := filepath.Join(t.TempDir(), "project", "gen")
+
+	if err := run(t, runner(t),
+		generator(t, "go", `mkdir -p "$4/pkg/orders"
+echo A > "$4/pkg/orders/order.go"
+echo B > "$4/orders.go"
+mkdir "$4/nothing"`, out),
+		generator(t, "docs", `echo C > "$4/orders.md"`, out),
+	); err != nil {
+		t.Fatalf("running the generators: %v", err)
+	}
+
+	// The output directory and every directory above it are made by the merge:
+	// a project that has never been generated into has none of them, and a run
+	// that asked the user to make one first would be a step nobody wrote down.
+	same(t, out, map[string]string{
+		"pkg":                 "<dir>",
+		"pkg/orders":          "<dir>",
+		"pkg/orders/order.go": "A\n",
+		"orders.go":           "B\n",
+		"orders.md":           "C\n",
+		"nothing":             "<dir>",
+	})
+}
+
+func TestTheScratchSpaceDoesNotOutliveTheRun(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		about string
+		body  string
+	}{
+		{about: "a run that succeeded", body: `echo A > "$4/orders.go"`},
+		{about: "a run that failed", body: `echo A > "$4/orders.go"; exit 1`},
+		{about: "a run refused at the merge", body: `ln -s /etc/passwd "$4/link"`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.about, func(t *testing.T) {
+			t.Parallel()
+
+			r := runner(t)
+			out := filepath.Join(t.TempDir(), "project")
+
+			_ = run(t, r, generator(t, "go", test.body, out))
+
+			if !empty(t, r.TempDir) {
+				t.Errorf("%s left %v behind", test.about, tree(t, r.TempDir))
+			}
+		})
+	}
+}
+
+func TestWhatAGeneratorWritesOutsideItsDirectoryIsNotOutput(t *testing.T) {
+	t.Parallel()
+
+	r := runner(t)
+	out := filepath.Join(t.TempDir(), "project")
+
+	// docs/plugin/SPEC.md forbids a plugin to write outside the directory it
+	// was handed, through `..` or through an absolute path. Neither is blocked
+	// — a plugin is a process and writes where its user can — and neither needs
+	// to be: only what is beneath the directory is ever read, so what it wrote
+	// elsewhere is not output, and the run produces what the contract says it
+	// produces.
+	escaped := filepath.Join(t.TempDir(), "escaped.go")
+
+	if err := run(t, r, generator(t, "go", `echo out > "$4/../escaped.go"
+echo out > `+escaped+`
+echo kept > "$4/orders.go"`, out)); err != nil {
+		t.Fatalf("running the generator: %v", err)
+	}
+
+	same(t, out, map[string]string{"orders.go": "kept\n"})
+
+	// The one it wrote into the scratch space went with the scratch space, and
+	// the one it wrote where it liked stayed where it wrote it — outside the
+	// project's tree, which is the claim.
+	if !empty(t, r.TempDir) {
+		t.Errorf("the scratch space still holds %v", tree(t, r.TempDir))
+	}
+
+	if !exists(t, escaped) {
+		t.Errorf("%s is gone; this package does not tidy up after a plugin, it declines to merge it", escaped)
+	}
+}
+
+func TestARunWithNoGeneratorsIsNotAFailure(t *testing.T) {
+	t.Parallel()
+
+	if err := run(t, runner(t)); err != nil {
+		t.Errorf("a run with no generators failed with %v", err)
+	}
+}
+
+func TestAGeneratorWithNowhereForItsOutputIsRefusedBeforeAnythingRuns(t *testing.T) {
+	t.Parallel()
+
+	r := runner(t)
+
+	marker := filepath.Join(t.TempDir(), "ran")
+
+	generator := generator(t, "go", `echo ran > `+marker, "")
+
+	if err := run(t, r, generator); err == nil {
+		t.Fatal("a generator with no output directory was accepted, want it refused")
+	}
+
+	if exists(t, marker) {
+		t.Error("the generator ran, want the run refused before anything started")
+	}
+
+	if !empty(t, r.TempDir) {
+		t.Errorf("the refused run left %v behind", tree(t, r.TempDir))
+	}
+}

--- a/internal/generate/merge.go
+++ b/internal/generate/merge.go
@@ -47,6 +47,11 @@ type entry struct {
 	// source is where it is now, inside the scratch directory.
 	source string
 
+	// root is the generator's output directory, absolute: the boundary between
+	// the path a person wrote and the path a plugin produced, which is what
+	// [merger.mkdirAll] treats the two halves of differently.
+	root string
+
 	// dest is where it is to be, inside the project's tree.
 	dest string
 
@@ -171,7 +176,7 @@ func produced(name, scratch, out string) ([]entry, error) {
 			return err
 		}
 
-		found := entry{generator: name, source: path, dest: filepath.Join(out, rel), path: rel}
+		found := entry{generator: name, source: path, root: out, dest: filepath.Join(out, rel), path: rel}
 
 		switch {
 		case d.IsDir():
@@ -277,44 +282,98 @@ type merger struct {
 // write puts one entry where it is to land.
 func (m *merger) write(e entry) error {
 	if e.dir {
-		return m.mkdirAll(e.dest)
+		return m.mkdirAll(e.root, e.dest)
 	}
 
-	if err := m.mkdirAll(filepath.Dir(e.dest)); err != nil {
+	if err := m.mkdirAll(e.root, filepath.Dir(e.dest)); err != nil {
 		return err
 	}
 
 	return m.copy(e.source, e.dest, e.exec)
 }
 
-// mkdirAll creates a directory and every parent of it that is missing, giving
-// this run's mode and ownership to the ones it created and to nothing else.
+// mkdirAll makes sure there is a directory at path, which is the generator's
+// output directory or somewhere beneath it, and at everything between the two.
+//
+// The two halves are examined differently, and that is the whole of this
+// function. Above and at the output directory the walk follows links; beneath
+// it, it does not. Which half a component is in decides who chose it: the
+// output directory and its parents are the path a person wrote in the manifest,
+// and everything below is a path a plugin produced.
+func (m *merger) mkdirAll(root, path string) error {
+	if path == root {
+		return m.mkdirRoot(path)
+	}
+
+	if err := m.mkdirAll(root, filepath.Dir(path)); err != nil {
+		return err
+	}
+
+	return m.mkdir(path)
+}
+
+// mkdirRoot makes sure there is a directory at the output directory and at
+// every parent of it, creating the ones that are missing.
+//
+// [os.Stat], so a component that is a symlink to a directory is followed: a
+// project reached through one — /tmp on a Mac, a checkout under a symlinked
+// home, an output directory a person deliberately pointed elsewhere — is the
+// path the manifest named, and writing there is writing where it asked. It is
+// not the case [mkdir] guards against, which is a link *underneath* that path.
 //
 // [os.MkdirAll] would do the creating and could not say which directories it
 // had made, and a merge that applied a mode to a directory that was already
-// there would be changing the project's tree rather than adding to it — the
-// output directory a person made themselves, and every directory above it.
-func (m *merger) mkdirAll(path string) error {
+// there would be changing the project's tree rather than adding to it.
+func (m *merger) mkdirRoot(path string) error {
 	switch info, err := os.Stat(path); {
 	case err == nil && info.IsDir():
 		return nil
 	case err == nil:
-		// Something is there and it is not a directory — a plugin producing
-		// `pkg` where a previous run or a person left a file called `pkg`. It
-		// is reported in the filesystem's own vocabulary rather than in a
-		// sentence of this package's, because the caller is holding a
-		// [MergeError] that already says which generator and which path.
 		return &fs.PathError{Op: "mkdir", Path: path, Err: syscall.ENOTDIR}
 	case !errors.Is(err, fs.ErrNotExist):
 		return err
 	}
 
 	if parent := filepath.Dir(path); parent != path {
-		if err := m.mkdirAll(parent); err != nil {
+		if err := m.mkdirRoot(parent); err != nil {
 			return err
 		}
 	}
 
+	return m.create(path)
+}
+
+// mkdir makes sure there is a directory at one path beneath the output
+// directory.
+//
+// [os.Lstat] rather than [os.Stat], and the difference is an escape. A symlink
+// standing where a plugin's path needs a directory — `pkg` pointing at /etc,
+// left by a previous run of something else or by a plugin that got its output
+// merged before this rule existed — reads to [os.Stat] as a perfectly good
+// directory, and every file the run wrote beneath it would go through the link
+// and out of the project's tree. It is refused instead, in the filesystem's own
+// vocabulary, because the caller is holding a [MergeError] that already says
+// which generator and which path.
+//
+// Refused rather than replaced: this is not a path the merge is writing but one
+// it is descending, and removing a directory a person put there — or a link
+// they pointed somewhere on purpose — would be this package throwing away an
+// arrangement it merely failed to understand.
+func (m *merger) mkdir(path string) error {
+	switch info, err := os.Lstat(path); {
+	case err == nil && info.IsDir():
+		return nil
+	case err == nil:
+		return &fs.PathError{Op: "mkdir", Path: path, Err: syscall.ENOTDIR}
+	case !errors.Is(err, fs.ErrNotExist):
+		return err
+	}
+
+	return m.create(path)
+}
+
+// create makes one directory and settles what it is.
+func (m *merger) create(path string) error {
 	if err := os.Mkdir(path, dirMode); err != nil {
 		// Another generator's entry got there first, in a run where two of them
 		// write into one directory. That is the directory being there, which is

--- a/internal/generate/merge.go
+++ b/internal/generate/merge.go
@@ -1,0 +1,420 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package generate
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+	"github.com/Zaba505/cpybkc/internal/plugin"
+)
+
+// The modes everything the merge creates is given, before this run's umask is
+// taken out of them.
+//
+// They are the modes an ordinary program creating a file and a directory asks
+// for, and not the modes the generator's own files carry. A plugin writes into
+// a scratch directory under whatever umask the process — or the container — it
+// ran in happened to have, so carrying its modes through would make the
+// permissions of a file in a checked-out project a function of where it was
+// generated. What is carried across is one bit of the plugin's intent: a file
+// it made executable is merged executable, because a generator that emits a
+// script means it.
+const (
+	fileMode fs.FileMode = 0o666
+	execMode fs.FileMode = 0o777
+	dirMode  fs.FileMode = 0o777
+)
+
+// probeName is the file the run's umask is read with, inside the run's own
+// scratch space and never inside a generator's directory.
+const probeName = ".umask"
+
+// entry is one thing a generator left in its scratch directory, and where it is
+// to land.
+type entry struct {
+	// generator is the generator that produced it, for a diagnostic about it.
+	generator string
+
+	// source is where it is now, inside the scratch directory.
+	source string
+
+	// dest is where it is to be, inside the project's tree.
+	dest string
+
+	// path is the same destination relative to the generator's output
+	// directory: what the plugin called the file, which is the half of the
+	// destination a plugin author recognises.
+	path string
+
+	// dir reports whether it is a directory rather than a file.
+	dir bool
+
+	// exec reports whether the plugin made the file executable.
+	exec bool
+}
+
+// merge puts what the generators left in their scratch directories into the
+// project's tree.
+//
+// Two passes, and the split is the point. The first reads every generator's
+// directory and refuses everything it will not merge, with nothing written; the
+// second writes. A single pass would have the first generator's files in the
+// project's tree by the time the second generator's symlink was found, which is
+// the half-generated tree the whole arrangement exists to avoid.
+func (r *Runner) merge(generators []Generator, invocations []plugin.Invocation, root string) error {
+	planned, err := plan(generators, invocations)
+	if err != nil {
+		return err
+	}
+
+	umask, err := r.umask(root)
+	if err != nil {
+		return err
+	}
+
+	m := &merger{umask: umask, owner: r.Owner}
+
+	for _, e := range planned {
+		if err := m.write(e); err != nil {
+			// The first failure ends the merge rather than being collected.
+			// Everything refusable was refused in the pass above, so a fault
+			// here is the filesystem — a full disk, a directory that is not
+			// writable — and carrying on would put more of the run into a tree
+			// already known to be half of one.
+			return &MergeError{Name: e.generator, Path: e.path, Dest: e.dest, Err: err}
+		}
+	}
+
+	return nil
+}
+
+// plan reads what every generator produced, in the order they were declared,
+// and refuses what cannot be merged.
+//
+// Every fault is collected rather than the first returned: a plugin that emits
+// symlinks emits them by the directory, and a run that named one of them would
+// be a run made once per symlink.
+func plan(generators []Generator, invocations []plugin.Invocation) ([]entry, error) {
+	var (
+		faults  diag.List
+		planned []entry
+	)
+
+	for i, generator := range generators {
+		out, err := filepath.Abs(generator.Out)
+		if err != nil {
+			faults.Fail(&MergeError{Name: generator.Name, Dest: generator.Out, Err: err})
+
+			continue
+		}
+
+		produced, err := produced(generator.Name, invocations[i].Out, out)
+		faults.Fail(err)
+		planned = append(planned, produced...)
+	}
+
+	if faults.Failed() {
+		return nil, faults.Err()
+	}
+
+	return planned, nil
+}
+
+// produced is everything one generator left beneath scratch, as entries landing
+// under out.
+//
+// The walk does not follow symlinks — neither into one that names a directory
+// nor through one that names a file — so nothing outside scratch is ever read.
+// That is the whole of the enforcement docs/plugin/SPEC.md asks for against `..`
+// and against an absolute path: a plugin that wrote through either wrote
+// somewhere this walk does not look, so it produced no output rather than
+// output cpybkc has to reason about.
+func produced(name, scratch, out string) ([]entry, error) {
+	// The directory itself is checked before it is walked, because a plugin
+	// that removed it and put a symlink in its place would otherwise be walked
+	// as a thing with nothing in it and reported as having produced nothing.
+	// It is a fault about the plugin and it is worth saying so.
+	root, err := os.Lstat(scratch)
+	if err != nil {
+		return nil, &MergeError{Name: name, Dest: out, Err: err}
+	}
+
+	if !root.IsDir() {
+		return nil, &UnmergeableError{Name: name, Path: ".", Mode: root.Mode(), Target: target(scratch)}
+	}
+
+	var (
+		faults  diag.List
+		planned []entry
+	)
+
+	err = filepath.WalkDir(scratch, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if path == scratch {
+			return nil
+		}
+
+		rel, err := filepath.Rel(scratch, path)
+		if err != nil {
+			return err
+		}
+
+		found := entry{generator: name, source: path, dest: filepath.Join(out, rel), path: rel}
+
+		switch {
+		case d.IsDir():
+			found.dir = true
+		case d.Type().IsRegular():
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+
+			found.exec = info.Mode().Perm()&0o111 != 0
+		default:
+			// A symlink, a device, a socket, a fifo. None of them is a file the
+			// project's tree can hold, and the first of them is how a plugin
+			// leaves the directory it was given, so it is refused rather than
+			// followed or copied.
+			faults.Fail(&UnmergeableError{Name: name, Path: rel, Mode: d.Type(), Target: target(path)})
+
+			return nil
+		}
+
+		planned = append(planned, found)
+
+		return nil
+	})
+	if err != nil {
+		faults.Fail(&MergeError{Name: name, Dest: out, Err: err})
+	}
+
+	if faults.Failed() {
+		return nil, faults.Err()
+	}
+
+	return planned, nil
+}
+
+// target is where a symlink pointed, for the diagnostic that refuses it, and
+// nothing at all for anything else.
+//
+// It is read rather than resolved: what a diagnostic can say is what the plugin
+// wrote, and resolving it would name a file the plugin never mentioned — or,
+// for a link into a directory that is about to be removed, name nothing.
+func target(path string) string {
+	read, err := os.Readlink(path)
+	if err != nil {
+		return ""
+	}
+
+	return read
+}
+
+// umask is the file-creation mask this run applies to everything it creates.
+func (r *Runner) umask(root string) (fs.FileMode, error) {
+	if r.Umask != nil {
+		return *r.Umask & fs.ModePerm, nil
+	}
+
+	return probeUmask(root)
+}
+
+// probeUmask asks the kernel what this process's umask is by creating a file
+// under it.
+//
+// Not syscall.Umask, whose only way to read the mask is to set it: it is a
+// process-wide setting, generators are started concurrently and inherit it, and
+// a run that read the mask that way could hand a generator a mask nobody chose
+// — for exactly as long as it took to put the old one back. Creating a file
+// with every permission bit asked for and reading back what it got is the same
+// question with nothing set, and it is the mask as the filesystem applies it
+// rather than as the process declares it.
+func probeUmask(dir string) (fs.FileMode, error) {
+	path := filepath.Join(dir, probeName)
+
+	probe, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, fs.ModePerm)
+	if err != nil {
+		return 0, &ScratchError{Err: err}
+	}
+
+	defer func() {
+		_ = os.Remove(path)
+	}()
+
+	info, err := probe.Stat()
+
+	if closed := probe.Close(); err == nil {
+		err = closed
+	}
+
+	if err != nil {
+		return 0, &ScratchError{Err: err}
+	}
+
+	return fs.ModePerm &^ info.Mode().Perm(), nil
+}
+
+// merger writes the plan, and is where the mode and the ownership of everything
+// in a project's generated output is decided.
+type merger struct {
+	umask fs.FileMode
+	owner *Owner
+}
+
+// write puts one entry where it is to land.
+func (m *merger) write(e entry) error {
+	if e.dir {
+		return m.mkdirAll(e.dest)
+	}
+
+	if err := m.mkdirAll(filepath.Dir(e.dest)); err != nil {
+		return err
+	}
+
+	return m.copy(e.source, e.dest, e.exec)
+}
+
+// mkdirAll creates a directory and every parent of it that is missing, giving
+// this run's mode and ownership to the ones it created and to nothing else.
+//
+// [os.MkdirAll] would do the creating and could not say which directories it
+// had made, and a merge that applied a mode to a directory that was already
+// there would be changing the project's tree rather than adding to it — the
+// output directory a person made themselves, and every directory above it.
+func (m *merger) mkdirAll(path string) error {
+	switch info, err := os.Stat(path); {
+	case err == nil && info.IsDir():
+		return nil
+	case err == nil:
+		// Something is there and it is not a directory — a plugin producing
+		// `pkg` where a previous run or a person left a file called `pkg`. It
+		// is reported in the filesystem's own vocabulary rather than in a
+		// sentence of this package's, because the caller is holding a
+		// [MergeError] that already says which generator and which path.
+		return &fs.PathError{Op: "mkdir", Path: path, Err: syscall.ENOTDIR}
+	case !errors.Is(err, fs.ErrNotExist):
+		return err
+	}
+
+	if parent := filepath.Dir(path); parent != path {
+		if err := m.mkdirAll(parent); err != nil {
+			return err
+		}
+	}
+
+	if err := os.Mkdir(path, dirMode); err != nil {
+		// Another generator's entry got there first, in a run where two of them
+		// write into one directory. That is the directory being there, which is
+		// what was wanted.
+		if errors.Is(err, fs.ErrExist) {
+			return nil
+		}
+
+		return err
+	}
+
+	return m.permit(atPath(path), dirMode)
+}
+
+// copy puts one file in the project's tree.
+func (m *merger) copy(source, dest string, exec bool) error {
+	from, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = from.Close()
+	}()
+
+	// Whatever is at the destination is removed rather than opened. A previous
+	// run's file would be truncated either way; a *symlink* left there by a
+	// person, or by something else that writes into this directory, would be
+	// followed — and the run would then write its output through a link to
+	// somewhere nobody asked for. Removing first is what makes the exclusive
+	// create below true rather than optimistic.
+	if err := os.Remove(dest); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+
+	// Created readable and writable by this process alone and given its real
+	// mode once it holds the whole file: a merged file is never briefly
+	// readable by more of the machine than it ends up being, and never visible
+	// at its final mode while it is still half of itself.
+	to, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+
+	if err := m.fill(to, from, exec); err != nil {
+		_ = to.Close()
+
+		return err
+	}
+
+	return to.Close()
+}
+
+// fill writes the file's contents and settles what it is.
+func (m *merger) fill(to *os.File, from *os.File, exec bool) error {
+	if _, err := io.Copy(to, from); err != nil {
+		return err
+	}
+
+	mode := fileMode
+	if exec {
+		mode = execMode
+	}
+
+	return m.permit(to, mode)
+}
+
+// permitted is something the merge can settle the mode and the ownership of: an
+// open file, by its descriptor, or a directory, by its name.
+type permitted interface {
+	Chmod(mode fs.FileMode) error
+	Chown(uid, gid int) error
+}
+
+// atPath is a directory, addressed the only way a directory can be — by name,
+// because the merge does not hold one open.
+type atPath string
+
+// Chmod implements [permitted].
+func (p atPath) Chmod(mode fs.FileMode) error { return os.Chmod(string(p), mode) }
+
+// Chown implements [permitted].
+func (p atPath) Chown(uid, gid int) error { return os.Chown(string(p), uid, gid) }
+
+// permit is the one place a generated file's mode and ownership are decided.
+//
+// Every file and every directory the merge creates passes through here and
+// nothing else does, which is what makes "output ownership and the umask are
+// applied in one place" (#43) a property of this package rather than a
+// convention its callers keep. A file is settled through its own open
+// descriptor, so nothing between the create and the chmod can substitute a
+// different file for it.
+func (m *merger) permit(target permitted, mode fs.FileMode) error {
+	if err := target.Chmod(mode &^ m.umask); err != nil {
+		return err
+	}
+
+	if m.owner == nil {
+		return nil
+	}
+
+	return target.Chown(m.owner.UID, m.owner.GID)
+}

--- a/internal/generate/merge_test.go
+++ b/internal/generate/merge_test.go
@@ -1,0 +1,358 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package generate
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+)
+
+// mode is the mode of whatever is at path, without following a link to it.
+func mode(t *testing.T, path string) fs.FileMode {
+	t.Helper()
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+
+	return info.Mode()
+}
+
+// owner is the user and the group of whatever is at path.
+func owner(t *testing.T, path string) Owner {
+	t.Helper()
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+
+	// cpybkc targets POSIX hosts and nothing else; see docs/plugin/SPEC.md,
+	// "Host platform". A test that went through a portable interface would be
+	// asserting against one that does not carry an owner.
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatalf("%s reports ownership as %T, want a syscall.Stat_t", path, info.Sys())
+	}
+
+	return Owner{UID: int(stat.Uid), GID: int(stat.Gid)}
+}
+
+// umask is a mask to hand a [Runner], stated rather than read: the process's own
+// is a process-wide setting, and a test that moved it would move it for every
+// other test running beside it.
+func umask(mask fs.FileMode) *fs.FileMode { return &mask }
+
+// tight is a generator that writes under a umask of its own, so that what lands
+// in the project's tree is visibly not what the plugin created.
+const tight = `umask 077
+echo A > "$4/orders.go"
+echo B > "$4/generate.sh"
+chmod 700 "$4/generate.sh"
+mkdir "$4/pkg"`
+
+func TestTheModesAreThisRunsRatherThanThePlugins(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		about string
+		mask  fs.FileMode
+		want  map[string]fs.FileMode
+	}{
+		{
+			about: "the usual mask",
+			mask:  0o022,
+			want: map[string]fs.FileMode{
+				".":             0o755,
+				"orders.go":     0o644,
+				"generate.sh":   0o755,
+				"pkg":           0o755,
+				"pkg/orders.go": 0o644,
+			},
+		},
+		{
+			about: "a mask that keeps the output to its owner",
+			mask:  0o077,
+			want: map[string]fs.FileMode{
+				".":             0o700,
+				"orders.go":     0o600,
+				"generate.sh":   0o700,
+				"pkg":           0o700,
+				"pkg/orders.go": 0o600,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.about, func(t *testing.T) {
+			t.Parallel()
+
+			r := runner(t)
+			r.Umask = umask(test.mask)
+
+			out := filepath.Join(t.TempDir(), "project", "gen")
+
+			if err := run(t, r, generator(t, "go", tight+`
+echo C > "$4/pkg/orders.go"`, out)); err != nil {
+				t.Fatalf("running the generator: %v", err)
+			}
+
+			for path, want := range test.want {
+				if got := mode(t, filepath.Join(out, path)).Perm(); got != want {
+					t.Errorf("%s came out %o, want %o", path, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestWithNoMaskStatedThisProcessesOwnIsWhatApplies(t *testing.T) {
+	t.Parallel()
+
+	// The mask is not read by setting it — see probeUmask — so the assertion is
+	// against what this process gets when it creates a file the ordinary way.
+	// That is the same question asked of the same kernel, and it holds whatever
+	// mask the machine running the tests happens to have.
+	reference := filepath.Join(t.TempDir(), "reference")
+
+	created, err := os.OpenFile(reference, os.O_WRONLY|os.O_CREATE|os.O_EXCL, fileMode)
+	if err != nil {
+		t.Fatalf("creating %s: %v", reference, err)
+	}
+
+	if err := created.Close(); err != nil {
+		t.Fatalf("closing %s: %v", reference, err)
+	}
+
+	out := filepath.Join(t.TempDir(), "project")
+
+	if err := run(t, runner(t), generator(t, "go", tight, out)); err != nil {
+		t.Fatalf("running the generator: %v", err)
+	}
+
+	if got, want := mode(t, filepath.Join(out, "orders.go")).Perm(), mode(t, reference).Perm(); got != want {
+		t.Errorf("the merged file came out %o, want the %o this process creates a file with", got, want)
+	}
+}
+
+func TestOwnershipIsGivenToEverythingTheMergeCreates(t *testing.T) {
+	t.Parallel()
+
+	// Somebody this process can give a file to. Where the tests run as root —
+	// which is how the pipeline runs them — that is anybody, and asking for a
+	// user this process is not makes the claim a real one; where they run as a
+	// person, the only user they can give a file to is themselves.
+	want := Owner{UID: os.Geteuid(), GID: os.Getegid()}
+	if want.UID == 0 {
+		want = Owner{UID: 65534, GID: 65534}
+	}
+
+	r := runner(t)
+	r.Owner = &want
+
+	out := filepath.Join(t.TempDir(), "project", "gen")
+
+	if err := run(t, r, generator(t, "go", `mkdir "$4/pkg"
+echo A > "$4/pkg/orders.go"`, out)); err != nil {
+		t.Fatalf("running the generator: %v", err)
+	}
+
+	// The output directory, the directory the plugin made beneath it, and the
+	// file: everything the merge created and nothing it did not.
+	for _, path := range []string{".", "pkg", "pkg/orders.go"} {
+		if got := owner(t, filepath.Join(out, path)); got != want {
+			t.Errorf("%s came out owned by %d:%d, want %d:%d", path, got.UID, got.GID, want.UID, want.GID)
+		}
+	}
+}
+
+func TestADirectoryThatWasAlreadyThereKeepsItsMode(t *testing.T) {
+	t.Parallel()
+
+	// A merge adds to a project's tree; it does not restate what the person who
+	// made the directory decided about it.
+	out := t.TempDir()
+
+	if err := os.Chmod(out, 0o777); err != nil {
+		t.Fatalf("setting the mode of %s: %v", out, err)
+	}
+
+	r := runner(t)
+	r.Umask = umask(0o022)
+
+	if err := run(t, r, generator(t, "go", `echo A > "$4/orders.go"`, out)); err != nil {
+		t.Fatalf("running the generator: %v", err)
+	}
+
+	if got, want := mode(t, out).Perm(), fs.FileMode(0o777); got != want {
+		t.Errorf("the directory that was already there came out %o, want the %o it was left at", got, want)
+	}
+}
+
+func TestASymlinkIsRefusedRatherThanFollowed(t *testing.T) {
+	t.Parallel()
+
+	elsewhere := filepath.Join(t.TempDir(), "elsewhere.go")
+
+	if err := os.WriteFile(elsewhere, []byte("untouched\n"), 0o644); err != nil {
+		t.Fatalf("writing the file outside the run: %v", err)
+	}
+
+	tests := []struct {
+		about string
+		body  string
+	}{
+		{
+			about: "one pointing out of the directory it was handed",
+			body:  `ln -s ` + elsewhere + ` "$4/orders.go"`,
+		},
+		{
+			about: "one pointing inside it",
+			body: `echo A > "$4/real.go"
+ln -s real.go "$4/orders.go"`,
+		},
+		{
+			about: "one in place of the directory it was handed",
+			body: `rmdir "$4"
+ln -s ` + filepath.Dir(elsewhere) + ` "$4"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.about, func(t *testing.T) {
+			t.Parallel()
+
+			out := filepath.Join(t.TempDir(), "project")
+
+			err := run(t, runner(t), generator(t, "go", test.body, out))
+
+			var refused *UnmergeableError
+			if !errors.As(err, &refused) {
+				t.Fatalf("the run failed with %v, want an UnmergeableError", err)
+			}
+
+			if refused.Mode&fs.ModeSymlink == 0 {
+				t.Errorf("what was refused is reported as %s, want a symlink", refused.Mode)
+			}
+
+			// Refused, and refused before anything was written: a run that
+			// merged the files beside the link and then stopped would be the
+			// half-generated tree the scratch directory exists to prevent.
+			if exists(t, out) {
+				t.Errorf("%s was created by a refused run: %v", out, tree(t, out))
+			}
+
+			if got := contents(t, elsewhere); got != "untouched\n" {
+				t.Errorf("the file outside the run reads %q, want it untouched", got)
+			}
+		})
+	}
+}
+
+func TestEveryEntryTheMergeRefusesIsReported(t *testing.T) {
+	t.Parallel()
+
+	out := filepath.Join(t.TempDir(), "project")
+
+	// A plugin that emits symlinks emits them by the directory. A run that
+	// named one of them would be a run made once per symlink.
+	err := run(t, runner(t),
+		generator(t, "one", `ln -s /etc/passwd "$4/a.go"
+ln -s /etc/passwd "$4/b.go"`, out),
+		generator(t, "two", `ln -s /etc/passwd "$4/c.go"`, out),
+	)
+
+	if got, want := len(diag.Diagnostics(err)), 3; got != want {
+		t.Errorf("the run reported %d faults, want %d:\n%s", got, want, diag.Render(err))
+	}
+}
+
+func TestAnythingThatIsNotAFileOrADirectoryIsRefused(t *testing.T) {
+	t.Parallel()
+
+	out := filepath.Join(t.TempDir(), "project")
+
+	// A named pipe is the one of these a test can make without privileges, and
+	// what it stands for is the rule: the merge takes files and directories and
+	// leaves everything else where it found it.
+	err := run(t, runner(t), generator(t, "go", `mkfifo "$4/orders.go"`, out))
+
+	var refused *UnmergeableError
+	if !errors.As(err, &refused) {
+		t.Fatalf("the run failed with %v, want an UnmergeableError", err)
+	}
+
+	if got, want := refused.Path, "orders.go"; got != want {
+		t.Errorf("the fault names %q, want %q", got, want)
+	}
+
+	if exists(t, out) {
+		t.Errorf("%s was created by a refused run: %v", out, tree(t, out))
+	}
+}
+
+func TestARerunReplacesWhatItProducedAndNeverWritesThroughALink(t *testing.T) {
+	t.Parallel()
+
+	elsewhere := filepath.Join(t.TempDir(), "elsewhere.go")
+
+	if err := os.WriteFile(elsewhere, []byte("untouched\n"), 0o644); err != nil {
+		t.Fatalf("writing the file outside the run: %v", err)
+	}
+
+	out := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(out, "orders.go"), []byte("the run before\n"), 0o644); err != nil {
+		t.Fatalf("writing the previous run's output: %v", err)
+	}
+
+	// A link where a generated file goes, left by a person or by something else
+	// that writes into this directory. Opening it would write the run's output
+	// through it, into a file nobody named.
+	if err := os.Symlink(elsewhere, filepath.Join(out, "order.go")); err != nil {
+		t.Fatalf("writing the link: %v", err)
+	}
+
+	if err := run(t, runner(t), generator(t, "go", `echo new > "$4/orders.go"
+echo new > "$4/order.go"`, out)); err != nil {
+		t.Fatalf("running the generator: %v", err)
+	}
+
+	same(t, out, map[string]string{"orders.go": "new\n", "order.go": "new\n"})
+
+	if got := contents(t, elsewhere); got != "untouched\n" {
+		t.Errorf("the file the link pointed at reads %q, want it untouched", got)
+	}
+}
+
+func TestAFileWhereADirectoryHasToGoIsAFaultAndNotASilence(t *testing.T) {
+	t.Parallel()
+
+	out := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(out, "pkg"), []byte("not a directory\n"), 0o644); err != nil {
+		t.Fatalf("writing the file in the way: %v", err)
+	}
+
+	err := run(t, runner(t), generator(t, "go", `mkdir "$4/pkg"
+echo A > "$4/pkg/orders.go"`, out))
+
+	var merge *MergeError
+	if !errors.As(err, &merge) {
+		t.Fatalf("the run failed with %v, want a MergeError", err)
+	}
+
+	if !errors.Is(err, syscall.ENOTDIR) {
+		t.Errorf("the fault is %v, want it to carry the filesystem's own", err)
+	}
+}

--- a/internal/generate/merge_test.go
+++ b/internal/generate/merge_test.go
@@ -335,6 +335,61 @@ echo new > "$4/order.go"`, out)); err != nil {
 	}
 }
 
+func TestALinkWhereADirectoryHasToGoIsNotWrittenThrough(t *testing.T) {
+	t.Parallel()
+
+	// The escape a merge that resolved its path components with os.Stat would
+	// make: `pkg` in the project's tree is a link to somewhere else entirely,
+	// os.Stat reads it as a perfectly good directory, and every file the plugin
+	// produced beneath `pkg` goes through it.
+	elsewhere := t.TempDir()
+	out := t.TempDir()
+
+	if err := os.Symlink(elsewhere, filepath.Join(out, "pkg")); err != nil {
+		t.Fatalf("writing the link: %v", err)
+	}
+
+	err := run(t, runner(t), generator(t, "go", `mkdir "$4/pkg"
+echo A > "$4/pkg/orders.go"`, out))
+
+	var merge *MergeError
+	if !errors.As(err, &merge) {
+		t.Fatalf("the run failed with %v, want a MergeError", err)
+	}
+
+	if !errors.Is(err, syscall.ENOTDIR) {
+		t.Errorf("the fault is %v, want it to carry the filesystem's own", err)
+	}
+
+	same(t, elsewhere, map[string]string{})
+}
+
+func TestAnOutputDirectoryReachedThroughALinkIsFollowed(t *testing.T) {
+	t.Parallel()
+
+	// The other half of the same rule. A person's project reached through a
+	// link — /tmp on a Mac, a checkout under a symlinked home, an output
+	// directory pointed somewhere on purpose — is the path the manifest named,
+	// and writing there is writing where it asked.
+	actual := t.TempDir()
+	link := filepath.Join(t.TempDir(), "project")
+
+	if err := os.Symlink(actual, link); err != nil {
+		t.Fatalf("writing the link: %v", err)
+	}
+
+	if err := run(t, runner(t), generator(t, "go", `mkdir "$4/pkg"
+echo A > "$4/pkg/orders.go"`, filepath.Join(link, "gen"))); err != nil {
+		t.Fatalf("running the generator: %v", err)
+	}
+
+	same(t, actual, map[string]string{
+		"gen":               "<dir>",
+		"gen/pkg":           "<dir>",
+		"gen/pkg/orders.go": "A\n",
+	})
+}
+
 func TestAFileWhereADirectoryHasToGoIsAFaultAndNotASilence(t *testing.T) {
 	t.Parallel()
 

--- a/internal/plugin/doc.go
+++ b/internal/plugin/doc.go
@@ -15,8 +15,9 @@
 // diagnostics": each generator is started once with the descriptor and the
 // directory it writes into, they run concurrently, what they write is surfaced
 // as they write it, and one that fails fails the run. What may be *in* the
-// directory afterwards, and how it reaches the project's output tree, is #43's
-// and #44's; this package hands a generator a path and reads its verdict.
+// directory afterwards, and how it reaches the project's output tree, is
+// [github.com/Zaba505/cpybkc/internal/generate]'s (#43, #44); this package
+// hands a generator a path and reads its verdict.
 //
 // # Why running is here rather than beside the caller
 //


### PR DESCRIPTION
Closes #43

`internal/generate` is the one place anything reaches a project's output tree. Each generator is handed a private, empty directory of the run's making; what it leaves there is merged only once **every** generator in the run has exited zero.

## Acceptance criteria

- [x] **Each plugin writes into a private scratch directory** — `Runner.scratch` makes one directory per invocation under a single `MkdirTemp` root, mode `0700`, named for the generator's position rather than its name (two manifest entries may name one generator with different options and different output directories). The plugin never learns where the project tree is; `Generator.Out` is this package's, and `plugin.Invocation.Out` is the scratch directory.
- [x] **Merge into the real `out` directory happens only after exit 0** — and after every *other* generator's, which is the stronger rule `docs/plugin/SPEC.md` states and #44 depends on. `Runner.Run` merges only when `plugin.Runner.Run` returns nil.
- [x] **A failing plugin leaves the `out` directory untouched** — down to not creating it. The scratch space is removed with the run either way.
- [x] **Ownership and umask applied in one place during the merge** — `merger.permit` is the only call that sets a mode or an owner, and every file and directory the merge creates passes through it. `Runner.Umask` (nil = this process's, probed) and `Runner.Owner` (nil = the merging process's) are the policy.
- [x] **Tests cover a plugin that exits non-zero after writing files** — two of them: one where the failing generator is beside a successful one and neither lands, and one against a project tree that already held a file, asserting it is byte-for-byte as it was found.

## Judgment calls

- **A new package rather than `internal/plugin`.** That package's doc comment already draws the line: it "hands a generator a path and reads its verdict". `generate.Generator` is deliberately not `plugin.Invocation` — the two disagree about what an output directory is, and one field spelling both would let a caller hand a plugin the project's tree by writing the obvious thing.
- **"Enforced rather than trusted" is stated precisely.** A plugin is a separate process and nothing here can stop one writing where its user can. What is enforced is what reaches the tree: only what is *beneath* the directory is ever read (so `..` and absolute-path writes are simply not output), a symlink is refused wherever it points rather than followed, and a destination is removed before it is created so a link already in the tree is replaced rather than written through. A test asserts the file a link pointed at is untouched.
- **Nothing but regular files and directories is merged.** Symlinks, devices, fifos and sockets are an `UnmergeableError`, reported for every entry rather than the first, with nothing written. Relaxing this later is a spec change; merging one now would be a decision made silently.
- **Modes come from the run, not from the plugin** — `0666`/`0777`/`0777` for an executable, less the run's umask. The umask is *probed* by creating a file rather than read with `syscall.Umask`, whose only way to read it is to set it, process-wide, while generators are being started concurrently. A directory that was already there keeps its mode: a merge adds to a tree rather than restating what the person who made it decided.
- **Collision detection (#44) and pruning (#45) are not here.** Two generators writing one path is still last-writer-wins, in declared order, which is at least the same answer twice.

## Verification

`dagger call ci` — green, and `go test -race ./...` locally. The new package's tests are real shell-script plugins against a real filesystem, in the style `internal/plugin`'s use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)