### PR TITLE
story(plugin): detect cross-plugin output collisions

### DIFF
--- a/internal/generate/doc.go
+++ b/internal/generate/doc.go
@@ -29,8 +29,24 @@
 // directory afterwards". No marker inside a generated file, no manifest a
 // plugin has to maintain, and no bookkeeping asked of a plugin author at all —
 // which is what lets the contract stay small enough for a generator to be a
-// shell script. Cross-generator collision detection (#44) and stale-file
-// pruning (#45) both rest on that equality; neither is here yet.
+// shell script. Cross-generator collision detection rests on that equality, and
+// so will stale-file pruning (#45), which is not here yet.
+//
+// # Why a collision is the run's fault and not a generator's
+//
+// Two generators producing one path in the project's tree fails the run with
+// nothing merged (docs/plugin/SPEC.md, "What a plugin does not own"), and
+// neither of them is the one that was wrong. A plugin is told nothing about the
+// others, cannot coordinate with them, and is entitled to produce the files its
+// options asked for; what is wrong is the pair, and the fix is a manifest that
+// stops asking two executables for one file.
+//
+// So the fault names both, and it is found in the pass that plans the merge
+// rather than as each generator finishes. A check made per generator would let
+// the first one's files land before the second was known about, and would then
+// name whichever of them lost a race — so identical inputs would fail
+// differently on different runs, which is the one thing generated output cannot
+// do.
 //
 // # Why the merge waits for every generator
 //

--- a/internal/generate/errors.go
+++ b/internal/generate/errors.go
@@ -147,7 +147,7 @@ func kind(mode fs.FileMode) string {
 }
 
 // CollisionError is one place in a project's tree that two generators both
-// produced.
+// claim.
 //
 // docs/plugin/SPEC.md: two generators producing the same output path is an
 // error cpybkc raises before anything is merged, naming both, and a collision
