### PR TITLE
story(plugin): prune stale generated files

### DIFF
--- a/internal/generate/doc.go
+++ b/internal/generate/doc.go
@@ -30,7 +30,50 @@
 // plugin has to maintain, and no bookkeeping asked of a plugin author at all —
 // which is what lets the contract stay small enough for a generator to be a
 // shell script. Cross-generator collision detection rests on that equality, and
-// so will stale-file pruning (#45), which is not here yet.
+// so does stale-file pruning.
+//
+// # The record of a previous run
+//
+// A record is removed from a layout, so a generator stops producing the file it
+// produced for it, and that file has to disappear rather than linger and keep
+// compiling. Which means this package has to know which files it generated, and
+// the only honest way to know is to have written it down: [Runner.Root] names
+// the project, [RecordName] is the file the run leaves there, and it holds the
+// version it was written under and every path the run generated — relative to
+// the root, slash-separated, and sorted, so that two runs producing one set of
+// files produce one set of bytes and a record in a diff means something
+// changed.
+//
+// Everything about pruning follows from the record being the *only* source:
+//
+//   - A run that finds no record prunes nothing. It does not decide for itself
+//     which files look generated, from a naming convention or a marker in a
+//     comment. A missing record costs one stale file one more run; a guess
+//     costs somebody a file they wrote.
+//   - An output directory shared with hand-written source therefore works,
+//     which is what lets a generator be pointed at `.`.
+//   - Only a regular file is removed. A recorded path that is now a directory
+//     or a symlink is left where it is and reported: a person who replaced a
+//     generated file has taken it over, and cpybkc's claim on a path ends
+//     there.
+//   - A directory pruning empties is removed, up to but never including the
+//     project's root — and never one this run is about to write into, which
+//     would be churn rather than tidying.
+//
+// The record is a committed file rather than a `DO NOT EDIT` marker inside each
+// generated file, and that is the load-bearing choice. Not every format a
+// generator emits has a comment syntax; a marker would ask every plugin for the
+// bookkeeping docs/plugin/SPEC.md deliberately refuses to ask for; and it would
+// make ownership a property of a file's contents, which a person copies into a
+// hand-written file the first time they start one from a generated example. One
+// record spanning every generator is also what lets a generator *removed* from
+// the manifest have its output pruned — there is nothing left to ask.
+//
+// A record this package cannot read fails the run rather than pruning nothing.
+// The two are indistinguishable to a person, and only one of them is honest:
+// pruning silently from a list that has been damaged is how a stale file
+// becomes permanent, and the fix — delete the file — is one the diagnostic can
+// state.
 //
 // # Why a collision is the run's fault and not a generator's
 //
@@ -98,7 +141,9 @@
 // plugin writes into a scratch directory with whatever umask the process — or
 // the container — it ran in happened to have, so carrying its modes through
 // would make the permissions in a checked-out project depend on where the
-// generator ran.
+// generator ran. The run's own record goes through the same call: it is a file
+// in a person's project and it lands in their commit, so a record they cannot
+// edit is the same fault as generated output they cannot edit.
 //
 // [Runner.Owner] is the same decision for ownership, and exists for one case:
 // cpybkc running as root in a container over a bind mount, where without it a

