### PR TITLE
story(cli): scaffold cmd/cpybkc with version and help

### DIFF
--- a/.dagger/dagger.gen.go
+++ b/.dagger/dagger.gen.go
@@ -202,6 +202,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 	switch parentName {
 	case "Cpybkc":
 		switch fnName {
+		case "Binary":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Cpybkc).Binary(&parent), nil
+		case "Build":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Cpybkc).Build(&parent, ctx)
 		case "Ci":
 			var parent Cpybkc
 			err = json.Unmarshal(parentJSON, &parent)

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -63,6 +63,21 @@
 // produces irpb/ir.pb.go, kept here because a generation recipe living anywhere
 // else is a second answer to how the committed stubs were made.
 //
+// # Why the CLI is built here as well as compiled
+//
+// The four check stages already compile cmd/cpybkc, because they run over
+// ./... . Build is here for the two things they say nothing about: that the
+// binary links CGO-free and that it is a single static file. Both are promises
+// docs/container/SPEC.md rests the published image on — the image carries the
+// executable and nothing a program needs to start — and neither is visible to
+// `go vet` or to a test, because the toolchain container has the loader and the
+// libc that the image will not.
+//
+// So Build compiles it with CGO off and runs it in an empty image, which is the
+// smallest thing that can tell a static binary from a dynamic one without
+// reading its headers. It lands with the CLI (#147) rather than with the image
+// (#55) because it is a claim about the binary, and the binary exists first.
+//
 // # Why the release artifacts are built here
 //
 // IrDescriptorSet and IrProtos produce two of the three files a release
@@ -98,6 +113,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"sync"
 
 	"dagger/cpybkc/internal/dagger"
