### PR TITLE
story(conformance): run the corpus against cpybkc-gen-go in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,10 +45,16 @@ jobs:
   # never as raw Go steps beside this one. `buf lint` over the IR schema is the
   # first of them and it is called by `ci` rather than by a second `dagger call`
   # here, so that the gate a contributor runs before pushing is the whole of what
-  # CI checks; the conformance corpus (#66-#68) lands the same way. A golden-file
-  # or corpus job written with `actions/setup-go` and `go test` would be a second
-  # toolchain, a second set of stage definitions and a second answer to what this
-  # repository checks.
+  # CI checks. A golden-file or corpus job written with `actions/setup-go` and
+  # `go test` would be a second toolchain, a second set of stage definitions and
+  # a second answer to what this repository checks.
+  #
+  # The conformance corpus (#66-#68) needed neither: it is Go tests under
+  # testdata/, so `go test` inside the standard pipeline already runs it, and a
+  # stage of its own would have been that same second definition arrived at from
+  # the other direction. That is also what makes it a gate on every platform in
+  # the matrix — the matrix is a matrix of this one call, so a platform added
+  # below carries the corpus with it rather than needing a job added beside it.
   ci:
     name: ci
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -302,9 +302,18 @@ go test ./internal/conformance/...
 ```
 
 That generates Go for every entry with `cpybkc-gen-go` built from the tree,
-compiles it, reads each entry's bytes with it, and holds what came out against
-what the entry says. `dagger call ci` runs it too, like every other test; the
-call above is for narrowing down what it reported.
+compiles it, reads each entry's bytes with it, writes those records back out with
+it, reads that file too, and holds both answers against what the entry says.
+`dagger call ci` runs it too, like every other test; the call above is for
+narrowing down what it reported.
+
+Being an ordinary test is what makes it a gate on every platform in the CI
+matrix: the matrix is a matrix of `dagger call ci`, and a conformance job of its
+own would be a second gate that a platform added to the matrix would silently not
+carry. What it is not is a check of the bytes the writer produced —
+[`docs/ir/SPEC.md`](docs/ir/SPEC.md)'s *Writing a file* makes byte identity a
+claim about a record and not about a file, and the corpus README's *Why the
+writing direction is checked by reading* is the rest of the argument.
 
 It exists because cpybkc is strictly a generator: nothing here reads a data file
 except the code a generator emitted, so nothing else holds two generators in two

--- a/internal/conformance/answer.go
+++ b/internal/conformance/answer.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package conformance
+
+import "fmt"
+
+// Answer is what a runner reports about one entry: what the generated reader
+// made of the entry's bytes, and what the file the generated writer laid those
+// records back out into reads as.
+//
+// Two documents rather than one because an entry states one set of values and a
+// generator is asked about it twice, once in each direction (#68). A generator
+// that reads a file correctly and writes one nobody can read back is a
+// generator half the ecosystem cannot use, and a corpus that only ever read
+// would call it conformant.
+//
+// # Why the writing direction is checked by reading, and not by comparing bytes
+//
+// The obvious check is that the bytes the writer produced are the entry's
+// bytes, and it is the wrong one twice over.
+//
+// [docs/ir/SPEC.md], "Writing a file", makes byte identity a claim about a
+// *record* and refuses to make it about a file: under an optional terminator a
+// writer emits a final delimiter the input need not have carried, and under
+// segmented framing it lays a record into as few segments as the largest
+// allows, whatever the input did. Both are deliberate, so a corpus demanding
+// the input's bytes back would fail two of the four framings by design.
+//
+// It is wrong at the field level too, and the corpus already holds the case:
+// packed-ascii carries the lenient sign nibble A, which a reader admits as
+// positive and a writer has no reason to emit — it writes the C the convention
+// prescribes. The same holds of every encoding that admits more than one
+// spelling of one value. Demanding the bytes back would make those entries
+// unpassable by a correct generator, and dropping them would cost the corpus
+// exactly the vectors it was seeded for.
+//
+// What the specification does make normative of a file is that "a file a writer
+// produces MUST be one that a reader built from the same descriptor reads back
+// as the records the writer was given", so that is what is compared: the
+// records read out of the written file, against the same values.json the
+// reading direction is held to. It holds for all four framings and for every
+// encoding, and it needs nothing of a runner that the reading direction did not
+// already need.
+//
+// [docs/ir/SPEC.md]: https://github.com/Zaba505/cpybkc/blob/main/docs/ir/SPEC.md
+type Answer struct {
+	// Decoded is what the generated reader made of the entry's bytes.
+	Decoded *Values `json:"decoded"`
+
+	// Written is what a reader makes of the file the generated writer produced
+	// from the records Decoded holds.
+	//
+	// It is absent where the reading direction did not reach the end of the
+	// file: a run that stopped at a failure holds no complete set of records to
+	// write back, and an entry expecting a failure is an entry about reading.
+	// It is absent, too, from a runner whose generator emits no writer at all —
+	// emitting one is the generator's decision (docs/ir/SPEC.md, "Writing a
+	// file"), and a runner is not asked to invent the direction. What this
+	// repository's own runner does with that latitude is not to take it: the Go
+	// generator emits a writer, so the Go runner reports this member, and
+	// [CompareAnswer] holds it to it.
+	Written *Values `json:"written,omitempty"`
+}
+
+// ParseAnswer reads a runner's answer, holding it to the shape the corpus
+// format states.
+//
+// Unknown fields are refused at every level, for the reason entry.json refuses
+// one: a key an author wrote in the expectation that it means something is a
+// typo, and a document that silently ignores it is a document that passes for
+// the wrong reason.
+func ParseAnswer(b []byte) (*Answer, error) {
+	var answer Answer
+	if err := decodeOne(b, &answer); err != nil {
+		return nil, err
+	}
+
+	var faults []error
+
+	if answer.Decoded == nil {
+		faults = append(faults, fmt.Errorf("decoded is what the generated reader made of the entry's bytes, and is required"))
+	} else {
+		faults = append(faults, prefixed("decoded", answer.Decoded.records())...)
+	}
+
+	if answer.Written != nil {
+		faults = append(faults, prefixed("written", answer.Written.records())...)
+
+		if answer.Decoded != nil && answer.Decoded.Failure != "" {
+			faults = append(faults, fmt.Errorf(
+				"written stands beside a decoded failure, and a file the reader refused holds no complete set of records to write back"))
+		}
+	}
+
+	return &answer, joined(faults)
+}
+
+// CompareAnswer holds a runner's answer against what an entry expects, in both
+// directions.
+//
+// One entry, one set of values, and both directions are held to it: the records
+// the generated reader made of the entry's bytes, and the records read back out
+// of the file the generated writer made of those records. The second comparison
+// is against the entry rather than against the first answer on purpose — a
+// reader and a writer that are wrong the same way agree with each other, and
+// only the entry knows what the file holds.
+func CompareAnswer(want *Values, got *Answer) error {
+	if got == nil || got.Decoded == nil {
+		return fmt.Errorf("the runner reported nothing it read")
+	}
+
+	var faults []error
+
+	if err := Compare(want, got.Decoded); err != nil {
+		faults = append(faults, fmt.Errorf("reading the entry's bytes: %w", err))
+	}
+
+	switch {
+	case want.Failure != "":
+		// Nothing is written back from a read that stopped, so there is nothing
+		// to compare. The entry is about the reading direction and says so by
+		// expecting a failure.
+	case got.Written == nil:
+		faults = append(faults, fmt.Errorf(
+			"the records were not written back, and a file read to its end is one the corpus asks to be written again"))
+	default:
+		if err := Compare(want, got.Written); err != nil {
+			faults = append(faults, fmt.Errorf("reading back the file written from those records: %w", err))
+		}
+	}
+
+	return joined(faults)
+}
+
+// prefixed says which document of an answer a fault is in.
+//
+// The two are the same shape, so a fault reported as itself would send an
+// author to whichever of them they looked at first.
+func prefixed(document string, faults []error) []error {
+	said := make([]error, 0, len(faults))
+
+	for _, fault := range faults {
+		said = append(said, fmt.Errorf("%s: %w", document, fault))
+	}
+
+	return said
+}

--- a/internal/conformance/answer.go
+++ b/internal/conformance/answer.go
@@ -35,7 +35,7 @@ import "fmt"
 // prescribes. The same holds of every encoding that admits more than one
 // spelling of one value. Demanding the bytes back would make those entries
 // unpassable by a correct generator, and dropping them would cost the corpus
-// exactly the vectors it was seeded for.
+// exactly the vectors it was seeded from.
 //
 // What the specification does make normative of a file is that "a file a writer
 // produces MUST be one that a reader built from the same descriptor reads back
@@ -95,7 +95,14 @@ func ParseAnswer(b []byte) (*Answer, error) {
 		}
 	}
 
-	return &answer, joined(faults)
+	// Nothing on a fault, as [ParseValues] answers nothing: an answer this
+	// function objected to is one whose required member may be missing, and a
+	// caller that read past the error would find out by dereferencing it.
+	if len(faults) > 0 {
+		return nil, joined(faults)
+	}
+
+	return &answer, nil
 }
 
 // CompareAnswer holds a runner's answer against what an entry expects, in both
@@ -119,10 +126,13 @@ func CompareAnswer(want *Values, got *Answer) error {
 	}
 
 	switch {
-	case want.Failure != "":
+	case want.Failure != "" || got.Decoded.Failure != "":
 		// Nothing is written back from a read that stopped, so there is nothing
-		// to compare. The entry is about the reading direction and says so by
-		// expecting a failure.
+		// to compare. Either the entry is about the reading direction and says
+		// so by expecting a failure, or the read failed where the entry expects
+		// it not to — which [Compare] has already reported, and reporting the
+		// writing direction as missing on top of it would send a reader after a
+		// second fault that is the first one's consequence.
 	case got.Written == nil:
 		faults = append(faults, fmt.Errorf(
 			"the records were not written back, and a file read to its end is one the corpus asks to be written again"))

--- a/internal/conformance/answer_test.go
+++ b/internal/conformance/answer_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package conformance
+
+import (
+	"strings"
+	"testing"
+)
+
+// the values every case below is written against: one record, read from a file
+// the reader reads to its end.
+const oneRecord = `{
+	"records": [
+		{"name": "ORDER-RECORD", "value": {"ORDER-ID": "A001", "ORDER-QTY": "42"}}
+	]
+}`
+
+// TestCompareAnswerHoldsBothDirectionsToTheEntry walks what a runner can say
+// about an entry once it is asked in both directions.
+//
+// The two directions are compared against the *entry* rather than against each
+// other, which is the case a reader and a writer that are wrong the same way
+// would otherwise pass: what the file holds is written down once, in
+// values.json, and both answers are held to it (#68).
+func TestCompareAnswerHoldsBothDirectionsToTheEntry(t *testing.T) {
+	tests := map[string]struct {
+		want   string
+		answer string
+		says   []string
+	}{
+		"both directions agree with the entry": {
+			want:   oneRecord,
+			answer: `{"decoded": ` + oneRecord + `, "written": ` + oneRecord + `}`,
+		},
+		"the reader disagrees": {
+			want: oneRecord,
+			answer: `{"decoded": ` + strings.Replace(oneRecord, `"A001"`, `"B002"`, 1) +
+				`, "written": ` + oneRecord + `}`,
+			says: []string{"reading the entry's bytes", "ORDER-RECORD.ORDER-ID", `"B002"`},
+		},
+		"the writer laid out a file that reads back as something else": {
+			want: oneRecord,
+			answer: `{"decoded": ` + oneRecord +
+				`, "written": ` + strings.Replace(oneRecord, `"42"`, `"41"`, 1) + `}`,
+			says: []string{"reading back the file written from those records", "ORDER-RECORD.ORDER-QTY"},
+		},
+		"the writer refused the records it was given": {
+			want: oneRecord,
+			answer: `{"decoded": ` + oneRecord +
+				`, "written": {"records": [], "failure": "writing record 1: a run of 3 bytes for a slack node 4 bytes wide"}}`,
+			says: []string{"reading back the file written from those records", "a run of 3 bytes"},
+		},
+		"the records were never written back": {
+			want:   oneRecord,
+			answer: `{"decoded": ` + oneRecord + `}`,
+			says:   []string{"were not written back"},
+		},
+		"an entry about a file the reader refuses": {
+			want:   `{"records": [], "failure": "the sign nibble is not one of the four"}`,
+			answer: `{"decoded": {"records": [], "failure": "invalid sign nibble 0xE at offset 7"}}`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := CompareAnswer(parsed(t, test.want), answered(t, test.answer))
+
+			if len(test.says) == 0 {
+				if err != nil {
+					t.Fatalf("the comparison reported %v, and the answer is what the entry expects", err)
+				}
+
+				return
+			}
+
+			if err == nil {
+				t.Fatal("the comparison passed, and the answer is not what the entry expects")
+			}
+
+			for _, says := range test.says {
+				if !strings.Contains(err.Error(), says) {
+					t.Errorf("the report is %q, and it does not say %q", err, says)
+				}
+			}
+		})
+	}
+}
+
+// TestParseAnswerRefuses walks the answers the format does not admit.
+func TestParseAnswerRefuses(t *testing.T) {
+	tests := map[string]string{
+		"nothing that was read":            `{"written": ` + oneRecord + `}`,
+		"a field nobody reads":             `{"decoded": ` + oneRecord + `, "bytes": "AAA="}`,
+		"a values document on its own":     oneRecord,
+		"a record with no name":            `{"decoded": {"records": [{"value": {}}]}}`,
+		"a record with no value":           `{"decoded": {"records": [{"name": "ORDER-RECORD"}]}}`,
+		"a written record with no name":    `{"decoded": ` + oneRecord + `, "written": {"records": [{"value": {}}]}}`,
+		"something behind the document":    `{"decoded": ` + oneRecord + `} and then some`,
+		"a file written back from nothing": `{"decoded": {"records": [], "failure": "short record"}, "written": {"records": []}}`,
+	}
+
+	for name, document := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseAnswer([]byte(document)); err == nil {
+				t.Fatal("the answer was read, and the format does not admit it")
+			}
+		})
+	}
+}
+
+// TestParseAnswerNamesWhichDocumentIsWrong asserts that a fault in one of the
+// two values documents says which one it is in.
+//
+// They are the same shape, so a report naming neither sends an author to
+// whichever they looked at first — and the two are written by different halves
+// of a runner.
+func TestParseAnswerNamesWhichDocumentIsWrong(t *testing.T) {
+	_, err := ParseAnswer([]byte(`{"decoded": ` + oneRecord + `, "written": {"records": [{"value": {}}]}}`))
+	if err == nil {
+		t.Fatal("the answer was read, and one of its records carries no name")
+	}
+
+	if !strings.Contains(err.Error(), "written") {
+		t.Errorf("the report is %q, and it does not say which document the record is in", err)
+	}
+}
+
+// answered is an answer document written inline, for a test to compare.
+func answered(t *testing.T, document string) *Answer {
+	t.Helper()
+
+	answer, err := ParseAnswer([]byte(document))
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	return answer
+}

--- a/internal/conformance/answer_test.go
+++ b/internal/conformance/answer_test.go
@@ -89,6 +89,28 @@ func TestCompareAnswerHoldsBothDirectionsToTheEntry(t *testing.T) {
 	}
 }
 
+// TestCompareAnswerReportsAFailedReadOnce asserts that a read the entry expects
+// to succeed and which failed is one fault and not two.
+//
+// A runner writes nothing back from a read that stopped, so the writing
+// direction is missing exactly because the reading one failed. Reporting it as a
+// fault of its own would send whoever reads the report after a second bug that
+// is the first one's consequence.
+func TestCompareAnswerReportsAFailedReadOnce(t *testing.T) {
+	err := CompareAnswer(parsed(t, oneRecord), answered(t, `{"decoded": {"records": [], "failure": "short record"}}`))
+	if err == nil {
+		t.Fatal("the comparison passed, and the entry expects the file to be read to its end")
+	}
+
+	if !strings.Contains(err.Error(), "short record") {
+		t.Errorf("the report is %q, and it does not carry what the runner said", err)
+	}
+
+	if strings.Contains(err.Error(), "written back") {
+		t.Errorf("the report is %q, and it faults a direction a failed read does not reach", err)
+	}
+}
+
 // TestParseAnswerRefuses walks the answers the format does not admit.
 func TestParseAnswerRefuses(t *testing.T) {
 	tests := map[string]string{

--- a/internal/conformance/doc.go
+++ b/internal/conformance/doc.go
@@ -36,10 +36,14 @@
 //     (#148); the descriptor an entry carries is hand-authored, so it is an
 //     oracle rather than a recording of what resolve happens to do today.
 //   - The IR, handed to a generator, produces code that decodes the entry's
-//     bytes into the entry's values. That is a claim about a *consumer*, it is
-//     what [github.com/Zaba505/cpybkc/internal/conformance/gorunner] checks for
-//     the Go generator, and it is what makes the corpus useful to a third party
-//     who has neither this repository's resolver nor its language.
+//     bytes into the entry's values — and writes those records back into a file
+//     that decodes to the entry's values again. That is a claim about a
+//     *consumer*, in both directions, it is what
+//     [github.com/Zaba505/cpybkc/internal/conformance/gorunner] checks for the
+//     Go generator, and it is what makes the corpus useful to a third party who
+//     has neither this repository's resolver nor its language. [Answer] carries
+//     both answers and says why the writing direction is checked by reading
+//     rather than by comparing bytes (#68).
 //
 // Both halves read the same entry, which is the point of carrying the IR in the
 // tuple rather than deriving it: a generator author who disagrees with cpybkc

--- a/internal/conformance/errors.go
+++ b/internal/conformance/errors.go
@@ -55,6 +55,34 @@ func (e *MismatchError) Error() string {
 
 func (e *MismatchError) Unwrap() error { return e.Err }
 
+// RunError is an entry a runner could not answer about at all: the generator
+// would not run, what it produced would not compile, or the runner could not be
+// driven.
+//
+// It carries the entry and its source for the reason [MismatchError] does, and
+// it is a separate type because the two send a reader somewhere different. A
+// mismatch is a disagreement about bytes, and whoever reads it decides whether
+// the generator or the entry is wrong. This one is the corpus failing to ask
+// the question, so nothing has been learned about either — and a run that
+// reported it as a disagreement would have a generator author reading a spec
+// section about a claim that was never tested (#68).
+type RunError struct {
+	// Entry is the entry's directory name.
+	Entry string
+
+	// Source is what the entry cites as the origin of its expected answer.
+	Source string
+
+	// Err is what stopped the run.
+	Err error
+}
+
+func (e *RunError) Error() string {
+	return fmt.Sprintf("conformance entry %s (%s) could not be run: %v", e.Entry, e.Source, e.Err)
+}
+
+func (e *RunError) Unwrap() error { return e.Err }
+
 // joined reports every fault at once, and nothing at all where there are none.
 //
 // It exists so that the readers above can accumulate into a slice and hand it

--- a/internal/conformance/errors_test.go
+++ b/internal/conformance/errors_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package conformance
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestAFailureNamesTheEntryAndItsSource asserts the two things every way a
+// corpus run can fail has to say (#68).
+//
+// Whoever reads a conformance failure has to decide whether the generator is
+// wrong or the entry is, and that decision starts at which entry disagreed and
+// at the section its expected answer was derived from. A report carrying only
+// the disagreement leaves them grepping a directory of thirty entries for a
+// field name.
+func TestAFailureNamesTheEntryAndItsSource(t *testing.T) {
+	const (
+		entry  = "packed-ascii"
+		source = `cobol-go codec/SPEC.md, "A.4 Packed decimal"`
+	)
+
+	tests := map[string]error{
+		"a disagreement about what the bytes hold": &MismatchError{
+			Entry:  entry,
+			Source: source,
+			Err:    fmt.Errorf("record 1 PACKED-RECORD.PACKED-POS is \"1234\" and the entry expects \"12345\""),
+		},
+		"a run that could not be made at all": &RunError{
+			Entry:  entry,
+			Source: source,
+			Err:    fmt.Errorf("the generated code did not compile"),
+		},
+	}
+
+	for name, err := range tests {
+		t.Run(name, func(t *testing.T) {
+			said := err.Error()
+
+			for _, says := range []string{entry, source} {
+				if !strings.Contains(said, says) {
+					t.Errorf("the report is %q, and it does not say %q", said, says)
+				}
+			}
+
+			if errors.Unwrap(err) == nil {
+				t.Error("the report carries nothing to unwrap, and what went wrong is behind it")
+			}
+		})
+	}
+}

--- a/internal/conformance/gorunner/doc.go
+++ b/internal/conformance/gorunner/doc.go
@@ -4,8 +4,9 @@
 // https://opensource.org/licenses/MIT
 
 // Package gorunner runs a conformance corpus entry through a Go generator: it
-// invokes the generator on the entry's descriptor, compiles what came out, and
-// reads the entry's bytes with it (#66).
+// invokes the generator on the entry's descriptor, compiles what came out,
+// reads the entry's bytes with it, and writes those records back out with it
+// (#66, #68).
 //
 // It is the Go half of the corpus and it is deliberately a package of its own.
 // [github.com/Zaba505/cpybkc/internal/conformance] is the corpus — the tuple, the
@@ -25,14 +26,27 @@
 //     cpybkc hands a plugin in a real run.
 //  2. Writes a driver beside the generated package: a main program that opens
 //     the entry's bytes with the generated reader, walks each record it produces
-//     against the descriptor, and writes the corpus's own values document on
-//     standard output.
+//     against the descriptor, lays those records back out with the generated
+//     writer, reads that file too, and writes the corpus's own answer document
+//     on standard output.
 //  3. Builds and runs that driver with the Go toolchain.
 //
-// The answer comes back as [github.com/Zaba505/cpybkc/internal/conformance.Values],
-// which is what the entry states too, so a caller compares them with
-// [github.com/Zaba505/cpybkc/internal/conformance.Compare] and needs nothing
-// from this package to interpret the result.
+// The answer comes back as
+// [github.com/Zaba505/cpybkc/internal/conformance.Answer], a values document per
+// direction, and each is what the entry states too — so a caller compares them
+// with [github.com/Zaba505/cpybkc/internal/conformance.CompareAnswer] and needs
+// nothing from this package to interpret the result.
+//
+// # Why the writing direction is a second read and not a byte comparison
+//
+// docs/ir/SPEC.md's "Writing a file" makes byte identity a claim about a record
+// and not about a file, and the corpus holds entries whose bytes a correct
+// writer would not reproduce anyway — the lenient sign nibble of packed-ascii is
+// one. [github.com/Zaba505/cpybkc/internal/conformance.Answer] carries the whole
+// argument; what it means here is that the driver reads the file it wrote rather
+// than comparing it, and that the records handed to the writer are the ones the
+// reader produced rather than records rebuilt from the values, so that the bytes
+// retained for a slack node travel with them.
 //
 // # Why the driver reads the descriptor rather than being written against it
 //

--- a/internal/conformance/gorunner/driver.go
+++ b/internal/conformance/gorunner/driver.go
@@ -29,7 +29,7 @@ const (
 )
 
 // writeDriver writes the program that reads the entry's bytes with the code the
-// generator produced.
+// generator produced, and writes those records back out with it.
 //
 // The source is formatted before it is written, which is not tidiness: the
 // driver is never read by a person unless a run failed, and go/format is what
@@ -94,6 +94,7 @@ var driverTemplate = template.Must(template.New("driver").Parse(`// Code generat
 package main
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -131,8 +132,9 @@ func main() {
 	}
 }
 
