### PR TITLE
chore(backlog): name the reviewer App env vars per account

### DIFF
--- a/.claude/backlog.json
+++ b/.claude/backlog.json
@@ -21,7 +21,11 @@
     "workflow": "auto-merge.yaml"
   },
   "review": {
-    "reviewers": ["copilot", "local"]
+    "reviewers": ["copilot", "local"],
+    "app": {
+      "idEnv": "ZABA505_REVIEW_APP_ID",
+      "keyEnv": "ZABA505_REVIEW_APP_KEY"
+    }
   },
   "worktreeDir": ".claude/worktrees"
 }


### PR DESCRIPTION
## What

Adds a `review.app` block to `.claude/backlog.json`, pointing the `local` reviewer rung at account-specific environment variable names:

```json
"review": {
  "reviewers": ["copilot", "local"],
  "app": {
    "idEnv":  "ZABA505_REVIEW_APP_ID",
    "keyEnv": "ZABA505_REVIEW_APP_KEY"
  }
}
```

These are **variable names, not credentials** — no App ID and no key material is in this diff.

## Why

A GitHub App is installed per **account**, not globally. This operator's repositories live under both the `z5labs` organisation and the `Zaba505` personal account, so there are two reviewer Apps and one process environment to hold both. Left on the shared defaults (`BACKLOG_REVIEW_APP_ID` / `BACKLOG_REVIEW_APP_KEY`), that environment can only hold whichever pair was exported last.

The resulting failure is quiet, which is why it is worth a config key. The wrong account's App is a real App with a valid key: it signs its JWT successfully and reaches `GET /repos/{owner}/{repo}/installation`, which answers *not installed* — exit 3, `UNAVAILABLE`. The roster reads `UNAVAILABLE` as a rung that is **down** and fails over rather than halting, so nothing is reported as misconfigured. The run just proceeds with one fewer reviewer. On a roster ending in `none` with the Copilot allowance exhausted, that is a merge with no review at all.

With the pair named per account, both stay resident and working the other account's backlog is no longer preceded by re-exporting a pair from memory.

## Verification

Not assumed — minted:

| check | result |
|---|---|
| `app-token.sh --login` | `zaba505-local-review[bot]` — the identity `local` reviews here will be authored under |
| `app-token.sh --token` | exit 0 — proves the App is installed on **this** repository and the installation grants `Pull requests: write` |
| `select-issue.sh` | reads the new pair: `reviewer App credentials: $ZABA505_REVIEW_APP_ID and $ZABA505_REVIEW_APP_KEY`; selection still resolves (`#53 eligible`) |

A quoting bug surfaced during that verification and was fixed outside this repository, in `~/.profile`: both key paths were written as `"~/..."`, and bash does not expand a tilde inside double quotes, so the value was a literal 36-character string rather than a path. `$HOME` replaces it. Worth recording because the symptom — `neither a readable file nor a PEM private key` — reads like a bad key rather than a bad path.

## Not in this change

The merge credential is deliberately untouched. `BACKLOG_APP_ID` and `BACKLOG_APP_KEY` are repository *secrets*, already scoped per repository, so this collision never existed for them and renaming them would buy nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