@@ -159,8 +159,8 @@ func kind(mode fs.FileMode) string {
 // It is found in the same pass as an [UnmergeableError] and before anything is
 // written, so a collision costs the run and never half a tree.
 type CollisionError struct {
-	// First and Second are the generators that produced it, in the order the
-	// run declared them rather than the order they finished in: generators run
+	// First and Second are the generators that claim it, in the order the run
+	// declared them rather than the order they finished in: generators run
 	// concurrently, and a fault naming whichever of them lost a race would
 	// report the same inputs differently on different runs.
 	First, Second string
@@ -173,9 +173,14 @@ type CollisionError struct {
 	// rather than coincide: a generator landing in `gen` that produced
 	// `pkg/orders.go` and one landing in `gen/pkg` that produced `orders.go`
 	// have produced one file between them.
+	//
+	// Either is `.` where what that generator claims is not something it
+	// produced at all but the output directory it was given, or a directory
+	// above it — a path the merge has to create for the generator to land
+	// anything, and the one claim on a project's tree a plugin had no say in.
 	FirstPath, SecondPath string
 
-	// Dest is where both were to land, in the project's tree.
+	// Dest is the path in the project's tree both of them claim.
 	Dest string
 }
 
@@ -184,30 +189,34 @@ func (e *CollisionError) Error() string { return e.Diagnostic().String() }
 
 // Diagnostic is what the error says, and where.
 //
-// The last span is the rule rather than a place, for the reason
-// [UnmergeableError.Diagnostic] gives: nothing in this repository decided this,
-// and what a reader needs is what to do about two executables that disagree.
+// One shape for every collision rather than a sentence per kind. The two sides
+// are not alike — a file against a file, a file against a directory, a file
+// against the directory another generator was told to land its output in — and
+// a single sentence saying which was which would need a clause per combination.
+// The path both claim is the message, each side says for itself what it wanted
+// with it, and the last span is the rule rather than a place, for the reason
+// [UnmergeableError.Diagnostic] gives.
 func (e *CollisionError) Diagnostic() diag.Diagnostic {
-	message := fmt.Sprintf("the generators %s and %s both produced %s, and nothing was merged",
-		strconv.Quote(e.First), strconv.Quote(e.Second), strconv.Quote(e.FirstPath))
-
-	// Where the output directories overlap, the two names are two names for one
-	// path, and a message quoting either alone would send half of its readers
-	// looking for something their plugin never wrote.
-	if e.FirstPath != e.SecondPath {
-		message = fmt.Sprintf("%s, from the generator %s, and %s, from the generator %s, land in the same place, and nothing was merged",
-			strconv.Quote(e.FirstPath), strconv.Quote(e.First),
-			strconv.Quote(e.SecondPath), strconv.Quote(e.Second))
-	}
-
 	return diag.Diagnostic{
-		Message: message,
+		Message: fmt.Sprintf("the generators %s and %s both claim %s, and nothing was merged",
+			strconv.Quote(e.First), strconv.Quote(e.Second), strconv.Quote(e.Dest)),
 		Spans: []diag.Span{
 			{},
-			{File: e.Dest, Note: "this is where both were to land"},
+			{Note: claim(e.First, e.FirstPath)},
+			{Note: claim(e.Second, e.SecondPath)},
 			{Note: "a path in a project's tree is one generator's, so cpybkc refuses the run rather than merging whichever it reached last: stop one of them producing it, or land the two in directories that do not overlap"},
 		},
 	}
+}
+
+// claim is one side of a collision saying what it wanted with the path.
+func claim(name, path string) string {
+	if path == "." {
+		return fmt.Sprintf("it has to be a directory for the generator %s to land its output",
+			strconv.Quote(name))
+	}
+
+	return fmt.Sprintf("the generator %s produced it as %s", strconv.Quote(name), strconv.Quote(path))
 }
 
 // MergeError is output that could not be put into the project's tree.

--- a/internal/generate/errors.go
+++ b/internal/generate/errors.go
@@ -146,15 +146,79 @@ func kind(mode fs.FileMode) string {
 	}
 }
 
+// CollisionError is one place in a project's tree that two generators both
+// produced.
+//
+// docs/plugin/SPEC.md: two generators producing the same output path is an
+// error cpybkc raises before anything is merged, naming both, and a collision
+// fails the run with nothing merged. Merging one of them would make what the
+// project holds a function of which generator the merge reached last — and
+// since a plugin is told nothing about the others and MUST NOT coordinate with
+// them, neither of the two is the one that meant it.
+//
+// It is found in the same pass as an [UnmergeableError] and before anything is
+// written, so a collision costs the run and never half a tree.
+type CollisionError struct {
+	// First and Second are the generators that produced it, in the order the
+	// run declared them rather than the order they finished in: generators run
+	// concurrently, and a fault naming whichever of them lost a race would
+	// report the same inputs differently on different runs.
+	First, Second string
+
+	// FirstPath and SecondPath are what each of them called it, relative to the
+	// directory that generator was handed — the name each plugin's author will
+	// recognise.
+	//
+	// They are the same path except where the two output directories overlap
+	// rather than coincide: a generator landing in `gen` that produced
+	// `pkg/orders.go` and one landing in `gen/pkg` that produced `orders.go`
+	// have produced one file between them.
+	FirstPath, SecondPath string
+
+	// Dest is where both were to land, in the project's tree.
+	Dest string
+}
+
+// Error implements the error interface.
+func (e *CollisionError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+//
+// The last span is the rule rather than a place, for the reason
+// [UnmergeableError.Diagnostic] gives: nothing in this repository decided this,
+// and what a reader needs is what to do about two executables that disagree.
+func (e *CollisionError) Diagnostic() diag.Diagnostic {
+	message := fmt.Sprintf("the generators %s and %s both produced %s, and nothing was merged",
+		strconv.Quote(e.First), strconv.Quote(e.Second), strconv.Quote(e.FirstPath))
+
+	// Where the output directories overlap, the two names are two names for one
+	// path, and a message quoting either alone would send half of its readers
+	// looking for something their plugin never wrote.
+	if e.FirstPath != e.SecondPath {
+		message = fmt.Sprintf("%s, from the generator %s, and %s, from the generator %s, land in the same place, and nothing was merged",
+			strconv.Quote(e.FirstPath), strconv.Quote(e.First),
+			strconv.Quote(e.SecondPath), strconv.Quote(e.Second))
+	}
+
+	return diag.Diagnostic{
+		Message: message,
+		Spans: []diag.Span{
+			{},
+			{File: e.Dest, Note: "this is where both were to land"},
+			{Note: "a path in a project's tree is one generator's, so cpybkc refuses the run rather than merging whichever it reached last: stop one of them producing it, or land the two in directories that do not overlap"},
+		},
+	}
+}
+
 // MergeError is output that could not be put into the project's tree.
 //
-// Everything the merge refuses of its own accord is an [UnmergeableError] and
-// is reported before anything is written, so this is the filesystem: a full
-// disk, a directory that is not writable, a path in the project's tree where a
-// file stands and a directory has to go. Unlike a refusal, it can be raised
-// with part of the run's output already merged — which is why it names both the
-// generator's own path and where that path was landing, so that a person can
-// see how far the run got.
+// Everything the merge refuses of its own accord is an [UnmergeableError] or a
+// [CollisionError] and is reported before anything is written, so this is the
+// filesystem: a full disk, a directory that is not writable, a path in the
+// project's tree where a file stands and a directory has to go. Unlike a
+// refusal, it can be raised with part of the run's output already merged —
+// which is why it names both the generator's own path and where that path was
+// landing, so that a person can see how far the run got.
 type MergeError struct {
 	// Name is the generator whose output it was.
 	Name string

--- a/internal/generate/errors_test.go
+++ b/internal/generate/errors_test.go
@@ -36,6 +36,11 @@ func TestEveryFaultReadsTheSameThroughEitherEnd(t *testing.T) {
 			Second: "docs", SecondPath: "orders.go",
 			Dest: "gen/orders.go",
 		},
+		&CollisionError{
+			First: "go", FirstPath: "gen",
+			Second: "docs", SecondPath: ".",
+			Dest: "gen",
+		},
 		&MergeError{Name: "go", Dest: "gen", Err: errors.New("permission denied")},
 		&MergeError{Name: "go", Path: "orders.go", Dest: "gen/orders.go", Err: errors.New("permission denied")},
 	}
@@ -121,22 +126,39 @@ func TestACollisionNamesBothGeneratorsAndWhatTheyProduced(t *testing.T) {
 				Second: "docs", SecondPath: "pkg/orders.go",
 				Dest: "/src/gen/pkg/orders.go",
 			},
-			want: `the generators "go" and "docs" both produced "pkg/orders.go", and nothing was merged
-  /src/gen/pkg/orders.go: this is where both were to land
+			want: `the generators "go" and "docs" both claim "/src/gen/pkg/orders.go", and nothing was merged
+  the generator "go" produced it as "pkg/orders.go"
+  the generator "docs" produced it as "pkg/orders.go"
 ` + rule,
 		},
 		{
 			// Neither plugin's author would recognise the other's name for it,
-			// so quoting one alone would send half the readers looking for a
-			// path their generator never wrote.
+			// so a message quoting one alone would send half the readers looking
+			// for a path their generator never wrote.
 			about: "output directories that overlap",
 			fault: &CollisionError{
 				First: "go", FirstPath: "pkg/orders.go",
 				Second: "docs", SecondPath: "orders.go",
 				Dest: "/src/gen/pkg/orders.go",
 			},
-			want: `"pkg/orders.go", from the generator "go", and "orders.go", from the generator "docs", land in the same place, and nothing was merged
-  /src/gen/pkg/orders.go: this is where both were to land
+			want: `the generators "go" and "docs" both claim "/src/gen/pkg/orders.go", and nothing was merged
+  the generator "go" produced it as "pkg/orders.go"
+  the generator "docs" produced it as "orders.go"
+` + rule,
+		},
+		{
+			// One of the two never produced anything at that path: it is where
+			// the manifest told it to land its output, and a message saying it
+			// produced a directory there would be describing a plugin's doing.
+			about: "a file where the other was told to land its output",
+			fault: &CollisionError{
+				First: "go", FirstPath: "pkg",
+				Second: "docs", SecondPath: ".",
+				Dest: "/src/gen/pkg",
+			},
+			want: `the generators "go" and "docs" both claim "/src/gen/pkg", and nothing was merged
+  the generator "go" produced it as "pkg"
+  it has to be a directory for the generator "docs" to land its output
 ` + rule,
 		},
 	}