-// run reads the file and writes what it decoded to, in the corpus's own value
-// language.
+// run reads the file, lays the records it read back out with the generated
+// writer, reads that file too, and writes what both directions produced in the
+// corpus's own value language.
 func run(descriptorPath, inputPath string) error {
 	encoded, err := os.ReadFile(descriptorPath)
 	if err != nil {
@@ -149,24 +151,59 @@ func run(descriptorPath, inputPath string) error {
 		nodes[node.GetId()] = node
 	}
 
-	input, err := os.Open(inputPath)
+	input, err := os.ReadFile(inputPath)
 	if err != nil {
 		return err
 	}
 
-	defer input.Close()
-
-	reader, err := corpus.NewReader(input, corpus.Encoding())
+	decoded, held, err := read(nodes, input)
 	if err != nil {
 		return err
+	}
+
+	answer := conformance.Answer{Decoded: decoded}
+
+	// A read that stopped at a failure has no complete set of records to write
+	// back, and an entry that expects one is an entry about the reading
+	// direction. The writing direction is exercised on every other entry.
+	if decoded.Failure == "" {
+		written, err := writeBack(nodes, held)
+		if err != nil {
+			return err
+		}
+
+		answer.Written = written
+	}
+
+	out := json.NewEncoder(os.Stdout)
+	out.SetIndent("", "  ")
+
+	return out.Encode(answer)
+}
+
+// read reads one file with the generated reader: what it decoded, in the
+// corpus's value language, and the records themselves, which are what the
+// writing direction is handed.
+//
+// The records are handed on as the reader produced them, and not rebuilt out of
+// the values beside them. docs/ir/SPEC.md's "Slack survives a read" is why: the
+// bytes no item covers travel with the record and are not a value anybody
+// decoded, so a record built from a values document is a different record — one
+// whose slack a writer fills rather than reproduces.
+func read(nodes map[uint64]*irpb.Node, file []byte) (*conformance.Values, []corpus.Record, error) {
+	reader, err := corpus.NewReader(bytes.NewReader(file), corpus.Encoding())
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// Not nil: a file holding no record is a values document carrying an empty
 	// list, and a nil slice would render as one carrying nothing at all.
-	values := conformance.Values{Records: []conformance.Record{}}
+	values := &conformance.Values{Records: []conformance.Record{}}
+
+	var held []corpus.Record
 
 	for {
-		read, err := reader.Next()
+		one, err := reader.Next()
 		if errors.Is(err, io.EOF) {
 			break
 		}
@@ -180,35 +217,76 @@ func run(descriptorPath, inputPath string) error {
 			break
 		}
 
-		held := reflect.ValueOf(read)
-		if held.Kind() != reflect.Pointer || held.IsNil() {
-			return fmt.Errorf("the reader produced %T, which is not a pointer to a record", read)
+		value := reflect.ValueOf(one)
+		if value.Kind() != reflect.Pointer || value.IsNil() {
+			return nil, nil, fmt.Errorf("the reader produced %T, which is not a pointer to a record", one)
 		}
 
-		name := held.Type().Elem().Name()
+		name := value.Type().Elem().Name()
 
 		id, ok := records[name]
 		if !ok {
-			return fmt.Errorf("the reader produced a %s, which stands for no record of this descriptor", name)
+			return nil, nil, fmt.Errorf("the reader produced a %s, which stands for no record of this descriptor", name)
 		}
 
 		record := nodes[id].GetRecord()
 
-		value, err := item(nodes, nodes[record.GetRootId()], held.Elem())
+		decoded, err := item(nodes, nodes[record.GetRootId()], value.Elem())
 		if err != nil {
-			return fmt.Errorf("record %d (%s): %w", len(values.Records)+1, record.GetNames().GetOriginal(), err)
+			return nil, nil, fmt.Errorf("record %d (%s): %w", len(values.Records)+1, record.GetNames().GetOriginal(), err)
 		}
 
 		values.Records = append(values.Records, conformance.Record{
 			Name:  record.GetNames().GetOriginal(),
-			Value: value,
+			Value: decoded,
 		})
+
+		held = append(held, one)
 	}
 
-	out := json.NewEncoder(os.Stdout)
-	out.SetIndent("", "  ")
+	return values, held, nil
+}
 
-	return out.Encode(values)
+// writeBack lays the records out again with the generated writer and reads the
+// file that came out.
+//
+// What comes back is a values document like any other, which is what lets the
+// comparison hold both directions to the one set of values the entry states.
+// The file itself is not compared: docs/ir/SPEC.md's "Writing a file" makes
+// byte identity a claim about a record and not about a file, and
+// conformance.Answer says so at length.
+//
+// A writer that refuses a record is an answer rather than a failure of this
+// program, for the reason a reader that refuses a file is one: it is something
+// the generated code did, and only the comparison against the entry knows what
+// the entry expected of it.
+func writeBack(nodes map[uint64]*irpb.Node, held []corpus.Record) (*conformance.Values, error) {
+	var file bytes.Buffer
+
+	writer, err := corpus.NewWriter(&file, corpus.Encoding())
+	if err != nil {
+		return nil, err
+	}
+
+	for i, one := range held {
+		if err := writer.Write(one); err != nil {
+			return &conformance.Values{
+				Records: []conformance.Record{},
+				Failure: fmt.Sprintf("writing record %d: %v", i+1, err),
+			}, nil
+		}
+	}
+
+	if err := writer.Close(); err != nil {
+		return &conformance.Values{
+			Records: []conformance.Record{},
+			Failure: fmt.Sprintf("closing the file: %v", err),
+		}, nil
+	}
+
+	values, _, err := read(nodes, file.Bytes())
+
+	return values, err
 }
 
 // item is what one node of the descriptor holds in the value it was decoded

--- a/internal/conformance/gorunner/gorunner.go
+++ b/internal/conformance/gorunner/gorunner.go
@@ -82,21 +82,23 @@ type Runner struct {
 	Options []plugin.Option
 }
 
-// Run generates code for the entry, compiles it, and reads the entry's bytes
-// with it.
+// Run generates code for the entry, compiles it, reads the entry's bytes with
+// it, and writes the records it read back out with it.
 //
-// What comes back is what the generated code decoded, in the corpus's own value
-// language, which is what [github.com/Zaba505/cpybkc/internal/conformance.Compare]
-// holds against the entry. A file the generated reader refused is not an error
-// here: it is a [github.com/Zaba505/cpybkc/internal/conformance.Values] carrying
-// a failure, because an entry is allowed to expect one and only the comparison
-// knows whether this entry did.
+// What comes back is what the generated code made of the entry in both
+// directions, in the corpus's own value language, which is what
+// [github.com/Zaba505/cpybkc/internal/conformance.CompareAnswer] holds against
+// the entry. A file the generated reader refused is not an error here, and
+// neither is a record the generated writer refused: each is a
+// [github.com/Zaba505/cpybkc/internal/conformance.Values] carrying a failure,
+// because an entry is allowed to expect one and only the comparison knows
+// whether this entry did.
 //
 // An error is this harness failing rather than the generator disagreeing: the
 // generator exited non-zero, its output did not compile, or the driver could not
 // be run. Those are not conformance failures and are deliberately not reported
 // as one.
-func (r *Runner) Run(ctx context.Context, entry *conformance.Entry) (*conformance.Values, error) {
+func (r *Runner) Run(ctx context.Context, entry *conformance.Entry) (*conformance.Answer, error) {
 	if err := r.check(entry); err != nil {
 		return nil, err
 	}
@@ -196,12 +198,12 @@ func (r *Runner) generate(ctx context.Context, entry *conformance.Entry, out str
 	return nil
 }
 
-// drive builds and runs the driver, and reads the values document it wrote.
+// drive builds and runs the driver, and reads the answer it wrote.
 //
 // The go tool is run from the repository root so that it resolves the module
 // there: the generated package imports what this module already requires, which
 // is what lets a run need no network and no module of its own.
-func (r *Runner) drive(ctx context.Context, scratch, descriptor, input string) (*conformance.Values, error) {
+func (r *Runner) drive(ctx context.Context, scratch, descriptor, input string) (*conformance.Answer, error) {
 	rel, err := filepath.Rel(r.Root, filepath.Join(scratch, driverDir))
 	if err != nil {
 		return nil, fmt.Errorf("failed to name the driver to the go tool: %w", err)
@@ -218,12 +220,12 @@ func (r *Runner) drive(ctx context.Context, scratch, descriptor, input string) (
 		return nil, fmt.Errorf("the generated code did not compile or did not run: %w\n%s", err, errs.String())
 	}
 
-	values, err := conformance.ParseValues(out.Bytes())
+	answer, err := conformance.ParseAnswer(out.Bytes())
 	if err != nil {
-		return nil, fmt.Errorf("the driver wrote a values document this harness cannot read: %w", err)
+		return nil, fmt.Errorf("the driver wrote an answer this harness cannot read: %w", err)
 	}
 
-	return values, nil
+	return answer, nil
 }
 
 // recordTypes pairs each record node of the descriptor with the Go type the

--- a/internal/conformance/gorunner/gorunner_test.go
+++ b/internal/conformance/gorunner/gorunner_test.go
@@ -16,19 +16,27 @@ import (
 	"github.com/Zaba505/cpybkc/internal/conformance/gorunner"
 )
 
-// TestTheGeneratedCodeDecodesEveryEntry is the corpus, run against this
-// repository's own generator.
+// TestTheGeneratedCodeReadsAndWritesEveryEntry is the corpus, run against this
+// repository's own generator, in both directions.
 //
 // It is the whole of what a conformance run is: the entry's descriptor goes to
 // cpybkc-gen-go, what came back is compiled, the entry's bytes are read with it,
-// and the values that came out are held against the values the entry states.
-// Nothing here knows what the records are — the entry says, and a generator in
-// another language is checked by the same two calls (#66).
+// those records are written back out with it, and both answers are held against
+// the values the entry states. Nothing here knows what the records are — the
+// entry says, and a generator in another language is checked by the same two
+// calls (#66, #68).
 //
-// A failure names the entry and the section the entry cites, because whoever
-// reads it has to decide whether the generator is wrong or the entry is, and
-// that decision starts at where the expected answer came from.
-func TestTheGeneratedCodeDecodesEveryEntry(t *testing.T) {
+// It is an ordinary Go test and not a stage of its own, which is what makes it
+// a gate on every platform CI runs on: `dagger call ci` runs `go test ./...`
+// over this module, so the corpus is inside the one call CI makes rather than
+// beside it. A conformance job of its own would be a second gate, and a
+// platform added to the matrix would carry the first and not the second.
+//
+// Every failure names the entry and the section the entry cites, whether it is
+// a disagreement or a run that could not be made at all, because whoever reads
+// it has to decide whether the generator is wrong or the entry is, and that
+// decision starts at where the expected answer came from.
+func TestTheGeneratedCodeReadsAndWritesEveryEntry(t *testing.T) {
 	root := repoRoot(t)
 
 	entries, err := conformance.Load(conformance.CorpusPath(root))
@@ -46,10 +54,10 @@ func TestTheGeneratedCodeDecodesEveryEntry(t *testing.T) {
 		t.Run(entry.Name, func(t *testing.T) {
 			got, err := runner.Run(t.Context(), entry)
 			if err != nil {
-				t.Fatalf("%v", err)
+				t.Fatalf("%v", &conformance.RunError{Entry: entry.Name, Source: entry.Source, Err: err})
 			}
 
-			if err := conformance.Compare(entry.Values, got); err != nil {
+			if err := conformance.CompareAnswer(entry.Values, got); err != nil {
 				t.Fatalf("%v", &conformance.MismatchError{Entry: entry.Name, Source: entry.Source, Err: err})
 			}
 		})
@@ -97,7 +105,7 @@ func TestAnEntryTheGeneratedCodeDisagreesWith(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	if err := conformance.Compare(entry.Values, got); err == nil {
+	if err := conformance.CompareAnswer(entry.Values, got); err == nil {
 		t.Fatal("the comparison passed against values the file does not hold")
 	}
 }

--- a/internal/conformance/values.go
+++ b/internal/conformance/values.go
@@ -64,9 +64,23 @@ func ParseValues(b []byte) (*Values, error) {
 		return nil, err
 	}
 
+	if faults := values.records(); len(faults) > 0 {
+		return nil, joined(faults)
+	}
+
+	return &values, nil
+}
+
+// records is what is wrong with the records of a values document, which is
+// everything the format asks of one beyond it being JSON.
+//
+// It is separate from [ParseValues] because a values document is read in two
+// places: on its own, as an entry's values.json, and as a member of the answer
+// document a runner writes (see [Answer]). Both hold it to this.
+func (v *Values) records() []error {
 	var faults []error
 
-	for i, record := range values.Records {
+	for i, record := range v.Records {
 		if record.Name == "" {
 			faults = append(faults, fmt.Errorf("record %d carries no name", i))
 		}
@@ -76,11 +90,7 @@ func ParseValues(b []byte) (*Values, error) {
 		}
 	}
 
-	if len(faults) > 0 {
-		return nil, joined(faults)
-	}
-
-	return &values, nil
+	return faults
 }
 
 // decodeOne reads exactly one JSON document out of b, and is how every JSON

--- a/internal/conformance/values.go
+++ b/internal/conformance/values.go
@@ -80,13 +80,17 @@ func ParseValues(b []byte) (*Values, error) {
 func (v *Values) records() []error {
 	var faults []error
 
+	// Counted from one, as [Compare] counts and as the driver counts: a record
+	// is named to whoever is reading a values document beside the file it came
+	// from, and two numbering conventions in one report is one of them being
+	// off by one.
 	for i, record := range v.Records {
 		if record.Name == "" {
-			faults = append(faults, fmt.Errorf("record %d carries no name", i))
+			faults = append(faults, fmt.Errorf("record %d carries no name", i+1))
 		}
 
 		if record.Value == nil {
-			faults = append(faults, fmt.Errorf("record %d (%s) carries no value", i, record.Name))
+			faults = append(faults, fmt.Errorf("record %d (%s) carries no value", i+1, record.Name))
 		}
 	}
 

--- a/testdata/conformance/README.md
+++ b/testdata/conformance/README.md
@@ -53,8 +53,10 @@ different readers:
   recording of what `resolve` happens to do today, and the pipeline that will
   check it against a real resolution is the CLI's (#148).
 - **`ir.json`, handed to a generator, produces code that decodes `input.bin`
-  into `values.json`.** That is a claim about a consumer, and it is what a
-  generator author in any language can run today.
+  into `values.json` — and writes those records back into a file that decodes
+  to `values.json` again.** That is a claim about a consumer, in both
+  directions, and it is what a generator author in any language can run today
+  (#68).
 
 Carrying both is what lets a failure be attributed. A generator author who
 disagrees with cpybkc about what a *layout* means and one who disagrees about
@@ -161,19 +163,74 @@ Given an entry it:
    the generator under test, with whatever options that generator needs;
 2. compiles what came back;
 3. reads `input.bin` with it, top to bottom;
-4. writes a values document, in exactly the form `values.json` is written in, on
-   standard output.
+4. where that read reached the end of the file, writes those records back out
+   with the generated writer and reads *that* file with the generated reader;
+5. writes an answer document on standard output, carrying a values document for
+   each direction.
 
-The comparison is then a comparison of two values documents and needs neither the
+The comparison is then a comparison of values documents and needs neither the
 descriptor nor a decoder, which is what makes a runner for a language this
 repository has never seen comparable by the same rules.
 
 Two things a runner is not asked for. It is not asked to explain a difference —
 that is the comparison's — and it does not exit non-zero for a file the generated
-reader refused: that is an answer, written as `failure`, because an entry is
-allowed to expect one and only the comparison knows whether this entry did. A
-non-zero exit means the runner itself failed: the generator would not run, its
-output would not compile, or the runner could not write a document.
+reader refused, or for a record the generated writer refused: those are answers,
+written as `failure`, because an entry is allowed to expect one and only the
+comparison knows whether this entry did. A non-zero exit means the runner itself
+failed: the generator would not run, its output would not compile, or the runner
+could not write a document.
+
+### The answer document
+
+```json
+{
+  "decoded": {
+    "records": [ ... ]
+  },
+  "written": {
+    "records": [ ... ]
+  }
+}
+```
+
+`decoded` is what the generated reader made of `input.bin`. `written` is what the
+generated reader makes of the file the generated *writer* produced from those
+records. Both are values documents, in exactly the form `values.json` is written
+in, and both are compared against `values.json` — against the entry rather than
+against each other, because a reader and a writer that are wrong the same way
+agree with each other and only the entry knows what the file holds.
+
+`written` is absent in two cases: where the read did not reach the end of the
+file, since a run that stopped at a failure holds no complete set of records to
+write back; and where the generator emits no writer at all, which
+[`docs/ir/SPEC.md`](../../docs/ir/SPEC.md)'s *Writing a file* leaves to the
+generator. It is present and carries a `failure` where the writer refused a
+record it was given.
+
+### Why the writing direction is checked by reading, and not by comparing bytes
+
+The obvious check is that the bytes the writer produced are `input.bin` again,
+and it is the wrong check twice over.
+
+*Writing a file* makes byte identity a claim about a **record** and deliberately
+not about a file: under an optional terminator a writer emits a final delimiter
+the input need not have carried, and under segmented framing it lays a record
+into as few segments as the largest allows, whatever the input did. A corpus
+demanding the input's bytes back would fail two of the four framings by design.
+
+It is wrong at the field level too, and this corpus already holds the case:
+[`packed-ascii`](packed-ascii) carries the lenient sign nibble `A`, which a
+reader admits as positive and a writer has no reason to emit — it writes the `C`
+the convention prescribes. The same goes for every encoding that admits more than
+one spelling of one value. Demanding the bytes back would make those entries
+unpassable by a correct generator, and dropping them would cost the corpus
+exactly the vectors it was seeded from.
+
+What *Writing a file* does make normative of a file is that a file a writer
+produces is one that a reader built from the same descriptor reads back as the
+records the writer was given. That holds for all four framings and every
+encoding, it is what `written` states, and it needs nothing of a runner that the
+reading direction did not already need.
 
 ## What this repository runs
 
@@ -191,9 +248,25 @@ how `cpybkc-gen-go` munges an identifier out of one. A copy would agree with the
 generator exactly until the rule changed, and then compare the wrong fields
 without failing.
 
+It hands the records the reader produced straight to the writer rather than
+rebuilding them from the values beside them, because a record built from a values
+document is a different record: *Slack survives a read* puts the bytes no item
+covers on the record a reader produced, and a constructed one has a writer fill
+them instead.
+
 `go test ./internal/conformance/...` runs the corpus against `cpybkc-gen-go`
-built from the tree under test. Making that a gate across the whole CI matrix,
-and exercising the encode direction as well as decode, is #68.
+built from the tree under test, in both directions and over every entry (#68).
+
+It is an ordinary Go test rather than a stage of its own, and that is what makes
+it a gate on every platform CI runs on. `dagger call ci` runs `go test` over this
+module, so the corpus is inside the one call CI makes rather than beside it: a
+platform added to the matrix carries the corpus with it, and a conformance job of
+its own would be a second gate that the new platform would silently not have. The
+matrix is one platform today, and
+[#56](https://github.com/Zaba505/cpybkc/issues/56) is why it holds no big-endian
+host — cpybkc runs on a developer's machine, and a big-endian *file* is a
+property of the data, which is what the byte-order entries here read on whatever
+platform they are run.
 
 ## Adding an entry
 


### PR DESCRIPTION
Closes #68

The corpus has run against `cpybkc-gen-go` in CI since #66 landed — it is an
ordinary Go test, so `go test` inside `dagger call ci` runs it. What it only ever
checked was reading. This adds the other direction and makes every failure
readable.

## Acceptance criteria

- [x] **CI generates Go for every corpus entry, compiles it, and runs it against
  the expected values.** `TestTheGeneratedCodeReadsAndWritesEveryEntry` loads
  every entry of `testdata/conformance/`, hands each descriptor to
  `cpybkc-gen-go` built from the tree under test, compiles the output, and holds
  what came out against the entry's `values.json`. `dagger call ci` runs it with
  every other test.
- [x] **Both decode and encode directions exercised.** A runner now reads
  `input.bin`, lays those records back out with the generated *writer*, reads
  that file with the generated reader, and reports both as an answer document —
  `{"decoded": …, "written": …}`. Both are compared against the entry's values.
- [x] **Failures name the corpus entry and the spec section it came from.**
  `MismatchError` already did for a disagreement; `RunError` is new and does it
  for an entry that could not be run at all — the generator would not run, or its
  output would not compile. `errors_test.go` asserts both.
- [x] **Runs on every platform in the CI matrix.** By staying an ordinary test
  rather than becoming a stage of its own: the matrix is a matrix of `dagger call
  ci`, so a platform added to it carries the corpus with it, while a conformance
  job beside it would be a second gate the new platform would silently not have.
  The comment in `.github/workflows/ci.yaml` that predicted a dedicated module
  function is updated to say why one is not wanted. The matrix holds one platform
  today, and #56 is why it holds no big-endian host — a big-endian *file* is a
  property of the data, and those entries decode on whatever platform runs them.

## The judgment call: the writing direction is checked by reading

The obvious check is that the writer's bytes are `input.bin` again. It is the
wrong check twice over, and both reasons are written down in
`conformance.Answer`'s doc comment and in the corpus README:

- `docs/ir/SPEC.md`, *Writing a file*, makes byte identity a claim about a
  **record** and deliberately not about a file — under an optional terminator a
  writer emits a final delimiter the input need not have carried, and under
  segmented framing it re-segments freely. Demanding the bytes back would fail
  two of the four framings by design.
- The corpus already holds a vector a correct writer would not reproduce:
  `packed-ascii` carries the lenient sign nibble `A`, which a reader admits as
  positive and a writer has no reason to emit over the prescribed `C`.

What that section *does* make normative of a file — a file a writer produces is
one a reader built from the same descriptor reads back as the records it was
given — holds for all four framings and every encoding, and is what `written`
states.

Two smaller calls, both in the code's comments: the records handed to the writer
are the ones the reader produced rather than records rebuilt from the values, so
that the bytes retained for a slack node travel with them (*Slack survives a
read*); and `written` is absent where the read stopped at a failure, since such a
run holds no complete set of records to write back.

## Public surface

All inside `internal/`, plus the corpus format that third-party runners read:
`conformance.Answer`, `ParseAnswer` and `CompareAnswer` are new,
`gorunner.Runner.Run` now returns an `*Answer` instead of a `*Values`, and the
runner's stdout contract in `testdata/conformance/README.md` gains the answer
document. `Values` and `Compare` are unchanged.

## Verified

- `dagger call ci` — green.
- `go test ./internal/conformance/... -count=1` — 28 entries, both directions.
- The encode half was checked to be load-bearing rather than vacuous: dropping
  one record inside the driver's write-back made `orders-fixed` fail with
  `reading back the file written from those records: the file holds 1 records and
  the entry expects 2`, naming the entry and its cited section. Reverted before
  commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)