### PR TITLE
story(plugin): enforce deterministic generator output

### DIFF
--- a/docs/plugin/SPEC.md
+++ b/docs/plugin/SPEC.md
@@ -283,8 +283,13 @@ convenient place to put it, and it costs a plugin one branch.
 
 ### The environment
 
-cpybkc passes its own environment through to a generator unchanged, except as
-[Determinism](#determinism) requires of `SOURCE_DATE_EPOCH` (#47).
+cpybkc passes its own environment through to a generator unchanged, and that
+pass-through **is** the propagation of `SOURCE_DATE_EPOCH` that
+[Determinism](#determinism) requires (#47): cpybkc adds no variable of its own,
+removes none, and names none, so that variable reaches a generator for the same
+reason every other one does. A plugin therefore sees exactly what cpybkc was
+started with, and a build that sets `SOURCE_DATE_EPOCH` for its other tools has
+already set it for every generator cpybkc runs.
 
 A plugin **MUST NOT** require an environment variable to be set in order to do
 its normal work; everything that configures its output arrives as `--opt`. The
@@ -503,14 +508,18 @@ several. When it is not set, a plugin **SHOULD** omit the timestamp rather than
 fall back to the clock: a missing generation date costs a reader nothing, and a
 present one costs every regeneration a diff.
 
-The requirement is checked rather than asserted — a pipeline stage generates
-twice and byte-compares, failing on any difference (#47) — because determinism
-is the kind of property that holds until nobody is looking. Repetition catches
-output ordered by map iteration, because Go randomises that on every range. It
-cannot catch a clock read, since two runs a moment apart agree on the date, so
-the generators in this repository are additionally held to the rule by a check
-on their source; a third-party plugin is bound by the requirement above however
-it chooses to meet it.
+The requirement is checked rather than asserted — the pipeline generates
+repeatedly, from runs that deliberately disagree about every surrounding named
+above and agree only about `SOURCE_DATE_EPOCH`, and byte-compares the trees,
+failing on any difference (#47) — because determinism is the kind of property
+that holds until nobody is looking. Repetition catches output ordered by map
+iteration, because Go randomises that on every range. It cannot catch a clock
+read, since two runs a moment apart agree on the date, so the generators in this
+repository are additionally held to the rule by a check on their source, which
+parses every package that decides what a run writes and refuses a call that
+reads the clock, the environment, the working directory, the host, the user or a
+random value. A third-party plugin is bound by the requirement above however it
+chooses to meet it.
 
 ## The version check, and why there is no handshake
 

--- a/docs/plugin/SPEC.md
+++ b/docs/plugin/SPEC.md
@@ -509,17 +509,23 @@ fall back to the clock: a missing generation date costs a reader nothing, and a
 present one costs every regeneration a diff.
 
 The requirement is checked rather than asserted — the pipeline generates
-repeatedly, from runs that deliberately disagree about every surrounding named
-above and agree only about `SOURCE_DATE_EPOCH`, and byte-compares the trees,
+repeatedly, from runs that deliberately disagree about every surrounding a
+generator can see through its environment and about the paths in its argument
+vector, agreeing only about `SOURCE_DATE_EPOCH`, and byte-compares the trees,
 failing on any difference (#47) — because determinism is the kind of property
 that holds until nobody is looking. Repetition catches output ordered by map
-iteration, because Go randomises that on every range. It cannot catch a clock
-read, since two runs a moment apart agree on the date, so the generators in this
+iteration, because Go randomises that on every range.
+
+It catches neither a clock read, since two runs a moment apart agree on the
+date, nor the same surroundings read through a call rather than through the
+environment, since two runs on one machine share the hostname, the user and the
+working directory whatever their environments say. So the generators in this
 repository are additionally held to the rule by a check on their source, which
 parses every package that decides what a run writes and refuses a call that
 reads the clock, the environment, the working directory, the host, the user or a
-random value. A third-party plugin is bound by the requirement above however it
-chooses to meet it.
+random value. The two checks are disjoint on purpose: one varies what can be
+varied, the other forbids what cannot. A third-party plugin is bound by the
+requirement above however it chooses to meet it.
 
 ## The version check, and why there is no handshake
 

--- a/internal/generate/determinism_test.go
+++ b/internal/generate/determinism_test.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package generate
+
+import (
+	"io"
+	"log/slog"
+	"maps"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/plugin"
+)
+
+// docs/plugin/SPEC.md, "Determinism": the same generators, the same descriptor
+// and the same options produce the same set of relative paths with
+// byte-identical contents, whatever the machine underneath. The requirement is
+// checked rather than asserted, and this is where the checking happens: the run
+// below is made repeatedly, from surroundings that disagree about everything the
+// spec says output must not vary with, and every tree is compared against the
+// first.
+//
+// Repetition is what catches an order decided by a map iteration, because Go
+// randomises that on every range — the record this package writes is a list of
+// every file the run produced, and a list assembled from a map would come out
+// in a different order most times it was written. It cannot catch a clock read,
+// since two runs a moment apart agree on the date; that is the source scan in
+// internal/plugin's determinism_test.go, and neither half sees the whole thing.
+
+// runs is how many times the project below is generated. Enough that an order
+// left to Go's map iteration would have to be unlucky many times over to come
+// out the same, and few enough that the check costs a second.
+const runs = 8
+
+// emitsAPackage is a generator that writes across two directories, in an order
+// its own loop decides rather than a sorted one, and records the timestamp the
+// runs agree about.
+//
+// More than one file on purpose: what a single-file run would fail to exercise
+// is the order this package's record puts them in, which is the map iteration
+// the repetition is here for.
+const emitsAPackage = `mkdir -p "$4/nested"
+for f in delta alpha foxtrot charlie bravo echo; do
+	echo "package pkg // $f" > "$4/$f.go"
+	echo "$f" > "$4/nested/$f.txt"
+done
+echo "$SOURCE_DATE_EPOCH" > "$4/generated_at"`
+
+// emitsBeside is a second generator landing in the first one's directory, which
+// is the ordinary case for a project generating one package from two of them.
+const emitsBeside = `echo "package pkg // docs" > "$4/docs.go"`
+
+// emitsItsHostname is a generator that breaks the rule, used to check that the
+// comparison would see it.
+const emitsItsHostname = `echo "$HOSTNAME" > "$4/host"`
+
+// machine is a runner whose surroundings are stated rather than inherited, so
+// that two runs can genuinely disagree about all of them: the user, the host,
+// the home directory, the temporary directory, the time zone, the locale and
+// the working directory a plugin would find in its environment, plus the
+// scratch space and the plugin's own path, which differ because every directory
+// here is the test's own.
+//
+// Everything varies with n except SOURCE_DATE_EPOCH, which is an input to
+// generation rather than an accident of the machine: docs/plugin/SPEC.md makes
+// it the one channel a timestamp may come from, so two runs that disagreed
+// about it would be entitled to differ.
+func machine(t *testing.T, n int) *Runner {
+	t.Helper()
+
+	id := strconv.Itoa(n)
+
+	return &Runner{
+		Plugins: &plugin.Runner{
+			Log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+			TempDir: t.TempDir(),
+			Env: []string{
+				// PATH so that a shell script can reach the commands it calls,
+				// and this process's because a stated one would be a claim
+				// about where a machine keeps mkdir.
+				"PATH=" + os.Getenv("PATH"),
+				"HOSTNAME=host-" + id,
+				"USER=person-" + id,
+				"LOGNAME=person-" + id,
+				"HOME=/home/person-" + id,
+				"PWD=" + t.TempDir(),
+				"TMPDIR=" + t.TempDir(),
+				"TZ=" + []string{"UTC", "Australia/Eucla"}[n%2],
+				"LANG=" + []string{"C", "tr_TR.UTF-8"}[n%2],
+				"SOURCE_DATE_EPOCH=1700000000",
+			},
+		},
+		TempDir: t.TempDir(),
+	}
+}
+
+// generate runs generators through the nth machine into a project of their own,
+// and hands back what is in that project afterwards.
+func generate(t *testing.T, n int, bodies ...string) map[string]string {
+	t.Helper()
+
+	project := t.TempDir()
+
+	r := machine(t, n)
+	r.Root = project
+
+	generators := make([]Generator, 0, len(bodies))
+
+	for i, body := range bodies {
+		generators = append(generators,
+			generator(t, "gen"+strconv.Itoa(i), body, filepath.Join(project, "pkg")))
+	}
+
+	if err := r.Run(t.Context(), descriptor(), generators); err != nil {
+		t.Fatalf("run %d: %v", n, err)
+	}
+
+	return tree(t, project)
+}
+
+func TestRunsFromMachinesThatDisagreeProduceOneTree(t *testing.T) {
+	t.Parallel()
+
+	first := generate(t, 0, emitsAPackage, emitsBeside)
+
+	// The record is part of what is compared, and it has to be: it is a file
+	// the project commits, so a list that came out in a different order would
+	// be a diff on every regeneration.
+	if _, written := first[RecordName]; !written {
+		t.Fatalf("the run wrote no %s, so the comparison below covers less than it claims", RecordName)
+	}
+
+	// The timestamp the runs agree about reaches the generator through the
+	// environment cpybkc was started with, which is the propagation
+	// docs/plugin/SPEC.md requires of SOURCE_DATE_EPOCH (#47). Asserted here
+	// rather than left to the comparison, because two runs that both saw
+	// nothing would agree too.
+	if got, want := first[filepath.Join("pkg", "generated_at")], "1700000000\n"; got != want {
+		t.Errorf("the generator recorded SOURCE_DATE_EPOCH as %q, want %q", got, want)
+	}
+
+	for n := 1; n < runs; n++ {
+		got := generate(t, n, emitsAPackage, emitsBeside)
+
+		if maps.Equal(got, first) {
+			continue
+		}
+
+		for path, content := range got {
+			if was, produced := first[path]; !produced {
+				t.Errorf("run %d produced %s, which the first run did not", n, path)
+			} else if was != content {
+				t.Errorf("run %d put %q in %s, and the first run put %q there", n, content, path, was)
+			}
+		}
+
+		for path := range first {
+			if _, produced := got[path]; !produced {
+				t.Errorf("run %d produced no %s, which the first run did", n, path)
+			}
+		}
+	}
+}
+
+func TestTheComparisonWouldSeeARunThatVariedWithItsMachine(t *testing.T) {
+	t.Parallel()
+
+	// A generator that embeds the hostname breaks the rule the test above
+	// checks. If the two trees came out equal anyway, the machines the runs are
+	// made from do not actually differ where a generator can see them, and the
+	// comparison above would pass on output that was not deterministic at all.
+	if maps.Equal(generate(t, 0, emitsItsHostname), generate(t, 1, emitsItsHostname)) {
+		t.Error("two runs whose machines disagree produced one tree from a generator that embeds its hostname")
+	}
+}

--- a/internal/generate/determinism_test.go
+++ b/internal/generate/determinism_test.go
@@ -21,16 +21,22 @@ import (
 // and the same options produce the same set of relative paths with
 // byte-identical contents, whatever the machine underneath. The requirement is
 // checked rather than asserted, and this is where the checking happens: the run
-// below is made repeatedly, from surroundings that disagree about everything the
-// spec says output must not vary with, and every tree is compared against the
-// first.
+// below is made repeatedly, from surroundings that disagree about everything a
+// generator can see of its machine through its environment and about every path
+// it is handed, and every tree is compared against the first.
+//
+// What this half cannot vary is the same facts read through a call rather than
+// through the environment — os.Hostname, os/user, os.Getwd, the clock. Two runs
+// in one process share all of those, and varying them would mean a container
+// per run for a property a comparison is the wrong instrument for anyway. The
+// source scan in internal/plugin's determinism_test.go is what covers them, by
+// refusing the calls outright, and neither half sees the whole thing.
 //
 // Repetition is what catches an order decided by a map iteration, because Go
 // randomises that on every range — the record this package writes is a list of
 // every file the run produced, and a list assembled from a map would come out
-// in a different order most times it was written. It cannot catch a clock read,
-// since two runs a moment apart agree on the date; that is the source scan in
-// internal/plugin's determinism_test.go, and neither half sees the whole thing.
+// in a different order most times it was written. It cannot catch a clock read
+// either, since two runs a moment apart agree on the date.
 
 // runs is how many times the project below is generated. Enough that an order
 // left to Go's map iteration would have to be unlucky many times over to come
@@ -62,9 +68,13 @@ const emitsItsHostname = `echo "$HOSTNAME" > "$4/host"`
 // machine is a runner whose surroundings are stated rather than inherited, so
 // that two runs can genuinely disagree about all of them: the user, the host,
 // the home directory, the temporary directory, the time zone, the locale and
-// the working directory a plugin would find in its environment, plus the
-// scratch space and the plugin's own path, which differ because every directory
-// here is the test's own.
+// the working directory, each as a generator finds it in its environment, plus
+// the scratch space and the plugin's own path, which differ because every
+// directory here is the test's own.
+//
+// Environment-visible throughout, which is the limit of what a run in this
+// process can vary; see the note at the top of this file for what covers the
+// same facts read through a call.
 //
 // Everything varies with n except SOURCE_DATE_EPOCH, which is an input to
 // generation rather than an accident of the machine: docs/plugin/SPEC.md makes

--- a/internal/plugin/determinism_test.go
+++ b/internal/plugin/determinism_test.go
@@ -1,0 +1,382 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package plugin
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// docs/plugin/SPEC.md, "Determinism": two invocations of one generator, given a
+// byte-identical descriptor and an identical option list, produce byte-identical
+// output — whatever the wall-clock time, the hostname, the user, the working
+// directory, the locale and the environment beyond SOURCE_DATE_EPOCH.
+//
+// Two halves of that are checked here, and neither sees the whole thing.
+// Repetition is the other half and lives where output is produced
+// (internal/generate's determinism_test.go): it catches an order decided by a
+// map iteration, because Go randomises that on every range, and it cannot catch
+// a clock read, since two runs a moment apart agree on the date. What is here is
+// the propagation the requirement rests on, and a scan of the source for the
+// calls repetition cannot catch.
+
+// sourceDateEpochVar is the one variable a generator may take a time from.
+//
+// docs/plugin/SPEC.md makes it the single permitted channel rather than one
+// convention among several, and cpybkc MUST propagate it when it is set in
+// cpybkc's own environment (#47).
+const sourceDateEpochVar = "SOURCE_DATE_EPOCH"
+
+func TestSourceDateEpochReachesAGeneratorFromCpybkcsOwnEnvironment(t *testing.T) {
+	// Not parallel, because it states a variable in this process's own
+	// environment, which is the only way to assert the propagation.
+	// TestTheEnvironmentReachesTheGeneratorUnchanged asserts the other side of
+	// it — that a stated [Runner.Env] arrives unchanged — and a test that
+	// stated one here would be asserting that cpybkc passes on what a caller
+	// handed it rather than that it passes on what it was started with.
+	t.Setenv(sourceDateEpochVar, "1700000000")
+
+	out := t.TempDir()
+	invocation := generator(t, "go", `echo "$SOURCE_DATE_EPOCH" > "$4/epoch"`, out)
+
+	log, _ := recorder()
+
+	// A nil Env: this process's environment, which is what a run made by
+	// anything but a test has.
+	r := &Runner{Log: log, TempDir: t.TempDir()}
+
+	if err := r.Run(t.Context(), descriptor(), []Invocation{invocation}); err != nil {
+		t.Fatalf("running the generator: %v", err)
+	}
+
+	if got, want := lines(t, filepath.Join(out, "epoch"))[0], "1700000000"; got != want {
+		t.Errorf("the generator saw %s=%q, want %q", sourceDateEpochVar, got, want)
+	}
+}
+
+// decidesOutput is every package whose source is held to the determinism rule:
+// the ones that decide what a run writes, from the descriptor a generator is
+// handed to the bytes that land in a project's tree.
+//
+// docs/plugin/SPEC.md holds "the generators in this repository" to the rule, and
+// this repository ships none yet — cpybkc-gen-go is #48–#53. Until it does, the
+// packages below are what plays that part, and a generator's package joins this
+// list when it lands — TestEveryGeneratorThisRepositoryShipsIsOnThatList is
+// what makes that happen rather than something to remember.
+//
+// A list rather than a scan of everything, because a command that resolves a
+// plugin against PATH has to read the environment to do it, and a check that
+// had to exempt cpybkc's own command is a check nobody would trust.
+var decidesOutput = []string{
+	"internal/assemble",
+	"internal/emit",
+	"internal/generate",
+	"internal/plugin",
+}
+
+// forbidden is what a package on that list may not call, by import path and
+// name. A nil name list is the whole package.
+//
+// Each entry is one of the inputs docs/plugin/SPEC.md says output must not vary
+// with, reached through the call that reads it: the clock, the environment, the
+// working directory, the host, the user, and a random value. A duration is not a
+// clock read, which is why the entry for time names the three functions that ask
+// what time it is and not the package.
+var forbidden = map[string][]string{
+	"crypto/rand":  nil,
+	"math/rand":    nil,
+	"math/rand/v2": nil,
+	"os":           {"Environ", "Getenv", "Getwd", "Hostname", "LookupEnv"},
+	"os/user":      nil,
+	"time":         {"Now", "Since", "Until"},
+}
+
+func TestNothingThatDecidesOutputReadsTheClockOrItsSurroundings(t *testing.T) {
+	t.Parallel()
+
+	for _, pkg := range decidesOutput {
+		t.Run(pkg, func(t *testing.T) {
+			t.Parallel()
+
+			dir := filepath.Join("..", "..", filepath.FromSlash(pkg))
+
+			if _, err := os.Stat(dir); err != nil {
+				t.Fatalf("%s is on the list of packages that decide output and is not there: %v", pkg, err)
+			}
+
+			for _, finding := range scan(t, dir) {
+				t.Errorf("%s, and output may not vary with what that reads", finding)
+			}
+		})
+	}
+}
+
+func TestEveryGeneratorThisRepositoryShipsIsOnThatList(t *testing.T) {
+	t.Parallel()
+
+	// The rule docs/plugin/SPEC.md states is about the generators in this
+	// repository, and the list above is a list somebody has to remember to add
+	// to. This is what remembers: a command whose name makes it a generator —
+	// the cpybkc-gen-<name> convention [Prefix] spells — is held to the
+	// determinism rule from the commit that adds it, rather than from the
+	// commit where somebody noticed.
+	commands := filepath.Join("..", "..", "cmd")
+
+	entries, err := os.ReadDir(commands)
+	if err != nil {
+		// There is no cmd/ yet, and a generator is #48–#53. A missing
+		// directory is nothing to report; anything else about it is.
+		if !os.IsNotExist(err) {
+			t.Fatalf("reading %s: %v", commands, err)
+		}
+
+		return
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), Prefix) {
+			continue
+		}
+
+		pkg := "cmd/" + entry.Name()
+		if !slices.Contains(decidesOutput, pkg) {
+			t.Errorf("%s is a generator this repository ships and is not held to the determinism rule; add it to decidesOutput", pkg)
+		}
+	}
+}
+
+// nondeterministic is source the scan has to see through: the calls are made
+// under an alias, and one of them is in a package whose name is not the last
+// element of its path.
+const nondeterministic = `package gen
+
+import (
+	"os"
+	clock "time"
+	"math/rand/v2"
+)
+
+func Header() string {
+	return clock.Now().String() + os.Getenv("USER") + string(rune(rand.Int()))
+}
+`
+
+// deterministic is source the scan has to leave alone: a duration, an
+// environment variable named in a string, and a call whose selector matches a
+// forbidden one on a receiver that is not a package.
+const deterministic = `package gen
+
+import (
+	"time"
+)
+
+type ticker struct{}
+
+func (ticker) Now() string { return "" }
+
+const grace = 5 * time.Second
+
+const epoch = "SOURCE_DATE_EPOCH"
+
+func Header(t ticker) string { return t.Now() + epoch + grace.String() }
+`
+
+func TestTheScanSeesACallAnAliasWouldHide(t *testing.T) {
+	t.Parallel()
+
+	got := scan(t, fixture(t, nondeterministic))
+
+	// The positions are the fixture's, so the findings are compared by what
+	// they name rather than by where they were: a line number in the assertion
+	// would make editing the fixture a two-place change.
+	want := []string{"clock.Now", "os.Getenv", "rand.Int"}
+
+	if named := slices.Sorted(slices.Values(names(got))); !slices.Equal(named, want) {
+		t.Errorf("the scan found %v, want %v", named, want)
+	}
+}
+
+func TestTheScanAcceptsSourceThatOnlyLooksLikeItReadsTheClock(t *testing.T) {
+	t.Parallel()
+
+	if found := scan(t, fixture(t, deterministic)); len(found) != 0 {
+		t.Errorf("the scan found %v in source that reads nothing", found)
+	}
+}
+
+// fixture is a directory holding src as one Go file, and a test file the scan
+// has to skip — a test may read the clock, and one that could not would not be
+// able to assert that nothing else does.
+func fixture(t *testing.T, src string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	for name, content := range map[string]string{
+		"gen.go":      src,
+		"gen_test.go": nondeterministic,
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+	}
+
+	return dir
+}
+
+// scan reports every call in dir's non-test Go files that a package deciding
+// output may not make, as `file:line:col: pkg.Name`.
+//
+// It is a parse rather than a grep because the name a package is imported under
+// is not the name in its path: an alias, or a major-version suffix, would carry
+// a forbidden call past a search for the text of one. The import block is what
+// says which is which, so it is read first and the selectors are resolved
+// against it.
+func scan(t *testing.T, dir string) []string {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", dir, err)
+	}
+
+	fset := token.NewFileSet()
+
+	var found []string
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+
+		path := filepath.Join(dir, name)
+
+		file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+
+		imported, dotted := imports(t, fset, file)
+		found = append(found, dotted...)
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			selector, ok := n.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+
+			// A qualified identifier is a package name and nothing else, so a
+			// method call on a value named for a package — a receiver called
+			// `rand`, a field called `os` — is not one. Shadowing is not
+			// resolved: the cost of missing a call made through a variable that
+			// took a package's name is a finding this scan does not report, and
+			// the cost of resolving it is a type-checker in a test.
+			ident, ok := selector.X.(*ast.Ident)
+			if !ok {
+				return true
+			}
+
+			pkg, ok := imported[ident.Name]
+			if !ok {
+				return true
+			}
+
+			names, watched := forbidden[pkg]
+			if !watched || (names != nil && !slices.Contains(names, selector.Sel.Name)) {
+				return true
+			}
+
+			found = append(found, fmt.Sprintf("%s: %s.%s",
+				fset.Position(selector.Pos()), ident.Name, selector.Sel.Name))
+
+			return true
+		})
+	}
+
+	slices.Sort(found)
+
+	return found
+}
+
+// imports is what each of file's imports is called where it is used, against the
+// path it names, and the findings the import block is itself.
+//
+// A dot import of a watched package is a finding rather than an entry: it puts
+// the package's names in the file's own scope, where nothing distinguishes
+// `Now()` from a function of the file's, so it is refused instead of being
+// resolved.
+func imports(t *testing.T, fset *token.FileSet, file *ast.File) (map[string]string, []string) {
+	t.Helper()
+
+	var found []string
+
+	names := map[string]string{}
+
+	for _, spec := range file.Imports {
+		path, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			t.Fatalf("%s: an import path that is not a string: %v", fset.Position(spec.Pos()), err)
+		}
+
+		name := packageName(path)
+		if spec.Name != nil {
+			name = spec.Name.Name
+		}
+
+		switch name {
+		case "_":
+			// Imported for its side effects; nothing is called through it.
+		case ".":
+			if _, watched := forbidden[path]; watched {
+				found = append(found, fmt.Sprintf("%s: a dot import of %s",
+					fset.Position(spec.Pos()), path))
+			}
+		default:
+			names[name] = path
+		}
+	}
+
+	return names, found
+}
+
+// packageName is what a path is called where it is imported without an alias:
+// the last element of the path, or the one before it where that is a
+// major-version suffix — math/rand/v2 is imported as rand.
+func packageName(path string) string {
+	parts := strings.Split(path, "/")
+
+	last := parts[len(parts)-1]
+	if len(parts) == 1 || len(last) < 2 || last[0] != 'v' {
+		return last
+	}
+
+	if _, err := strconv.Atoi(last[1:]); err != nil {
+		return last
+	}
+
+	return parts[len(parts)-2]
+}
+
+// names is what each finding calls, with the position dropped.
+func names(found []string) []string {
+	called := make([]string, 0, len(found))
+
+	for _, finding := range found {
+		_, call, _ := strings.Cut(finding, ": ")
+		called = append(called, call)
+	}
+
+	return called
+}