--- a/internal/generate/errors_test.go
+++ b/internal/generate/errors_test.go
@@ -26,6 +26,16 @@ func TestEveryFaultReadsTheSameThroughEitherEnd(t *testing.T) {
 		&UnmergeableError{Name: "go", Path: "orders.go", Mode: fs.ModeSymlink, Target: "/etc/passwd"},
 		&UnmergeableError{Name: "go", Path: "orders.go", Mode: fs.ModeNamedPipe},
 		&UnmergeableError{Name: "go", Path: ".", Mode: fs.ModeSymlink},
+		&CollisionError{
+			First: "go", FirstPath: "orders.go",
+			Second: "docs", SecondPath: "orders.go",
+			Dest: "gen/orders.go",
+		},
+		&CollisionError{
+			First: "go", FirstPath: "gen/orders.go",
+			Second: "docs", SecondPath: "orders.go",
+			Dest: "gen/orders.go",
+		},
 		&MergeError{Name: "go", Dest: "gen", Err: errors.New("permission denied")},
 		&MergeError{Name: "go", Path: "orders.go", Dest: "gen/orders.go", Err: errors.New("permission denied")},
 	}
@@ -79,6 +89,55 @@ func TestARefusalSaysWhatWasLeftAndWhyItWasNotMerged(t *testing.T) {
 			fault: &UnmergeableError{Name: "go", Path: "orders.go", Mode: fs.ModeNamedPipe},
 			want: `the generator "go" left a named pipe at "orders.go", and its output was not merged
   a generator's output is the files and the directories it leaves beneath the directory it was handed, and cpybkc merges nothing else`,
+		},
+	}
+
+	for _, test := range tests {
+		if got := diag.Render(test.fault); got != test.want {
+			t.Errorf("%s renders as\n%s\nwant\n%s", test.about, got, test.want)
+		}
+	}
+}
+
+// TestACollisionNamesBothGeneratorsAndWhatTheyProduced is what #44 asks of the
+// message. A person reading it has two plugins and one path, neither plugin is
+// the one that was wrong, and what they have to change is the manifest that
+// asked both for it — so the fault names both, names the path each of them
+// called it, and says where the two would have landed.
+func TestACollisionNamesBothGeneratorsAndWhatTheyProduced(t *testing.T) {
+	t.Parallel()
+
+	const rule = "  a path in a project's tree is one generator's, so cpybkc refuses the run rather than merging whichever it reached last: stop one of them producing it, or land the two in directories that do not overlap"
+
+	tests := []struct {
+		about string
+		fault *CollisionError
+		want  string
+	}{
+		{
+			about: "two generators landing in one directory",
+			fault: &CollisionError{
+				First: "go", FirstPath: "pkg/orders.go",
+				Second: "docs", SecondPath: "pkg/orders.go",
+				Dest: "/src/gen/pkg/orders.go",
+			},
+			want: `the generators "go" and "docs" both produced "pkg/orders.go", and nothing was merged
+  /src/gen/pkg/orders.go: this is where both were to land
+` + rule,
+		},
+		{
+			// Neither plugin's author would recognise the other's name for it,
+			// so quoting one alone would send half the readers looking for a
+			// path their generator never wrote.
+			about: "output directories that overlap",
+			fault: &CollisionError{
+				First: "go", FirstPath: "pkg/orders.go",
+				Second: "docs", SecondPath: "orders.go",
+				Dest: "/src/gen/pkg/orders.go",
+			},
+			want: `"pkg/orders.go", from the generator "go", and "orders.go", from the generator "docs", land in the same place, and nothing was merged
+  /src/gen/pkg/orders.go: this is where both were to land
+` + rule,
 		},
 	}
 

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -53,10 +53,8 @@ type Generator struct {
 	// as the path in the argument vector is.
 	//
 	// Two generators may name the same directory, and a project that generates
-	// a package from two of them usually does. What happens when two of them
-	// also produce the same path *within* it is #44's; until that lands they
-	// are merged in the order they were declared, which is at least the same
-	// order twice.
+	// a package from two of them usually does. Two that also produce the same
+	// path *within* it fail the run with nothing merged; see [CollisionError].
 	Out string
 
 	// Options are the options to pass, in the order they are to be passed —
@@ -127,10 +125,13 @@ type Runner struct {
 // ran and failed is a fault about that generator and not about the merge that
 // never happened.
 //
-// What the merge itself refuses is [UnmergeableError], reported for every entry
-// it refused rather than for the first: a plugin that emits symlinks emits them
-// by the directory, and a run that named one of them would be run once per
-// symlink.
+// What the merge itself refuses is [UnmergeableError] — something a generator
+// left that is neither a file nor a directory — and [CollisionError], one place
+// in the project's tree that two generators both produced. Both are reported
+// for every entry refused rather than for the first: a plugin that emits
+// symlinks emits them by the directory, and a run that named one of them would
+// be run once per symlink. Both are decided before anything is written, so
+// either costs the run and never half a tree.
 //
 // The context bounds the generators, exactly as it bounds
 // [github.com/Zaba505/cpybkc/internal/plugin.Runner.Run]. It does not interrupt

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"syscall"
 	"testing"
 
 	"github.com/Zaba505/cpybkc/internal/plugin"
@@ -34,12 +35,24 @@ import (
 
 // generator writes an executable plugin named for name, running body, and hands
 // back the [Generator] that lands what it writes in out.
+//
+// The script is written under [syscall.ForkLock], held for reading, which is
+// the lock's purpose: a fork made anywhere in this process while the script is
+// open for writing hands the child a copy of that descriptor, and the child
+// holds it until it execs — so an exec of the script inside that window fails
+// with ETXTBSY (golang/go#22315). The tests here write scripts and fork them at
+// the same time, all in one process, so the window is real; it is CI, with more
+// tests running than the machine has cores, that finds it.
 func generator(t *testing.T, name, body, out string) Generator {
 	t.Helper()
 
 	path := filepath.Join(t.TempDir(), plugin.Filename(name))
 
-	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body+"\n"), 0o755); err != nil {
+	syscall.ForkLock.RLock()
+	err := os.WriteFile(path, []byte("#!/bin/sh\n"+body+"\n"), 0o755)
+	syscall.ForkLock.RUnlock()
+
+	if err != nil {
 		t.Fatalf("writing %s: %v", path, err)
 	}
 

--- a/internal/generate/merge.go
+++ b/internal/generate/merge.go
@@ -71,10 +71,11 @@ type entry struct {
 // project's tree.
 //
 // Two passes, and the split is the point. The first reads every generator's
-// directory and refuses everything it will not merge, with nothing written; the
-// second writes. A single pass would have the first generator's files in the
-// project's tree by the time the second generator's symlink was found, which is
-// the half-generated tree the whole arrangement exists to avoid.
+// directory and refuses everything it will not merge — what cannot be merged at
+// all, and what two generators both produced — with nothing written; the second
+// writes. A single pass would have the first generator's files in the project's
+// tree by the time the second generator's symlink was found, which is the
+// half-generated tree the whole arrangement exists to avoid.
 func (r *Runner) merge(generators []Generator, invocations []plugin.Invocation, root string) error {
 	planned, err := plan(generators, invocations)
 	if err != nil {
@@ -103,7 +104,8 @@ func (r *Runner) merge(generators []Generator, invocations []plugin.Invocation, 
 }
 
 // plan reads what every generator produced, in the order they were declared,
-// and refuses what cannot be merged.
+// refuses what cannot be merged, and refuses what two of them produced between
+// them.
 //
 // Every fault is collected rather than the first returned: a plugin that emits
 // symlinks emits them by the directory, and a run that named one of them would
@@ -131,7 +133,76 @@ func plan(generators []Generator, invocations []plugin.Invocation) ([]entry, err
 		return nil, faults.Err()
 	}
 
+	// After the refusals rather than beside them. A generator whose output was
+	// refused contributed no entries to compare against, so a collision report
+	// built from what is left would be a claim about a run this one is not: the
+	// paths of a refused generator are unknown here, not absent. Nothing is lost
+	// by reporting one fault at a time — the run fails either way, and it fails
+	// before anything is written either way.
+	if err := collide(planned); err != nil {
+		return nil, err
+	}
+
 	return planned, nil
+}
+
+// collide is every place in the project's tree that two generators both
+// produced.
+//
+// docs/plugin/SPEC.md: cpybkc MUST have resolved every generator's output
+// before it writes any of it, and a collision MUST fail the run with nothing
+// merged. Both halves are this function's position rather than its content: it
+// runs over every generator's entries at once, which is the only place the
+// second producer of a path is knowable, and it runs before [merger.write] has
+// been called at all.
+//
+// The key is the destination and not the path a generator chose, because the
+// two are different questions. One relative path under two output directories
+// is two files, and two relative paths under directories that overlap are one;
+// what would actually be written over is the destination, so the destination is
+// what is compared.
+//
+// Every collision is reported rather than the first, for the reason every
+// refusal is: two generators that produce one path usually produce a directory
+// of them, and a run naming one would be a run made once per file.
+func collide(planned []entry) error {
+	var faults diag.List
+
+	// Walked in the order the entries were planned — the order the run declared
+	// the generators, and lexical within each — so the pair a collision names is
+	// the same pair on every run of the same inputs. Generators run
+	// concurrently, and naming the one that lost a race is the one thing
+	// generated output cannot do.
+	claimed := make(map[string]entry, len(planned))
+
+	for _, e := range planned {
+		held, taken := claimed[e.dest]
+		if !taken {
+			claimed[e.dest] = e
+
+			continue
+		}
+
+		// Two generators asking for one directory is not a collision, and is
+		// what two of them landing in the same place ordinarily do: a directory
+		// carries nothing to disagree about, and the files inside it are
+		// compared here in their own right. A directory against a *file* is a
+		// collision — one of the two would have to stop being what its plugin
+		// made it.
+		if held.dir && e.dir {
+			continue
+		}
+
+		faults.Fail(&CollisionError{
+			First:      held.generator,
+			FirstPath:  held.path,
+			Second:     e.generator,
+			SecondPath: e.path,
+			Dest:       e.dest,
+		})
+	}
+
+	return faults.Err()
 }
 
 // produced is everything one generator left beneath scratch, as entries landing

--- a/internal/generate/merge.go
+++ b/internal/generate/merge.go
@@ -114,6 +114,7 @@ func plan(generators []Generator, invocations []plugin.Invocation) ([]entry, err
 	var (
 		faults  diag.List
 		planned []entry
+		claims  []entry
 	)
 
 	for i, generator := range generators {
@@ -126,6 +127,17 @@ func plan(generators []Generator, invocations []plugin.Invocation) ([]entry, err
 
 		produced, err := produced(generator.Name, invocations[i].Out, out)
 		faults.Fail(err)
+
+		// The claims are the entries plus the directories the merge has to
+		// create to reach them, in one list and in the run's own order, because
+		// a generator's hold on the project's tree is wider than the files it
+		// produced. They are kept apart from the plan rather than merged into
+		// it: a directory the merge creates on the way to an entry is created
+		// because that entry needs it, and a generator that produced nothing at
+		// all leaves the project exactly as it was.
+		claims = append(claims, required(generator.Name, out)...)
+		claims = append(claims, produced...)
+
 		planned = append(planned, produced...)
 	}
 
@@ -139,22 +151,48 @@ func plan(generators []Generator, invocations []plugin.Invocation) ([]entry, err
 	// paths of a refused generator are unknown here, not absent. Nothing is lost
 	// by reporting one fault at a time — the run fails either way, and it fails
 	// before anything is written either way.
-	if err := collide(planned); err != nil {
+	if err := collide(claims); err != nil {
 		return nil, err
 	}
 
 	return planned, nil
 }
 
-// collide is every place in the project's tree that two generators both
-// produced.
+// required is the directories one generator needs there to be before any of its
+// output can land: the output directory the manifest gave it, and every
+// directory above that.
+//
+// They are claims on the project's tree as much as a produced file is, and
+// leaving them out leaves a hole exactly where the merge cannot recover from
+// one. A generator landing in `gen` that produces the *file* `pkg`, beside one
+// landing in `gen/pkg`, is two generators disagreeing about what `gen/pkg` is —
+// and with only produced entries compared, nothing would notice until
+// [merger.mkdirRoot] met the file, with the first generator's output already
+// written.
+//
+// Every directory above the output directory and not only the directory itself,
+// because [merger.mkdirRoot] creates those too, and a file standing where one of
+// them has to go fails the merge in the same way and just as late.
+func required(name, out string) []entry {
+	var claims []entry
+
+	for path := out; ; path = filepath.Dir(path) {
+		claims = append(claims, entry{generator: name, root: out, dest: path, path: ".", dir: true})
+
+		if parent := filepath.Dir(path); parent == path {
+			return claims
+		}
+	}
+}
+
+// collide is every place in the project's tree that two generators both claim.
 //
 // docs/plugin/SPEC.md: cpybkc MUST have resolved every generator's output
 // before it writes any of it, and a collision MUST fail the run with nothing
 // merged. Both halves are this function's position rather than its content: it
-// runs over every generator's entries at once, which is the only place the
-// second producer of a path is knowable, and it runs before [merger.write] has
-// been called at all.
+// runs over every generator's claims at once, which is the only place the second
+// claimant of a path is knowable, and it runs before [merger.write] has been
+// called at all.
 //
 // The key is the destination and not the path a generator chose, because the
 // two are different questions. One relative path under two output directories
@@ -165,17 +203,17 @@ func plan(generators []Generator, invocations []plugin.Invocation) ([]entry, err
 // Every collision is reported rather than the first, for the reason every
 // refusal is: two generators that produce one path usually produce a directory
 // of them, and a run naming one would be a run made once per file.
-func collide(planned []entry) error {
+func collide(claims []entry) error {
 	var faults diag.List
 
-	// Walked in the order the entries were planned — the order the run declared
-	// the generators, and lexical within each — so the pair a collision names is
-	// the same pair on every run of the same inputs. Generators run
-	// concurrently, and naming the one that lost a race is the one thing
-	// generated output cannot do.
-	claimed := make(map[string]entry, len(planned))
+	// Walked in the order the claims were made — the order the run declared the
+	// generators, and lexical within each — so the pair a collision names is the
+	// same pair on every run of the same inputs. Generators run concurrently,
+	// and naming the one that lost a race is the one thing generated output
+	// cannot do.
+	claimed := make(map[string]entry, len(claims))
 
-	for _, e := range planned {
+	for _, e := range claims {
 		held, taken := claimed[e.dest]
 		if !taken {
 			claimed[e.dest] = e

--- a/internal/generate/merge_test.go
+++ b/internal/generate/merge_test.go
@@ -301,6 +301,176 @@ func TestAnythingThatIsNotAFileOrADirectoryIsRefused(t *testing.T) {
 	}
 }
 
+func TestTwoGeneratorsProducingOnePathFailTheRun(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		about string
+
+		// scenario is the generators of one run, landing beneath project, and
+		// the fault the run is to report. It is built inside the test because
+		// every path in it is the test's own temporary directory's.
+		scenario func(t *testing.T, project string) ([]Generator, CollisionError)
+	}{
+		{
+			about: "two generators landing in one directory",
+			scenario: func(t *testing.T, project string) ([]Generator, CollisionError) {
+				out := filepath.Join(project, "gen")
+
+				return []Generator{
+						generator(t, "one", `echo A > "$4/orders.go"`, out),
+						generator(t, "two", `echo B > "$4/orders.go"`, out),
+					}, CollisionError{
+						First: "one", FirstPath: "orders.go",
+						Second: "two", SecondPath: "orders.go",
+						Dest: filepath.Join(out, "orders.go"),
+					}
+			},
+		},
+		{
+			// The two plugins agree about nothing: one of them produced
+			// `gen/orders.go` and the other `orders.go`, and they are one file
+			// because the directories the manifest gave them overlap.
+			about: "output directories that overlap rather than coincide",
+			scenario: func(t *testing.T, project string) ([]Generator, CollisionError) {
+				out := filepath.Join(project, "gen")
+
+				return []Generator{
+						generator(t, "one", `mkdir "$4/gen"
+echo A > "$4/gen/orders.go"`, project),
+						generator(t, "two", `echo B > "$4/orders.go"`, out),
+					}, CollisionError{
+						First: "one", FirstPath: "gen/orders.go",
+						Second: "two", SecondPath: "orders.go",
+						Dest: filepath.Join(out, "orders.go"),
+					}
+			},
+		},
+		{
+			// Not a file against a file, and still one path two generators both
+			// produced: merging either would decide for a plugin what its own
+			// output is.
+			about: "a file where the other generator produced a directory",
+			scenario: func(t *testing.T, project string) ([]Generator, CollisionError) {
+				out := filepath.Join(project, "gen")
+
+				return []Generator{
+						generator(t, "one", `echo A > "$4/pkg"`, out),
+						generator(t, "two", `mkdir "$4/pkg"
+echo B > "$4/pkg/orders.go"`, out),
+					}, CollisionError{
+						First: "one", FirstPath: "pkg",
+						Second: "two", SecondPath: "pkg",
+						Dest: filepath.Join(out, "pkg"),
+					}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.about, func(t *testing.T) {
+			t.Parallel()
+
+			project := filepath.Join(t.TempDir(), "project")
+			generators, want := test.scenario(t, project)
+
+			err := run(t, runner(t), generators...)
+
+			var collision *CollisionError
+			if !errors.As(err, &collision) {
+				t.Fatalf("the run failed with %v, want a CollisionError", err)
+			}
+
+			if *collision != want {
+				t.Errorf("the fault is %+v, want %+v", *collision, want)
+			}
+
+			// Refused before anything was written. A run that merged what did
+			// not collide and then stopped would leave the half-generated tree
+			// the two passes exist to prevent, and would leave it differently
+			// depending on which generator got there first.
+			if exists(t, project) {
+				t.Errorf("%s was created by a refused run: %v", project, tree(t, project))
+			}
+		})
+	}
+}
+
+func TestTwoGeneratorsMayProduceOneDirectory(t *testing.T) {
+	t.Parallel()
+
+	// A directory carries nothing for two generators to disagree about, and two
+	// of them landing in one place ordinarily both need `pkg`. What is one
+	// generator's each is the files inside it.
+	out := filepath.Join(t.TempDir(), "project", "gen")
+
+	if err := run(t, runner(t),
+		generator(t, "one", `mkdir "$4/pkg"
+echo A > "$4/pkg/orders.go"`, out),
+		generator(t, "two", `mkdir "$4/pkg"
+echo B > "$4/pkg/invoices.go"`, out),
+	); err != nil {
+		t.Fatalf("running the generators: %v", err)
+	}
+
+	same(t, out, map[string]string{
+		"pkg":             "<dir>",
+		"pkg/orders.go":   "A\n",
+		"pkg/invoices.go": "B\n",
+	})
+}
+
+func TestEveryCollisionIsReported(t *testing.T) {
+	t.Parallel()
+
+	project := filepath.Join(t.TempDir(), "project")
+	out := filepath.Join(project, "gen")
+
+	// Two generators that produce one path usually produce a directory of them
+	// — a manifest that asked both for the same package asked for every file in
+	// it — and a run that named one would be a run made once per file.
+	err := run(t, runner(t),
+		generator(t, "one", `echo A > "$4/orders.go"
+echo A > "$4/invoices.go"`, out),
+		generator(t, "two", `echo B > "$4/orders.go"
+echo B > "$4/invoices.go"`, out),
+	)
+
+	if got, want := len(diag.Diagnostics(err)), 2; got != want {
+		t.Errorf("the run reported %d faults, want %d:\n%s", got, want, diag.Render(err))
+	}
+
+	if exists(t, project) {
+		t.Errorf("%s was created by a refused run: %v", project, tree(t, project))
+	}
+}
+
+func TestACollisionNamesTheGeneratorsInTheOrderTheyWereDeclared(t *testing.T) {
+	t.Parallel()
+
+	out := filepath.Join(t.TempDir(), "project")
+
+	// Generators run concurrently, so the one that produced a path first is not
+	// the one that finished first. A fault naming whichever of them lost the
+	// race would report the same unchanged inputs differently on different runs
+	// — so the generator the run declared first is named first, however long it
+	// takes to produce anything.
+	err := run(t, runner(t),
+		generator(t, "slow", `sleep 1
+echo A > "$4/orders.go"`, out),
+		generator(t, "quick", `echo B > "$4/orders.go"`, out),
+	)
+
+	var collision *CollisionError
+	if !errors.As(err, &collision) {
+		t.Fatalf("the run failed with %v, want a CollisionError", err)
+	}
+
+	if got, want := collision.First, "slow"; got != want {
+		t.Errorf("the fault names %q first, want %q, which the run declared first", got, want)
+	}
+}
+
 func TestARerunReplacesWhatItProducedAndNeverWritesThroughALink(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generate/merge_test.go
+++ b/internal/generate/merge_test.go
@@ -365,6 +365,44 @@ echo B > "$4/pkg/orders.go"`, out),
 					}
 			},
 		},
+		{
+			// The second generator produced nothing at that path and could not
+			// have: it is the output directory the manifest gave it, which the
+			// merge creates on its behalf. Compared as produced entries alone,
+			// the two would agree right up until the merge tried to make a
+			// directory of the first generator's file — with that file written.
+			about: "a file where the other was told to land its output",
+			scenario: func(t *testing.T, project string) ([]Generator, CollisionError) {
+				out := filepath.Join(project, "gen")
+
+				return []Generator{
+						generator(t, "one", `echo A > "$4/pkg"`, out),
+						generator(t, "two", `echo B > "$4/orders.go"`, filepath.Join(out, "pkg")),
+					}, CollisionError{
+						First: "one", FirstPath: "pkg",
+						Second: "two", SecondPath: ".",
+						Dest: filepath.Join(out, "pkg"),
+					}
+			},
+		},
+		{
+			// The same fault a directory further up: what the merge has to
+			// create to reach an output directory is every directory above it,
+			// and a file standing in the way of one of those fails just as late.
+			about: "a file where the other's output directory has to be reached through",
+			scenario: func(t *testing.T, project string) ([]Generator, CollisionError) {
+				out := filepath.Join(project, "gen")
+
+				return []Generator{
+						generator(t, "one", `echo A > "$4/pkg"`, out),
+						generator(t, "two", `echo B > "$4/orders.go"`, filepath.Join(out, "pkg", "orders")),
+					}, CollisionError{
+						First: "one", FirstPath: "pkg",
+						Second: "two", SecondPath: ".",
+						Dest: filepath.Join(out, "pkg"),
+					}
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Closes #44

Two generators producing one path in the project's tree is now an error
raised before anything is merged, rather than last-writer-wins.

## Acceptance criteria

- [x] **Two plugins writing the same relative path is an error, not
  last-writer-wins.** `collide` in `internal/generate/merge.go` keys every
  planned entry by the destination it would be written to and fails the run
  on the second claim.
- [x] **The error names both plugins and the conflicting path.**
  `CollisionError` carries both generators, the path each of them called it
  and where the two would have landed. It names them in the order the run
  *declared* them, never the order they finished in.
- [x] **Detection happens before any file is merged into the `out`
  directory.** It runs inside `plan`, the first of the merge's two passes,
  over every generator's entries at once — so nothing has been written when
  it reports, and the tests assert the output directory was never created.
- [x] **Tests cover a two-plugin collision.**
  `TestTwoGeneratorsProducingOnePathFailTheRun` covers two generators
  landing in one directory, two whose output directories *overlap* rather
  than coincide, and a file against a directory.

## Judgment calls

- **Keyed on the destination, not on the relative path.** The same relative
  path under two different output directories is two files, and two
  different relative paths under directories that overlap (`gen` and
  `gen/pkg`) are one. The destination is what would actually be written
  over, so it is what is compared — which makes the second case a collision
  and the first not one.
- **Two generators asking for one directory is not a collision.** A
  directory carries nothing to disagree about, and two generators landing in
  one place ordinarily both need `pkg`; the files inside it are compared in
  their own right. A directory against a *file* at one path **is** a
  collision: without it, the merge would write one of them and then fail
  `ENOTDIR` with the tree already half generated.
- **Reported after the unmergeable refusals rather than beside them.** A
  generator whose output was refused contributed no entries to compare
  against, so a collision report built from what is left would be a claim
  about a different run. Both fail the run before anything is written.
- **Every collision is reported, not the first.** Two generators that
  produce one path usually produce a directory of them.
- **`docs/plugin/SPEC.md` is unchanged.** It already specifies this under
  *What a plugin does not own* and already carries the `#44` citations; this
  is the implementation catching up to it.

## Verified

- `dagger call ci` — green.
- `TestACollisionNamesTheGeneratorsInTheOrderTheyWereDeclared` makes the
  determinism argument mechanical: the generator declared first sleeps and
  finishes last, and is still the one named first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)