### PR TITLE
story(gen-go): apply rename overrides with Go identifier munging

### DIFF
--- a/cmd/cpybkc-gen-go/README.md
+++ b/cmd/cpybkc-gen-go/README.md
@@ -56,11 +56,14 @@ cpybkc chooses and varies between runs. A package name taken from either would
 make the output a function of a path, which is what the contract's *Determinism*
 forbids.
 
-The vocabulary grows with what this generator emits: the rename overrides and
-identifier munging are [#50](https://github.com/Zaba505/cpybkc/issues/50), and
-the method receiver the manifest example in the root `README.md` shows arrives
-with the decode and encode methods in
-[#51](https://github.com/Zaba505/cpybkc/issues/51).
+The vocabulary grows with what this generator emits: the method receiver the
+manifest example in the root `README.md` shows arrives with the decode and
+encode methods in [#51](https://github.com/Zaba505/cpybkc/issues/51).
+
+Renaming an item is **not** an option here. A rename is a property of one item
+of one copybook, it names its target fully qualified, and it is written in the
+layout beside the item it is about — where cpybkc resolves it and carries it
+into the IR for every generator to see. See [Names](#names).
 
 ## The IR version check
 
@@ -117,14 +120,15 @@ beside them, each in a file of its own.
 One exported struct per record, in the order the descriptor's node list carries
 them. A group *inside* a record is an anonymous struct inside its record's, so
 that the whole of a record is one declaration and this generator names nothing
-the copybook did not: a nested type would need a name, and a name a copybook
-never wrote is a name an adopter cannot predict and a later copybook edit can
-move.
+the copybook or the layout did not: a nested type would need a name, and a name
+neither of them wrote is a name an adopter cannot predict and a later copybook
+edit can move.
 
 ```go
 type OrderRecord struct {
-	// OrderId is ORDER-ID — numeric, DISPLAY, 5 digits, unsigned, 5 bytes.
-	OrderId int32
+	// OrderID is ORDER-ID — numeric, DISPLAY, 5 digits, unsigned, 5 bytes.
+	// The layout renames it to OrderID.
+	OrderID int32
 
 	// LineItem is LINE-ITEM — a group of 3 members, OCCURS 3.
 	LineItem [3]struct {
@@ -134,12 +138,61 @@ type OrderRecord struct {
 }
 ```
 
-Field names are the copybook's, with the separators dropped and each word
-capitalised. Two names that come out the same are an **error** rather than a
-silent disambiguation, and so is a name with no Go identifier in it at all —
-one beginning with a digit, say. Applying a layout's rename overrides, and the
-rest of what munging owes an adopter, is
-[#50](https://github.com/Zaba505/cpybkc/issues/50).
+### Names
+
+An identifier is munged from the item's **rename override** where the layout
+gave it one, and from the copybook's own name otherwise. The override is munged
+rather than taken as written, so one rule decides what an identifier looks like
+whatever it was spelled from — and so a rename is not a hole in the two refusals
+below.
+
+Munging drops the separators and opens every word with a capital. What happens
+to the rest of each word turns on whether the name was written in one case
+throughout:
+
+| The name | The identifier | Why |
+|---|---|---|
+| `ORDER-ID` | `OrderId` | one case throughout, so the tail is lowered |
+| `order_id` | `OrderId` | the same, from the other case |
+| `ADDRESS-2ND-LINE` | `Address2ndLine` | a digit opens a word and stands as it is |
+| `CustomerID` | `CustomerID` | more than one case, so the tail is kept |
+| `custId` | `CustId` | only the first letter is made a capital |
+
+A name written in one case throughout — every copybook name, and most renames —
+carries no casing of its own, so this supplies it. A name written in more than
+one carries the casing somebody chose, so this keeps it.
+
+That second row is what makes the rename override a control over the identifier
+rather than another string to be flattened, and it is the whole of this
+generator's answer to Go's initialisms. There is **no** table of them here and
+there is deliberately not going to be one: a table is a list of words this
+generator has heard of, `OrderId` and `OrderID` would then differ by whether
+`ID` made the list, and a name an adopter cannot predict is the thing this
+generator refuses to produce everywhere else. If you want `OrderID`, rename the
+item to `OrderID` and you get exactly that.
+
+Reserved words need no handling and get none. Every identifier this generator
+produces is exported, so it opens with a capital, and every Go keyword is
+lowercase; there is no name that munges to one.
+
+Two things are an **error** rather than something quietly worked around:
+
+- **A collision.** Two names that munge to one identifier — two records of a
+  descriptor, or two items of one group — are refused, and the refusal names
+  both, and the rename where a rename is what was munged. A generator that
+  appended a number would put an identifier in your source that your copybook
+  does not contain and that a later copybook edit would move from one item to
+  the other, with nothing failing while it happened.
+- **A name with no Go identifier in it**, one beginning with a digit say. The
+  refusal is about the rename where you have already written one, because
+  telling you to rename an item you have just renamed sends you to a line you
+  have already written.
+
+Whichever name the identifier came from, the **copybook's** name is in the
+field's doc comment, and a renamed item's comment also says what the layout
+renamed it to. That is what keeps the generated source traceable back to the
+copybook: an identifier your copybook does not contain is one you would
+otherwise have no way to connect to the item it stands for.
 
 ### COBOL to Go
 

--- a/cmd/cpybkc-gen-go/errors.go
+++ b/cmd/cpybkc-gen-go/errors.go
@@ -43,7 +43,31 @@ func (e *malformedError) Error() string {
 // Notes is what follows it as a `note:` diagnostic.
 func (e *malformedError) Notes() []string { return []string{e.Rule} }
 
-// collisionError is two COBOL names that munge to one Go identifier.
+// colliding is one of the two items a collision is between: the copybook's name
+// for it, and the rename the layout gave it where it gave one.
+//
+// The rename is carried because it is what was munged, and a collision naming
+// only the copybook's two names would send an adopter to look at a copybook
+// whose names do not collide — the rename in their layout is the half they can
+// edit, and it is the half that has to be on the page.
+type colliding struct {
+	// Original is the name as the copybook spells it.
+	Original string
+
+	// Override is the rename, empty where the layout renamed nothing.
+	Override string
+}
+
+// String is the item as a diagnostic names it.
+func (c colliding) String() string {
+	if c.Override == "" {
+		return c.Original
+	}
+
+	return fmt.Sprintf("%s (renamed %s)", c.Original, c.Override)
+}
+
+// collisionError is two names that munge to one Go identifier.
 //
 // Reported rather than resolved. A generator that disambiguated silently would
 // put a name in an adopter's source that their copybook does not contain and
@@ -53,9 +77,9 @@ type collisionError struct {
 	// Go is the identifier both names produced.
 	Go string
 
-	// Cobol is the two copybook names that produced it, in the order the
-	// descriptor carries them.
-	Cobol []string
+	// Cobol is the two items that produced it, in the order the descriptor
+	// carries them.
+	Cobol []colliding
 
 	// Where is what the two names collide inside, as a phrase.
 	Where string
@@ -74,24 +98,42 @@ func (e *collisionError) Notes() []string {
 	}
 }
 
-// unmungeableError is a COBOL name this generator's munging does not turn into
-// an exported Go identifier: one with no letter or digit in it at all, or one
-// whose first is a digit.
+// unmungeableError is a name this generator's munging does not turn into an
+// exported Go identifier: one with no letter or digit in it at all, or one whose
+// first is a digit.
 type unmungeableError struct {
 	// Kind is what sort of node carries the name — a record, a group, a field.
 	Kind string
 
 	// Cobol is the name as the copybook spells it.
 	Cobol string
+
+	// Override is the rename the layout gave it, empty where it gave none.
+	//
+	// It is what was munged where it is set, so it is what the diagnostic is
+	// about: an adopter told to rename an item they have already renamed has
+	// been sent somewhere they have been.
+	Override string
 }
 
 // Error implements the error interface.
 func (e *unmungeableError) Error() string {
+	if e.Override != "" {
+		return fmt.Sprintf("%s is the rename of the %s named %s, and there is no exported Go identifier in it",
+			e.Override, e.Kind, e.Cobol)
+	}
+
 	return fmt.Sprintf("%s is the name of a %s, and there is no exported Go identifier in it", e.Cobol, e.Kind)
 }
 
 // Notes is what follows it as a `note:` diagnostic.
 func (e *unmungeableError) Notes() []string {
+	if e.Override != "" {
+		return []string{
+			"a Go identifier begins with a letter; the rename in your layout is the name this generator munges, so it is the one to change",
+		}
+	}
+
 	return []string{
 		"a Go identifier begins with a letter; rename the item in the layout so that the name this generator munges does too",
 	}

--- a/cmd/cpybkc-gen-go/internal/orders/records.go
+++ b/cmd/cpybkc-gen-go/internal/orders/records.go
@@ -6,8 +6,9 @@ import "math/big"
 
 // OrderRecord is the ORDER-RECORD record, as docs/ir/SPEC.md resolved it.
 type OrderRecord struct {
-	// OrderId is ORDER-ID — numeric, DISPLAY, 5 digits, unsigned, 5 bytes.
-	OrderId int32
+	// OrderID is ORDER-ID — numeric, DISPLAY, 5 digits, unsigned, 5 bytes.
+	// The layout renames it to OrderID.
+	OrderID int32
 
 	// CustomerName is CUSTOMER-NAME — alphanumeric, DISPLAY, 20 bytes.
 	CustomerName string

--- a/cmd/cpybkc-gen-go/record.go
+++ b/cmd/cpybkc-gen-go/record.go
@@ -61,7 +61,7 @@ func records(d *irpb.Descriptor, opts options) (string, error) {
 
 	var decls []string
 
-	declared := make(map[string]string)
+	declared := make(map[string]colliding)
 
 	for _, node := range d.GetNodes() {
 		record := node.GetRecord()
@@ -77,22 +77,22 @@ func records(d *irpb.Descriptor, opts options) (string, error) {
 		if first, dup := declared[name]; dup {
 			return "", &collisionError{
 				Go:    name,
-				Cobol: []string{first, record.GetNames().GetOriginal()},
+				Cobol: []colliding{first, namedBy(record.GetNames())},
 				Where: "the generated package",
 			}
 		}
 
-		declared[name] = record.GetNames().GetOriginal()
+		declared[name] = namedBy(record.GetNames())
 
 		body, err := e.structType(record.GetRootId())
 		if err != nil {
 			return "", err
 		}
 
-		decl := fmt.Sprintf("// %s is the %s record, as docs/ir/SPEC.md resolved it.\ntype %s %s",
-			name, record.GetNames().GetOriginal(), name, body)
+		doc := fmt.Sprintf("%s is the %s record, as docs/ir/SPEC.md resolved it.%s",
+			name, record.GetNames().GetOriginal(), renameNote(record.GetNames()))
 
-		decls = append(decls, decl)
+		decls = append(decls, commentLines(doc)+fmt.Sprintf("type %s %s", name, body))
 	}
 
 	if len(decls) == 0 {
@@ -196,7 +196,7 @@ func (e *emitter) structType(id uint64) (string, error) {
 
 	var (
 		fields []string
-		named  = make(map[string]string)
+		named  = make(map[string]colliding)
 		slack  int
 	)
 
@@ -227,12 +227,12 @@ func (e *emitter) structType(id uint64) (string, error) {
 		if first, dup := named[name]; dup {
 			return "", &collisionError{
 				Go:    name,
-				Cobol: []string{first, originalOf(member)},
+				Cobol: []colliding{first, namedBy(namesOf(member))},
 				Where: "the " + group.GetNames().GetOriginal() + " group",
 			}
 		}
 
-		named[name] = originalOf(member)
+		named[name] = namedBy(namesOf(member))
 
 		fields = append(fields, field)
 	}
@@ -269,7 +269,7 @@ func (e *emitter) member(node *irpb.Node) (string, string, error) {
 			return "", "", err
 		}
 
-		return comment(name, kind.Group.GetNames().GetOriginal(), summary) + name + " " + typ, name, nil
+		return comment(name, kind.Group.GetNames(), summary) + name + " " + typ, name, nil
 	case *irpb.Node_Field:
 		name, err := identifier("field", kind.Field.GetNames())
 		if err != nil {
@@ -291,7 +291,7 @@ func (e *emitter) member(node *irpb.Node) (string, string, error) {
 			return "", "", err
 		}
 
-		return comment(name, kind.Field.GetNames().GetOriginal(), summary) + name + " " + typ, name, nil
+		return comment(name, kind.Field.GetNames(), summary) + name + " " + typ, name, nil
 	default:
 		return "", "", malformed(fmt.Sprintf("node %d is not something a group may contain", node.GetId()),
 			"a member list names a group, variant, field or slack node; see docs/ir/SPEC.md, \"The node kinds\"")
@@ -599,10 +599,24 @@ func slackDeclaration(runs int) string {
 
 // comment is a struct field's doc comment, opening with the Go name Go's own
 // convention wants there and naming the copybook's word for it.
-func comment(name, original, summary string) string {
+//
+// The copybook's name is in it whether or not the layout renamed the item, and
+// that is what makes the identifier traceable: a reader holding the generated
+// source can get back to the item in the copybook without holding the layout as
+// well. Where a rename is what produced the identifier, [renameNote] says so
+// beneath, because otherwise the name in the comment is one this generator's
+// munging visibly did not produce and there is nothing on the page to say why.
+func comment(name string, names *irpb.Names, summary string) string {
+	return commentLines(fmt.Sprintf("%s is %s — %s%s", name, names.GetOriginal(), summary, renameNote(names)))
+}
+
+// commentLines is a doc comment's text as the lines of one, each line of it
+// commented in turn so that a sentence added beneath is a sentence rather than
+// source.
+func commentLines(text string) string {
 	var b strings.Builder
 
-	for _, line := range strings.Split(fmt.Sprintf("%s is %s — %s", name, original, summary), "\n") {
+	for _, line := range strings.Split(text, "\n") {
 		b.WriteString("// ")
 		b.WriteString(line)
 		b.WriteString("\n")
@@ -611,13 +625,29 @@ func comment(name, original, summary string) string {
 	return b.String()
 }
 
-// identifier is the exported Go identifier for a node's names.
+// renameNote is the sentence a renamed item's doc comment carries, or the empty
+// string where the layout renamed nothing.
 //
-// The original COBOL name and nothing else: the rename override is #50's, along
-// with the rest of what munging owes an adopter — the traceability tag and what
-// a collision after munging is. What is here is the least that turns a copybook
-// name into an identifier, and it refuses rather than invents where that is not
-// enough.
+// It names the override as the layout spells it rather than as this generator
+// munged it, so that the sentence points at a line the adopter can go and edit.
+func renameNote(names *irpb.Names) string {
+	if names.GetOverrideName() == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("\nThe layout renames it to %s.", names.GetOverrideName())
+}
+
+// identifier is the exported Go identifier for a node's names: the override
+// where the layout gave one and the copybook's own name otherwise, munged.
+//
+// The override is munged rather than taken as written, so that one rule decides
+// what an identifier looks like whatever it was spelled from — an adopter who
+// writes `customer_id` in a layout gets the identifier they would have got from
+// a copybook item spelled that way. Being munged is also what keeps a rename
+// from being a hole in the rest of this: a name that cannot become an exported
+// identifier is refused wherever it came from, and two names that arrive at one
+// identifier collide whether or not a rename put them there.
 func identifier(kind string, names *irpb.Names) (string, error) {
 	original := names.GetOriginal()
 
@@ -631,22 +661,59 @@ func identifier(kind string, names *irpb.Names) (string, error) {
 			"record, group and field nodes each carry the name the copybook spells; see docs/ir/SPEC.md, \"The node kinds\"")
 	}
 
-	munged := munge(original)
+	// An override that is present and empty is the same kind of bug, one step
+	// further along: a rename substitutes a name, and the empty string is not
+	// one. Falling back to the original would generate from a layout line that
+	// silently did nothing.
+	if names.OverrideName != nil && names.GetOverrideName() == "" {
+		return "", malformed(fmt.Sprintf("the %s named %s carries an empty rename override", kind, original),
+			"a rename substitutes a name for the copybook's, and there is no name in the empty string; see docs/ir/SPEC.md, \"Names\"")
+	}
+
+	spelled := original
+	if names.GetOverrideName() != "" {
+		spelled = names.GetOverrideName()
+	}
+
+	munged := munge(spelled)
 
 	if munged == "" {
-		return "", &unmungeableError{Kind: kind, Cobol: original}
+		return "", &unmungeableError{Kind: kind, Cobol: original, Override: names.GetOverrideName()}
 	}
 
 	if unicode.IsDigit(rune(munged[0])) {
-		return "", &unmungeableError{Kind: kind, Cobol: original}
+		return "", &unmungeableError{Kind: kind, Cobol: original, Override: names.GetOverrideName()}
 	}
 
 	return munged, nil
 }
 
-// munge turns a COBOL name into an exported Go identifier: each run of letters
-// and digits becomes one word, capitalised, and the separators between them go.
+// munge turns a name into an exported Go identifier: each run of letters and
+// digits becomes one word, the separators between them go, and every word opens
+// with a capital.
+//
+// What happens to the rest of each word turns on whether the name was written
+// in one case throughout. A name that is — `ORDER-ID` as a copybook spells one,
+// or `order_id` as an adopter might spell a rename — carries no casing of its
+// own, so this supplies it and lowercases the tail: `OrderId`. A name written in
+// more than one case carries the casing somebody chose, so this keeps it and
+// only ensures the first letter is a capital: `CustomerID` stays `CustomerID`,
+// and `custId` becomes `CustId`.
+//
+// That second half is what makes the rename override a control over the
+// identifier rather than another string to be flattened. There is no table of
+// initialisms here and there is deliberately not going to be one: a table is a
+// list of words this generator has heard of, `OrderId` and `OrderID` would then
+// differ by whether `ID` made the list, and a name an adopter cannot predict is
+// the thing this generator refuses to produce everywhere else. An adopter who
+// wants `OrderID` renames the item to `OrderID` and gets exactly that.
+//
+// Reserved words need no handling and get none: every identifier this produces
+// is exported, so its first letter is a capital, and every Go keyword is
+// lowercase. There is no COBOL name that munges to one.
 func munge(name string) string {
+	uniform := uniformCase(name)
+
 	var b strings.Builder
 
 	boundary := true
@@ -654,10 +721,13 @@ func munge(name string) string {
 	for _, r := range name {
 		switch {
 		case unicode.IsLetter(r):
-			if boundary {
+			switch {
+			case boundary:
 				b.WriteRune(unicode.ToUpper(r))
-			} else {
+			case uniform:
 				b.WriteRune(unicode.ToLower(r))
+			default:
+				b.WriteRune(r)
 			}
 
 			boundary = false
@@ -673,19 +743,50 @@ func munge(name string) string {
 	return b.String()
 }
 
-// originalOf is a node's COBOL name, for a diagnostic about it. A node the
-// copybook gives no name — a slack node, a state, a register — has none.
-func originalOf(node *irpb.Node) string {
+// uniformCase is whether a name is written in one case throughout, which is
+// what says its casing carries no information for [munge] to keep.
+//
+// A name with no letter in it at all counts as uniform; it has no tail for the
+// answer to change, and it is refused a line later for having no identifier in
+// it.
+func uniformCase(name string) bool {
+	var upper, lower bool
+
+	for _, r := range name {
+		switch {
+		case unicode.IsUpper(r):
+			upper = true
+		case unicode.IsLower(r):
+			lower = true
+		}
+	}
+
+	return !(upper && lower)
+}
+
+// namesOf is what a node is called: the copybook's name for it and the rename
+// the layout asked for beside it. A node the copybook gives no name — a slack
+// node, a state, a register — carries none, and nil is what those are called.
+func namesOf(node *irpb.Node) *irpb.Names {
 	switch kind := node.GetKind().(type) {
 	case *irpb.Node_Record:
-		return kind.Record.GetNames().GetOriginal()
+		return kind.Record.GetNames()
 	case *irpb.Node_Group:
-		return kind.Group.GetNames().GetOriginal()
+		return kind.Group.GetNames()
 	case *irpb.Node_Field:
-		return kind.Field.GetNames().GetOriginal()
+		return kind.Field.GetNames()
 	default:
-		return ""
+		return nil
 	}
+}
+
+// originalOf is a node's COBOL name, for a diagnostic about it.
+func originalOf(node *irpb.Node) string { return namesOf(node).GetOriginal() }
+
+// namedBy is what a set of names collides as: both of them, so that a collision
+// a rename caused names the rename.
+func namedBy(names *irpb.Names) colliding {
+	return colliding{Original: names.GetOriginal(), Override: names.GetOverrideName()}
 }
 
 // plural is a count and its unit, with the unit pluralised.

--- a/cmd/cpybkc-gen-go/record_test.go
+++ b/cmd/cpybkc-gen-go/record_test.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"testing"
 
+	"google.golang.org/protobuf/proto"
+
 	"github.com/Zaba505/cpybkc/irpb"
 )
 
@@ -196,13 +198,15 @@ func TestAVariantIsRefusedRatherThanEmittedWithoutItsArms(t *testing.T) {
 	}
 }
 
-// TestTwoNamesThatMungeToOneIdentifierAreRefused covers both places a collision
-// lands: two records of one descriptor, and two items of one group.
+// TestTwoNamesThatMungeToOneIdentifierAreRefused covers every place a collision
+// lands: two records of one descriptor, two items of one group, and a rename
+// that lands on a name something else already munges to.
 //
 // Refused rather than disambiguated. A generator that appended a number would
 // put an identifier in an adopter's source that their copybook does not contain
 // and that a later copybook edit would move from one item to the other, with
-// nothing failing while it happened.
+// nothing failing while it happened. A rename is no exception: it is munged like
+// any other name, so it collides like any other name.
 func TestTwoNamesThatMungeToOneIdentifierAreRefused(t *testing.T) {
 	t.Parallel()
 
@@ -225,6 +229,24 @@ func TestTwoNamesThatMungeToOneIdentifierAreRefused(t *testing.T) {
 				alphanumeric(4, "ORDER_ID", 4),
 			},
 		},
+		"a rename onto the name of the item beside it": {
+			Version: supportedIRVersion,
+			Nodes: []*irpb.Node{
+				record(1, "ORDER-RECORD", 2),
+				group(2, "ORDER-RECORD", nil, 3, 4),
+				alphanumeric(3, "ORDER-ID", 4),
+				renamed(alphanumeric(4, "CUSTOMER-NAME", 20), "order_id"),
+			},
+		},
+		"a rename onto the name of the record beside it": {
+			Version: supportedIRVersion,
+			Nodes: []*irpb.Node{
+				record(1, "ORDER-RECORD", 2),
+				group(2, "ORDER-RECORD", nil),
+				renamed(record(3, "TRAILER-RECORD", 4), "order-record"),
+				group(4, "TRAILER-RECORD", nil),
+			},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -237,15 +259,187 @@ func TestTwoNamesThatMungeToOneIdentifierAreRefused(t *testing.T) {
 			}
 
 			if len(collision.Cobol) != 2 {
-				t.Fatalf("the collision names %d copybook names, want the two that produced it", len(collision.Cobol))
+				t.Fatalf("the collision names %d items, want the two that produced it", len(collision.Cobol))
 			}
 
+			// Both halves of what an adopter needs: the copybook's name, which
+			// says which item it is, and the rename where a rename is what was
+			// munged, which says which line of the layout to go and edit.
 			for _, want := range collision.Cobol {
-				if !strings.Contains(collision.Error(), want) {
-					t.Errorf("the collision reads %q and does not name %s", collision.Error(), want)
+				if !strings.Contains(collision.Error(), want.Original) {
+					t.Errorf("the collision reads %q and does not name %s", collision.Error(), want.Original)
+				}
+
+				if want.Override != "" && !strings.Contains(collision.Error(), want.Override) {
+					t.Errorf("the collision reads %q and does not name the rename %s", collision.Error(), want.Override)
 				}
 			}
 		})
+	}
+}
+
+// TestARenameIsTheIdentifierAndTheCopybookNameIsStillOnThePage is what a rename
+// override buys an adopter, on all three of the named node kinds.
+//
+// Two properties, and the second is the one a story about names could lose
+// without noticing: the identifier is the rename's, and the copybook's own name
+// is still in the generated source. An adopter reading the struct has to be able
+// to get back to the item in the copybook, and a generator that substituted the
+// name would leave them holding an identifier that appears nowhere in the
+// copybook and nothing to connect the two.
+func TestARenameIsTheIdentifierAndTheCopybookNameIsStillOnThePage(t *testing.T) {
+	t.Parallel()
+
+	d := &irpb.Descriptor{
+		Version: supportedIRVersion,
+		Nodes: []*irpb.Node{
+			renamed(record(1, "ORDER-RECORD", 2), "purchase_order"),
+			group(2, "ORDER-RECORD", nil, 3, 4, 5),
+			renamed(alphanumeric(3, "CUST-NM", 20), "CustomerName"),
+			alphanumeric(4, "SKU", 8),
+			renamed(group(5, "LINE-ITEM", constant(2), 6), "Lines"),
+			alphanumeric(6, "ITEM-CODE", 8),
+		},
+	}
+
+	out := t.TempDir()
+
+	if err := generate(d, out, options{packageName: goldenPackage}); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	source := written(t, out)[recordsFile]
+
+	for _, want := range []string{
+		// The record, the field and the group each take the rename.
+		"type PurchaseOrder struct",
+		"CustomerName string",
+		"Lines [2]struct",
+
+		// And each says what the copybook calls it, and that the name it is
+		// declared under came from the layout rather than from munging.
+		"// PurchaseOrder is the ORDER-RECORD record",
+		"// The layout renames it to purchase_order.",
+		"// CustomerName is CUST-NM —",
+		"// The layout renames it to CustomerName.",
+		"// Lines is LINE-ITEM —",
+		"// The layout renames it to Lines.",
+
+		// The item the layout said nothing about keeps the copybook's name and
+		// carries no note about a rename that did not happen.
+		"// Sku is SKU — alphanumeric, DISPLAY, 8 bytes.\n\tSku string",
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("%s does not contain %q\n%s", recordsFile, want, source)
+		}
+	}
+
+	for _, unwanted := range []string{"OrderRecord", "CustNm", "LineItem "} {
+		if strings.Contains(source, unwanted) {
+			t.Errorf("%s declares %s, and the layout renamed it", recordsFile, unwanted)
+		}
+	}
+}
+
+// TestMungingIsWhatTheReadmeDocuments walks the rule an adopter is told, from
+// both sides of it.
+//
+// A name written in one case throughout carries no casing of its own, so munging
+// supplies it. A name written in more than one carries somebody's choice, so
+// munging keeps it — which is what makes the rename override a control over the
+// identifier rather than another string to be flattened, and what stands in for
+// the table of initialisms this generator deliberately does not carry.
+func TestMungingIsWhatTheReadmeDocuments(t *testing.T) {
+	t.Parallel()
+
+	for name, want := range map[string]string{
+		// One case throughout: each word capitalised, the rest lowered.
+		"ORDER-ID":         "OrderId",
+		"order_id":         "OrderId",
+		"CUSTOMER NAME":    "CustomerName",
+		"ADDRESS-2ND-LINE": "Address2ndLine",
+
+		// More than one: the tail is left as it was written, and only the first
+		// letter of each word is made a capital.
+		"CustomerID": "CustomerID",
+		"custId":     "CustId",
+		"XMLDoc":     "XMLDoc",
+		"order-ID":   "OrderID",
+	} {
+		if got := munge(name); got != want {
+			t.Errorf("%s munges to %s, want %s", name, got, want)
+		}
+	}
+}
+
+// TestARenameWithNoGoIdentifierInItIsRefusedAndSaysSo is the unmungeable name
+// again, one step along: the adopter has already renamed the item, and the
+// rename is the name that will not munge.
+//
+// The diagnostic has to be about the rename. Telling somebody to rename an item
+// they have just renamed sends them to a line they have already written and
+// leaves them looking for a second one.
+func TestARenameWithNoGoIdentifierInItIsRefusedAndSaysSo(t *testing.T) {
+	t.Parallel()
+
+	for _, override := range []string{"1st_address_line", "___"} {
+		d := &irpb.Descriptor{
+			Version: supportedIRVersion,
+			Nodes: []*irpb.Node{
+				record(1, "ORDER-RECORD", 2),
+				group(2, "ORDER-RECORD", nil, 3),
+				renamed(alphanumeric(3, "ADDRESS-LINE", 30), override),
+			},
+		}
+
+		err := generate(d, t.TempDir(), options{packageName: goldenPackage})
+
+		var unmungeable *unmungeableError
+		if !errors.As(err, &unmungeable) {
+			t.Fatalf("generate returned %v for the rename %s, want a refusal", err, override)
+		}
+
+		if unmungeable.Override != override {
+			t.Errorf("the refusal is about the rename %q, want %s", unmungeable.Override, override)
+		}
+
+		if !strings.Contains(unmungeable.Error(), override) || !strings.Contains(unmungeable.Error(), "ADDRESS-LINE") {
+			t.Errorf("the refusal reads %q, and names neither the rename nor the item", unmungeable.Error())
+		}
+
+		if len(unmungeable.Notes()) == 0 {
+			t.Error("the refusal says nothing about what to change")
+		}
+	}
+}
+
+// TestARenameToNothingIsMalformedRatherThanIgnored is a descriptor carrying an
+// override that is present and empty.
+//
+// A rename substitutes a name and the empty string is not one, so this is a bug
+// in the producer rather than a layout an adopter can fix. Falling back to the
+// copybook's name would generate from a rename that silently did nothing.
+func TestARenameToNothingIsMalformedRatherThanIgnored(t *testing.T) {
+	t.Parallel()
+
+	d := &irpb.Descriptor{
+		Version: supportedIRVersion,
+		Nodes: []*irpb.Node{
+			record(1, "ORDER-RECORD", 2),
+			group(2, "ORDER-RECORD", nil, 3),
+			renamed(alphanumeric(3, "ADDRESS-LINE", 30), ""),
+		},
+	}
+
+	err := generate(d, t.TempDir(), options{packageName: goldenPackage})
+
+	var refusal *malformedError
+	if !errors.As(err, &refusal) {
+		t.Fatalf("generate returned %v, want a malformed descriptor", err)
+	}
+
+	if !strings.Contains(refusal.Error(), "ADDRESS-LINE") {
+		t.Errorf("the refusal reads %q and does not name the item carrying the override", refusal.Error())
 	}
 }
 
@@ -567,7 +761,7 @@ func ordersDescriptor() *irpb.Descriptor {
 
 			record(10, "ORDER-RECORD", 11),
 			group(11, "ORDER-RECORD", nil, 12, 13, 14, 15, 16, 22, 23),
-			zoned(12, "ORDER-ID", 5, 5, 0, false),
+			renamed(zoned(12, "ORDER-ID", 5, 5, 0, false), "OrderID"),
 			alphanumeric(13, "CUSTOMER-NAME", 20),
 			slack(14, 2),
 			packed(15, "ORDER-TOTAL", 4, 7, 2, true),
@@ -597,6 +791,14 @@ func ordersDescriptor() *irpb.Descriptor {
 			}}},
 		},
 	}
+}
+
+// renamed is a node the layout gave a substitute name for, which is the name
+// this generator munges into an identifier.
+func renamed(node *irpb.Node, override string) *irpb.Node {
+	namesOf(node).OverrideName = proto.String(override)
+
+	return node
 }
 
 // record is a record node whose top level is the group root names.
@@ -679,20 +881,6 @@ func resolvedEncoding() *irpb.Encoding {
 		SignConvention: irpb.SignConvention_SIGN_CONVENTION_EBCDIC,
 		ByteOrder:      irpb.ByteOrder_BYTE_ORDER_BIG_ENDIAN,
 		FloatFormat:    irpb.FloatFormat_FLOAT_FORMAT_IBM_HFP,
-	}
-}
-
-// namesOf is a node's names, for a test that has one in hand.
-func namesOf(node *irpb.Node) *irpb.Names {
-	switch kind := node.GetKind().(type) {
-	case *irpb.Node_Record:
-		return kind.Record.GetNames()
-	case *irpb.Node_Group:
-		return kind.Group.GetNames()
-	case *irpb.Node_Field:
-		return kind.Field.GetNames()
-	default:
-		return nil
 	}
 }
 


### PR DESCRIPTION
Closes #50

The Go generator now takes the item's rename override as the name it munges
where the layout gave one, and the copybook's own name otherwise.

## Acceptance criteria

- [x] **The override name is used when present, the original COBOL name
  otherwise.** `identifier` picks the override where `Names.override_name` is
  set, and munges it rather than taking it as written, so one rule decides what
  an identifier looks like whatever it was spelled from. An override that is
  present and *empty* is a malformed descriptor rather than a silent fallback to
  the original — a rename substitutes a name, and there is no name in the empty
  string.
- [x] **Munging produces exported, idiomatic Go identifiers.** Separators go and
  every word opens with a capital, as before. What is new is the tail: a name
  written in one case throughout carries no casing of its own, so munging
  supplies it (`ORDER-ID` and `order_id` both become `OrderId`), and a name
  written in more than one carries somebody's choice, so munging keeps it
  (`CustomerID` stays `CustomerID`, `custId` becomes `CustId`). Before this,
  an adopter's `CustomerID` came out as `Customerid`.
- [x] **Collisions after munging are an error, not a silent rename.** Already
  true for two copybook names; now true of a rename landing on a name something
  else munges to, in both places a collision lands — two records of a
  descriptor and two items of one group. The diagnostic names the rename as well
  as the copybook name, because the rename is the half the adopter can edit.
- [x] **The original COBOL name is preserved in a struct tag or comment for
  traceability.** The comment, which already named it. A renamed item's comment
  additionally says what the layout renamed it to, so a reader is never left
  holding an identifier that appears nowhere in the copybook with nothing on the
  page connecting the two.
- [x] **Tests cover a rename, a non-rename, and a post-munging collision.**
  `TestARenameIsTheIdentifierAndTheCopybookNameIsStillOnThePage` covers a rename
  on all three named node kinds and a non-renamed item beside them;
  `TestTwoNamesThatMungeToOneIdentifierAreRefused` gains a rename onto a
  neighbouring item's name and onto a neighbouring record's;
  `TestMungingIsWhatTheReadmeDocuments` walks the casing rule from both sides.
  The golden package now carries a rename, so a renamed field is checked-in
  output somebody reviews and the compiler still reaches.

## The judgment call: no table of initialisms

`ORDER-ID` munges to `OrderId`, not `OrderID`, and there is deliberately no
table of Go's initialisms here. A table is a list of words this generator has
heard of; `OrderId` and `OrderID` would then differ by whether `ID` made the
list, and a name an adopter cannot predict is what this generator refuses to
produce everywhere else — it will not disambiguate a collision or prefix a
leading digit for the same reason. Keeping the casing of a mixed-case name is
what stands in for it: an adopter who wants `OrderID` renames the item to
`OrderID` in the layout and gets exactly that, which is the escape hatch the
rename override exists to be.

Reserved words needed no handling and got none: every identifier here is
exported and every Go keyword is lowercase, so no name munges to one. That is
recorded as a comment on `munge` rather than as a check that can never fire.

## Verified

- `dagger call ci` — clean.
- The golden package is regenerated and checked in, so `go build`, `go vet` and
  golangci-lint all reach the renamed field.
- `cmd/cpybkc-gen-go/README.md` gains a `Names` section documenting the rule,
  the two refusals and the traceability comment; `TestMungingIsWhatTheReadmeDocuments`
  is the table in it, held to the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)