### PR DESCRIPTION
Closes #47

Determinism was stated by `docs/plugin/SPEC.md` and checked by nothing. This
promotes it to a checked property, from both ends the spec names.

## Acceptance criteria

- [x] **`SOURCE_DATE_EPOCH` propagated to plugins.** It already was, by the
  environment pass-through `internal/plugin.Runner` documents — but nothing said
  so and nothing pinned it. *The environment* now states that the pass-through
  **is** the propagation (cpybkc adds no variable, removes none, names none), and
  `TestSourceDateEpochReachesAGeneratorFromCpybkcsOwnEnvironment` states the
  variable in this process and runs with a nil `Runner.Env` — the arrangement
  every run outside a test has. The existing
  `TestTheEnvironmentReachesTheGeneratorUnchanged` covers the other side, a
  stated `Env` arriving intact.
- [x] **A test runs generation twice and asserts byte-identical output.**
  `TestRunsFromMachinesThatDisagreeProduceOneTree` generates one project eight
  times, each run from a machine that disagrees about everything the spec says
  output must not vary with — the user, host, home, `TMPDIR`, `PWD`, `TZ`, the
  locale, the scratch space, the plugin's own path and the project's absolute
  path — and agreeing only about `SOURCE_DATE_EPOCH`, which is an input to
  generation rather than an accident of the machine. Every tree, including the
  `cpybkc.gen.json` record, is compared against the first.