--- a/internal/generate/errors.go
+++ b/internal/generate/errors.go
@@ -8,6 +8,7 @@ package generate
 import (
 	"fmt"
 	"io/fs"
+	"path/filepath"
 	"strconv"
 
 	"github.com/Zaba505/cpybkc/internal/diag"
@@ -131,8 +132,15 @@ func (e *UnmergeableError) Diagnostic() diag.Diagnostic {
 // reader has to already know. The default is deliberately vague rather than
 // exhaustive — what a reader does about anything in this list is the same, and
 // the list is the operating system's to extend.
+//
+// A directory is in the list for pruning's sake rather than the merge's: a
+// directory is something the merge makes and never something it refuses, but a
+// recorded path that has *become* one is left alone and said so about, and the
+// sentence saying so has to name what it found.
 func kind(mode fs.FileMode) string {
 	switch {
+	case mode.IsDir():
+		return "a directory"
 	case mode&fs.ModeSymlink != 0:
 		return "a symlink"
 	case mode&fs.ModeDevice != 0:
@@ -265,5 +273,172 @@ func (e *MergeError) Diagnostic() diag.Diagnostic {
 		Message: fmt.Sprintf("%s, from the generator %s, could not be merged: %v",
 			strconv.Quote(e.Path), strconv.Quote(e.Name), e.Err),
 		Spans: []diag.Span{{}, {File: e.Dest, Note: "this is where it was to be written"}},
+	}
+}
+
+// RecordError is the record of what a run generated, which could not be read,
+// could not be written, or is not one this cpybkc wrote.
+//
+// The record is what makes pruning safe: only a file some run recorded is ever
+// removed, so the list is the whole of what cpybkc claims to own. That is why a
+// record it cannot read is a failed run rather than a run that quietly prunes
+// nothing — the two look identical to a person and only one of them is honest,
+// and the fix is one file to delete, which the diagnostic says.
+//
+// A record that is simply *not there* is not this: a first run has none, and a
+// person who deleted theirs has said cpybkc owns nothing in their tree yet. It
+// prunes nothing and says nothing.
+type RecordError struct {
+	// Path is the record file, as this run named it.
+	Path string
+
+	// Fault is what is wrong with the record itself — a version this cpybkc
+	// does not know, a path it could not have written. Empty where what went
+	// wrong is [RecordError.Err].
+	Fault string
+
+	// Err is what the filesystem or [encoding/json] returned. Nil where the
+	// file was read perfectly well and [RecordError.Fault] says what it holds.
+	Err error
+
+	// Writing reports whether the run was writing this run's record rather
+	// than reading the last one's. It is the direction and not the fault: the
+	// two fail for entirely different reasons — a record nobody can parse
+	// against a disk with nothing left on it — and a message that did not say
+	// which would send a reader to look at the wrong one.
+	Writing bool
+}
+
+// Error implements the error interface.
+func (e *RecordError) Error() string { return e.Diagnostic().String() }
+
+// Unwrap is the underlying error, so that a caller can ask what kind of failure
+// it was. It is nil where the record was read and is the record that is wrong.
+func (e *RecordError) Unwrap() error { return e.Err }
+
+// Diagnostic is what the error says, and where.
+//
+// The last span is the file's provenance rather than a second place, because
+// the thing a reader most needs to know about this file is that it is not one
+// of theirs: it is cpybkc's, it is rewritten by every run, and deleting it
+// costs a stale file one more run and nothing else.
+func (e *RecordError) Diagnostic() diag.Diagnostic {
+	message := fmt.Sprintf("the record of what the last run generated could not be read: %v", e.Err)
+
+	switch {
+	case e.Writing:
+		message = fmt.Sprintf("the record of what this run generated could not be written: %v", e.Err)
+	case e.Fault != "":
+		message = "the record of what the last run generated is not one this cpybkc wrote: " + e.Fault
+	}
+
+	return diag.Diagnostic{
+		Message: message,
+		Spans: []diag.Span{
+			{File: e.Path},
+			{Note: "cpybkc writes this file itself at the end of every run and reads it at the start of the next, to remove what it generated before and no longer does; deleting it is safe and costs one run's worth of stale files"},
+		},
+	}
+}
+
+// PruneError is a file a previous run generated, which this run does not, and
+// which could not be removed.
+//
+// Everything pruning declines to remove of its own accord — a recorded path
+// that is now a directory, a symlink, or gone already — is reported to the user
+// and is not a fault. This is the filesystem: a directory that is not writable,
+// a file somebody else's process holds. It fails the run rather than being
+// carried, because the alternative is a project whose record no longer
+// describes it and a stale file nothing will ever mention again.
+type PruneError struct {
+	// Path is the file as the record spells it: relative to the project's root
+	// and slash-separated, which is how a person reading their record and their
+	// diff will find it.
+	Path string
+
+	// Dest is where that path is, in the project's tree.
+	Dest string
+
+	// Err is what went wrong, from the filesystem.
+	Err error
+}
+
+// Error implements the error interface.
+func (e *PruneError) Error() string { return e.Diagnostic().String() }
+
+// Unwrap is the filesystem's error, so that a caller can ask what kind of
+// failure it was.
+func (e *PruneError) Unwrap() error { return e.Err }
+
+// Diagnostic is what the error says, and where.
+func (e *PruneError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf("%s, which a previous run generated and this one does not, could not be removed: %v",
+			strconv.Quote(e.Path), e.Err),
+		Spans: []diag.Span{{}, {File: e.Dest, Note: "this is the file it is"}},
+	}
+}
+
+// UnrecordableError is output a run produced that it cannot record, and so
+// could never prune.
+//
+// Two ways to get one, and neither is a plugin's doing. A generator pointed at
+// a directory outside the project's root lands files the record has no way to
+// name — the record holds paths beneath the root, so that it means the same
+// thing in a checkout as it did on the machine that wrote it. And a generator
+// that produces the record's own file is producing something the end of the run
+// overwrites.
+//
+// It fails the run before anything is written, rather than being merged and
+// left out of the record. A file cpybkc generates and does not record is one no
+// later run will ever remove, which is the single failure pruning exists to
+// prevent — and it would be invisible, because the output would be perfectly
+// correct on the run that produced it.
+type UnrecordableError struct {
+	// Name is the generator that produced it.
+	Name string
+
+	// Path is what that generator called it, relative to the directory it was
+	// handed.
+	Path string
+
+	// Dest is where it was to land, in the project's tree.
+	Dest string
+
+	// Root is the project's root, which is what the record's paths are
+	// relative to and what the destination has to be beneath.
+	Root string
+}
+
+// Error implements the error interface.
+func (e *UnrecordableError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+//
+// Two shapes, because the two faults have different fixes: one is an output
+// directory to move and the other is a filename to change. The last span is the
+// rule rather than a place, for the reason [UnmergeableError.Diagnostic] gives.
+func (e *UnrecordableError) Diagnostic() diag.Diagnostic {
+	if e.Dest == filepath.Join(e.Root, RecordName) {
+		return diag.Diagnostic{
+			Message: fmt.Sprintf("the generator %s produced %s, which is the file cpybkc keeps its own record of a run in",
+				strconv.Quote(e.Name), strconv.Quote(e.Path)),
+			Spans: []diag.Span{
+				{},
+				{File: e.Dest, Note: "this is where it was to be written"},
+				{Note: "cpybkc rewrites that file at the end of every run, so what a generator put there would be thrown away: have it produce some other path"},
+			},
+		}
+	}
+
+	return diag.Diagnostic{
+		Message: fmt.Sprintf("the generator %s produced %s, which lands outside the project and cannot be recorded",
+			strconv.Quote(e.Name), strconv.Quote(e.Path)),
+		Spans: []diag.Span{
+			{},
+			{File: e.Dest, Note: "this is where it was to be written"},
+			{Note: fmt.Sprintf("cpybkc records what it generated beneath %s so that a later run can remove what it no longer generates, and a file outside that could never be recorded or removed: land this generator's output inside the project",
+				strconv.Quote(e.Root))},
+		},
 	}
 }

--- a/internal/generate/errors_test.go
+++ b/internal/generate/errors_test.go
@@ -43,6 +43,12 @@ func TestEveryFaultReadsTheSameThroughEitherEnd(t *testing.T) {
 		},
 		&MergeError{Name: "go", Dest: "gen", Err: errors.New("permission denied")},
 		&MergeError{Name: "go", Path: "orders.go", Dest: "gen/orders.go", Err: errors.New("permission denied")},
+		&RecordError{Path: "/src/" + RecordName, Err: errors.New("unexpected end of JSON input")},
+		&RecordError{Path: "/src/" + RecordName, Fault: "it declares version 2, and this cpybkc writes and reads version 1"},
+		&RecordError{Path: "/src/" + RecordName, Writing: true, Err: errors.New("no space left on device")},
+		&PruneError{Path: "gen/orders.go", Dest: "/src/gen/orders.go", Err: errors.New("permission denied")},
+		&UnrecordableError{Name: "go", Path: "orders.go", Dest: "/elsewhere/orders.go", Root: "/src"},
+		&UnrecordableError{Name: "go", Path: RecordName, Dest: "/src/" + RecordName, Root: "/src"},
 	}
 
 	for _, fault := range faults {
@@ -204,5 +210,111 @@ func TestAMergeFailureSaysHowFarTheRunGot(t *testing.T) {
 		if got := diag.Render(test.fault); got != test.want {
 			t.Errorf("%s renders as\n%s\nwant\n%s", test.about, got, test.want)
 		}
+	}
+}
+
+// TestARecordFaultSaysWhoseFileItIs is what a person needs from a fault about a
+// file they have never heard of and did not write. It leads with the direction
+// — a record read against a record written, which fail for entirely unrelated
+// reasons — and it says who keeps the file and what deleting it costs, because
+// that is the fix for every fault in this list that is not a full disk.
+func TestARecordFaultSaysWhoseFileItIs(t *testing.T) {
+	t.Parallel()
+
+	const provenance = "  cpybkc writes this file itself at the end of every run and reads it at the start of the next, to remove what it generated before and no longer does; deleting it is safe and costs one run's worth of stale files"
+
+	tests := []struct {
+		about string
+		fault *RecordError
+		want  string
+	}{
+		{
+			about: "a record that would not parse",
+			fault: &RecordError{Path: "/src/cpybkc.gen.json", Err: errors.New("unexpected end of JSON input")},
+			want: `/src/cpybkc.gen.json: the record of what the last run generated could not be read: unexpected end of JSON input
+` + provenance,
+		},
+		{
+			about: "a record from a cpybkc that has not been written yet",
+			fault: &RecordError{
+				Path:  "/src/cpybkc.gen.json",
+				Fault: "it declares version 2, and this cpybkc writes and reads version 1",
+			},
+			want: `/src/cpybkc.gen.json: the record of what the last run generated is not one this cpybkc wrote: it declares version 2, and this cpybkc writes and reads version 1
+` + provenance,
+		},
+		{
+			about: "a record that could not be written",
+			fault: &RecordError{
+				Path:    "/src/cpybkc.gen.json",
+				Writing: true,
+				Err:     errors.New("no space left on device"),
+			},
+			want: `/src/cpybkc.gen.json: the record of what this run generated could not be written: no space left on device
+` + provenance,
+		},
+	}
+
+	for _, test := range tests {
+		if got := diag.Render(test.fault); got != test.want {
+			t.Errorf("%s renders as\n%s\nwant\n%s", test.about, got, test.want)
+		}
+	}
+}
+
+// TestOutputThatCannotBeRecordedSaysWhichOfTheTwoWaysItIs keeps the two shapes
+// apart, because they have different fixes: one is an output directory to move
+// and the other is a filename to change.
+func TestOutputThatCannotBeRecordedSaysWhichOfTheTwoWaysItIs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		about string
+		fault *UnrecordableError
+		want  string
+	}{
+		{
+			about: "output outside the project",
+			fault: &UnrecordableError{Name: "go", Path: "orders.go", Dest: "/elsewhere/orders.go", Root: "/src"},
+			want: `the generator "go" produced "orders.go", which lands outside the project and cannot be recorded
+  /elsewhere/orders.go: this is where it was to be written
+  cpybkc records what it generated beneath "/src" so that a later run can remove what it no longer generates, and a file outside that could never be recorded or removed: land this generator's output inside the project`,
+		},
+		{
+			about: "the record's own file",
+			fault: &UnrecordableError{
+				Name: "go", Path: "cpybkc.gen.json",
+				Dest: "/src/cpybkc.gen.json", Root: "/src",
+			},
+			want: `the generator "go" produced "cpybkc.gen.json", which is the file cpybkc keeps its own record of a run in
+  /src/cpybkc.gen.json: this is where it was to be written
+  cpybkc rewrites that file at the end of every run, so what a generator put there would be thrown away: have it produce some other path`,
+		},
+	}
+
+	for _, test := range tests {
+		if got := diag.Render(test.fault); got != test.want {
+			t.Errorf("%s renders as\n%s\nwant\n%s", test.about, got, test.want)
+		}
+	}
+}
+
+// TestAStaleFileThatCouldNotBeRemovedNamesItAsTheRecordSpellsIt. A person
+// holding this fault is looking at their record and at their diff, and both of
+// them spell the path relative to the project's root.
+func TestAStaleFileThatCouldNotBeRemovedNamesItAsTheRecordSpellsIt(t *testing.T) {
+	t.Parallel()
+
+	fault := &PruneError{
+		Path: "gen/pkg/orders.go",
+		Dest: "/src/gen/pkg/orders.go",
+		Err:  errors.New("permission denied"),
+	}
+
+	want := `"gen/pkg/orders.go", which a previous run generated and this one does not, could not be removed: permission denied
+  /src/gen/pkg/orders.go: this is the file it is`
+
+	if got := diag.Render(fault); got != want {
+		t.Errorf("it renders as\n%s\nwant\n%s", got, want)
 	}
 }

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -105,6 +106,32 @@ type Runner struct {
 	// Owner, when set, is the user and group given to every file and directory
 	// the merge creates. Nil leaves them as the merging process's.
 	Owner *Owner
+
+	// Root is the project's root: the directory this run keeps its record of
+	// what it generated in, and the directory every path in that record is
+	// relative to. It may be relative, and is resolved against the working
+	// directory the run is made from, exactly as a generator's Out is.
+	//
+	// Empty keeps no record and prunes nothing. That is the zero value, and it
+	// is the honest answer rather than a degraded one: the record is a file at
+	// a project's root, and a run that has not been told where that is must not
+	// guess — a wrong guess is a run that deletes something a person wrote.
+	// Whatever found the project's cpybkc.json knows where its root is, and
+	// that is the one place the answer exists.
+	Root string
+
+	// Log is where pruning is reported: a file a previous run generated and
+	// this one did not, removed, and a recorded path a person has since taken
+	// over, left alone. Nil is [log/slog.Default] read at the moment of the
+	// run, so that a caller that configures logging after building a Runner is
+	// still heard.
+	//
+	// It is separate from the logger the generators' own output is surfaced
+	// through, which is
+	// [github.com/Zaba505/cpybkc/internal/plugin.Runner.Log]'s: a line here is
+	// cpybkc saying what it did to a project's tree, and a line there is a
+	// generator talking.
+	Log *slog.Logger
 }
 
 // Run runs every generator against d, each in a private empty directory of its
