### PR TITLE
story(container): specify the base-image contract

### DIFF
--- a/.dagger/dagger.gen.go
+++ b/.dagger/dagger.gen.go
@@ -293,6 +293,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Cpybkc).Vet(&parent, ctx)
+		case "WorkedExample":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Cpybkc).WorkedExample(&parent, ctx)
 		case "":
 			var parent Cpybkc
 			err = json.Unmarshal(parentJSON, &parent)

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -81,6 +81,14 @@
 // invocation of protoc, which is what makes the release asset and the in-image
 // copy two ways of getting one artifact.
 //
+// # Why a document is one of the stages
+//
+// WorkedExample builds the Dockerfile docs/container/SPEC.md hands an adopter
+// (#54), and its own file says why at length. The short reason it belongs in Ci
+// rather than in a release step is the one above turned around: that example is
+// the first thing somebody outside this repository runs and the last thing
+// anybody inside it would notice was broken, because no other stage reads it.
+//
 // Ci is what CI calls and what a contributor should run before pushing. The
 // stage functions are for narrowing down what Ci reported.
 package main
@@ -148,12 +156,13 @@ func New(
 
 // Ci runs the whole pipeline: fmt, vet, golangci-lint and `go test -race`, as
 // the Z5Labs standard defines them, over each of this repository's two Go
-// modules, plus `buf lint` over the IR schema and a build of the three artifacts
-// a release publishes. This is the single entrypoint — CI is one
-// `dagger call ci` and stays one, because a workflow step that reran any of
-// these stages would be a second definition of them.
+// modules, plus `buf lint` over the IR schema, a build of the three artifacts a
+// release publishes, and the worked example docs/container/SPEC.md hands an
+// adopter. This is the single entrypoint — CI is one `dagger call ci` and stays
+// one, because a workflow step that reran any of these stages would be a second
+// definition of them.
 //
-// The five parts run concurrently and all are reported, for the reason the
+// The six parts run concurrently and all are reported, for the reason the
 // standard runs its own four that way: waiting on a Go stage to learn that the
 // schema is unlintable, or the reverse, is a second push to find out about the
 // second failure.
@@ -161,10 +170,10 @@ func New(
 // +check
 // +cache="session"
 func (m *Cpybkc) Ci(ctx context.Context) error {
-	var goErr, irErr, protoErr, artifactErr, layoutErr error
+	var goErr, irErr, protoErr, artifactErr, layoutErr, exampleErr error
 
 	var wg sync.WaitGroup
-	wg.Add(5)
+	wg.Add(6)
 
 	go func() {
 		defer wg.Done()
@@ -193,9 +202,14 @@ func (m *Cpybkc) Ci(ctx context.Context) error {
 		layoutErr = m.LayoutArtifact(ctx)
 	}()
 
+	go func() {
+		defer wg.Done()
+		exampleErr = m.WorkedExample(ctx)
+	}()
+
 	wg.Wait()
 
-	return errors.Join(goErr, irErr, protoErr, artifactErr, layoutErr)
+	return errors.Join(goErr, irErr, protoErr, artifactErr, layoutErr, exampleErr)
 }
 
 // IrCi runs the same standard pipeline over irpb/, the published IR module.

--- a/.dagger/worked_example.go
+++ b/.dagger/worked_example.go
@@ -1,0 +1,418 @@
+// This file checks docs/container/SPEC.md's worked example: the multi-stage
+// Dockerfile a stranger copies out of that document to add a generator cpybkc
+// has never heard of (#54).
+//
+// # Why the pipeline reads a document
+//
+// The extension mechanism is only real if somebody who has never read this
+// repository can follow it end to end, and the worked example is the only place
+// that claim is made in a form they can run. A worked example that has stopped
+// working is worse than none at all: it is the first thing an adopter tries and
+// the last thing anybody here would notice was broken, because nothing in the Go
+// build, the tests or the release artifacts reads it. It can rot through a dozen
+// releases in perfect silence.
+//
+// So the Dockerfile in the document is the input to this check rather than a
+// copy of it — the fenced block is extracted from docs/container/SPEC.md itself,
+// and an edit that breaks it fails CI on the pull request that made it.
+// Extracted rather than committed beside the document for the same reason: a
+// Dockerfile in a testdata directory would be the thing that is checked while
+// the thing in the document is the thing people read, and the two would drift
+// exactly as far apart as nobody notices.
+//
+// # Why the final stage is read rather than built
+//
+// `FROM ghcr.io/zaba505/cpybkc:v0` names a *published* image. This repository
+// does not publish one yet — that is #55 — and even once it does, a pull request
+// has to check the base it just built rather than the one on the registry, and
+// there is no way to point a Dockerfile's FROM at a container that exists only
+// inside the pipeline.
+//
+// So the build stage — every line that compiles the generator, including the
+// heredocs that make the example runnable with an empty build context and the
+// CGO_ENABLED=0 that makes the result run in a scratch image — is handed to the
+// builder exactly as committed, and the final stage is *interpreted*: its FROM
+// is required to name the published base, and its COPY is read for the flags and
+// the paths the document itself wrote. Building that stage against a base image
+// of this pipeline's own is what #55 adds, when there is one to build against.
+//
+// Interpreting is only honest if it cannot silently diverge, so the parser
+// refuses anything it does not know how to replay: an instruction other than
+// COPY in the final stage is an error naming it, rather than a line that quietly
+// goes unchecked. A worked example that grows an ENV has to teach this function
+// what an ENV means before CI will accept it.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+
+	"dagger/cpybkc/internal/dagger"
+)
+
+const (
+	// containerSpec is the document this check reads, and the only source of the
+	// Dockerfile it builds.
+	containerSpec = "docs/container/SPEC.md"
+
+	// workedExampleHeading is the section the Dockerfile is taken from, matched
+	// as a whole line. It is the fenced block a stranger is given; a second
+	// fenced Dockerfile elsewhere in the document is not this check's business.
+	workedExampleHeading = "## Worked example: adding a generator"
+
+	// publishedBaseImage is the repository half of the reference the final stage
+	// is required to name — without a tag, because which tag the document tells
+	// an adopter to pin is docs/container/SPEC.md's decision and a check that
+	// fixed it here would fail the day that advice changed.
+	publishedBaseImage = "ghcr.io/zaba505/cpybkc"
+
+	// pluginDir is the plugin directory the document promises, and the only
+	// destination a copied generator may have.
+	pluginDir = "/usr/local/bin"
+
+	// generatorPrefix is what docs/plugin/SPEC.md's discovery rule makes of a
+	// generator's name, and so what the copied executable has to be called for
+	// cpybkc to find it at all.
+	generatorPrefix = "cpybkc-gen-"
+
+	// ownGenerator is this project's own generator. The worked example exists to
+	// show a generator cpybkc has never heard of being added, so an example that
+	// drifted into copying cpybkc-gen-go would be demonstrating the mechanism
+	// against the one plugin whose absence from the base image nobody would
+	// notice.
+	ownGenerator = "go"
+
+	// imageUser is the UID:GID pair docs/container/SPEC.md pins, spelled the way
+	// a COPY --chown is spelled.
+	imageUser = "65532:65532"
+
+	// executableMode is the mode the copied generator has to land with. cpybkc
+	// discovers a candidate only if it carries an execute bit.
+	executableMode = "0755"
+)
+
+// WorkedExample is docs/container/SPEC.md's worked example checked rather than
+// read (#54): it extracts the Dockerfile from that document, builds its build
+// stage against an empty build context, and reads its final stage for the
+// promises the document makes about one.
+//
+// Three groups, and each one is a sentence in that document that would otherwise
+// only be a sentence:
+//
+//   - The Dockerfile is what the document says it is. Two stages, the second of
+//     them FROM the published base, containing no RUN — the COPY-only rule the
+//     absence of a shell imposes — and copying exactly one executable, named
+//     cpybkc-gen-<name> for a name that is not cpybkc's own generator, into the
+//     plugin directory with the owner and the mode the document requires.
+//   - It builds. The build stage is handed to the builder as committed, so a
+//     heredoc that no longer parses, a Go program that no longer compiles, a
+//     module path that no longer resolves or a toolchain that has moved on fails
+//     here.
+//   - What it builds can run in a scratch image: the executable the final stage
+//     copies is present at the path that stage reads from, carries an execute
+//     bit, and is statically linked. That last one is the CGO_ENABLED=0 claim,
+//     and it is checked rather than grepped for, because what matters is the
+//     property of the file and not the spelling of the line that produced it.
+//
+// One platform — the engine's own. What is under test is a document, and the
+// document is platform-agnostic; the platform-specific claims are the image's,
+// and #55 is where they get checked on every platform this project publishes
+// for.
+//
+// +check
+// +cache="session"
+func (m *Cpybkc) WorkedExample(ctx context.Context) error {
+	example, err := m.workedExample(ctx)
+	if err != nil {
+		return err
+	}
+	return errors.Join(example.rules(), example.checkBuilds(ctx))
+}
+
+// workedExample is the document's Dockerfile, parsed and judged.
+type workedExample struct {
+	// dockerfile is the fenced block verbatim, as it appears in the document.
+	dockerfile string
+	// buildStage is everything before the final FROM: the stages that compile
+	// the generator, with the document's own preamble kept, since the heredocs
+	// depend on the syntax directive it carries.
+	buildStage string
+	// base is the image reference the final stage is FROM, tag and all.
+	base string
+	// copies is every COPY in the final stage, and other holds every instruction
+	// there that is not one — which is a fault, reported by rules.
+	copies []copyInstruction
+	other  []string
+	// stages is the set of stage names the build half defines, so that a
+	// --from naming a stage that does not exist is caught here rather than by a
+	// builder error nobody reads.
+	stages map[string]bool
+}
+
+// copyInstruction is one COPY in the final stage, split into what it is flagged
+// with and what it moves.
+type copyInstruction struct {
+	flags    map[string]string
+	operands []string
+}
+
+// workedExample reads the Dockerfile out of the document and parses it.
+func (m *Cpybkc) workedExample(ctx context.Context) (*workedExample, error) {
+	spec, err := m.Source.File(containerSpec).Contents(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", containerSpec, err)
+	}
+
+	dockerfile, err := workedExampleDockerfile(spec)
+	if err != nil {
+		return nil, err
+	}
+	return parseWorkedExample(dockerfile)
+}
+
+// workedExampleDockerfile returns the fenced dockerfile block under the worked
+// example heading, verbatim.
+func workedExampleDockerfile(spec string) (string, error) {
+	lines := strings.Split(spec, "\n")
+
+	i := 0
+	for ; i < len(lines); i++ {
+		if strings.TrimRight(lines[i], " ") == workedExampleHeading {
+			break
+		}
+	}
+	if i == len(lines) {
+		return "", fmt.Errorf("%s: no %q heading; this check reads the Dockerfile out of that section",
+			containerSpec, workedExampleHeading)
+	}
+
+	for ; i < len(lines); i++ {
+		if lines[i] == "```dockerfile" {
+			break
+		}
+		if strings.HasPrefix(lines[i], "## ") && strings.TrimRight(lines[i], " ") != workedExampleHeading {
+			return "", fmt.Errorf("%s: %q holds no ```dockerfile block; the worked example is what this check builds",
+				containerSpec, workedExampleHeading)
+		}
+	}
+	if i == len(lines) {
+		return "", fmt.Errorf("%s: %q holds no ```dockerfile block; the worked example is what this check builds",
+			containerSpec, workedExampleHeading)
+	}
+
+	i++
+	start := i
+	for ; i < len(lines); i++ {
+		if lines[i] == "```" {
+			return strings.Join(lines[start:i], "\n") + "\n", nil
+		}
+	}
+	return "", fmt.Errorf("%s: the worked example's ```dockerfile block is never closed", containerSpec)
+}
+
+// parseWorkedExample splits the Dockerfile at its final FROM and reads the stage
+// that follows.
+func parseWorkedExample(dockerfile string) (*workedExample, error) {
+	lines := strings.Split(dockerfile, "\n")
+
+	var froms []int
+	for n, line := range lines {
+		if fields := strings.Fields(line); len(fields) > 0 && strings.EqualFold(fields[0], "FROM") {
+			froms = append(froms, n)
+		}
+	}
+	if len(froms) == 0 {
+		return nil, fmt.Errorf("%s: the worked example has no FROM instruction", containerSpec)
+	}
+	if len(froms) == 1 {
+		return nil, fmt.Errorf("%s: the worked example is a single stage; it is a multi-stage Dockerfile, "+
+			"because the stage built FROM the cpybkc image cannot compile anything",
+			containerSpec)
+	}
+
+	final := froms[len(froms)-1]
+	stages := map[string]bool{}
+	for _, n := range froms[:len(froms)-1] {
+		if name, ok := stageName(strings.Fields(lines[n])); ok {
+			stages[name] = true
+		}
+	}
+
+	fields := strings.Fields(lines[final])
+	if len(fields) < 2 {
+		return nil, fmt.Errorf("%s: the worked example's final FROM names no image", containerSpec)
+	}
+
+	example := &workedExample{
+		dockerfile: dockerfile,
+		buildStage: strings.Join(lines[:final], "\n") + "\n",
+		base:       fields[1],
+		stages:     stages,
+	}
+
+	for _, instruction := range instructions(lines[final+1:]) {
+		fields := strings.Fields(instruction)
+		if len(fields) == 0 {
+			continue
+		}
+		if !strings.EqualFold(fields[0], "COPY") {
+			example.other = append(example.other, fields[0])
+			continue
+		}
+		copied := copyInstruction{flags: map[string]string{}}
+		for _, field := range fields[1:] {
+			if !strings.HasPrefix(field, "--") {
+				copied.operands = append(copied.operands, field)
+				continue
+			}
+			name, value, _ := strings.Cut(strings.TrimPrefix(field, "--"), "=")
+			copied.flags[name] = value
+		}
+		example.copies = append(example.copies, copied)
+	}
+	return example, nil
+}
+
+// stageName returns the name a FROM line gives its stage.
+func stageName(fields []string) (string, bool) {
+	for i := 1; i+1 < len(fields); i++ {
+		if strings.EqualFold(fields[i], "AS") {
+			return fields[i+1], true
+		}
+	}
+	return "", false
+}
+
+// instructions joins a stage's continued lines and drops its comments and its
+// blank lines, so that a rule below reads one instruction at a time however the
+// document chose to wrap it.
+func instructions(lines []string) []string {
+	var out []string
+	var current string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if current == "" && (trimmed == "" || strings.HasPrefix(trimmed, "#")) {
+			continue
+		}
+		if strings.HasSuffix(trimmed, `\`) {
+			current += strings.TrimSuffix(trimmed, `\`) + " "
+			continue
+		}
+		out = append(out, current+trimmed)
+		current = ""
+	}
+	if current != "" {
+		out = append(out, current)
+	}
+	return out
+}
+
+// rules reports every way the document's Dockerfile is not the Dockerfile the
+// document describes. They are reported together rather than one per run,
+// because an example with two things wrong with it is one edit and not two.
+func (e *workedExample) rules() error {
+	var errs []error
+
+	repository, tag, _ := strings.Cut(e.base, ":")
+	switch {
+	case repository != publishedBaseImage:
+		errs = append(errs, fmt.Errorf("the final stage is FROM %s; it has to be FROM %s, "+
+			"because the worked example is the published image being extended",
+			e.base, publishedBaseImage))
+	case tag == "":
+		errs = append(errs, fmt.Errorf("the final stage is FROM %s with no tag; a derived Dockerfile pins one, "+
+			"and which one to pin is what the tags section is for", e.base))
+	}
+
+	for _, instruction := range e.other {
+		errs = append(errs, fmt.Errorf("the final stage carries a %s; the image has no shell, so extension is "+
+			"COPY-only, and an instruction this check cannot replay is one nothing verifies",
+			strings.ToUpper(instruction)))
+	}
+
+	if len(e.copies) != 1 {
+		errs = append(errs, fmt.Errorf("the final stage carries %d COPY instructions; the worked example adds "+
+			"exactly one generator", len(e.copies)))
+		return errors.Join(errs...)
+	}
+
+	copied := e.copies[0]
+	if from := copied.flags["from"]; !e.stages[from] {
+		errs = append(errs, fmt.Errorf("the final stage's COPY is --from=%q, which names no earlier stage; "+
+			"the generator is compiled in one of them", from))
+	}
+	if chown := copied.flags["chown"]; chown != imageUser {
+		errs = append(errs, fmt.Errorf("the final stage's COPY is --chown=%q; it has to be --chown=%s, "+
+			"the UID and GID the image runs as", chown, imageUser))
+	}
+	if chmod := copied.flags["chmod"]; chmod != executableMode {
+		errs = append(errs, fmt.Errorf("the final stage's COPY is --chmod=%q; it has to be --chmod=%s, "+
+			"because cpybkc discovers only a file carrying an execute bit", chmod, executableMode))
+	}
+
+	if len(copied.operands) != 2 {
+		errs = append(errs, fmt.Errorf("the final stage's COPY moves %d paths; it copies one executable to one "+
+			"destination", len(copied.operands)))
+		return errors.Join(errs...)
+	}
+
+	source, destination := copied.operands[0], copied.operands[1]
+	if dir := path.Dir(destination); dir != pluginDir {
+		errs = append(errs, fmt.Errorf("the final stage copies into %s; the plugin directory is %s, and nothing "+
+			"else in the image is on PATH", dir, pluginDir))
+	}
+	name := path.Base(destination)
+	switch {
+	case !strings.HasPrefix(name, generatorPrefix):
+		errs = append(errs, fmt.Errorf("the final stage copies %s into the plugin directory; cpybkc resolves a "+
+			"generator called <name> to %s<name>, so nothing would ever run it", name, generatorPrefix))
+	case strings.TrimPrefix(name, generatorPrefix) == "":
+		errs = append(errs, fmt.Errorf("the final stage copies %q, which names no generator", name))
+	case strings.TrimPrefix(name, generatorPrefix) == ownGenerator:
+		errs = append(errs, fmt.Errorf("the final stage copies %s; the worked example adds a generator cpybkc "+
+			"has never heard of, which is the whole thing it demonstrates", name))
+	}
+	if path.Base(source) != name {
+		errs = append(errs, fmt.Errorf("the final stage copies %s to %s; a generator renamed on its way in is a "+
+			"generator whose build produced the wrong name", source, destination))
+	}
+
+	return errors.Join(errs...)
+}
+
+// checkBuilds hands the build half of the Dockerfile to the builder exactly as
+// committed, against a context holding nothing but that Dockerfile, and then
+// asks the result for the file the final stage copies out of it.
+func (e *workedExample) checkBuilds(ctx context.Context) error {
+	if len(e.copies) != 1 || len(e.copies[0].operands) != 2 {
+		// rules has already reported this; there is no source path to look for.
+		return nil
+	}
+	source := e.copies[0].operands[0]
+
+	built := dag.Directory().
+		WithNewFile("Dockerfile", e.buildStage).
+		DockerBuild(dagger.DirectoryDockerBuildOpts{Dockerfile: "Dockerfile"})
+
+	// One exec, so that a build stage which produced nothing reports that rather
+	// than three variations on it. ldd exits non-zero for a static executable and
+	// prints its libraries for a dynamic one, which is the difference
+	// CGO_ENABLED=0 makes and the reason a plugin runs at all in an image with no
+	// libc.
+	script := fmt.Sprintf(`set -e
+test -f %[1]q || { echo "the build stage produced no %[1]s, which is what the final stage copies" >&2; exit 1; }
+test -x %[1]q || { echo "%[1]s carries no execute bit" >&2; exit 1; }
+if ldd %[1]q >/dev/null 2>&1; then
+  echo "%[1]s is dynamically linked; it needs a loader and a libc the image does not have" >&2
+  ldd %[1]q >&2
+  exit 1
+fi`, source)
+
+	if _, err := built.WithExec([]string{"sh", "-c", script}).Sync(ctx); err != nil {
+		return fmt.Errorf("%s: the worked example: %w", containerSpec, err)
+	}
+	return nil
+}

--- a/.dagger/worked_example.go
+++ b/.dagger/worked_example.go
@@ -328,8 +328,14 @@ func (e *workedExample) rules() error {
 	}
 
 	for _, instruction := range e.other {
-		errs = append(errs, fmt.Errorf("the final stage carries a %s; the image has no shell, so extension is "+
-			"COPY-only, and an instruction this check cannot replay is one nothing verifies",
+		if strings.EqualFold(instruction, "RUN") {
+			errs = append(errs, errors.New("the final stage carries a RUN; the image has no shell, so a stage "+
+				"built FROM it cannot run anything and extension is COPY-only"))
+			continue
+		}
+		errs = append(errs, fmt.Errorf("the final stage carries a %s, which this check does not know how to "+
+			"replay; the document permits it — ENV, CMD and LABEL only edit metadata — so what is missing is "+
+			"the rule that checks one, not the instruction",
 			strings.ToUpper(instruction)))
 	}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,11 +2,11 @@
 
 ## The pipeline
 
-fmt, vet, golangci-lint, `go test -race`, `buf lint` and the three artifacts a
-release attaches are defined once, in the root Dagger module under
-[`.dagger/`](.dagger/). CI calls that module and so do you, which is the point:
-there is no arrangement of local commands that passes while CI fails, because
-they are the same functions.
+fmt, vet, golangci-lint, `go test -race`, `buf lint`, the three artifacts a
+release attaches and the worked example in the base-image contract are defined
+once, in the root Dagger module under [`.dagger/`](.dagger/). CI calls that
+module and so do you, which is the point: there is no arrangement of local
+commands that passes while CI fails, because they are the same functions.
 
 Run the whole thing before pushing:
 
@@ -16,8 +16,9 @@ dagger call ci
 
 That is the same call CI makes, with no arguments on either side. It runs the
 four Go stages in parallel and reports every failure, not just the first, and it
-runs the schema lint, the IR module's own stages and a build of the [release
-artifacts](#the-release-artifacts) alongside them.
+runs the schema lint, the IR module's own stages, a build of the [release
+artifacts](#the-release-artifacts) and a build of the [base-image
+contract](docs/container/SPEC.md)'s worked example alongside them.
 
 ### Running one stage
 
@@ -33,6 +34,7 @@ dagger call proto-lint    # buf lint over proto/ against buf.yaml
 dagger call ir-ci         # the whole standard again, over the irpb/ module
 dagger call ir-artifacts  # builds the two IR artifacts a release attaches
 dagger call layout-artifact  # builds the layout schema a release attaches
+dagger call worked-example   # builds docs/container/SPEC.md's worked example
 ```
 
 The first four are not a second definition of the pipeline. Each drives the same
@@ -47,7 +49,13 @@ module; see [The IR module](#the-ir-module) for why there is one. `ir-artifacts`
 and `layout-artifact` are not stages either; see [The release
 artifacts](#the-release-artifacts).
 
-`dagger check` runs all nine as a checklist, if you would rather see them
+`worked-example` is the odd one out: it builds a document. The multi-stage
+Dockerfile in [the base-image contract](docs/container/SPEC.md#worked-example-adding-a-generator)
+is the first thing an adopter runs and the last thing anybody here would notice
+had broken, since no other stage reads it, so `ci` extracts it from that file and
+builds it. Edit that example and this is the stage that will tell you about it.
+
+`dagger check` runs all ten as a checklist, if you would rather see them
 together than pick one.
 
 ### Getting the tools

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -1,9 +1,5 @@
 # The Base-Image Contract
 
-> **Stub.** #54 writes this document. `Scope`, `Governing sources` and `Out of
-> Scope` are settled (#15); the headings between them are its outline and are
-> empty on purpose. See [CONVENTIONS.md](../CONVENTIONS.md).
-
 ## Overview
 
 Adding a generator to cpybkc means building an image: a multi-stage Dockerfile
@@ -67,43 +63,539 @@ descriptive.
 
 ## The plugin directory
 
-<!-- #54: the one stable directory on PATH that a derived image copies a
-     generator into. It is a path in strangers' Dockerfiles, so state the
-     stability guarantee alongside it, not separately. -->
+The plugin directory is **`/usr/local/bin`**, and it is on `PATH` (#55).
+
+That is the whole of the promise a derived Dockerfile depends on, and it is
+worth saying what each half of it buys. The path is what a `COPY` line writes
+to; the `PATH` membership is what makes the copied file reachable by the name a
+manifest asks for. Either half alone is useless, which is why this is one
+requirement rather than two facts in different sections.
+
+The image **MUST** set `Env` so that `PATH` contains `/usr/local/bin`, and the
+directory **MUST** exist in the base image even when it is empty, so that a
+`COPY` into it never depends on the builder creating it. A derived image **MUST
+NOT** remove it from `PATH`, and **MUST NOT** shadow it with an earlier `PATH`
+entry holding an executable of the same name: the plugin contract's rule that
+[the earliest `PATH` match wins](../plugin/SPEC.md#discovery) is exactly what
+makes that a way to substitute a generator silently.
+
+An executable copied there **MUST** be executable by the [image's
+user](#the-user), and **MUST** be a statically linked native executable for the
+image's platform. It **MUST NOT** be a script: there is [no
+shell](#shell-or-no-shell) and no interpreter, so a `#!` line names a file that
+does not exist and the generator fails to start with an error naming the
+interpreter rather than the plugin. The plugin contract deliberately keeps [a
+shell script with `chmod +x`](../plugin/SPEC.md#discovery) a first-class plugin;
+that freedom is real on a host and is spent inside this image, and what buys it
+back is an image with nothing in it to run.
+
+**Stability.** `/usr/local/bin` is covered by the [compatibility
+guarantees](#compatibility-guarantees) below: it does not move within a major
+version, and the release that moved it would ship both directories for a full
+minor release first. It is stated here as well as there because a path in a
+stranger's Dockerfile is not something they should have to go looking for a
+guarantee about.
+
+`/usr/local/bin` is chosen over a `/opt/cpybkc/plugins` precisely because it is
+not cpybkc-specific. It is the conventional destination for a locally installed
+executable on a Unix-alike, it is what a `COPY --from=build` line reads
+naturally against, and a reader who has never seen this document guesses it
+correctly. A project-specific directory would have been equally stable and would
+have taught every adopter one more thing.
+
+### Why cpybkc's own generator is not in the base image
+
+The base image holds **one** executable in the plugin directory — the cpybkc CLI
+— and **no generator** (#55). `cpybkc-gen-go` (#48–#53) is this project's own
+generator and reaches a user the way a stranger's does: as an image built `FROM`
+the base, adding one executable at the path this section names and changing
+nothing else.
+
+A base image carrying its own generator would publish the same bytes and would
+quietly stop testing anything. A generator that is on `PATH` because the build
+put it there is not a consumer of this contract; it is a private arrangement
+that resembles one. If it needed a path this document does not promise, an
+entrypoint edit, or a shell in the final stage, nobody here would find out — the
+first person to find out would be a stranger, at their own `docker build`,
+against a mechanism that had never been used.
+
+So the mechanism has a user before it has any, and the cost is one extra image
+reference in a consumer's Dockerfile.
+
+### The CLI's own path is not part of the contract
+
+Where the `cpybkc` executable itself lives inside the image is **implementation
+detail**. A derived image reaches it through the [entrypoint](#the-entrypoint),
+never by path.
+
+Keeping it out is deliberate: the image is built by a shared pipeline archetype
+with its own opinion about where a binary goes (#55), and pinning the CLI's path
+here would make a promise to strangers out of a detail of this repository's
+build. Nothing a derived image legitimately does requires knowing it.
 
 ## The entrypoint
 
-<!-- #54: the cpybkc CLI, and what a derived image must not do to it. -->
+The image's `Entrypoint` is the cpybkc CLI, and its `Cmd` is empty (#55). The
+arguments a caller passes to `docker run` are therefore cpybkc's arguments:
+
+```console
+$ docker run --rm -v "$PWD:/src" -w /src ghcr.io/zaba505/cpybkc:v0 <arguments>
+```
+
+Which arguments those are is the CLI's own documentation and not this
+document's. What this document promises is that they arrive at the CLI
+unaltered, and that nothing sits between them and it.
+
+A derived image **MUST NOT** replace or clear `Entrypoint`. That is the one edit
+which turns a derived image into a different program wearing cpybkc's
+filesystem: the plugin it added would no longer be run by cpybkc, and the `FROM`
+would be doing nothing but supplying a base. A derived image **MAY** set `Cmd`,
+which is how an image supplies default arguments while leaving a caller free to
+override them.
+
+A derived image **MUST NOT** rely on `Entrypoint` having any particular *value*,
+only on its behaviour: it accepts cpybkc's arguments. The array itself is
+[implementation
+detail](#the-clis-own-path-is-not-part-of-the-contract), which is what allows
+the CLI to move without a major version.
 
 ## The user
 
-<!-- #54: a stable non-root UID, why it is pinned rather than allocated, the
-     ownership of the plugin directory and the output directory that follows
-     from it, and guidance on --user $(id -u):$(id -g) for writing files a
-     caller can then read. -->
+The image runs as UID **65532**, GID **65532** — `User` is the literal string
+`65532:65532` (#55). It is not root, and there is no `/etc/passwd` entry for it.
+
+### Why the UID is pinned rather than allocated
+
+The number is part of the contract, not an artifact of whichever `useradd` ran
+last. Three things need it and none of them can ask the image what it is:
+
+- A derived Dockerfile writes `COPY --chown=65532:65532` to hand ownership of a
+  copied plugin to the runtime user. `--chown=cpybkc` would need a name the
+  image has no passwd file to resolve.
+- A Kubernetes `securityContext` writing `runAsUser: 65532`, or a policy
+  admitting only known non-root UIDs, is written against a number in a manifest
+  a long way from this repository.
+- A caller reasoning about the ownership of files that appear in a bind mount is
+  reasoning about a number, because a number is all their host kernel ever sees.
+
+An allocated UID would be a value that could differ between two rebuilds of the
+same tag, which is precisely the kind of change [a published version
+tag](#tags-and-what-pinning-one-buys) promises does not happen. 65532 is the
+conventional non-root UID for a distroless-style image; it is chosen for being
+the number other people's tooling already expects.
+
+### What it means for ownership
+
+The [plugin directory](#the-plugin-directory) is owned by 65532:65532 in the
+base image. A derived image copying a plugin in **SHOULD** use
+`--chown=65532:65532` and **MUST** ensure the result is readable and executable
+by that user; a world-readable, world-executable file satisfies this without the
+`--chown`, which is what makes the omission a latent bug rather than an
+immediate one.
+
+Files cpybkc writes are created by the process, so they are owned by whichever
+UID the container is actually running as — 65532 unless a caller says otherwise.
+
+### Writing files a caller can read
+
+Generated output that lands in a bind mount is owned by the UID that wrote it,
+and a host user who is not 65532 then owns none of it. Depending on the mount,
+they may be unable to edit or delete it either.
+
+A caller **SHOULD** therefore run as themselves:
+
+```console
+$ docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/src" -w /src \
+    ghcr.io/zaba505/cpybkc:v0 <arguments>
+```
+
+This is supported, and it is the recommended invocation whenever output is
+written into a mount. The image **MUST NOT** require its own UID: nothing in it
+is readable only by 65532, no directory a run needs to write is owned only by
+it, and no code path looks the running user up in a passwd file it would not
+find. An overridden UID is an ordinary configuration and not a workaround.
+
+The default exists for the case where no host user is involved — a CI runner, a
+Kubernetes job, a Dagger pipeline — where running as a pinned non-root UID is
+what a policy wants to see.
 
 ## Shell or no shell
 
-<!-- #54: whether the base image has one. If it does not, extension is
-     COPY-only — no RUN in a stage built FROM it — and that has to be said
-     plainly, because it is the difference between a Dockerfile that works and
-     one that fails on its second line. -->
+**There is no shell in the image**, and no package manager, no `cp`, no `chmod`
+and no libc. The base is `scratch` plus the files this document names (#55).
+
+The consequence is a rule rather than a nuance, because it is the difference
+between a Dockerfile that builds and one that fails on its second line:
+**extension is `COPY`-only.** A stage built `FROM` the cpybkc image **MUST NOT**
+contain a `RUN` instruction, and **MUST** do everything it needs with `COPY`,
+`COPY --from`, `ENV`, `CMD`, `LABEL` and the other instructions that only edit
+metadata.
+
+The shell form of `RUN` is the one that bites first: it is implemented as
+`/bin/sh -c`, and there is no `/bin/sh`. The exec form fails for a different
+reason — the image is not empty, so an exec-form `RUN` naming an executable on
+`PATH` would in fact execute, but every executable in the image is either a
+generator or the CLI, whose [path is not part of this
+contract](#the-clis-own-path-is-not-part-of-the-contract). There is no `cp`, no
+`chmod`, no `mkdir` and no package manager, so nothing a build step would
+plausibly want to `RUN` is there to be run.
+
+Everything that needs a shell belongs in an earlier stage, which is a full
+distribution image and may do as it likes. That is not a restriction on what a
+generator may be built with; it is a restriction on where the building happens,
+and the multi-stage form the [worked
+example](#worked-example-adding-a-generator) uses is how an image in this model
+is written anyway.
+
+Two consequences are worth stating outright, because each has been discovered
+the hard way by somebody:
+
+- A plugin **MUST** be statically linked, as [the plugin
+  directory](#the-plugin-directory) requires. For a Go generator that means
+  `CGO_ENABLED=0`; a dynamically linked executable finds no loader and no libc,
+  and fails with `no such file or directory` naming a file that is plainly
+  there.
+- `docker run --entrypoint sh` does not work, and neither does `docker exec`
+  into a running container. Debugging is done by running the CLI with different
+  arguments, or against an image built `FROM` this one with a busybox copied in
+  for the purpose.
+
+One directory in the image holds no file and is worth naming anyway: there is a
+writable temporary directory, because cpybkc writes [each invocation's
+descriptor](../plugin/SPEC.md#the-descriptors-location-and-lifetime) into a
+directory it creates under one, and hands each generator [an empty output
+directory](../plugin/SPEC.md#the-output-directory) it created the same way. It
+is **not covered** — its path, its mode and its existence are implementation
+detail like everything else in the filesystem that is not named above, and a
+derived image writing into it by path would be depending on something that may
+change in a patch release. It is mentioned only so that "`scratch` plus the
+files named above" is not read as a promise that the image cannot write
+anywhere at all.
+
+Keeping the shell out is the same decision as having no plugin registry: the
+image's contents are exactly the executables somebody deliberately put there,
+and there is nothing else in it to run, exploit or depend on by accident.
 
 ## Tags and what pinning one buys
 
-<!-- #54: which tags exist and what each promises across a rebuild. A derived
-     Dockerfile pins one, so the tag is as much a part of this contract as the
-     paths are. Published by #59. -->
+A derived Dockerfile names a tag in its `FROM` line, so the tag is as much a
+part of this contract as the paths are. Four tags are published (#59), and a
+digest is the fifth way to name the image:
+
+| Reference | Example | Moves? |
+| --- | --- | --- |
+| Full version tag | `v0.2.0` | Never |
+| Minor tag | `v0.2` | On each patch release of that minor |
+| Major tag | `v0` | On each release within that major |
+| Rolling tag | `latest` | On each release |
+| Digest | `@sha256:…` | Never, by construction |
+
+A published full-version tag **MUST NOT** be repointed at a different manifest
+after it is published — not for a rebuild, not for a base-image refresh, not to
+correct a broken release. A release that has to be corrected gets a new version
+number. That is the promise which makes `v0.2.0` mean something across a
+rebuild: two builds naming it resolve to the same digest, forever, or the tag
+was a lie.
+
+The other three **MUST** move, and moving is what they are for. `v0` picks up
+every fix in the major version and, by the [guarantee
+below](#compatibility-guarantees), keeps every path this document names; it is
+the right pin for a derived image that wants security updates without a
+Dockerfile change, and it is what the [worked
+example](#worked-example-adding-a-generator) uses. A **prerelease** —
+`v0.3.0-rc.1` — publishes its own full version tag and **MUST NOT** move any of
+the other three, because a release candidate is not a fix anybody consented to
+be given (#59).
+
+A digest is the only reference that pins the bytes rather than a promise about
+them, and it is what to use when reproducibility is the requirement — the
+position the plugin contract takes under [Plugin
+distribution](../plugin/SPEC.md#also-out-of-scope). Pinning a digest fixes the
+generators in the image along with cpybkc itself, which is the whole reason this
+project has no lockfile.
+
+### What a tag carries besides the image
+
+Every published tag resolves to a **multi-platform index**, and two things are
+attached to what it resolves to (#58), both of which a consumer can check
+without any prior arrangement with this project:
+
+- a **signature**, over the published index and over each per-platform manifest
+  beneath it, so the manifest a runtime actually pulls is signed and not only
+  the one the tag named;
+- **attestations** — a provenance statement and an SBOM — attached to the
+  published index digest and to that alone. They are statements about the
+  release, and the release is the index; a per-platform manifest carries none of
+  its own, and looking for one there finds nothing.
+
+Signing is **keyless**: there is no cpybkc public key to obtain or trust. The
+signing identity is [this repository's release
+workflow](../../.github/workflows/release.yaml), certified for the length of one
+run from the OIDC token the CI provider mints and recorded in a public
+transparency log, so verification asks *what built this image* and gets an
+answer anybody can check. Verification therefore names that workflow as the
+certificate identity and the CI provider as the OIDC issuer; a verification
+passing neither asks only whether *somebody* signed the image, which is not a
+question worth the command.
+
+Nothing is ever attached to a **tag**, only to a digest. An attestation about a
+name that moves would say nothing, which is why verifying a moving tag is
+verifying whatever it resolves to at that moment.
+
+That this verification is *possible* is in scope here, because it is something a
+consumer performs. How the signature comes to exist is not, and is under [Out of
+Scope](#how-the-image-is-built-and-published).
 
 ## Worked example: adding a generator
 
-<!-- #54: a complete multi-stage Dockerfile that builds a custom plugin and
-     copies it in, runnable as written. -->
+A complete multi-stage Dockerfile that builds a generator cpybkc has never heard
+of and copies it into the plugin directory. It is runnable as written, against
+an empty build context:
+
+```dockerfile
+# syntax=docker/dockerfile:1
+
+FROM golang:1.25 AS build
+WORKDIR /src
+
+COPY <<'EOF' go.mod
+module example.com/cpybkc-gen-hello
+
+go 1.24
+EOF
+
+COPY <<'EOF' main.go
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/Zaba505/cpybkc/irpb"
+)
+
+// The highest IR version this generator implements, and its own version. Both
+// are named in the refusal below, because cpybkc never learns there was a
+// mismatch and cannot compose that diagnostic on the plugin's behalf.
+const (
+	irVersion     = irpb.IrVersion_IR_VERSION_1
+	pluginVersion = "0.1.0"
+)
+
+func main() {
+	descriptor, out, greeting := "", "", "hello"
+
+	args := os.Args[1:]
+	for len(args) > 0 && args[0] != "--" {
+		if len(args) < 2 {
+			fail("%s: missing value", args[0])
+		}
+		flag, value := args[0], args[1]
+		args = args[2:]
+		switch flag {
+		case "--descriptor":
+			descriptor = value
+		case "--out":
+			out = value
+		case "--opt":
+			key, v, ok := strings.Cut(value, "=")
+			if !ok || key != "greeting" {
+				fail("--opt %s: unrecognised option", value)
+			}
+			greeting = v
+		default:
+			fail("%s: unrecognised flag", flag)
+		}
+	}
+	if descriptor == "" || out == "" {
+		fail("--descriptor and --out are both required")
+	}
+
+	b, err := os.ReadFile(descriptor)
+	if err != nil {
+		fail("%v", err)
+	}
+	var d irpb.Descriptor
+	if err := proto.Unmarshal(b, &d); err != nil {
+		fail("%v", err)
+	}
+
+	// The version, before anything else in the message.
+	if d.GetVersion() != irVersion {
+		fail("descriptor IR version %d; cpybkc-gen-hello %s implements IR version %d",
+			d.GetVersion(), pluginVersion, irVersion)
+	}
+
+	name := filepath.Join(out, "hello.txt")
+	if err := os.WriteFile(name, []byte(greeting+"\n"), 0o644); err != nil {
+		fail("%v", err)
+	}
+}
+
+func fail(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "error: "+format+"\n", args...)
+	os.Exit(1)
+}
+EOF
+
+RUN go get github.com/Zaba505/cpybkc/irpb \
+ && CGO_ENABLED=0 go build -trimpath -o /out/cpybkc-gen-hello .
+
+FROM ghcr.io/zaba505/cpybkc:v0
+COPY --from=build --chown=65532:65532 --chmod=0755 \
+     /out/cpybkc-gen-hello /usr/local/bin/cpybkc-gen-hello
+```
+
+Build it, and run it against a project whose `cpybkc.json` names the `hello`
+generator and nothing else:
+
+```console
+$ docker build -t cpybkc-hello .
+$ docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/src" -w /src \
+    cpybkc-hello <arguments>
+$ cat out/hello.txt
+hello
+```
+
+The `--opt` half of the plugin contract works from here unchanged: an
+`"options": {"greeting": "hei"}` in that generator's manifest entry is what
+cpybkc turns into `--opt greeting=hei` on its command line, and `hello.txt` says
+`hei` instead.
+
+Five things in it are the contract rather than the example, and each one is a
+line that would be wrong in a Dockerfile written from habit:
+
+- The final stage contains **no `RUN`**. Every command ran in the `golang`
+  stage, which has a shell; the stage built `FROM` the cpybkc image only copies.
+  See [Shell or no shell](#shell-or-no-shell).
+- `CGO_ENABLED=0` produces a static executable. Without it the build succeeds
+  and the generator fails to start inside the image.
+- The destination is `/usr/local/bin`, on `PATH`, and the filename is
+  `cpybkc-gen-hello` — the name cpybkc searches for when a manifest asks for
+  `hello`, per the [plugin contract](../plugin/SPEC.md#discovery).
+- `--chown=65532:65532 --chmod=0755` hands the file to the [image's
+  user](#the-user) as an executable. `COPY` otherwise preserves the source's
+  ownership, which is root's in the build stage.
+- `ENTRYPOINT` is untouched, so the image is still cpybkc — now with one more
+  generator on its `PATH`.
+
+The generator itself is deliberately small: it parses the argument vector it is
+promised, refuses an option it does not know, reads the descriptor's IR version
+before anything else in the message and refuses one it does not implement, and
+writes one deterministic file beneath `--out`. Every one of those is required of
+it by the [plugin contract](../plugin/SPEC.md), and none of them is required of
+it by this one — which is the point. This document's whole involvement in the
+generator is the two lines that put it on `PATH`.
+
+### This example is built by the pipeline
+
+`dagger call worked-example` extracts the Dockerfile above out of this file and
+checks it, and CI runs that on every pull request (#54). So the example is
+executable documentation rather than a transcription, and an edit that breaks it
+fails on the pull request that made it.
+
+It is checked rather than trusted because nothing else in this repository reads
+it: this project's build, its tests and its own images would all pass on an
+example that stopped building releases ago, and the first person to find out
+would be an adopter, at the first thing they tried.
+
+Two details of how it is checked bound what passing means. The **build stage is
+handed to the builder exactly as committed**, with an empty build context, which
+is what makes "runnable as written" something somebody measured rather than
+remembered — a heredoc that no longer parses, a Go program that no longer
+compiles, a module path that no longer resolves or a toolchain that has moved on
+all fail there, and so does an executable that comes out dynamically linked. The
+**final stage is interpreted rather than built**: `FROM ghcr.io/zaba505/cpybkc`
+names a published image, and its `FROM` line, its absence of a `RUN` and its
+`COPY` flags and paths are read and checked against the requirements above.
+Building that stage against the base image the pipeline itself produced is what
+#55 adds, when there is one to build it against.
+
+The check refuses what it cannot replay: an instruction in the final stage other
+than the ones this document permits is an error naming it, rather than a line
+that quietly goes unchecked. A worked example that grows an `ENV` teaches the
+pipeline what an `ENV` means before CI accepts it.
 
 ## Compatibility guarantees
 
-<!-- #54: what is covered, what is explicitly not, and how a covered thing
-     would change if it had to. -->
+**Covered.** Within a major version of the image each of these holds, and a
+change to any of them is a breaking change:
+
+| Guarantee | Value |
+| --- | --- |
+| [The plugin directory](#the-plugin-directory) | `/usr/local/bin`, on `PATH`, existing and owned by the image's user |
+| [The entrypoint](#the-entrypoint) | Is the cpybkc CLI, and takes its arguments |
+| [The user](#the-user) | UID 65532, GID 65532, non-root, overridable |
+| [Shell or no shell](#shell-or-no-shell) | Absent; extension is `COPY`-only |
+| [Platforms](#why-linuxs390x-is-inside-the-guarantee) | `linux/amd64`, `linux/arm64` and `linux/s390x` |
+| [Tags](#tags-and-what-pinning-one-buys) | A published full-version tag never moves |
+| [Signatures](#what-a-tag-carries-besides-the-image) | The published index and each manifest beneath it are signed; the index digest carries provenance and an SBOM |
+
+**Not covered**, and explicitly implementation detail. Depending on any of it is
+depending on something that may change in a patch release, with no notice:
+
+- The base image, and everything in the filesystem other than what is named
+  above — its existence, its contents and its paths, including the writable
+  temporary directory.
+- The path of the `cpybkc` executable itself, and the literal value of
+  `Entrypoint`.
+- The value of `PATH` beyond its containing `/usr/local/bin`, and the value of
+  any other environment variable.
+- `WorkingDir`, and the existence of any directory a caller mounts over. A
+  caller passes `--workdir`, or paths, or both; cpybkc resolves a manifest's
+  relative paths against the manifest rather than against a working directory,
+  so where a project is mounted is the caller's arrangement and not a promise
+  this image makes.
+- Layer count, layer ordering, image size, build timestamps, and every other
+  label or annotation on the manifest.
+- Which UID owns a file that is not in the plugin directory.
+
+### Why `linux/s390x` is inside the guarantee
+
+The covered platform set is the deliberate part of that table, because it is the
+one place this contract does not follow the prior art it is otherwise modelled
+on: `avroc` publishes `linux/amd64` and `linux/arm64` and puts every further
+platform explicitly *outside* its guarantee.
+
+cpybkc brings `linux/s390x` inside instead (#55, #56). The audience is the
+reason. Files composed of COBOL copybook records come from mainframes, and Linux
+on Z and z/OS Container Extensions are where a shop with those files already
+runs containers; a derived image that cannot be built for the machine holding
+the data is an extension mechanism that mostly works. It is also the only
+big-endian platform in the matrix, which makes it the leg that tests the
+[byte-order fork](https://github.com/Zaba505/cobol-go/blob/main/codec/SPEC.md)
+the generated code is written against rather than merely packaging for it — the
+class of bug that passes everywhere else (#56).
+
+The cost is honest and small: CGO-free Go cross-compiles to it for nothing, and
+the emulated test leg (#56) is CI time rather than a promise. What putting it in
+the table buys is that a Dockerfile in a mainframe shop's repository may say
+`FROM` and mean it, and that dropping the platform later would be the breaking
+change it ought to be rather than a quiet change of mind.
+
+The *set* is covered; the machinery that fills it is not. Which platforms a
+published index carries is something a consumer reads out of the index and
+builds against, so it is a guarantee. How each one is cross-compiled, tested
+under emulation or assembled is [out of
+scope](#how-the-image-is-built-and-published) like the rest of the build.
+
+### How a covered thing would change
+
+Not by moving it. A covered path or value changes in a new major version, and
+the transition **MUST** hold both forms simultaneously for at least one full
+minor release of that new major: a moved plugin directory means both directories
+exist and both are on `PATH`, with the old one deprecated in the release notes
+and removed no earlier than the following minor release.
+
+The overlap is the entire point. A derived Dockerfile is in a repository this
+project cannot see, is built by a pipeline this project cannot warn, and fails
+at `COPY` time with an error naming a path rather than a version. Giving it a
+release in which both the old and the new form work is what turns that into a
+deprecation notice somebody reads instead of a broken build somebody bisects.
 
 ## Out of Scope
 
@@ -147,13 +639,19 @@ Go install with no document that applies to them.
 | Section | Implemented by |
 |---|---|
 | [The plugin directory](#the-plugin-directory) | #54, #55 `container` |
+| [Why cpybkc's own generator is not in the base image](#why-cpybkcs-own-generator-is-not-in-the-base-image) | #55 `container` for the base holding none, #48–#53 `gen-go` for the generator that goes through the front door |
+| [The CLI's own path is not part of the contract](#the-clis-own-path-is-not-part-of-the-contract) | #55 `container` |
 | [The entrypoint](#the-entrypoint) | #55 `container` |
 | [The user](#the-user) | #55 `container` |
 | [Shell or no shell](#shell-or-no-shell) | #55 `container` |
 | [Tags and what pinning one buys](#tags-and-what-pinning-one-buys) | #59 `container` |
+| [What a tag carries besides the image](#what-a-tag-carries-besides-the-image) | #58 `container` |
 | [Worked example: adding a generator](#worked-example-adding-a-generator) | #54 `container` |
+| [This example is built by the pipeline](#this-example-is-built-by-the-pipeline) | #54 `container` for the build stage and the reading of the final one, #55 `container` for building that stage against a base image of this pipeline's own |
 | [Compatibility guarantees](#compatibility-guarantees) | #54, #58 `container` |
+| [Why `linux/s390x` is inside the guarantee](#why-linuxs390x-is-inside-the-guarantee) | #54 `container` decides it, #55, #56 `container` build and test it |
 | The IR proto shipped in the image — a consumer-visible file, sized here | #57 `container` |
 | Multi-platform build and s390x testing — out of scope, see above | #55, #56 `container` |
 | Signing, provenance and SBOM — verifiable, so the tags section cites them | #58 `container` |
+| This document | #54 `container`; its shape and the settled `Scope`, `Governing sources` and `Out of Scope`, #15 `setup` |
 | Conventions this document follows | #15 `setup` |

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -369,10 +369,12 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/Zaba505/cpybkc/irpb"
@@ -415,19 +417,22 @@ func main() {
 		fail("--descriptor and --out are both required")
 	}
 
-	b, err := os.ReadFile(descriptor)
+	b, err := read(descriptor)
 	if err != nil {
 		fail("%v", err)
 	}
-	var d irpb.Descriptor
-	if err := proto.Unmarshal(b, &d); err != nil {
-		fail("%v", err)
+
+	// The version, off the wire, before the message is decoded at all: a
+	// descriptor this generator does not implement is refused with no part of
+	// it interpreted.
+	if version := versionOf(b); version != irVersion {
+		fail("descriptor IR version %d; cpybkc-gen-hello %s implements IR version %d",
+			version, pluginVersion, irVersion)
 	}
 
-	// The version, before anything else in the message.
-	if d.GetVersion() != irVersion {
-		fail("descriptor IR version %d; cpybkc-gen-hello %s implements IR version %d",
-			d.GetVersion(), pluginVersion, irVersion)
+	var d irpb.Descriptor
+	if err := proto.Unmarshal(b, &d); err != nil {
+		fail("the descriptor is not a cpybkc IR message: %v", err)
 	}
 
 	name := filepath.Join(out, "hello.txt")
@@ -436,13 +441,51 @@ func main() {
 	}
 }
 
+// read is the descriptor's bytes, from the path or from standard input where
+// the path is `-`. cpybkc always passes a real path, and a plugin accepts `-`
+// anyway.
+func read(path string) ([]byte, error) {
+	if path == "-" {
+		return io.ReadAll(os.Stdin)
+	}
+	return os.ReadFile(path)
+}
+
+// versionOf is the IR version the descriptor's bytes state, read without
+// decoding the rest of the message. Field 1 is the version; anything else is
+// skipped, and bytes that are not a message read as no version stated, which is
+// a version this generator does not implement.
+func versionOf(descriptor []byte) irpb.IrVersion {
+	stated := irpb.IrVersion_IR_VERSION_UNSPECIFIED
+	for rest := descriptor; len(rest) > 0; {
+		number, kind, n := protowire.ConsumeTag(rest)
+		if n < 0 {
+			return stated
+		}
+		rest = rest[n:]
+		if number == 1 && kind == protowire.VarintType {
+			v, n := protowire.ConsumeVarint(rest)
+			if n < 0 {
+				return stated
+			}
+			stated, rest = irpb.IrVersion(v), rest[n:]
+			continue
+		}
+		if n = protowire.ConsumeFieldValue(number, kind, rest); n < 0 {
+			return stated
+		}
+		rest = rest[n:]
+	}
+	return stated
+}
+
 func fail(format string, args ...any) {
 	fmt.Fprintf(os.Stderr, "error: "+format+"\n", args...)
 	os.Exit(1)
 }
 EOF
 
-RUN go get github.com/Zaba505/cpybkc/irpb \
+RUN go mod tidy \
  && CGO_ENABLED=0 go build -trimpath -o /out/cpybkc-gen-hello .
 
 FROM ghcr.io/zaba505/cpybkc:v0


### PR DESCRIPTION
Closes #54

Fills the `docs/container/SPEC.md` stub (#15 gave it its shape). The document
now says what a Dockerfile building `FROM` the published image may rely on, and
what it may not.

## Acceptance criteria

- [x] **A documented, stable plugin directory on `PATH`** — [The plugin
  directory](https://github.com/Zaba505/cpybkc/blob/issue-54/docs/container/SPEC.md#the-plugin-directory):
  `/usr/local/bin`, on `PATH`, existing even when empty, with the stability
  guarantee stated beside the path rather than only in the table, and the
  earliest-`PATH`-match-wins shadowing rule the plugin contract makes dangerous.
- [x] **A stable non-root UID documented, with guidance on `--user $(id -u):$(id -g)`**
  — [The user](https://github.com/Zaba505/cpybkc/blob/issue-54/docs/container/SPEC.md#the-user):
  65532:65532, why it is pinned rather than allocated, what it means for
  ownership, and the recommended invocation whenever output lands in a mount.
- [x] **Entrypoint documented as the cpybkc CLI** — [The
  entrypoint](https://github.com/Zaba505/cpybkc/blob/issue-54/docs/container/SPEC.md#the-entrypoint),
  with the CLI's own path explicitly *not* part of the contract.
- [x] **States whether the base image has a shell, and that extension is
  COPY-only if it does not** — [Shell or no
  shell](https://github.com/Zaba505/cpybkc/blob/issue-54/docs/container/SPEC.md#shell-or-no-shell):
  `scratch` plus the named files, no `RUN` in a derived stage, `CGO_ENABLED=0`,
  no `docker exec`, and the writable temp directory named so that "scratch plus
  the files above" is not read as denying it.
- [x] **A worked multi-stage Dockerfile example adding a custom plugin** —
  [Worked example](https://github.com/Zaba505/cpybkc/blob/issue-54/docs/container/SPEC.md#worked-example-adding-a-generator),
  runnable as written against an empty build context, building a
  `cpybkc-gen-hello` that obeys the plugin contract's option handling and reads
  the descriptor's IR version before anything else in the message.
- [x] **Documents what is and is not covered by compatibility guarantees** —
  [Compatibility guarantees](https://github.com/Zaba505/cpybkc/blob/issue-54/docs/container/SPEC.md#compatibility-guarantees),
  plus *How a covered thing would change*: both forms for at least a full minor
  release, because a derived Dockerfile fails at `COPY` time with an error
  naming a path rather than a version.

## The example is built by the pipeline

`dagger call worked-example` (new, and part of `ci`) extracts the Dockerfile out
of `SPEC.md` and checks it, so the example is executable documentation rather
than a transcription. Nothing else in this repository reads it, so the first
person to find it stale would otherwise be an adopter.

Two halves, following avroc#169's technique:

- The **build stage is handed to the builder exactly as committed**, against a
  context holding nothing but that Dockerfile. A heredoc that stops parsing, a
  Go program that stops compiling, a module path that stops resolving or a
  toolchain that moves on all fail there — and so does an executable that comes
  out dynamically linked, which is `CGO_ENABLED=0` checked as a property of the
  file rather than grepped for as a spelling.
- The **final stage is interpreted**: `FROM ghcr.io/zaba505/cpybkc` names a
  published image, which does not exist yet (#55), so its `FROM`, its absence of
  a `RUN` and its `COPY` flags and paths are read and checked instead. The
  parser refuses an instruction it cannot replay rather than letting it go
  unchecked. Building that stage against a base image of this pipeline's own is
  #55's.

## Judgment calls worth a reviewer's attention

- **`linux/s390x` is inside the compatibility guarantee**, which is the one
  place this contract does not follow avroc — avroc covers amd64 and arm64 and
  puts every further platform outside its guarantee. #54's issue asked for this
  to be decided rather than inherited; [the
  reasoning](https://github.com/Zaba505/cpybkc/blob/issue-54/docs/container/SPEC.md#why-linuxs390x-is-inside-the-guarantee)
  is the audience and the big-endian test leg (#55, #56). The platform *set* is
  covered; the machinery that fills it stays out of scope.
- **No working-directory promise.** `WorkingDir` is under *not covered*, and the
  run examples pass `-w` explicitly. The settled `Scope` (#15) does not list a
  working directory, cpybkc resolves a manifest's relative paths against the
  manifest rather than against a working directory, and the CLI's argument
  surface does not exist yet — so promising `/work` here would be inventing a
  contract nothing implements.
- **No CLI arguments are invented.** The entrypoint and run examples write
  `<arguments>` rather than a subcommand, because which arguments the CLI takes
  is not this document's and there is no CLI yet to read them off.
- **`cpybkc-gen-go` is stated to be outside the base image** (#55), so this
  project's own generator is a consumer of the mechanism rather than a private
  arrangement that resembles one — the point avroc#167 makes, and what #55's
  issue asks to copy.
- The stub's settled parts — `Scope`, `Governing sources`, `Out of Scope` — are
  untouched.

## Verified

`dagger call ci` passes locally, including the new `worked-example` stage. The
check was also run against a deliberately broken copy of the document (a
`--chmod=0644` and a build output renamed out from under the final `COPY`) and
failed on both, so it is not passing vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)