- [x] **Determinism requirements stated in the plugin contract spec.** The
  *Determinism* section already carried the requirement; it now describes the
  check that holds it up accurately, and *The environment* no longer reads as
  though `SOURCE_DATE_EPOCH` were an exception to the pass-through.
- [x] **Built-in generators emit no timestamps and no map-iteration-ordered
  output.** This repository ships no generator yet — that is #48–#53 — so the
  rule binds what plays that part today:
  `TestNothingThatDecidesOutputReadsTheClockOrItsSurroundings` parses every
  non-test file of `internal/assemble`, `internal/emit`, `internal/generate` and
  `internal/plugin` and fails on `time.Now`/`Since`/`Until`, `os.Getenv`,
  `LookupEnv`, `Environ`, `Getwd`, `Hostname`, `os/user`, either `rand` and a dot
  import of any of them — resolving aliases and major-version suffixes, so
  `clock "time"` and `math/rand/v2` cannot smuggle one past. Map-iteration order
  is the repetition above, because a static scan cannot see it and repetition
  cannot see a clock read. `TestEveryGeneratorThisRepositoryShipsIsOnThatList`
  fails when a `cmd/cpybkc-gen-*` lands without joining the list, so #48 is held
  to the rule by the commit that adds it rather than by somebody remembering.