@@ -159,6 +186,15 @@ func (r *Runner) Run(ctx context.Context, d *irpb.Descriptor, generators []Gener
 		return invalid.Err()
 	}
 
+	// Read here, before a generator has been started, for the same reason: a
+	// record this cpybkc cannot read is a fault in the project rather than in
+	// the output, and finding it after the run would mean discovering it once
+	// the work was done.
+	ledger, err := r.ledger()
+	if err != nil {
+		return err
+	}
+
 	root, err := os.MkdirTemp(r.TempDir, scratchPattern)
 	if err != nil {
 		return &ScratchError{Err: err}
@@ -188,7 +224,7 @@ func (r *Runner) Run(ctx context.Context, d *irpb.Descriptor, generators []Gener
 		return err
 	}
 
-	return r.merge(generators, invocations, root)
+	return r.merge(ctx, ledger, generators, invocations, root)
 }
 
 // scratch gives each generator its own empty directory and hands back the
@@ -229,4 +265,13 @@ func (r *Runner) plugins() *plugin.Runner {
 	}
 
 	return &plugin.Runner{}
+}
+
+// logger is where this run says what it did to the project's tree.
+func (r *Runner) logger() *slog.Logger {
+	if r.Log != nil {
+		return r.Log
+	}
+
+	return slog.Default()
 }

--- a/internal/generate/merge.go
+++ b/internal/generate/merge.go
@@ -6,6 +6,7 @@
 package generate
 
 import (
+	"context"
 	"errors"
 	"io"
 	"io/fs"
@@ -68,17 +69,41 @@ type entry struct {
 }
 
 // merge puts what the generators left in their scratch directories into the
-// project's tree.
+// project's tree, and takes out what a previous run put there and this one does
+// not produce.
 //
 // Two passes, and the split is the point. The first reads every generator's
 // directory and refuses everything it will not merge — what cannot be merged at
-// all, and what two generators both produced — with nothing written; the second
-// writes. A single pass would have the first generator's files in the project's
-// tree by the time the second generator's symlink was found, which is the
-// half-generated tree the whole arrangement exists to avoid.
-func (r *Runner) merge(generators []Generator, invocations []plugin.Invocation, root string) error {
+// all, what two generators both produced, and what this run could produce but
+// could never record — with nothing written; the second writes. A single pass
+// would have the first generator's files in the project's tree by the time the
+// second generator's symlink was found, which is the half-generated tree the
+// whole arrangement exists to avoid.
+//
+// Pruning goes between the two, which is the one place it fits: everything
+// refusable has been refused, so nothing that deletes a file can still turn out
+// to be a run that fails for a reason of its own; and nothing has been written,
+// so a path that was a file last run and is a directory this one — or the other
+// way about — has the stale entry taken out from under it before the merge ever
+// meets it.
+func (r *Runner) merge(
+	ctx context.Context,
+	ledger *ledger,
+	generators []Generator,
+	invocations []plugin.Invocation,
+	root string,
+) error {
 	planned, err := plan(generators, invocations)
 	if err != nil {
+		return err
+	}
+
+	generated, err := ledger.generated(planned)
+	if err != nil {
+		return err
+	}
+
+	if err := ledger.prune(ctx, planned, generated); err != nil {
 		return err
 	}
 
@@ -100,7 +125,14 @@ func (r *Runner) merge(generators []Generator, invocations []plugin.Invocation, 
 		}
 	}
 
-	return nil
+	// Last, so that a record is only ever written for a merge that finished.
+	// One that failed partway leaves the previous run's record in place, which
+	// still names every file this package has ever put in the tree — the ones
+	// pruning has already removed have simply gone, and a recorded path that is
+	// not there prunes nothing and says nothing. So the next run's list is
+	// complete, and re-running after fixing whatever the filesystem objected to
+	// is what repairs the tree.
+	return ledger.write(m, generated)
 }
 
 // plan reads what every generator produced, in the order they were declared,
@@ -398,7 +430,16 @@ func (m *merger) write(e entry) error {
 		return err
 	}
 
-	return m.copy(e.source, e.dest, e.exec)
+	from, err := os.Open(e.source)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = from.Close()
+	}()
+
+	return m.copy(from, e.dest, e.exec)
 }
 
 // mkdirAll makes sure there is a directory at path, which is the generator's
@@ -498,16 +539,15 @@ func (m *merger) create(path string) error {
 }
 
 // copy puts one file in the project's tree.