@@ -108,6 +124,21 @@ import (
 // image cannot change what this repository lints against without the change
 // appearing in a diff — the same promise dagger.json's dependency pins make.
 const bufImage = "bufbuild/buf:1.72.0@sha256:65bd496a89c762ad7151ca9e7d885a45dacb3671a8e8ec39738b9f844d3405ea"
+
+const (
+	// cliPackage is the main package Binary builds, and cliBinary is what the
+	// build is asked to call it. The name is the command's own — it is what a
+	// person types, what docs/cli/SPEC.md's synopsis writes and what the
+	// published image's entrypoint is — so it is stated rather than left to
+	// `go build`'s naming.
+	cliPackage = "./cmd/cpybkc"
+	cliBinary  = "cpybkc"
+
+	// cliBinaryPath is where Build puts it in the empty image it runs it in.
+	// The image has no PATH to find it on, which is the point of running it
+	// there at all.
+	cliBinaryPath = "/cpybkc"
+)
 
 // Cpybkc is the root module type. Source and the lint configuration are bound
 // once at construction so every function below checks the same tree the same
@@ -156,13 +187,13 @@ func New(
 
 // Ci runs the whole pipeline: fmt, vet, golangci-lint and `go test -race`, as
 // the Z5Labs standard defines them, over each of this repository's two Go
-// modules, plus `buf lint` over the IR schema, a build of the three artifacts a
-// release publishes, and the worked example docs/container/SPEC.md hands an
-// adopter. This is the single entrypoint — CI is one `dagger call ci` and stays
-// one, because a workflow step that reran any of these stages would be a second
-// definition of them.
+// modules, plus `buf lint` over the IR schema, a build of the CLI itself, a
+// build of the three artifacts a release publishes, and the worked example
+// docs/container/SPEC.md hands an adopter. This is the single entrypoint — CI
+// is one `dagger call ci` and stays one, because a workflow step that reran any
+// of these stages would be a second definition of them.
 //
-// The six parts run concurrently and all are reported, for the reason the
+// The seven parts run concurrently and all are reported, for the reason the
 // standard runs its own four that way: waiting on a Go stage to learn that the
 // schema is unlintable, or the reverse, is a second push to find out about the
 // second failure.
@@ -170,10 +201,10 @@ func New(
 // +check
 // +cache="session"
 func (m *Cpybkc) Ci(ctx context.Context) error {
-	var goErr, irErr, protoErr, artifactErr, layoutErr, exampleErr error
+	var goErr, irErr, protoErr, buildErr, artifactErr, layoutErr, exampleErr error
 
 	var wg sync.WaitGroup
-	wg.Add(6)
+	wg.Add(7)
 
 	go func() {
 		defer wg.Done()
@@ -194,6 +225,11 @@ func (m *Cpybkc) Ci(ctx context.Context) error {
 
 	go func() {
 		defer wg.Done()
+		buildErr = m.Build(ctx)
+	}()
+
+	go func() {
+		defer wg.Done()
 		artifactErr = m.IrArtifacts(ctx)
 	}()
 
@@ -209,7 +245,7 @@ func (m *Cpybkc) Ci(ctx context.Context) error {
 
 	wg.Wait()
 
-	return errors.Join(goErr, irErr, protoErr, artifactErr, layoutErr, exampleErr)
+	return errors.Join(goErr, irErr, protoErr, buildErr, artifactErr, layoutErr, exampleErr)
 }
 
 // IrCi runs the same standard pipeline over irpb/, the published IR module.
@@ -433,6 +469,74 @@ func (m *Cpybkc) IrArtifacts(ctx context.Context) error {
 	}
 
 	return errors.Join(errs...)
+}
+
+// Binary builds the cpybkc executable itself — the one thing this repository
+// exists to ship — CGO-free, so that it is a single statically linked file:
+//
+//	dagger call binary export --path=cpybkc
+//
+// CGO_ENABLED=0 is not an optimisation. docs/container/SPEC.md's image carries
+// this binary and nothing else a program needs to start — no loader, no libc,
+// no shell — so a dynamically linked cpybkc is one that cannot run in the image
+// this project publishes (#55). -trimpath goes with it because the same
+// document's reproducibility is a claim about the bytes, and a binary carrying
+// the path it was compiled under is a build that depends on where it ran.
+//
+// It is a function on this module rather than steps in a workflow for the
+// reason IrDescriptorSet is: a recipe that only ever ran inside a workflow
+// would be a build nobody can reproduce locally.
+func (m *Cpybkc) Binary() *dagger.File {
+	return dag.Go().
+		Build(m.Source, dagger.GoBuildOpts{
+			Pkg:          cliPackage,
+			ArtifactName: cliBinary,
+			Trimpath:     true,
+			DisableCgo:   true,
+		}).
+		File(cliBinary)
+}
+
+// Build builds the CLI and runs it in an empty image.
+//
+// The Go stages already compile cmd/cpybkc — vet, lint and test all reach it
+// through ./... — so what this adds is the two claims they cannot make. That
+// the binary is CGO-free and statically linked, and that a single file is all
+// of it: an image holding nothing but the executable has no loader to resolve
+// an interpreter with and no libc to load, so a dynamically linked binary does
+// not start, and the failure is the check rather than an image somebody
+// publishes.
+//
+// --version is what it is run with because it is the one invocation
+// docs/cli/SPEC.md requires to succeed without touching anything: it contacts
+// nothing, reads no manifest, writes one line to standard output and exits 0.
+// A binary that gets that far has linked, started and run its own main.
+//
+// One platform — the engine's own. Which platforms the published image carries
+// is docs/container/SPEC.md's, and #55 is where that build is checked on each
+// of them.
+//
+// +check
+// +cache="session"
+func (m *Cpybkc) Build(ctx context.Context) error {
+	line, err := dag.Container().
+		WithFile(cliBinaryPath, m.Binary(), dagger.ContainerWithFileOpts{Permissions: 0o755}).
+		WithExec([]string{cliBinaryPath, "--version"}).
+		Stdout(ctx)
+	if err != nil {
+		return fmt.Errorf("cpybkc does not run in an image holding nothing but itself, which is the image it "+
+			"ships in: %w", err)
+	}
+
+	// Only that it is the version line's shape. What the line says is
+	// cmd/cpybkc's own test's business, and asserting the version here would
+	// pin a release number in the pipeline.
+	if !strings.HasPrefix(line, cliBinary+" ") || !strings.Contains(line, "IR version") {
+		return fmt.Errorf("cpybkc --version wrote %q, and the line names the program, its version and the IR "+
+			"version this build produces", line)
+	}
+
+	return nil
 }
 
 // LayoutSchema builds the published layout schema — the released

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,8 @@ dagger call ci
 
 That is the same call CI makes, with no arguments on either side. It runs the
 four Go stages in parallel and reports every failure, not just the first, and it
-runs the schema lint, the IR module's own stages, a build of the [release
+runs the schema lint, the IR module's own stages, a build of [the CLI
+itself](#building-the-cli), a build of the [release
 artifacts](#the-release-artifacts) and a build of the [base-image
 contract](docs/container/SPEC.md)'s worked example alongside them.
 
@@ -32,6 +33,7 @@ dagger call lint          # golangci-lint over ./... against .golangci.yml
 dagger call test          # go test -race ./...
 dagger call proto-lint    # buf lint over proto/ against buf.yaml
 dagger call ir-ci         # the whole standard again, over the irpb/ module
+dagger call build         # builds cpybkc CGO-free and runs it in an empty image
 dagger call ir-artifacts  # builds the two IR artifacts a release attaches
 dagger call layout-artifact  # builds the layout schema a release attaches
 dagger call worked-example   # builds docs/container/SPEC.md's worked example
@@ -45,9 +47,9 @@ standard has no protobuf stage to wrap; see [Linting the IR
 schema](#linting-the-ir-schema).
 
 `ir-ci` is not a stage but the whole standard a second time, over the second Go
-module; see [The IR module](#the-ir-module) for why there is one. `ir-artifacts`
-and `layout-artifact` are not stages either; see [The release
-artifacts](#the-release-artifacts).
+module; see [The IR module](#the-ir-module) for why there is one. `build`,
+`ir-artifacts` and `layout-artifact` are not stages either; see [Building the
+CLI](#building-the-cli) and [The release artifacts](#the-release-artifacts).
 
 `worked-example` is the odd one out: it builds a document. The multi-stage
 Dockerfile in [the base-image contract](docs/container/SPEC.md#worked-example-adding-a-generator)
@@ -55,8 +57,29 @@ is the first thing an adopter runs and the last thing anybody here would notice
 had broken, since no other stage reads it, so `ci` extracts it from that file and
 builds it. Edit that example and this is the stage that will tell you about it.
 
-`dagger check` runs all ten as a checklist, if you would rather see them
+`dagger check` runs all eleven as a checklist, if you would rather see them
 together than pick one.
+
+### Building the CLI
+
+```sh
+dagger call binary export --path=cpybkc   # the executable itself
+dagger call build                         # the check `ci` runs over it
+```
+
+The four Go stages already compile `cmd/cpybkc`, since they run over `./...`, so
+`build` is not there to find a compile error. It is there for the two things they
+say nothing about: that the binary links with `CGO_ENABLED=0` and that it is a
+single static file. Both are what [the base-image
+contract](docs/container/SPEC.md) rests the published image on — that image
+carries the executable and nothing a program needs to start — and neither is
+visible to `go vet` or to a test, because the toolchain container has the loader
+and the libc the image will not.
+
+So `build` compiles it CGO-free and runs `cpybkc --version` in an *empty* image.
+Nothing else is in there: a binary needing an interpreter or a libc does not
+start at all, and that failure is this check rather than an image somebody
+publishes.
 
 ### Getting the tools
 

--- a/cmd/cpybkc/args.go
+++ b/cmd/cpybkc/args.go
@@ -1,0 +1,335 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// The whole argument vector docs/cli/SPEC.md fixes, and nothing else:
+//
+//	cpybkc [--manifest <path>] [--emit-ir <dest> [--emit-ir-format <format>]]
+//	cpybkc --version
+//	cpybkc --help
+//
+// A flag this list does not carry is a usage error naming it. There is no
+// --out, no --include, no --jobs, no --verbose and no --config; that document's
+// "Out of Scope" refuses each one with its reason, and the refusal is only real
+// if the parser has no case for it.
+const (
+	manifestFlag     = "--manifest"
+	emitIRFlag       = "--emit-ir"
+	emitIRFormatFlag = "--emit-ir-format"
+	versionFlag      = "--version"
+	helpFlag         = "--help"
+
+	// shortHelpFlag is the one single-hyphen spelling docs/cli/SPEC.md states.
+	// A single leading hyphen MAY be accepted as a synonym for the others and
+	// MUST NOT be documented; none is, because a spelling nothing documents is
+	// one nobody can be told about and one this parser would have to keep
+	// forever. -h is here because it is the one every user already has in their
+	// fingers.
+	shortHelpFlag = "-h"
+
+	// endOfOptions is POSIX's delimiter. cpybkc defines no operand, so it can
+	// only ever be followed by arguments that are usage errors; it is honoured
+	// anyway, as the end of options, so that this program behaves the way its
+	// neighbours on the system do.
+	endOfOptions = "--"
+)
+
+// The encodings --emit-ir-format selects between.
+//
+// binaryFormat is the default because it is the form the rest of the system
+// uses — the canonical protobuf wire encoding a plugin is handed — and the
+// debug form is the one you ask for by name.
+const (
+	binaryFormat = "binary"
+	jsonFormat   = "json"
+)
+
+// defaultManifest is the manifest a run reads when the line names none: the one
+// in the working directory, and nowhere else. docs/cli/SPEC.md forbids an
+// upward search, so this is a file name rather than the start of one.
+const defaultManifest = "cpybkc.json"
+
+// standardOutput is what `--emit-ir -` names, and it is deliberately the
+// plugin contract's reading of a dash, so that the character means one thing
+// across this project.
+const standardOutput = "-"
+
+// answer is what a command line asks cpybkc for.
+//
+// It is a member of the invocation rather than a pair of booleans because the
+// three are exclusive by docs/cli/SPEC.md's own rule — --help beats --version
+// and both beat everything else — and a pair of booleans is a shape in which
+// "both were asked for" is representable and has to be resolved again at every
+// use site.
+type answer int
+
+const (
+	// answerRun is a line that asked for a run: the default, and the only
+	// answer that reads a manifest.
+	answerRun answer = iota
+
+	// answerHelp is --help or -h, anywhere on the line.
+	answerHelp
+
+	// answerVersion is --version, with no --help anywhere on the line.
+	answerVersion
+)
+
+// invocation is one command line, resolved.
+type invocation struct {
+	// answer is what the line asked for.
+	answer answer
+
+	// manifest is the path --manifest named, empty where it named none.
+	// [invocation.manifestPath] is what a run reads.
+	manifest string
+
+	// emitIR is the destination --emit-ir named — a path, or
+	// [standardOutput] — and is empty where the line asked for no emission.
+	emitIR string
+
+	// emitIRFormat is the encoding the emission is written in, and is
+	// [binaryFormat] where an emission was asked for and no format was.
+	emitIRFormat string
+}
+
+// manifestPath is the manifest this run reads: the one --manifest named, or
+// [defaultManifest] in the working directory.
+//
+// A method rather than a default filled in during the parse, so that "the line
+// named no manifest" survives parsing. #148 resolves this path and reports what
+// it could not open, and a diagnostic has to be able to say whether the path it
+// names was typed or defaulted.
+func (inv invocation) manifestPath() string {
+	if inv.manifest == "" {
+		return defaultManifest
+	}
+
+	return inv.manifest
+}
+
+// emitting reports whether this run writes a descriptor instead of generating.
+func (inv invocation) emitting() bool { return inv.emitIR != "" }
+
+// parse reads the argument vector.
+//
+// Every fault it reports is a usage error, which is the whole of status 2: the
+// vector could not be understood, and cpybkc did nothing at all — no file was
+// opened, no generator was started, and the project's tree was not touched.
+// Nothing here opens anything, and that is what makes the promise true rather
+// than intended.
+func parse(args []string) (invocation, error) {
+	// docs/cli/SPEC.md: --help and --version are answered before anything
+	// else, and every other flag on the line is ignored, including one that
+	// would otherwise be a usage error. So the question is asked before the
+	// vector is read rather than during it — a person asking a program what it
+	// is has usually typed the rest of the line already, and answering with a
+	// complaint about a flag they were in the middle of getting wrong teaches
+	// them nothing they asked to learn.
+	if asked, ok := answerAsked(args); ok {
+		return invocation{answer: asked}, nil
+	}
+
+	var (
+		inv  invocation
+		seen = map[string]bool{}
+	)
+
+	for at := 0; at < len(args); at++ {
+		argument := args[at]
+
+		if argument == endOfOptions {
+			// Everything after it is an operand by definition, and cpybkc
+			// takes none. The delimiter itself is honoured; what follows it
+			// cannot be.
+			if operands := args[at+1:]; len(operands) > 0 {
+				return invocation{}, operandError(operands[0])
+			}
+
+			break
+		}
+
+		if !isFlag(argument) {
+			return invocation{}, operandError(argument)
+		}
+
+		// The joined form, --manifest=cpybkc.json. Only the first = separates a
+		// flag from its value, so a value may itself contain one.
+		name, value, joined := strings.Cut(argument, "=")
+
+		if !takesAValue(name) {
+			// A value-less flag written with one is a vector this parser
+			// refuses rather than one it strips a value off: --version=2 asks
+			// for something --version does not do.
+			if joined && (name == versionFlag || name == helpFlag || name == shortHelpFlag) {
+				return invocation{}, usagef("%s takes no value, and %q gives it one", name, argument)
+			}
+
+			return invocation{}, unrecognisedError(name)
+		}
+
+		if !joined {
+			at++
+			if at >= len(args) {
+				return invocation{}, usagef("%s takes a value and was passed as the last argument", name)
+			}
+
+			value = args[at]
+		}
+
+		// docs/cli/SPEC.md: a flag given twice is a usage error, even where
+		// both occurrences carry the same value. Taking the last is the rule
+		// most parsers default to, and it makes a line that names one file
+		// twice a line that reads the file it also names as something else.
+		if seen[name] {
+			return invocation{}, usagef("%s appears more than once, and each flag appears at most once", name)
+		}
+
+		seen[name] = true
+
+		switch name {
+		case manifestFlag:
+			if err := setManifest(&inv, value); err != nil {
+				return invocation{}, err
+			}
+		case emitIRFlag:
+			if value == "" {
+				return invocation{}, usagef("%s names nowhere to write the descriptor", emitIRFlag)
+			}
+
+			inv.emitIR = value
+		case emitIRFormatFlag:
+			if value != binaryFormat && value != jsonFormat {
+				return invocation{}, usagef("%s is %s or %s, and %q is neither",
+					emitIRFormatFlag, binaryFormat, jsonFormat, value)
+			}
+
+			inv.emitIRFormat = value
+		}
+	}
+
+	// docs/cli/SPEC.md: --emit-ir-format given without --emit-ir is a usage
+	// error. It selects the encoding of an emission that is not happening, and
+	// a flag on a command line that reads as configuration and does nothing is
+	// the same fault an unknown field in a manifest is.
+	if seen[emitIRFormatFlag] && !inv.emitting() {
+		return invocation{}, usagef("%s selects the encoding %s writes, and this line asks for no emission",
+			emitIRFormatFlag, emitIRFlag)
+	}
+
+	if inv.emitting() && inv.emitIRFormat == "" {
+		inv.emitIRFormat = binaryFormat
+	}
+
+	return inv, nil
+}
+
+// setManifest applies --manifest.
+//
+// The dash is refused here rather than left to the open: every path inside a
+// manifest is relative to the manifest's own directory, and a manifest arriving
+// on a stream has no directory for them to be relative to. Refusing it is a
+// statement about the vector, decided with nothing opened, which is why it
+// carries status 2 and not the status a manifest that cannot be read carries.
+func setManifest(inv *invocation, value string) error {
+	switch value {
+	case "":
+		return usagef("%s names no manifest to read", manifestFlag)
+	case standardOutput:
+		return usagef("%s cannot be %q: a manifest's paths are relative to the directory holding it, "+
+			"and a manifest on a stream is in no directory", manifestFlag, standardOutput)
+	}
+
+	inv.manifest = value
+
+	return nil
+}
+
+// takesAValue reports whether a flag is one of the three that carry one.
+func takesAValue(name string) bool {
+	switch name {
+	case manifestFlag, emitIRFlag, emitIRFormatFlag:
+		return true
+	default:
+		return false
+	}
+}
+
+// answerAsked reports whether the line asks what cpybkc is rather than for a
+// run, and which of the two questions it asks.
+//
+// Only a whole argument counts, so `--manifest=--help` is a manifest named
+// --help and not a request for usage; and the scan stops at [endOfOptions],
+// because an argument after it is an operand rather than a flag, and cpybkc's
+// answer to an operand is that it takes none.
+//
+// --help beats --version wherever the two appear, which is the precedence
+// docs/cli/SPEC.md states rather than one this function chooses.
+func answerAsked(args []string) (answer, bool) {
+	asked, found := answerRun, false
+
+	for _, argument := range args {
+		switch argument {
+		case endOfOptions:
+			return asked, found
+		case helpFlag, shortHelpFlag:
+			return answerHelp, true
+		case versionFlag:
+			asked, found = answerVersion, true
+		}
+	}
+
+	return asked, found
+}
+
+// isFlag reports whether an argument is written as one.
+//
+// A lone dash is an operand rather than a flag: POSIX gives it its meaning as
+// an operand standing for a standard stream, and cpybkc has no operand for it
+// to stand in.
+func isFlag(argument string) bool {
+	return strings.HasPrefix(argument, "-") && argument != standardOutput
+}
+
+// operandError is a non-flag argument, wherever it appeared.
+//
+// The operand position is reserved and empty on purpose: it is where a
+// subcommand would go, and a CLI that has already spent it on a path can never
+// add one without deciding whether an argument is a file or a verb.
+func operandError(argument string) error {
+	return usagef("cpybkc takes no operand, and %q is one; every input is named by a flag, and the manifest "+
+		"is named by %s", argument, manifestFlag)
+}
+
+// unrecognisedError is a flag this vector does not carry, named as it was
+// typed.
+func unrecognisedError(name string) error {
+	return usagef("%s is not a cpybkc flag", name)
+}
+
+// usagef is a [usageError], spelled at its use sites the way a sentence is
+// rather than as a struct literal.
+func usagef(format string, a ...any) error {
+	return &usageError{message: fmt.Sprintf(format, a...)}
+}
+
+// usageError is a vector cpybkc could not understand.
+//
+// It is a type rather than a sentinel because it is what [statusOf] reads: the
+// one distinction docs/cli/SPEC.md thinks worth encoding in an exit status is
+// whether cpybkc understood the request at all, so "this is that failure" has
+// to survive the trip from the parser to the exit path.
+type usageError struct {
+	message string
+}
+
+// Error implements the error interface.
+func (e *usageError) Error() string { return e.message }

--- a/cmd/cpybkc/args_test.go
+++ b/cmd/cpybkc/args_test.go
@@ -1,0 +1,338 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestParseReadsTheWholeVector is the argument vector docs/cli/SPEC.md fixes,
+// in the separated form, with every flag a run may carry.
+func TestParseReadsTheWholeVector(t *testing.T) {
+	t.Parallel()
+
+	inv, err := parse([]string{
+		manifestFlag, "projects/orders/cpybkc.json",
+		emitIRFlag, "orders.json",
+		emitIRFormatFlag, jsonFormat,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if inv.answer != answerRun {
+		t.Errorf("the line asks for answer %d, want a run", inv.answer)
+	}
+
+	if inv.manifestPath() != "projects/orders/cpybkc.json" {
+		t.Errorf("the manifest is %q", inv.manifestPath())
+	}
+
+	if inv.emitIR != "orders.json" {
+		t.Errorf("%s is %q", emitIRFlag, inv.emitIR)
+	}
+
+	if inv.emitIRFormat != jsonFormat {
+		t.Errorf("%s is %q, want %s", emitIRFormatFlag, inv.emitIRFormat, jsonFormat)
+	}
+}
+
+// TestParseAcceptsTheJoinedForm covers --manifest=cpybkc.json.
+//
+// Both spellings are required here where the plugin contract requires exactly
+// one, and the difference is who is typing: that vector is built by a program,
+// this one by a person who has already learned both spellings from every other
+// tool on their machine.
+func TestParseAcceptsTheJoinedForm(t *testing.T) {
+	t.Parallel()
+
+	inv, err := parse([]string{
+		manifestFlag + "=projects/orders/cpybkc.json",
+		emitIRFlag + "=" + standardOutput,
+		emitIRFormatFlag + "=" + binaryFormat,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if inv.manifestPath() != "projects/orders/cpybkc.json" {
+		t.Errorf("the manifest is %q", inv.manifestPath())
+	}
+
+	if inv.emitIR != standardOutput {
+		t.Errorf("%s is %q, want %q", emitIRFlag, inv.emitIR, standardOutput)
+	}
+}
+
+// TestParseAcceptsAValueCarryingAnEquals holds the joined form to splitting on
+// the first = only, so that a path or a format containing one arrives whole.
+func TestParseAcceptsAValueCarryingAnEquals(t *testing.T) {
+	t.Parallel()
+
+	inv, err := parse([]string{manifestFlag + "=odd=name/cpybkc.json"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if inv.manifestPath() != "odd=name/cpybkc.json" {
+		t.Errorf("the manifest is %q", inv.manifestPath())
+	}
+}
+
+// TestParseDefaultsTheManifestToTheWorkingDirectorys is docs/cli/SPEC.md's
+// discovery rule: with no --manifest, cpybkc reads cpybkc.json in the working
+// directory and looks nowhere else. There is no upward search, so the default
+// is a file name rather than the start of one.
+func TestParseDefaultsTheManifestToTheWorkingDirectorys(t *testing.T) {
+	t.Parallel()
+
+	inv, err := parse(nil)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if inv.manifestPath() != defaultManifest {
+		t.Errorf("the manifest is %q, want %s", inv.manifestPath(), defaultManifest)
+	}
+
+	if inv.manifest != "" {
+		t.Errorf("the line named the manifest %q, and it named none", inv.manifest)
+	}
+}
+
+// TestParseDefaultsTheEmissionToBinary covers the other default: binary is the
+// form the rest of the system uses, and the debug form is the one you ask for
+// by name.
+func TestParseDefaultsTheEmissionToBinary(t *testing.T) {
+	t.Parallel()
+
+	inv, err := parse([]string{emitIRFlag, "orders.binpb"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if inv.emitIRFormat != binaryFormat {
+		t.Errorf("%s is %q, want %s", emitIRFormatFlag, inv.emitIRFormat, binaryFormat)
+	}
+
+	if !inv.emitting() {
+		t.Error("the line asks for an emission and the invocation says it does not")
+	}
+}
+
+// TestParseHonoursTheEndOfOptions covers `--` with nothing after it. cpybkc
+// defines no operand, so the delimiter can only ever be followed by a usage
+// error; it is honoured anyway, as a courtesy to muscle memory.
+func TestParseHonoursTheEndOfOptions(t *testing.T) {
+	t.Parallel()
+
+	inv, err := parse([]string{manifestFlag, "cpybkc.json", endOfOptions})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if inv.manifestPath() != "cpybkc.json" {
+		t.Errorf("the manifest is %q", inv.manifestPath())
+	}
+}
+
+// TestParseRefusesTheVector is every way docs/cli/SPEC.md says a vector can
+// fail to be understood. Each is status 2, and each is a fault decided with
+// nothing opened.
+func TestParseRefusesTheVector(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name string
+		args []string
+		says string
+	}{
+		{
+			name: "an unrecognised flag",
+			args: []string{"--out", "gen"},
+			says: "--out",
+		},
+		{
+			name: "a flag this document refuses by name",
+			args: []string{"--verbose"},
+			says: "--verbose",
+		},
+		{
+			name: "a single-hyphen synonym nothing documents",
+			args: []string{"-manifest", "cpybkc.json"},
+			says: "-manifest",
+		},
+		{
+			name: "an operand",
+			args: []string{"cpybkc.json"},
+			says: "no operand",
+		},
+		{
+			name: "an operand after the end of options",
+			args: []string{endOfOptions, "cpybkc.json"},
+			says: "no operand",
+		},
+		{
+			name: "a lone dash, which POSIX makes an operand",
+			args: []string{standardOutput},
+			says: "no operand",
+		},
+		{
+			name: "an operand between two flags",
+			args: []string{manifestFlag, "cpybkc.json", "generate"},
+			says: "no operand",
+		},
+		{
+			name: "a missing value",
+			args: []string{manifestFlag},
+			says: "takes a value",
+		},
+		{
+			name: "an empty value",
+			args: []string{manifestFlag + "="},
+			says: "names no manifest",
+		},
+		{
+			name: "a repeated flag",
+			args: []string{manifestFlag, "one.json", manifestFlag, "two.json"},
+			says: "more than once",
+		},
+		{
+			name: "a repeated flag carrying the same value twice",
+			args: []string{manifestFlag, "one.json", manifestFlag + "=one.json"},
+			says: "more than once",
+		},
+		{
+			name: "a manifest on a stream",
+			args: []string{manifestFlag, standardOutput},
+			says: "relative to the directory holding it",
+		},
+		{
+			name: "an emission with nowhere to go",
+			args: []string{emitIRFlag + "="},
+			says: "names nowhere",
+		},
+		{
+			name: "a format that is neither encoding",
+			args: []string{emitIRFlag, "orders.out", emitIRFormatFlag, "xml"},
+			says: "is neither",
+		},
+		{
+			name: "a format selecting the encoding of an emission that is not happening",
+			args: []string{emitIRFormatFlag, jsonFormat},
+			says: "asks for no emission",
+		},
+		{
+			name: "a value on a flag that takes none",
+			args: []string{versionFlag + "=2"},
+			says: "takes no value",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			inv, err := parse(test.args)
+			if err == nil {
+				t.Fatalf("parse(%q) returned %+v, want a usage error", test.args, inv)
+			}
+
+			if !errors.As(err, new(*usageError)) {
+				t.Errorf("parse(%q) returned %T, want a usage error", test.args, err)
+			}
+
+			if got := statusOf(err); got != statusUsage {
+				t.Errorf("parse(%q) failed with status %d, want %d", test.args, got, statusUsage)
+			}
+
+			if !strings.Contains(err.Error(), test.says) {
+				t.Errorf("parse(%q) reads %q, and does not name %q", test.args, err, test.says)
+			}
+		})
+	}
+}
+
+// TestHelpIsAnsweredBeforeEverythingElse is docs/cli/SPEC.md's deliberate
+// exception to the refusal of an unrecognised flag and to the at-most-once
+// rule: a person asking a program what it is has usually typed the rest of the
+// line already, and answering with a complaint about a flag they were in the
+// middle of getting wrong teaches them nothing they asked to learn.
+func TestHelpIsAnsweredBeforeEverythingElse(t *testing.T) {
+	t.Parallel()
+
+	for _, args := range [][]string{
+		{helpFlag},
+		{shortHelpFlag},
+		{"--nonsense", helpFlag},
+		{manifestFlag, manifestFlag, helpFlag},
+		{helpFlag, "an-operand"},
+		{versionFlag, helpFlag},
+		{helpFlag, versionFlag},
+	} {
+		inv, err := parse(args)
+		if err != nil {
+			t.Errorf("parse(%q): %v", args, err)
+
+			continue
+		}
+
+		if inv.answer != answerHelp {
+			t.Errorf("parse(%q) asks for answer %d, want help", args, inv.answer)
+		}
+	}
+}
+
+// TestVersionIsAnsweredBeforeEverythingButHelp is the other half of the same
+// rule, and the precedence between the two.
+func TestVersionIsAnsweredBeforeEverythingButHelp(t *testing.T) {
+	t.Parallel()
+
+	for _, args := range [][]string{
+		{versionFlag},
+		{"--nonsense", versionFlag},
+		{versionFlag, versionFlag},
+		{manifestFlag, versionFlag},
+	} {
+		inv, err := parse(args)
+		if err != nil {
+			t.Errorf("parse(%q): %v", args, err)
+
+			continue
+		}
+
+		if inv.answer != answerVersion {
+			t.Errorf("parse(%q) asks for answer %d, want the version", args, inv.answer)
+		}
+	}
+}
+
+// TestAskingIsAWholeArgument holds the question to whole arguments only.
+//
+// A joined value is a value: `--manifest=--help` names a manifest called
+// --help, however odd, and is not a request for usage. And an argument after
+// `--` is an operand rather than a flag, so `-- --help` is the usage error
+// every operand is.
+func TestAskingIsAWholeArgument(t *testing.T) {
+	t.Parallel()
+
+	inv, err := parse([]string{manifestFlag + "=" + helpFlag})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if inv.answer != answerRun {
+		t.Errorf("a manifest named %s asks for answer %d, want a run", helpFlag, inv.answer)
+	}
+
+	if inv.manifestPath() != helpFlag {
+		t.Errorf("the manifest is %q, want %q", inv.manifestPath(), helpFlag)
+	}
+
+	if _, err := parse([]string{endOfOptions, helpFlag}); !errors.As(err, new(*usageError)) {
+		t.Errorf("%s after %s returned %v, want the usage error every operand is", helpFlag, endOfOptions, err)
+	}
+}

--- a/cmd/cpybkc/args_test.go
+++ b/cmd/cpybkc/args_test.go
@@ -84,11 +84,11 @@ func TestParseAcceptsAValueCarryingAnEquals(t *testing.T) {
 	}
 }
 
-// TestParseDefaultsTheManifestToTheWorkingDirectorys is docs/cli/SPEC.md's
+// TestParseDefaultsTheManifestToTheWorkingDirectory is docs/cli/SPEC.md's
 // discovery rule: with no --manifest, cpybkc reads cpybkc.json in the working
 // directory and looks nowhere else. There is no upward search, so the default
 // is a file name rather than the start of one.
-func TestParseDefaultsTheManifestToTheWorkingDirectorys(t *testing.T) {
+func TestParseDefaultsTheManifestToTheWorkingDirectory(t *testing.T) {
 	t.Parallel()
 
 	inv, err := parse(nil)

--- a/cmd/cpybkc/diagnostic.go
+++ b/cmd/cpybkc/diagnostic.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// The diagnostic form docs/cli/SPEC.md fixes: everything cpybkc says about a
+// run goes to standard error, one diagnostic per line, encoded in UTF-8, as
+// `<severity>: <message>`.
+//
+// The severity set is closed and matched case-sensitively, and it is the plugin
+// contract's set spelled the same way on purpose — a person watching one
+// terminal sees one stream in one shape whether a line was written by cpybkc or
+// relayed from a generator, and a script that greps for `^error: ` catches
+// both.
+//
+// `warning` is the third severity that set names, and this program has nothing
+// to say at it yet: it arrives with the relayed generator line, the spans and
+// the continuation lines, which are all #150's. It is spelled where it is used
+// rather than declared here for a caller that does not exist.
+const (
+	severityError = "error"
+	severityNote  = "note"
+
+	severitySeparator = ": "
+)
+
+// report writes err to w as the diagnostics a failed run owes its user.
+//
+// The error's own message is the `error:` line. A message that arrived with
+// newlines in it — a wrapped error, most likely — has its remaining lines
+// written as `note:` diagnostics, so that a fault cannot put a line on standard
+// error that no severity opens.
+func report(w io.Writer, err error) {
+	message := err.Error()
+	if strings.TrimSpace(message) == "" {
+		// A bare `error: ` says nothing anybody can act on. An error with no
+		// message is a bug in this program, and it is reported as one rather
+		// than as silence beside a non-zero exit.
+		message = "cpybkc failed and said nothing about why, which is a bug in cpybkc"
+	}
+
+	lines := strings.Split(message, "\n")
+
+	diagnostic(w, severityError, lines[0])
+
+	for _, line := range lines[1:] {
+		diagnostic(w, severityNote, line)
+	}
+}
+
+// diagnostic writes one line.
+//
+// The write is unchecked because there is nowhere left to report a failure to
+// write to the diagnostic channel to — the exit status is what the caller
+// reads, and it is already about to say the run failed.
+func diagnostic(w io.Writer, severity, message string) {
+	message = strings.TrimRight(message, " \t")
+	if message == "" {
+		return
+	}
+
+	_, _ = fmt.Fprint(w, severity+severitySeparator+message+"\n")
+}

--- a/cmd/cpybkc/exit.go
+++ b/cmd/cpybkc/exit.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import "errors"
+
+// The three statuses docs/cli/SPEC.md enumerates, and cpybkc exits with no
+// other:
+//
+//	0  what was asked for was done
+//	1  the run failed
+//	2  the argument vector could not be understood
+//
+// A status per failing stage would look more informative and is not: it would
+// make every new stage a compatibility question, it would have to answer which
+// status a run with a manifest fault and a layout fault carries, and a script
+// branches on zero against non-zero anyway. The one distinction worth encoding
+// is whether cpybkc understood the request at all, because that is the failure
+// a caller can fix without knowing anything about the project.
+//
+// The small integers are spoken for by parties this project does not control —
+// a shell exits 126 and 127 for a file it cannot execute or find, and reports a
+// signalled process as 128 plus the signal number — so a caller seeing one of
+// those knows it came from their shell rather than from this program.
+type status int
+
+const (
+	statusOK status = 0
+
+	statusFailed status = 1
+
+	statusUsage status = 2
+)
+
+// statusOf is the whole of how a failure becomes an exit status, and it is the
+// only place in this program that decides one.
+//
+// docs/cli/SPEC.md requires every enumerated status to be reachable and this is
+// where each is reached from: a run that did what was asked exits 0, a vector
+// cpybkc could not understand exits 2, and every other fault — a manifest that
+// is not there, a layout that does not resolve, a generator that failed, a
+// cancelled run — is the run failing and exits 1. Scattering that decision
+// across the stages that raise the faults is how a stage acquires a status of
+// its own, which is the table growing a fourth row nobody wrote down.
+//
+// A generator's own exit status never reaches here. It is a verdict on one
+// invocation, delivered to cpybkc; this is a verdict on the whole run, and a
+// run has several generators.
+func statusOf(err error) status {
+	switch {
+	case err == nil:
+		return statusOK
+	case errors.As(err, new(*usageError)):
+		return statusUsage
+	default:
+		return statusFailed
+	}
+}

--- a/cmd/cpybkc/main.go
+++ b/cmd/cpybkc/main.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Command cpybkc is the executable a person runs: it finds the project's
+// manifest, reads the layout that manifest names, resolves it against the
+// copybooks it names, and hands the resolved descriptor to every generator the
+// manifest asks for.
+//
+//	cpybkc [--manifest <path>] [--emit-ir <dest> [--emit-ir-format <format>]]
+//	cpybkc --version
+//	cpybkc --help
+//
+// docs/cli/SPEC.md is the contract, and this command implements it rather than
+// restating it. The command set, the argument vector, where the manifest is
+// looked for, what arrives on each stream, the diagnostic format, the exit
+// statuses and what --version prints are all that document's.
+//
+// # Why this is the outermost layer and nothing more
+//
+// This program parses the command line, answers --help and --version, and turns
+// a fault into an exit status. It does not read a manifest, resolve a layout,
+// emit a descriptor or start a generator: those are #148, #149 and #150, and a
+// run that asks for them fails with a diagnostic saying so.
+//
+// The split is not tidiness. The published image's entrypoint is this CLI and
+// its Cmd is empty (docs/container/SPEC.md), so the arguments in somebody's
+// `docker run` line are the arguments below, and a flag renamed here breaks a
+// Dockerfile in a repository this project cannot see. That surface is harder to
+// change than the code behind it, so it is settled — and checked — on its own,
+// against a document, rather than as a side effect of whichever story first
+// needed a binary to exist.
+//
+// # Why main is three lines
+//
+// [run] is the whole program with the exit path taken out, and it takes its
+// streams as parameters. Both are what let the argument vector be tested as a
+// vector: a test drives a whole invocation, reads what landed on each stream
+// and asserts the status, without ending the test binary and without either
+// stream being this process's own. os.Exit appears once, in main, and the
+// status it is handed is decided in exactly one place ([statusOf]).
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+func main() {
+	os.Exit(int(run(os.Args[1:], os.Stdout, os.Stderr)))
+}
+
+// run is one invocation: the argument vector in, the two streams written, and
+// the exit status back.
+//
+// Standard output is the data channel and carries only what was asked for by
+// name — the version line for --version, usage for --help, and the descriptor
+// for `--emit-ir -`. Everything cpybkc says about a run goes to standard error.
+// That is why a failure is reported here, where both streams are in hand,
+// rather than by whatever raised it.
+func run(args []string, stdout, stderr io.Writer) status {
+	err := execute(args, stdout)
+	if err == nil {
+		return statusOK
+	}
+
+	report(stderr, err)
+
+	// docs/cli/SPEC.md: usage goes to standard error when it accompanies a
+	// usage error. A vector cpybkc could not understand is the one failure a
+	// caller can fix without knowing anything about the project, and the
+	// command set is what they need in front of them to fix it.
+	//
+	// A blank line first, because usage is the one thing on this stream that is
+	// not a diagnostic and nothing about it should read as one — a reader, and
+	// a script scanning for `^error: `, both see where the diagnostics ended.
+	if errors.As(err, new(*usageError)) {
+		_, _ = io.WriteString(stderr, "\n")
+
+		writeUsage(stderr)
+	}
+
+	return statusOf(err)
+}
+
+// execute performs what the line asked for, and writes to standard output only
+// what was asked for by name.
+func execute(args []string, stdout io.Writer) error {
+	inv, err := parse(args)
+	if err != nil {
+		return err
+	}
+
+	switch inv.answer {
+	case answerHelp:
+		writeUsage(stdout)
+
+		return nil
+	case answerVersion:
+		_, _ = io.WriteString(stdout, versionLine()+"\n")
+
+		return nil
+	case answerRun:
+		return perform(inv)
+	}
+
+	// Unreachable: parse returns one of the three answers above. It is a
+	// failure rather than a panic because a fourth answer arriving here is a
+	// bug in this program, and a bug is a run that failed.
+	return errors.New("cpybkc did not understand what its own parser asked for, which is a bug in cpybkc")
+}
+
+// perform is the run itself, and it is the half of this command that #148,
+// #149 and #150 build.
+//
+// It fails rather than succeeding silently. A scaffold that exited 0 having
+// generated nothing would be a binary that reports success to whatever CI step
+// runs it — silence is success by docs/cli/SPEC.md's own rule for a generating
+// run, so an unwired pipeline exiting 0 is indistinguishable from a project
+// whose generators all ran. Status 1 with a diagnostic naming the story is the
+// honest answer, and it is a status the document already enumerates.
+func perform(inv invocation) error {
+	if inv.emitting() {
+		return fmt.Errorf("this build cannot write the %s descriptor %s asked for: it parses the command "+
+			"line and answers %s and %s, and it has not read %s (#149)",
+			inv.emitIRFormat, emitIRFlag, versionFlag, helpFlag, inv.manifestPath())
+	}
+
+	return fmt.Errorf("this build generates nothing: it parses the command line and answers %s and %s, "+
+		"and it has not read %s (#148)", versionFlag, helpFlag, inv.manifestPath())
+}

--- a/cmd/cpybkc/main.go
+++ b/cmd/cpybkc/main.go
@@ -3,34 +3,34 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-// Command cpybkc is the executable a person runs: it finds the project's
-// manifest, reads the layout that manifest names, resolves it against the
-// copybooks it names, and hands the resolved descriptor to every generator the
-// manifest asks for.
+// Command cpybkc is the executable a person runs.
 //
 //	cpybkc [--manifest <path>] [--emit-ir <dest> [--emit-ir-format <format>]]
 //	cpybkc --version
 //	cpybkc --help
+//
+// As it stands it is the outermost layer of that command and nothing behind it:
+// it parses the argument vector, answers --help and --version, and turns a
+// fault into an exit status. It reads no manifest, resolves no layout, emits no
+// descriptor and starts no generator, and a run that asks for any of that fails
+// with a diagnostic saying so. Finding the manifest and resolving it is #148,
+// --emit-ir is #149, and the diagnostics the stages owe are #150.
 //
 // docs/cli/SPEC.md is the contract, and this command implements it rather than
 // restating it. The command set, the argument vector, where the manifest is
 // looked for, what arrives on each stream, the diagnostic format, the exit
 // statuses and what --version prints are all that document's.
 //
-// # Why this is the outermost layer and nothing more
+// # Why the outermost layer lands on its own
 //
-// This program parses the command line, answers --help and --version, and turns
-// a fault into an exit status. It does not read a manifest, resolve a layout,
-// emit a descriptor or start a generator: those are #148, #149 and #150, and a
-// run that asks for them fails with a diagnostic saying so.
-//
-// The split is not tidiness. The published image's entrypoint is this CLI and
-// its Cmd is empty (docs/container/SPEC.md), so the arguments in somebody's
-// `docker run` line are the arguments below, and a flag renamed here breaks a
-// Dockerfile in a repository this project cannot see. That surface is harder to
-// change than the code behind it, so it is settled — and checked — on its own,
-// against a document, rather than as a side effect of whichever story first
-// needed a binary to exist.
+// Not tidiness, and not because the vector is the easy part. The published
+// image's entrypoint is this CLI and its Cmd is empty
+// (docs/container/SPEC.md), so the arguments in somebody's `docker run` line
+// are the arguments above, and a flag renamed here breaks a Dockerfile in a
+// repository this project cannot see. That surface is harder to change than the
+// code behind it, so it is settled — and checked — on its own, against a
+// document, rather than as a side effect of whichever story first needed a
+// binary to exist.
 //
 // # Why main is three lines
 //

--- a/cmd/cpybkc/main_test.go
+++ b/cmd/cpybkc/main_test.go
@@ -1,0 +1,299 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// invoke drives one whole invocation and hands back what landed on each stream
+// and the status the process would have exited with.
+func invoke(args ...string) (stdout, stderr string, code status) {
+	var out, errs bytes.Buffer
+
+	code = run(args, &out, &errs)
+
+	return out.String(), errs.String(), code
+}
+
+// TestHelpIsWrittenToStandardOutputAndSucceeds is docs/cli/SPEC.md's rule about
+// which stream usage goes to. The distinction is the whole of what makes
+// `cpybkc --help | less` work while keeping a failing run's output off the data
+// channel.
+func TestHelpIsWrittenToStandardOutputAndSucceeds(t *testing.T) {
+	t.Parallel()
+
+	for _, flag := range []string{helpFlag, shortHelpFlag} {
+		stdout, stderr, code := invoke(flag)
+
+		if code != statusOK {
+			t.Errorf("%s exited %d, want %d", flag, code, statusOK)
+		}
+
+		if stdout != usage {
+			t.Errorf("%s wrote %q to standard output, want the usage text", flag, stdout)
+		}
+
+		if stderr != "" {
+			t.Errorf("%s wrote %q to standard error, and usage that was asked for is not a diagnostic", flag, stderr)
+		}
+	}
+}
+
+// TestUsageNamesTheSettledCommandSet holds the help text to the surface
+// docs/cli/SPEC.md fixes: the three forms, the five flags, and no sixth.
+//
+// The wording is explicitly not a covered guarantee, so this asserts what is
+// named rather than how it reads.
+func TestUsageNamesTheSettledCommandSet(t *testing.T) {
+	t.Parallel()
+
+	stdout, _, _ := invoke(helpFlag)
+
+	for _, want := range []string{
+		manifestFlag, emitIRFlag, emitIRFormatFlag, versionFlag, helpFlag, shortHelpFlag,
+		binaryFormat, jsonFormat, defaultManifest,
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("usage does not name %s:\n%s", want, stdout)
+		}
+	}
+
+	// No subcommand set, so no line offering one. Generating is what the
+	// command does when nothing else is asked of it, and a usage text that
+	// spelled a verb would be documenting a command set this document refuses.
+	for _, refused := range []string{"--out", "--include", "--jobs", "--verbose", "--config", "Commands:"} {
+		if strings.Contains(stdout, refused) {
+			t.Errorf("usage offers %s, which cpybkc does not have:\n%s", refused, stdout)
+		}
+	}
+}
+
+// TestVersionWritesOneLineAndSucceeds holds --version to the form
+// docs/cli/SPEC.md fixes: exactly one line naming the program, its own version
+// and the IR version this build produces.
+func TestVersionWritesOneLineAndSucceeds(t *testing.T) {
+	t.Parallel()
+
+	stdout, stderr, code := invoke(versionFlag)
+
+	if code != statusOK {
+		t.Errorf("%s exited %d, want %d", versionFlag, code, statusOK)
+	}
+
+	if stderr != "" {
+		t.Errorf("%s wrote %q to standard error", versionFlag, stderr)
+	}
+
+	if lines := strings.Count(stdout, "\n"); lines != 1 || !strings.HasSuffix(stdout, "\n") {
+		t.Errorf("%s wrote %q, want exactly one line", versionFlag, stdout)
+	}
+
+	// Derived from the constants rather than written out, so that this asserts
+	// the line names what the build is made of whatever those become. A literal
+	// here would pass on the wrong numbers the day one of them moves.
+	want := versionLine() + "\n"
+	if stdout != want {
+		t.Errorf("%s wrote %q, want %q", versionFlag, stdout, want)
+	}
+
+	for _, fact := range []string{programName, version, "IR version"} {
+		if !strings.Contains(stdout, fact) {
+			t.Errorf("the version line does not name %q: %q", fact, stdout)
+		}
+	}
+}
+
+// TestVersionCarriesNoBuildProvenance is what the line deliberately does not
+// promise. A version number is what identifies a release and the rest is
+// recoverable from it, so a commit, a build date or a Go version on this line
+// would be surface nobody agreed to keep.
+func TestVersionCarriesNoBuildProvenance(t *testing.T) {
+	t.Parallel()
+
+	stdout, _, _ := invoke(versionFlag)
+
+	for _, absent := range []string{"go1.", "commit", "built"} {
+		if strings.Contains(strings.ToLower(stdout), absent) {
+			t.Errorf("the version line carries %q: %q", absent, stdout)
+		}
+	}
+}
+
+// TestAUsageErrorExitsTwoAndSaysSoOnStandardError is the status a caller can
+// act on without knowing anything about the project, and the stream the
+// diagnostic owes.
+func TestAUsageErrorExitsTwoAndSaysSoOnStandardError(t *testing.T) {
+	t.Parallel()
+
+	stdout, stderr, code := invoke("--out", "gen")
+
+	if code != statusUsage {
+		t.Errorf("an unrecognised flag exited %d, want %d", code, statusUsage)
+	}
+
+	// docs/cli/SPEC.md: cpybkc MUST NOT write a diagnostic to standard output
+	// under any circumstance. A descriptor going to standard output shares that
+	// stream with nothing, which is what keeps `--emit-ir -` pipeable.
+	if stdout != "" {
+		t.Errorf("a usage error wrote %q to standard output", stdout)
+	}
+
+	if !strings.HasPrefix(stderr, severityError+severitySeparator) {
+		t.Errorf("the diagnostic reads %q, want an %s%s line", stderr, severityError, severitySeparator)
+	}
+
+	if !strings.Contains(stderr, "--out") {
+		t.Errorf("the diagnostic does not name the flag that was refused: %q", stderr)
+	}
+
+	// Usage accompanies a usage error, on standard error, because the vector is
+	// the one failure the command set in front of the reader is enough to fix.
+	if !strings.Contains(stderr, "Usage:") {
+		t.Errorf("a usage error was reported without usage: %q", stderr)
+	}
+}
+
+// TestARunFailsUntilThePipelineIsWired is what this scaffold does with a line
+// it understood.
+//
+// It fails rather than succeeding silently: silence is success for a generating
+// run by docs/cli/SPEC.md's own rule, so a scaffold exiting 0 having generated
+// nothing would be indistinguishable from a project whose generators all ran.
+func TestARunFailsUntilThePipelineIsWired(t *testing.T) {
+	t.Parallel()
+
+	for _, args := range [][]string{
+		nil,
+		{manifestFlag, "projects/orders/cpybkc.json"},
+		{emitIRFlag, standardOutput},
+		{emitIRFlag, "orders.json", emitIRFormatFlag, jsonFormat},
+	} {
+		stdout, stderr, code := invoke(args...)
+
+		if code != statusFailed {
+			t.Errorf("%q exited %d, want %d", args, code, statusFailed)
+		}
+
+		// A run writes nothing to standard output — no progress, no timing, no
+		// summary, and no line saying a run succeeded.
+		if stdout != "" {
+			t.Errorf("%q wrote %q to standard output, and a run writes nothing there", args, stdout)
+		}
+
+		if !strings.HasPrefix(stderr, severityError+severitySeparator) {
+			t.Errorf("%q failed with %q, want an %s%s line", args, stderr, severityError, severitySeparator)
+		}
+
+		// A failure of the work is not a failure of the vector, so the command
+		// set is not what the reader needs in front of them.
+		if strings.Contains(stderr, "Usage:") {
+			t.Errorf("%q was answered with usage, and the vector was understood: %q", args, stderr)
+		}
+	}
+}
+
+// TestEveryEnumeratedStatusIsReachable is the acceptance criterion stated as a
+// test: docs/cli/SPEC.md enumerates three statuses and cpybkc exits with no
+// other, so each has to be reachable from a real invocation and none may be
+// dead.
+func TestEveryEnumeratedStatusIsReachable(t *testing.T) {
+	t.Parallel()
+
+	reached := map[status][]string{}
+
+	for _, args := range [][]string{
+		{versionFlag},
+		{helpFlag},
+		nil,
+		{"--nope"},
+		{"an-operand"},
+		{emitIRFormatFlag, jsonFormat},
+	} {
+		_, _, code := invoke(args...)
+		reached[code] = append(reached[code], strings.Join(args, " "))
+	}
+
+	for _, want := range []status{statusOK, statusFailed, statusUsage} {
+		if len(reached[want]) == 0 {
+			t.Errorf("no invocation exits %d, and every status this document enumerates is reachable", want)
+		}
+	}
+
+	for got, by := range reached {
+		switch got {
+		case statusOK, statusFailed, statusUsage:
+		default:
+			t.Errorf("`cpybkc %s` exits %d, which is not a status this document enumerates", by[0], got)
+		}
+	}
+}
+
+// TestEveryDiagnosticLineCarriesASeverity holds standard error to the
+// diagnostic format: one diagnostic per line, `<severity>: <message>`, from the
+// closed set of three matched case-sensitively.
+//
+// Usage is the one thing on that stream that is not a diagnostic, and it is
+// there because docs/cli/SPEC.md puts it there; it is skipped by starting at
+// the first blank line, which is where the diagnostics end and usage begins.
+func TestEveryDiagnosticLineCarriesASeverity(t *testing.T) {
+	t.Parallel()
+
+	_, stderr, _ := invoke("--nope")
+
+	diagnostics, _, _ := strings.Cut(stderr, "\n\n")
+
+	for _, line := range strings.Split(strings.TrimRight(diagnostics, "\n"), "\n") {
+		switch {
+		case strings.HasPrefix(line, "  "):
+			// A continuation line carries no severity of its own, and the
+			// two-space indent is what tells the two apart.
+		case strings.HasPrefix(line, severityError+severitySeparator),
+			strings.HasPrefix(line, severityNote+severitySeparator),
+			strings.HasPrefix(line, "warning"+severitySeparator):
+		default:
+			t.Errorf("standard error carries %q, which opens with no severity", line)
+		}
+	}
+}
+
+// TestAnErrorWithNothingToSayIsReportedAsABug covers the one line report has to
+// invent. A bare `error: ` says nothing anybody can act on, and cpybkc's
+// diagnostics are the explanation its exit status is the verdict on.
+func TestAnErrorWithNothingToSayIsReportedAsABug(t *testing.T) {
+	t.Parallel()
+
+	var stderr bytes.Buffer
+
+	report(&stderr, &usageError{})
+
+	if !strings.HasPrefix(stderr.String(), severityError+severitySeparator) {
+		t.Errorf("an empty error reported as %q", stderr.String())
+	}
+
+	if !strings.Contains(stderr.String(), "bug") {
+		t.Errorf("an empty error reported as %q, and it is a bug in cpybkc", stderr.String())
+	}
+}
+
+// TestAWrappedMessagesExtraLinesBecomeNotes keeps a multi-line message from
+// putting a line on standard error that no severity opens.
+func TestAWrappedMessagesExtraLinesBecomeNotes(t *testing.T) {
+	t.Parallel()
+
+	var stderr bytes.Buffer
+
+	report(&stderr, &usageError{message: "the first line\nthe second"})
+
+	want := severityError + severitySeparator + "the first line\n" +
+		severityNote + severitySeparator + "the second\n"
+
+	if stderr.String() != want {
+		t.Errorf("report wrote %q, want %q", stderr.String(), want)
+	}
+}

--- a/cmd/cpybkc/usage.go
+++ b/cmd/cpybkc/usage.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import (
+	"fmt"
+	"io"
+)
+
+// usage is what --help prints, and what accompanies a usage error.
+//
+// It is written out rather than assembled from the flag constants: what a flag
+// is called is a covered guarantee and what usage says about it is explicitly
+// not one, so a generated block would tie the wording docs/cli/SPEC.md leaves
+// free to the spellings it fixes, and every wording change would read as a
+// change to the surface.
+//
+// The synopsis is the document's, line for line, because the three forms are
+// the command set — one command, no subcommands, and no operand in any of them.
+// -h is the one single-hyphen spelling that appears here; the document requires
+// any other to go undocumented.
+const usage = `cpybkc generates code from the copybooks a project's layout names.
+
+Usage:
+  cpybkc [--manifest <path>] [--emit-ir <dest> [--emit-ir-format <format>]]
+  cpybkc --version
+  cpybkc --help
+
+Flags:
+  --manifest <path>          the project manifest to read (default: cpybkc.json
+                             in the working directory)
+  --emit-ir <dest>           write the run's resolved IR descriptor to <dest>,
+                             or to standard output for -, instead of generating
+  --emit-ir-format <format>  the encoding --emit-ir writes: binary or json
+                             (default: binary)
+  --version                  print the version and exit
+  -h, --help                 print this help and exit
+
+Every input is named by a flag: cpybkc takes no operand, and each flag appears
+at most once. docs/cli/SPEC.md is the contract this summarises.
+`
+
+// writeUsage writes usage to w.
+//
+// Which w is the whole of what makes `cpybkc --help | less` work while keeping
+// a failing run's output off the data channel: usage goes to standard output
+// when it was asked for and to standard error when it accompanies a usage
+// error, and nothing else about it changes between the two.
+func writeUsage(w io.Writer) {
+	_, _ = fmt.Fprint(w, usage)
+}

--- a/cmd/cpybkc/version.go
+++ b/cmd/cpybkc/version.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/Zaba505/cpybkc/internal/assemble"
+)
+
+const (
+	// programName is what this executable is called, and what --version names
+	// first.
+	//
+	// It is stated rather than taken from os.Args[0], because a line naming
+	// whatever path a caller happened to invoke this program by is one the
+	// reader cannot compare against a release — and the published image's
+	// entrypoint is this program under a path of the image's choosing.
+	programName = "cpybkc"
+
+	// version is this build's own version, and it is the fact --version exists
+	// to report.
+	//
+	// docs/cli/SPEC.md requires the released version for a build made from a
+	// release tag and 0.0.0-dev for one made outside a release. Nothing has
+	// been released yet, which 0.0.0-dev says out loud; it moves with the
+	// repository's first release tag, the way cmd/cpybkc-gen-go's own version
+	// does.
+	//
+	// A constant rather than a variable a linker stamps: a stamped version is a
+	// build whose output depends on how it was invoked, and this repository
+	// builds its binaries from the tree alone.
+	version = "0.0.0-dev"
+)
+
+// producedIRVersion is the IR version this build produces, which is the third
+// fact on the --version line.
+//
+// It is [github.com/Zaba505/cpybkc/internal/assemble.Version] rather than a
+// second statement of the same number, because the line is a promise about what
+// this build writes into a descriptor and the assembler is what writes it. Two
+// constants would be two facts able to disagree, and the day they did, the
+// --version line would be the one that lied.
+const producedIRVersion = assemble.Version
+
+// versionLine is the one line --version writes.
+//
+// The IR version is on it because of what a plugin's refusal says: a plugin
+// that will not read a descriptor names the descriptor's IR version, the
+// highest it implements and its own version, and the user reading that refusal
+// has to decide whether to upgrade the generator or pin the CLI. Two of the
+// three are in the message; the third is what the CLI in front of them
+// produces, and without a way to ask for it the next step is a guess.
+//
+// One line, so that it can be read by an eye and by a script without either
+// needing a parser. What is deliberately not on it is the rest of a build's
+// provenance — no commit, no build date, no Go version — because a version
+// number is what identifies a release and the rest is recoverable from it.
+//
+// The IR version is rendered as the integer docs/ir/SPEC.md makes it rather
+// than as the enum's Go spelling, which is a name for a number and not the
+// number a plugin's refusal quotes.
+func versionLine() string {
+	return fmt.Sprintf("%s %s (IR version %d)", programName, version, int32(producedIRVersion))
+}

--- a/internal/assemble/assemble.go
+++ b/internal/assemble/assemble.go
@@ -17,8 +17,8 @@ import (
 	"github.com/Zaba505/cpybkc/irpb"
 )
 
-// Version is the IR version this build produces, and the one every descriptor
-// [Assemble] returns states.
+// Version is the IR version this build produces: the value of the Version field
+// on every descriptor [Assemble] returns.
 //
 // It is exported because it is a fact about the build rather than about this
 // package: docs/cli/SPEC.md has `cpybkc --version` name "the IR version this

--- a/internal/assemble/assemble.go
+++ b/internal/assemble/assemble.go
@@ -17,6 +17,21 @@ import (
 	"github.com/Zaba505/cpybkc/irpb"
 )
 
+// Version is the IR version this build produces, and the one every descriptor
+// [Assemble] returns states.
+//
+// It is exported because it is a fact about the build rather than about this
+// package: docs/cli/SPEC.md has `cpybkc --version` name "the IR version this
+// build produces", and the only honest source for that is the constant the
+// assembler stamps into the descriptor. A second constant beside the CLI would
+// be a second statement of one fact, and the day the two disagreed the version
+// line would be the one that lied.
+//
+// docs/ir/SPEC.md makes the version a single monotonic integer: an addition a
+// consumer can ignore and still be correct about leaves it alone, and every
+// addition it cannot advances it.
+const Version = irpb.IrVersion_IR_VERSION_1
+
 // Options are the resolved layout: everything a descriptor is assembled out of,
 // and nothing that still needs resolving.
 //
@@ -238,7 +253,7 @@ func (a *assembler) assemble() *irpb.Descriptor {
 
 	file.Kind = &irpb.Node_File{File: fileOf(a.opts.Framing, a.states[a.opts.Automaton.Start])}
 
-	return &irpb.Descriptor{Version: irpb.IrVersion_IR_VERSION_1, Nodes: a.nodes}
+	return &irpb.Descriptor{Version: Version, Nodes: a.nodes}
 }
 
 // record assembles one record type: the record node, then its tree.


### PR DESCRIPTION
Closes #147

`cmd/cpybkc` exists. This is the outermost layer and nothing behind it: argument parsing, `--version`, help, and the exit-code discipline. It reads no manifest, resolves no layout, emits no descriptor and starts no generator — #148, #149 and #150 — so a run that asks for one fails with a diagnostic naming the story.

`docs/cli/SPEC.md` is the contract, and this implements it rather than restating it.

## Acceptance criteria

- [x] **`cmd/cpybkc` exists, builds CGO-free, and produces a single static binary** — `dagger call binary` builds it with `CGO_ENABLED=0` and `-trimpath`.
- [x] **The command set matches `docs/cli/SPEC.md` exactly** — five flags and no sixth, one command and no subcommand, and no operand anywhere including after `--`. `--out`, `--include`, `--jobs`, `--verbose` and `--config` have no case in the parser and no line in usage, and a test asserts usage offers none of them.
- [x] **`--version` prints what the spec says it prints** — one line, `cpybkc 0.0.0-dev (IR version 1)`, naming the program, its own version and the IR version this build produces. Nothing is contacted, and no commit, build date or Go version is on it.
- [x] **`-h` / `--help` prints usage for the settled command set and exits 0** — to standard output, which is what makes `cpybkc --help | less` work. Both spellings, anywhere on the line, beating `--version` and beating anything that would otherwise be a usage error.
- [x] **Unknown flags, missing required arguments and malformed argv exit 2 with a diagnostic on stderr** — sixteen table cases: an unrecognised flag, a refused-by-name flag, an undocumented single-hyphen synonym, an operand (bare, after `--`, between flags, and a lone `-`), a missing value, an empty value, a repeated flag (with different and identical values), `--manifest -`, `--emit-ir=`, an unknown format, `--emit-ir-format` without `--emit-ir`, and a value on a flag that takes none. Standard output stays empty in every one.
- [x] **Every exit code is reachable and emitted from one place** — `statusOf` is the only thing that decides a status, `main` is the only `os.Exit`, and `TestEveryEnumeratedStatusIsReachable` drives real invocations to 0, 1 and 2 and fails on a fourth value.
- [x] **`go test ./cmd/cpybkc/...` covers argv parsing, each failure mode and its exit code** — 15 tests over the parser and whole invocations, driving both streams and the status.
- [x] **The binary is built by the dagger pipeline and exercised by `dagger call ci`** — `Binary` and `Build` on the root module, `Build` wired into `Ci` as its seventh part.

## Judgment calls that shaped the surface

- **A plain run fails with status 1.** Silence is success for a generating run, so a scaffold exiting 0 having generated nothing would be indistinguishable from a project whose generators all ran — for a person and for whatever CI step runs it. 1 is a status the document already enumerates and the diagnostic names the story that wires the pipeline.
- **`--help` / `--version` are decided by a whole-argument pre-scan, stopping at `--`.** `--manifest --help` is help, because the spec says every other flag on the line is ignored including one that would otherwise be a usage error. `--manifest=--help` is not, because a joined value is a value. `-- --help` is not, because an argument after the delimiter is an operand and cpybkc takes none.
- **No undocumented single-hyphen synonyms.** They are a MAY, and a spelling nothing documents is one nobody can be told about and one the parser keeps forever. `-h` is the exception the document itself states.
- **`--manifest -` and an unknown `--emit-ir-format` value exit 2, not 1.** Both are decided with nothing opened, and status 2 is the promise that cpybkc did nothing at all.
- **`--version` reads `internal/assemble.Version`**, newly exported and used by the assembler itself, rather than restating `IR_VERSION_1` beside the CLI. The line is a promise about what this build writes into a descriptor; two constants would be two facts able to disagree, and the version line would be the one that lied.
- **Usage on stderr is preceded by a blank line**, so a reader — and a script scanning for `^error: ` — can see where the diagnostics ended and the one non-diagnostic thing on that stream began.
- **`Build` runs the binary in an empty image.** The Go stages already compile `cmd/cpybkc` through `./...`; what they cannot say is that it links CGO-free and is a single file. An image with no loader, no libc and no shell cannot start a dynamically linked binary, so `cpybkc --version` succeeding there is the claim itself rather than a grep for `CGO_ENABLED=0`.

## Verification

`dagger call ci` passes locally — the same call CI makes. `.dagger/dagger.gen.go` was regenerated with `dagger develop` in this commit, as CONTRIBUTING.md requires of a module change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