## Judgment calls

- **No new non-test code, and no variable injected into a stated `Env`.** Forcing
  `SOURCE_DATE_EPOCH` from the ambient environment into a caller-stated
  `Runner.Env` would make the environment not a function of what the caller
  said — the one thing that field exists to guarantee — and would surprise a test
  that stated an environment deliberately. The MUST is met because what a
  generator gets *is* cpybkc's own environment.
- **A Go test rather than a new Dagger stage.** avroc's equivalent is
  `dagger call regeneration`, which runs a built CLI over a worked example. There
  is no `cmd/` here yet and nothing end to end to run, so a stage would be a
  second definition of a check the Go tests already make; `dagger call ci` runs
  them. An end-to-end regeneration stage becomes possible with #48–#53.
- **An explicit package list rather than scanning the tree.** A command that
  resolves a plugin against `PATH` has to read the environment to do it, so a
  whole-tree scan would need an exemption for cpybkc's own command, and a check
  with an exemption is a check nobody trusts. The list is guarded by the test
  above instead.
- **New public surface:** none. Both files are `_test.go` in `internal/`
  packages.

## Verified

`dagger call ci` passes, as do `gofmt -l .`, `go vet ./...` and
`go test -race ./...`.

Both checks were mutation-tested rather than only watched to pass:

- replacing `slices.Sort(files)` in `internal/generate/record.go` with a map
  round-trip failed `TestRunsFromMachinesThatDisagreeProduceOneTree` on all seven
  comparisons, naming `cpybkc.gen.json` and printing both orderings;
- adding `clock "time"`.`Now()` and `sys "os/user"`.`Current()` to
  `internal/generate/generate.go` failed the scan at
  `generate.go:265:10` and `generate.go:266:9`;
- `TestTheScanSeesACallAnAliasWouldHide` and
  `TestTheScanAcceptsSourceThatOnlyLooksLikeItReadsTheClock` keep the scan honest
  in both directions, and
  `TestTheComparisonWouldSeeARunThatVariedWithItsMachine` keeps the byte
  comparison honest — a generator embedding `$HOSTNAME` must produce two
  different trees, or the machines the runs are made from do not really differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)