-func (m *merger) copy(source, dest string, exec bool) error {
-	from, err := os.Open(source)
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		_ = from.Close()
-	}()
-
+//
+// A reader rather than a path, because this run puts two kinds of file there:
+// what a generator produced, opened out of its scratch directory, and the run's
+// own record, which is bytes in hand and never a file anywhere else. Everything
+// below is the same for both — a destination removed rather than opened, an
+// exclusive create, a mode settled through the descriptor — and the one thing
+// this package must not have two of is the place a file enters a project's
+// tree.
+func (m *merger) copy(from io.Reader, dest string, exec bool) error {
 	// Whatever is at the destination is removed rather than opened. A previous
 	// run's file would be truncated either way; a *symlink* left there by a
 	// person, or by something else that writes into this directory, would be
@@ -537,7 +577,7 @@ func (m *merger) copy(source, dest string, exec bool) error {
 }
 
 // fill writes the file's contents and settles what it is.
-func (m *merger) fill(to *os.File, from *os.File, exec bool) error {
+func (m *merger) fill(to *os.File, from io.Reader, exec bool) error {
 	if _, err := io.Copy(to, from); err != nil {
 		return err
 	}

--- a/internal/generate/prune.go
+++ b/internal/generate/prune.go
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package generate
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+)
+
+// prune removes the files the previous run recorded and this one does not
+// produce.
+//
+// The set it works from is the previous record minus this run's output, and
+// nothing else is ever considered. A file nobody recorded is a file a person
+// wrote — that is the whole of the guarantee, and it is what lets a generator
+// land its output in a directory that also holds hand-written source, up to and
+// including the project's root.
+//
+// It runs after [plan] and before anything is written, which is the one moment
+// that works. Before the plan, a run still refusable — a symlink in a scratch
+// directory, two generators claiming one path — would have deleted files on its
+// way to failing. After the write, a path that was a file last run and is a
+// directory this run (or the other way about) would meet the stale entry during
+// the merge and fail on it, every run, until somebody removed it by hand.
+// Between the two, everything refusable has been refused and nothing has been
+// written: the only faults left are the filesystem's, and a run that hits one
+// leaves a tree a re-run repairs.
+func (l *ledger) prune(ctx context.Context, planned []entry, generated []string) error {
+	if l.root == "" || len(l.previous) == 0 {
+		return nil
+	}
+
+	produced := make(map[string]struct{}, len(generated))
+	for _, file := range generated {
+		produced[file] = struct{}{}
+	}
+
+	var (
+		faults  diag.List
+		emptied []string
+	)
+
+	for _, file := range l.previous {
+		if _, again := produced[file]; again {
+			continue
+		}
+
+		dest := filepath.Join(l.root, filepath.FromSlash(file))
+
+		removed, err := l.remove(ctx, file, dest)
+		if err != nil {
+			faults.Fail(err)
+
+			continue
+		}
+
+		if removed {
+			emptied = append(emptied, filepath.Dir(dest))
+		}
+	}
+
+	if faults.Failed() {
+		return faults.Err()
+	}
+
+	l.tidy(ctx, planned, emptied)
+
+	return nil
+}
+
+// remove takes one file the previous run generated out of the project's tree,
+// and reports whether it took anything.
+//
+// [os.Lstat] rather than [os.Stat], and only a regular file is removed. A
+// recorded path that is now a directory or a symlink is somebody's doing: a
+// person who replaced a generated file has taken it over, and cpybkc's claim on
+// a path ends where a person's begins. It is reported rather than removed and
+// rather than passed over in silence, because the alternative to saying so is a
+// stale file that never goes away and never explains why.
+func (l *ledger) remove(ctx context.Context, file, dest string) (bool, error) {
+	info, err := os.Lstat(dest)
+
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		// Already gone — a person deleted it, or a previous run removed it and
+		// could not say so. Nothing to do and nothing worth telling anybody.
+		return false, nil
+	case err != nil:
+		return false, &PruneError{Path: file, Dest: dest, Err: err}
+	}
+
+	if !info.Mode().IsRegular() {
+		l.log.LogAttrs(ctx, slog.LevelWarn,
+			"a path a previous run generated is no longer a file and was left where it is",
+			slog.String("path", file), slog.String("found", kind(info.Mode())))
+
+		return false, nil
+	}
+
+	if err := os.Remove(dest); err != nil {
+		return false, &PruneError{Path: file, Dest: dest, Err: err}
+	}
+
+	l.log.LogAttrs(ctx, slog.LevelInfo,
+		"a file a previous run generated and this one does not was removed",
+		slog.String("path", file))
+
+	return true, nil
+}
+
+// tidy removes the directories pruning emptied, up to but never including the
+// project's root.
+//
+// A generator that stops producing a package should not leave the package's
+// directory behind — an empty directory in a diff is a thing a reviewer has to
+// work out. Never the root, whatever pruning empties: that directory is the
+// project, it holds the manifest and the record, and it is not something a
+// generator was ever given.
+//
+// A directory this run is about to write into is left alone even when pruning
+// empties it, and so is one that is not empty. The first is not tidying but
+// churn — the merge would recreate the directory a moment later, with this
+// run's mode in place of whatever a person had set on it. The second is the
+// ordinary case and is how the walk upward ends.
+//
+// Nothing here fails the run. A directory that could not be removed is the
+// project keeping an empty directory, and refusing a run over that would be
+// this package holding output hostage to housekeeping.
+func (l *ledger) tidy(ctx context.Context, planned []entry, emptied []string) {
+	keep := wanted(planned)
+
+	// The walk stops at the project's root, and at the filesystem's if a record
+	// ever named a path that reached one — the second is unreachable through a
+	// record this package wrote or would read, and it is here because a loop
+	// that removes directories is not the place to be relying on that.
+	for _, dir := range emptied {
+		for dir != l.root && filepath.Dir(dir) != dir {
+			if _, needed := keep[dir]; needed {
+				break
+			}
+
+			if err := os.Remove(dir); err != nil {
+				break
+			}
+
+			l.log.LogAttrs(ctx, slog.LevelInfo,
+				"a directory pruning left empty was removed",
+				slog.String("path", l.relative(dir)))
+
+			dir = filepath.Dir(dir)
+		}
+	}
+}
+
+// wanted is every directory the merge is about to create or write into,
+// including the ones above them, up to the filesystem's root.
+//
+// Built from the plan and not from the generators' output directories, for the
+// reason [plan] keeps the two apart: a generator that produced nothing leaves
+// the project exactly as it was, so the directory it was pointed at is not one
+// this run wants there.
+func wanted(planned []entry) map[string]struct{} {
+	dirs := make(map[string]struct{}, len(planned))
+
+	for _, e := range planned {
+		dir := e.dest
+		if !e.dir {
+			dir = filepath.Dir(e.dest)
+		}
+
+		for {
+			if _, held := dirs[dir]; held {
+				break
+			}
+
+			dirs[dir] = struct{}{}
+
+			parent := filepath.Dir(dir)
+			if parent == dir {
+				break
+			}
+
+			dir = parent
+		}
+	}
+
+	return dirs
+}
+
+// relative is a path as the record spells it, for a message about it: what a
+// person reading their project recognises, rather than wherever the run's
+// working directory happened to make it absolute from.
+func (l *ledger) relative(path string) string {
+	rel, err := filepath.Rel(l.root, path)
+	if err != nil {
+		return path
+	}
+
+	return filepath.ToSlash(rel)
+}

--- a/internal/generate/prune_test.go
+++ b/internal/generate/prune_test.go
@@ -1,0 +1,638 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package generate
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The runs below are real: real generators writing real files, run twice
+// against a real project directory, because what a stale-file test claims is
+// what is on disk after the second run — and every part of that a fake could
+// agree with this package about, it could agree with wrongly.
+
+// project is a runner keeping its record in a project directory of the test's
+// own, with what it says about pruning collected rather than printed.
+func project(t *testing.T) (*Runner, string, *lines) {
+	t.Helper()
+
+	root := t.TempDir()
+
+	said := &lines{}
+
+	r := runner(t)
+	r.Root = root
+	r.Log = slog.New(slog.NewTextHandler(said, nil))
+
+	return r, root, said
+}
+
+// lines is what a run said, kept so that a test can ask whether pruning was
+// reported.
+type lines struct {
+	strings.Builder
+}
+
+// said reports whether anything the run wrote mentions every one of want.
+func (l *lines) said(want ...string) bool {
+	for _, phrase := range want {
+		if !strings.Contains(l.String(), phrase) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// record is what the project's record holds, as bytes.
+func recorded(t *testing.T, root string) string {
+	t.Helper()
+
+	return contents(t, filepath.Join(root, RecordName))
+}
+
+// TestARecordRemovedFromALayoutTakesItsFileWithIt is the story: a layout
+// declares two records, a generator produces a file for each, the layout loses
+// one, and the file it produced goes with it. The generator here is the layout
+// — what it emits is what a resolved one asked for — because the two runs have
+// to differ in what they generate and in nothing else.
+func TestARecordRemovedFromALayoutTakesItsFileWithIt(t *testing.T) {
+	t.Parallel()
+
+	r, root, said := project(t)
+	out := filepath.Join(root, "gen")
+
+	both := `echo A > "$4/order.go"
+echo B > "$4/customer.go"`
+
+	if err := run(t, r, generator(t, "go", both, out)); err != nil {
+		t.Fatalf("the first run failed: %v", err)
+	}
+
+	same(t, out, map[string]string{"order.go": "A\n", "customer.go": "B\n"})
+
+	// The layout loses CUSTOMER-REC, so the generator stops producing the file
+	// it produced for it.
+	one := `echo A > "$4/order.go"`
+
+	if err := run(t, r, generator(t, "go", one, out)); err != nil {
+		t.Fatalf("the second run failed: %v", err)
+	}
+
+	same(t, out, map[string]string{"order.go": "A\n"})
+
+	if !said.said("gen/customer.go") {
+		t.Errorf("the run said\n%s\nwant it to report removing gen/customer.go", said)
+	}
+}
+
+// TestTheRecordHoldsEveryPathTheRunGenerated pins the file itself. It is
+// committed, so it is read in diffs, and two runs producing one set of files
+// have to produce one set of bytes or every regeneration is a change.
+func TestTheRecordHoldsEveryPathTheRunGenerated(t *testing.T) {
+	t.Parallel()
+
+	r, root, _ := project(t)
+
+	body := `mkdir -p "$4/pkg/orders"
+echo A > "$4/pkg/orders/order.go"
+echo B > "$4/orders.go"
+mkdir "$4/nothing"`
+
+	if err := run(t, r,
+		generator(t, "go", body, filepath.Join(root, "gen")),
+		generator(t, "docs", `echo C > "$4/orders.md"`, filepath.Join(root, "docs")),
+	); err != nil {
+		t.Fatalf("running the generators: %v", err)
+	}
+
+	// Sorted, slash-separated and relative to the project's root, across every
+	// generator in the run rather than one record per generator: the record
+	// outlives the manifest entry that produced any of it, which is what lets a
+	// generator removed from the manifest have its output pruned.
+	//
+	// Directories are not in it. `gen/nothing` was produced and is not
+	// recorded, because what the record holds is what a later run may remove,
+	// and a directory goes when pruning empties it.
+	want := `{
+  "version": 1,
+  "files": [
+    "docs/orders.md",
+    "gen/orders.go",
+    "gen/pkg/orders/order.go"
+  ]
+}
+`
+
+	if got := recorded(t, root); got != want {
+		t.Errorf("the record holds\n%s\nwant\n%s", got, want)
+	}
+
+	// Byte-identical for the same set of files, so that a record showing up in
+	// a diff is a run that generated something different.
+	if err := run(t, r,
+		generator(t, "go", body, filepath.Join(root, "gen")),
+		generator(t, "docs", `echo C > "$4/orders.md"`, filepath.Join(root, "docs")),
+	); err != nil {
+		t.Fatalf("running the generators again: %v", err)
+	}
+
+	if got := recorded(t, root); got != want {
+		t.Errorf("a second run of the same generators recorded\n%s\nwant\n%s", got, want)
+	}
+}
+
+// TestAFileNoRunRecordedIsNeverTouched is the guarantee the whole arrangement
+// exists for. An output directory shared with hand-written source is the case
+// that matters — it is what lets a generator be pointed at a package a person
+// also works in.
+func TestAFileNoRunRecordedIsNeverTouched(t *testing.T) {
+	t.Parallel()
+
+	r, root, _ := project(t)
+	out := filepath.Join(root, "orders")
+
+	if err := os.MkdirAll(out, 0o755); err != nil {
+		t.Fatalf("making the package directory: %v", err)
+	}
+
+	// Written by a person, in the directory the generator lands in, before
+	// cpybkc has ever run over the project.
+	handwritten := filepath.Join(out, "service.go")
+	if err := os.WriteFile(handwritten, []byte("package orders\n"), 0o644); err != nil {
+		t.Fatalf("writing the hand-written file: %v", err)
+	}
+
+	if err := run(t, r, generator(t, "go", `echo A > "$4/order.go"`, out)); err != nil {
+		t.Fatalf("the first run failed: %v", err)
+	}
+
+	if err := run(t, r, generator(t, "go", `echo A > "$4/other.go"`, out)); err != nil {
+		t.Fatalf("the second run failed: %v", err)
+	}
+
+	// order.go went, because the first run recorded it and the second did not
+	// produce it. service.go stayed, because no run ever recorded it.
+	same(t, out, map[string]string{"other.go": "A\n", "service.go": "package orders\n"})
+}
+
+// TestARunThatFindsNoRecordPrunesNothing is the missing-record rule, and it is
+// the one that decides what pruning is allowed to infer: nothing. A first run
+// over a tree that already holds output — a project generated by an older
+// cpybkc, a record somebody deleted — leaves every bit of it alone.
+func TestARunThatFindsNoRecordPrunesNothing(t *testing.T) {
+	t.Parallel()
+
+	r, root, said := project(t)
+	out := filepath.Join(root, "gen")
+
+	if err := os.MkdirAll(out, 0o755); err != nil {
+		t.Fatalf("making the output directory: %v", err)
+	}
+
+	// Output that looks exactly like this generator's, which is the whole
+	// temptation: it is named the way generated files are named, and pruning
+	// still may not touch it.
+	stale := filepath.Join(out, "customer.go")
+	if err := os.WriteFile(stale, []byte("// Code generated by cpybkc.\n"), 0o644); err != nil {
+		t.Fatalf("writing the file the previous cpybkc left: %v", err)
+	}
+
+	if err := run(t, r, generator(t, "go", `echo A > "$4/order.go"`, out)); err != nil {
+		t.Fatalf("the run failed: %v", err)
+	}
+
+	same(t, out, map[string]string{
+		"order.go":    "A\n",
+		"customer.go": "// Code generated by cpybkc.\n",
+	})
+
+	if said.said("customer.go") {
+		t.Errorf("the run said\n%s\nwant it to say nothing about a file no record names", said)
+	}
+
+	// The record it writes covers what *this* run generated and nothing else,
+	// so the file it left alone stays left alone on every run after this one
+	// too.
+	if strings.Contains(recorded(t, root), "customer.go") {
+		t.Errorf("the record holds\n%s\nwant a file no run generated left out of it", recorded(t, root))
+	}
+}
+
+// TestARunnerWithNoRootKeepsNoRecord is the zero value's answer. A run that has
+// not been told where the project is cannot resolve a record's paths and must
+// not guess at them, so it keeps none and prunes nothing.
+func TestARunnerWithNoRootKeepsNoRecord(t *testing.T) {
+	t.Parallel()
+
+	r := runner(t)
+	out := t.TempDir()
+
+	if err := run(t, r, generator(t, "go", `echo A > "$4/order.go"`, out)); err != nil {
+		t.Fatalf("the first run failed: %v", err)
+	}
+
+	if err := run(t, r, generator(t, "go", `echo B > "$4/customer.go"`, out)); err != nil {
+		t.Fatalf("the second run failed: %v", err)
+	}
+
+	same(t, out, map[string]string{"order.go": "A\n", "customer.go": "B\n"})
+}
+
+// TestAPathAPersonTookOverIsLeftAloneAndReported is where cpybkc's claim on a
+// path ends. Somebody replaced a generated file with a directory or a link, on
+// purpose; removing it would be this package throwing away an arrangement it
+// merely failed to understand.
+func TestAPathAPersonTookOverIsLeftAloneAndReported(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		about string
+		take  func(t *testing.T, path string)
+		want  string
+	}{
+		{
+			about: "a directory",
+			take: func(t *testing.T, path string) {
+				if err := os.Mkdir(path, 0o755); err != nil {
+					t.Fatalf("taking the path over: %v", err)
+				}
+			},
+			want: "<dir>",
+		},
+		{
+			about: "a symlink",
+			take: func(t *testing.T, path string) {
+				if err := os.Symlink("/etc/passwd", path); err != nil {
+					t.Fatalf("taking the path over: %v", err)
+				}
+			},
+			want: "<a symlink>",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.about, func(t *testing.T) {
+			t.Parallel()
+
+			r, root, said := project(t)
+			out := filepath.Join(root, "gen")
+
+			if err := run(t, r, generator(t, "go", `echo A > "$4/order.go"
+echo B > "$4/customer.go"`, out)); err != nil {
+				t.Fatalf("the first run failed: %v", err)
+			}
+
+			taken := filepath.Join(out, "customer.go")
+			if err := os.Remove(taken); err != nil {
+				t.Fatalf("removing the generated file: %v", err)
+			}
+
+			test.take(t, taken)
+
+			if err := run(t, r, generator(t, "go", `echo A > "$4/order.go"`, out)); err != nil {
+				t.Fatalf("the second run failed: %v", err)
+			}
+
+			same(t, out, map[string]string{"order.go": "A\n", "customer.go": test.want})
+
+			if !said.said("gen/customer.go", "no longer a file") {
+				t.Errorf("the run said\n%s\nwant it to report leaving gen/customer.go alone", said)
+			}
+
+			// The claim is released with it: the run recorded what it
+			// generated, that path is not in it, and no later run will consider
+			// the path again.
+			if strings.Contains(recorded(t, root), "customer.go") {
+				t.Errorf("the record holds\n%s\nwant the taken-over path left out of it", recorded(t, root))
+			}
+		})
+	}
+}
+
+// TestADirectoryPruningEmptiesIsRemoved keeps a generator that stops producing
+// a package from leaving the package's directory behind — an empty directory in
+// a diff is a thing a reviewer has to work out.
+func TestADirectoryPruningEmptiesIsRemoved(t *testing.T) {
+	t.Parallel()
+
+	r, root, _ := project(t)
+	out := filepath.Join(root, "gen")
+
+	if err := run(t, r, generator(t, "go", `mkdir -p "$4/pkg/orders"
+echo A > "$4/pkg/orders/order.go"
+echo B > "$4/keep.go"`, out)); err != nil {
+		t.Fatalf("the first run failed: %v", err)
+	}
+
+	if err := run(t, r, generator(t, "go", `echo B > "$4/keep.go"`, out)); err != nil {
+		t.Fatalf("the second run failed: %v", err)
+	}
+
+	// Both directories, not only the one holding the file: pruning walks up
+	// until a directory still holds something.
+	same(t, out, map[string]string{"keep.go": "B\n"})
+
+	// Never the project's root, and never the output directory the run is still
+	// writing into.
+	if !exists(t, root) || !exists(t, out) {
+		t.Errorf("pruning removed a directory the run was still using: %s or %s", root, out)
+	}
+}
+
+// TestADirectoryPruningEmptiesIsKeptWhereSomethingElseIsInIt is the other half:
+// a directory a person also keeps files in is not this package's to delete just
+// because a generator once wrote into it.
+func TestADirectoryPruningEmptiesIsKeptWhereSomethingElseIsInIt(t *testing.T) {
+	t.Parallel()
+
+	r, root, _ := project(t)
+	out := filepath.Join(root, "gen")
+
+	if err := run(t, r, generator(t, "go", `mkdir "$4/pkg"
+echo A > "$4/pkg/order.go"
+echo B > "$4/keep.go"`, out)); err != nil {
+		t.Fatalf("the first run failed: %v", err)
+	}
+
+	handwritten := filepath.Join(out, "pkg", "service.go")
+	if err := os.WriteFile(handwritten, []byte("package pkg\n"), 0o644); err != nil {
+		t.Fatalf("writing the hand-written file: %v", err)
+	}
+
+	if err := run(t, r, generator(t, "go", `echo B > "$4/keep.go"`, out)); err != nil {
+		t.Fatalf("the second run failed: %v", err)
+	}
+
+	same(t, out, map[string]string{
+		"keep.go":        "B\n",
+		"pkg":            "<dir>",
+		"pkg/service.go": "package pkg\n",
+	})
+}
+
+// TestAPathThatChangesFromAFileToADirectoryBetweenRuns is why pruning happens
+// before anything is written. A generator that produced `orders.go` and now
+// produces `orders/order.go` would otherwise meet its own stale file where the
+// merge needs a directory, and fail there on every run until somebody removed
+// it by hand.
+func TestAPathThatChangesFromAFileToADirectoryBetweenRuns(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		about  string
+		first  string
+		second string
+		want   map[string]string
+	}{
+		{
+			about:  "a file that becomes a directory",
+			first:  `echo A > "$4/orders"`,
+			second: `mkdir "$4/orders"; echo B > "$4/orders/order.go"`,
+			want:   map[string]string{"orders": "<dir>", "orders/order.go": "B\n"},
+		},
+		{
+			about:  "a directory that becomes a file",
+			first:  `mkdir "$4/orders"; echo B > "$4/orders/order.go"`,
+			second: `echo A > "$4/orders"`,
+			want:   map[string]string{"orders": "A\n"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.about, func(t *testing.T) {
+			t.Parallel()
+
+			r, root, _ := project(t)
+			out := filepath.Join(root, "gen")
+
+			if err := run(t, r, generator(t, "go", test.first, out)); err != nil {
+				t.Fatalf("the first run failed: %v", err)
+			}
+
+			if err := run(t, r, generator(t, "go", test.second, out)); err != nil {
+				t.Fatalf("the second run failed: %v", err)
+			}
+
+			same(t, out, test.want)
+		})
+	}
+}
+
+// TestARecordThisCpybkcDidNotWriteFailsTheRunBeforeAnythingStarts is the
+// refusal. Pruning from a list that has been damaged is how a stale file
+// becomes permanent, and a run that read one as far as it happened to parse
+// would be deleting from a list it had guessed at.
+func TestARecordThisCpybkcDidNotWriteFailsTheRunBeforeAnythingStarts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		about string
+		held  string
+	}{
+		{about: "not JSON at all", held: "{"},
+		{about: "a version nobody here knows", held: `{"version": 2, "files": []}`},
+		{about: "a field nobody here writes", held: `{"version": 1, "files": [], "pruned": true}`},
+		{about: "a path out of the project", held: `{"version": 1, "files": ["../../etc/passwd"]}`},
+		{about: "an absolute path", held: `{"version": 1, "files": ["/etc/passwd"]}`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.about, func(t *testing.T) {
+			t.Parallel()
+
+			r, root, _ := project(t)
+
+			if err := os.WriteFile(filepath.Join(root, RecordName), []byte(test.held), 0o644); err != nil {
+				t.Fatalf("writing the record: %v", err)
+			}
+
+			marker := filepath.Join(t.TempDir(), "ran")
+
+			err := run(t, r, generator(t, "go", `echo ran > `+marker, filepath.Join(root, "gen")))
+
+			var fault *RecordError
+			if !errors.As(err, &fault) {
+				t.Fatalf("the run failed with %v, want a RecordError", err)
+			}
+
+			// Read before a generator is started, for the reason an invocation
+			// is checked before one is: it is a fault in the project rather
+			// than in the output, and finding it afterwards would mean
+			// discovering it once the work was done.
+			if exists(t, marker) {
+				t.Error("the generator ran, want the run refused before anything started")
+			}
+		})
+	}
+}
+
+// TestOutputThatCouldNeverBeRecordedFailsTheRun. A file cpybkc generates and
+// does not record is one no later run will ever remove — the single failure
+// pruning exists to prevent, and an invisible one, because the output is
+// perfectly correct on the run that produced it.
+func TestOutputThatCouldNeverBeRecordedFailsTheRun(t *testing.T) {
+	t.Parallel()
+
+	t.Run("output that lands outside the project", func(t *testing.T) {
+		t.Parallel()
+
+		r, root, _ := project(t)
+		out := filepath.Join(t.TempDir(), "elsewhere")
+
+		err := run(t, r, generator(t, "go", `echo A > "$4/order.go"`, out))
+
+		var fault *UnrecordableError
+		if !errors.As(err, &fault) {
+			t.Fatalf("the run failed with %v, want an UnrecordableError", err)
+		}
+
+		if exists(t, out) {
+			t.Errorf("%s was created by a refused run, want nothing written", out)
+		}
+
+		if exists(t, filepath.Join(root, RecordName)) {
+			t.Error("a refused run wrote a record, want none")
+		}
+	})
+
+	t.Run("a generator that produces the record itself", func(t *testing.T) {
+		t.Parallel()
+
+		r, root, _ := project(t)
+
+		err := run(t, r, generator(t, "go", `echo A > "$4/`+RecordName+`"`, root))
+
+		var fault *UnrecordableError
+		if !errors.As(err, &fault) {
+			t.Fatalf("the run failed with %v, want an UnrecordableError", err)
+		}
+
+		if exists(t, filepath.Join(root, RecordName)) {
+			t.Error("the generator's file was merged over the record, want the run refused")
+		}
+	})
+}
+
+// TestARefusedRunPrunesNothing keeps pruning behind every refusal there is. A
+// run that was going to fail anyway must not take a project's files with it on
+// the way out.
+func TestARefusedRunPrunesNothing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		about string
+		body  string
+	}{
+		{about: "a generator that failed", body: `echo A > "$4/order.go"; exit 1`},
+		{about: "a generator that left a symlink", body: `ln -s /etc/passwd "$4/link"`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.about, func(t *testing.T) {
+			t.Parallel()
+
+			r, root, _ := project(t)
+			out := filepath.Join(root, "gen")
+
+			if err := run(t, r, generator(t, "go", `echo A > "$4/order.go"
+echo B > "$4/customer.go"`, out)); err != nil {
+				t.Fatalf("the first run failed: %v", err)
+			}
+
+			before := recorded(t, root)
+
+			if err := run(t, r, generator(t, "go", test.body, out)); err == nil {
+				t.Fatal("the run succeeded, want it refused")
+			}
+
+			same(t, out, map[string]string{"order.go": "A\n", "customer.go": "B\n"})
+
+			// And the record still describes the tree, so the run after this
+			// one prunes from a list that is still true.
+			if got := recorded(t, root); got != before {
+				t.Errorf("a refused run rewrote the record as\n%s\nwant\n%s", got, before)
+			}
+		})
+	}
+}
+
+// TestAStaleFileThatCannotBeRemovedFailsTheRun. Everything pruning declines to
+// remove of its own accord is reported and carried; this is the filesystem
+// saying no, and carrying that would leave a project whose record no longer
+// describes it and a stale file nothing will ever mention again.
+func TestAStaleFileThatCannotBeRemovedFailsTheRun(t *testing.T) {
+	t.Parallel()
+
+	if os.Geteuid() == 0 {
+		t.Skip("root removes files out of a directory it has no write permission on")
+	}
+
+	r, root, _ := project(t)
+	out := filepath.Join(root, "gen")
+
+	if err := run(t, r, generator(t, "go", `mkdir "$4/pkg"
+echo A > "$4/pkg/order.go"
+echo B > "$4/keep.go"`, out)); err != nil {
+		t.Fatalf("the first run failed: %v", err)
+	}
+
+	pkg := filepath.Join(out, "pkg")
+
+	// Restored before the test's own directory is torn down, which is
+	// registered earlier and so runs after this.
+	t.Cleanup(func() {
+		if err := os.Chmod(pkg, 0o755); err != nil {
+			t.Errorf("restoring %s: %v", pkg, err)
+		}
+	})
+
+	if err := os.Chmod(pkg, 0o555); err != nil {
+		t.Fatalf("making the directory read-only: %v", err)
+	}
+
+	err := run(t, r, generator(t, "go", `echo B > "$4/keep.go"`, out))
+
+	var fault *PruneError
+	if !errors.As(err, &fault) {
+		t.Fatalf("the run failed with %v, want a PruneError", err)
+	}
+
+	if got, want := fault.Path, "gen/pkg/order.go"; got != want {
+		t.Errorf("the fault names %q, want %q", got, want)
+	}
+}
+
+// TestTheRecordIsWrittenWithTheRunsOwnMode is the same claim the merged files
+// carry, and it exists for the same case: cpybkc running as root in a container
+// over a bind mount, where a record its user cannot edit is as much of a fault
+// as generated output they cannot edit.
+func TestTheRecordIsWrittenWithTheRunsOwnMode(t *testing.T) {
+	t.Parallel()
+
+	r, root, _ := project(t)
+
+	mask := os.FileMode(0o027)
+	r.Umask = &mask
+
+	if err := run(t, r, generator(t, "go", `echo A > "$4/order.go"`, filepath.Join(root, "gen"))); err != nil {
+		t.Fatalf("the run failed: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(root, RecordName))
+	if err != nil {
+		t.Fatalf("reading the record: %v", err)
+	}
+
+	if got, want := info.Mode().Perm(), fileMode.Perm()&^mask; got != want {
+		t.Errorf("the record is %v, want %v", got, want)
+	}
+}

--- a/internal/generate/prune_test.go
+++ b/internal/generate/prune_test.go
@@ -441,6 +441,8 @@ func TestARecordThisCpybkcDidNotWriteFailsTheRunBeforeAnythingStarts(t *testing.
 		{about: "not JSON at all", held: "{"},
 		{about: "a version nobody here knows", held: `{"version": 2, "files": []}`},
 		{about: "a field nobody here writes", held: `{"version": 1, "files": [], "pruned": true}`},
+		{about: "more than the one object a record is", held: `{"version": 1, "files": []}{"version": 1, "files": []}`},
+		{about: "something appended to the record", held: `{"version": 1, "files": []}` + "\n<<<<<<< HEAD\n"},
 		{about: "a path out of the project", held: `{"version": 1, "files": ["../../etc/passwd"]}`},
 		{about: "an absolute path", held: `{"version": 1, "files": ["/etc/passwd"]}`},
 	}

--- a/internal/generate/record.go
+++ b/internal/generate/record.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -131,6 +132,18 @@ func readRecord(path string) ([]string, error) {
 
 	if err := decoder.Decode(&held); err != nil {
 		return nil, &RecordError{Path: path, Err: err}
+	}
+
+	// A record is one JSON object and nothing else. [encoding/json] stops at
+	// the end of the first value it reads, so without this a second object
+	// concatenated onto the file — or anything at all after it — would be read
+	// past in silence, and a file that has been appended to is exactly the file
+	// this run must not be deleting from.
+	if _, err := decoder.Token(); !errors.Is(err, io.EOF) {
+		return nil, &RecordError{
+			Path:  path,
+			Fault: "it holds more than the one JSON object a record is",
+		}
 	}
 
 	if held.Version != recordVersion {

--- a/internal/generate/record.go
+++ b/internal/generate/record.go
@@ -1,0 +1,230 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package generate
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+)
+
+// RecordName is the file a project keeps the record of its last run in, beside
+// the manifest that drove it.
+//
+// It is a constant rather than a string typed out at each call site for the
+// reason [github.com/Zaba505/cpybkc/internal/manifest.Name] is one: the name
+// appears in a diagnostic, in whatever eventually writes a project's
+// .gitignore, and in the file a person finds in their diff. A project keeps
+// exactly one of them.
+const RecordName = "cpybkc.gen.json"
+
+// recordVersion is the version this cpybkc writes and the only one it reads.
+//
+// It is a number in the file rather than a shape inferred from what is there,
+// so that a record written by a later cpybkc is refused by name instead of
+// being read as far as it happens to parse — a misread record is a list of
+// files this run would delete.
+const recordVersion = 1
+
+// record is the file's shape: the version it was written under, and every path
+// the run that wrote it generated.
+//
+// The paths are relative to the project's root, slash-separated whatever the
+// host separates with, and sorted — so two runs that produce the same set of
+// files produce a byte-identical file, and a record that shows up in a diff is
+// a run that generated something different.
+type record struct {
+	Version int      `json:"version"`
+	Files   []string `json:"files"`
+}
+
+// ledger is one run's bookkeeping: where the project's root is, what the
+// previous run recorded there, and where pruning is reported.
+//
+// A ledger with no root keeps no record and prunes nothing. That is a
+// [Runner] whose Root is unset, and it is the honest answer rather than a
+// degraded one: the record is a file at a project's root, and a run that has
+// not been told where that is cannot write one, cannot resolve the paths in one,
+// and must not guess — guessing wrong is a run that deletes a file somebody
+// wrote.
+type ledger struct {
+	// root is the project's root, absolute, or empty for a run that keeps no
+	// record.
+	root string
+
+	// previous is what the last run recorded it had generated, root-relative
+	// and slash-separated as the file holds it. Nil where there was no record,
+	// which is the case a first run and a deleted record are both in.
+	previous []string
+
+	// log is where pruning is reported.
+	log *slog.Logger
+}
+
+// ledger opens this run's bookkeeping, reading what the last run left.
+//
+// It is read before any generator is started, for the reason an invocation is
+// checked before one is: a record this cpybkc cannot read is a fault in the
+// project and not in the output, and finding it after a run would mean
+// discovering it once the work was done.
+func (r *Runner) ledger() (*ledger, error) {
+	l := &ledger{log: r.logger()}
+
+	if r.Root == "" {
+		return l, nil
+	}
+
+	root, err := filepath.Abs(r.Root)
+	if err != nil {
+		return nil, &RecordError{Path: filepath.Join(r.Root, RecordName), Err: err}
+	}
+
+	l.root = root
+
+	l.previous, err = readRecord(filepath.Join(root, RecordName))
+	if err != nil {
+		return nil, err
+	}
+
+	return l, nil
+}
+
+// readRecord is what the run recorded at path generated, or nothing at all
+// where there is no record there.
+//
+// A record that is not there is not a fault and prunes nothing: a first run has
+// none, and a person who deleted theirs has said that cpybkc owns none of what
+// is in their tree. The cost of that is one stale file surviving one more run,
+// and what it buys is that no run ever decides for itself which files look
+// generated.
+//
+// Everything else about the file is a fault, and fails the run rather than
+// being read past. The alternative to refusing a record this cpybkc does not
+// understand is pruning from a list it has guessed at, and the list is what a
+// run deletes.
+func readRecord(path string) ([]string, error) {
+	src, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+
+		return nil, &RecordError{Path: path, Err: err}
+	}
+
+	var held record
+
+	decoder := json.NewDecoder(bytes.NewReader(src))
+	decoder.DisallowUnknownFields()
+
+	if err := decoder.Decode(&held); err != nil {
+		return nil, &RecordError{Path: path, Err: err}
+	}
+
+	if held.Version != recordVersion {
+		return nil, &RecordError{
+			Path: path,
+			Fault: fmt.Sprintf("it declares version %d, and this cpybkc writes and reads version %d",
+				held.Version, recordVersion),
+		}
+	}
+
+	for _, file := range held.Files {
+		// A path this cpybkc could not have written, which means the file has
+		// been edited or is not a cpybkc record at all. Every entry is a file
+		// pruning may remove, so one that reaches outside the project — an
+		// absolute path, a `..`, an empty string — is refused rather than
+		// skipped: a record that is wrong about one path is not a record this
+		// run should be deleting from at all.
+		if !filepath.IsLocal(filepath.FromSlash(file)) {
+			return nil, &RecordError{
+				Path:  path,
+				Fault: fmt.Sprintf("it names %s, which is not a path beneath the project's root", strconv.Quote(file)),
+			}
+		}
+	}
+
+	return held.Files, nil
+}
+
+// generated is every file this run produces, root-relative, slash-separated and
+// sorted: the list the record is written from and the list pruning subtracts.
+//
+// Directories are not in it. What a record holds is what a later run may
+// remove, and a directory is removed because pruning emptied it rather than
+// because it was generated — a directory a person also keeps files in is not
+// cpybkc's to delete just because a generator once wrote into it.
+func (l *ledger) generated(planned []entry) ([]string, error) {
+	if l.root == "" {
+		return nil, nil
+	}
+
+	var faults diag.List
+
+	files := []string{}
+
+	for _, e := range planned {
+		if e.dir {
+			continue
+		}
+
+		rel, err := filepath.Rel(l.root, e.dest)
+		if err != nil || !filepath.IsLocal(rel) || rel == RecordName {
+			faults.Fail(&UnrecordableError{Name: e.generator, Path: e.path, Dest: e.dest, Root: l.root})
+
+			continue
+		}
+
+		files = append(files, filepath.ToSlash(rel))
+	}
+
+	if faults.Failed() {
+		return nil, faults.Err()
+	}
+
+	slices.Sort(files)
+
+	return files, nil
+}
+
+// write puts this run's record where the next run will read it.
+//
+// Through the merger, so that the record gets this run's umask and this run's
+// ownership exactly as the generated files beside it do. It is a file in a
+// person's project and it goes into their commit; a record they cannot edit,
+// because cpybkc ran as root in a container over a bind mount, is the same
+// fault as generated output they cannot edit.
+func (l *ledger) write(m *merger, generated []string) error {
+	if l.root == "" {
+		return nil
+	}
+
+	path := filepath.Join(l.root, RecordName)
+
+	src, err := json.MarshalIndent(record{Version: recordVersion, Files: generated}, "", "  ")
+	if err != nil {
+		return &RecordError{Path: path, Writing: true, Err: err}
+	}
+
+	// A trailing newline, because this is a file a person commits and every
+	// other line-oriented tool they own expects one.
+	src = append(src, '\n')
+
+	if err := m.copy(bytes.NewReader(src), path, false); err != nil {
+		return &RecordError{Path: path, Writing: true, Err: err}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Closes #45

A run now writes down what it generated, and the next run removes what it
generated before and no longer does. The record is `cpybkc.gen.json`, beside
the manifest that drove the run: `{"version": 1, "files": [...]}`, root-relative,
slash-separated and sorted, so two runs producing the same set of files produce
byte-identical bytes and a record in a diff means something changed.

It lands in `internal/generate`, which is where the package comment already said
it would (`#45`, "which is not here yet") — the record spans every generator in
the run, so it outlives the manifest entry that produced any of it, which is
what lets a generator *removed* from the manifest have its output pruned.

## Acceptance criteria

- [x] **A run manifest records every generated path** — `ledger.generated` turns
  the merge plan into the record's file list, and `ledger.write` puts it at the
  project's root through the same call the merged files go through, so it gets
  the run's umask and ownership. Pinned byte for byte by
  `TestTheRecordHoldsEveryPathTheRunGenerated`, twice, so that a re-run of the
  same generators is not a diff.
- [x] **Files in the previous run manifest but absent from the current run are
  removed** — `ledger.prune`. `TestARecordRemovedFromALayoutTakesItsFileWithIt`
  is the story end to end.
- [x] **Files not recorded in any run manifest are never touched** — the set
  pruning works from is the previous record minus this run's output and nothing
  else. `TestAFileNoRunRecordedIsNeverTouched` puts hand-written source in the
  directory a generator lands in; `TestARunThatFindsNoRecordPrunesNothing` leaves
  alone a file that is named exactly the way generated files are named, because
  a run that finds no record infers nothing.
- [x] **Pruning is reported to the user** — a new `Runner.Log`, separate from the
  logger a generator's own output is surfaced through. A file removed is `INFO`,
  a directory emptied and removed is `INFO`, and a recorded path a person has
  taken over is `WARN`.
- [x] **Tests cover removing a record from a layout and regenerating** — the
  first test above, plus the taken-over, emptied-directory, file↔directory,
  refused-run and unreadable-record cases.

## Judgment calls

**`Runner.Root` is what turns the record on, and the zero value keeps none.**
The record is a file at a project's root and its paths are relative to it, so a
run that has not been told where the root is cannot write one and must not guess
— a wrong guess deletes something a person wrote. Whatever finds the project's
`cpybkc.json` knows where its root is, and that is the one place the answer
exists. Existing callers and the zero `Runner` are unchanged.

**Pruning happens after the plan and before anything is written.** That is the
only moment that works. Earlier, a run still refusable — a symlink in a scratch
directory, two generators claiming one path — would have deleted files on its way
to failing. Later, a path that was a file last run and is a directory this one
would meet the stale entry during the merge and fail there on *every* run until
somebody removed it by hand; `TestAPathThatChangesFromAFileToADirectoryBetweenRuns`
covers both directions.

**A record that exists and cannot be read fails the run, before any generator
starts.** Pruning nothing would be the safe direction and it is the dishonest one:
it is indistinguishable from a first run, and it is how a stale file becomes
permanent. The diagnostic says whose file it is and that deleting it is safe and
costs one run's worth of stale files. A record that is simply *absent* is not
this — it prunes nothing and says nothing.

**Output that could never be recorded fails the run** (`UnrecordableError`): a
generator pointed outside the project's root, or one producing the record's own
file. A file cpybkc generates and does not record is one no later run will ever
remove — the single failure pruning exists to prevent, and an invisible one,
because the output is perfectly correct on the run that produced it.

**A stale file that cannot be removed fails the run** (`PruneError`), while a
recorded path that is now a directory or a symlink is left alone and reported.
The second is a person taking a path over, which ends cpybkc's claim on it; the
first is the filesystem saying no, and carrying that leaves a project whose
record no longer describes it.

`merger.copy` now takes an `io.Reader` rather than a source path, so the record
enters the project's tree through the same remove-first / exclusive-create /
settle-the-mode-through-the-descriptor path as every generated file. No second
place a file gets written.

No spec change: `docs/plugin/SPEC.md` already assigns pruning to cpybkc and says
the record's "form and where it lives are #45's and not this contract's", and
its Mapping to Stories table already carries #45.

## Verified

`dagger call ci` — green. `go test -race ./...` locally as well.
