### PR TITLE
story(cli): report diagnostics with source spans to stderr

### DIFF
--- a/cmd/cpybkc/diagnostic.go
+++ b/cmd/cpybkc/diagnostic.go
@@ -9,11 +9,14 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
 )
 
 // The diagnostic form docs/cli/SPEC.md fixes: everything cpybkc says about a
 // run goes to standard error, one diagnostic per line, encoded in UTF-8, as
-// `<severity>: <message>`.
+// `<severity>: <message>` — or `<severity>: <generator>: <message>` for a line
+// that came from a generator.
 //
 // The severity set is closed and matched case-sensitively, and it is the plugin
 // contract's set spelled the same way on purpose — a person watching one
@@ -21,42 +24,137 @@ import (
 // relayed from a generator, and a script that greps for `^error: ` catches
 // both.
 //
-// `warning` is the third severity that set names, and this program has nothing
-// to say at it yet: it arrives with the relayed generator line, the spans and
-// the continuation lines, which are all #150's. It is spelled where it is used
-// rather than declared here for a caller that does not exist.
+// `warning` reaches this stream only from a generator: an `error:` cpybkc wrote
+// itself fails the run, and a fault that did not fail the run is not something
+// any stage of this pipeline raises today.
 const (
-	severityError = "error"
-	severityNote  = "note"
+	severityError   = "error"
+	severityWarning = "warning"
+	severityNote    = "note"
 
+	// severitySeparator is a colon and a single space and nothing else. It is
+	// also what separates a span from the message at it, and a generator's name
+	// from the line it wrote, because docs/cli/SPEC.md spells all three the
+	// same way.
 	severitySeparator = ": "
 )
 
+// continuationIndent opens a line that carries a further place a fault
+// implicates.
+//
+// Exactly two spaces, and it is the whole of what tells a continuation line
+// from a diagnostic: docs/cli/SPEC.md requires a continuation to carry no
+// severity and requires it not to be read as a diagnostic of its own, so the
+// indent has to be enough on its own for a reader scanning a column of faults
+// and for a script matching `^error: `.
+const continuationIndent = "  "
+
+// emptyMessage is what a fault with nothing to say is reported as.
+//
+// A bare `error: ` says nothing anybody can act on. An error with no message is
+// a bug in this program, and it is reported as one rather than as silence
+// beside a non-zero exit.
+const emptyMessage = "cpybkc failed and said nothing about why, which is a bug in cpybkc"
+
 // report writes err to w as the diagnostics a failed run owes its user.
 //
-// The error's own message is the `error:` line. A message that arrived with
-// newlines in it — a wrapped error, most likely — has its remaining lines
-// written as `note:` diagnostics, so that a fault cannot put a line on standard
-// error that no severity opens.
+// Every fault in err is reported, not the first: docs/cli/SPEC.md requires more
+// than one fault found in one pass to come out together, and the readers in
+// this repository already collect rather than stopping, so what arrives here is
+// routinely an [errors.Join] of several. [diag.Diagnostics] is what walks that
+// tree, in the order the faults were reported, which is also what makes this
+// stream deterministic for a given failing input.
 func report(w io.Writer, err error) {
-	message := err.Error()
+	found := diag.Diagnostics(err)
+	if len(found) == 0 {
+		// Only reachable for a nil error, which is not a failed run. Reporting
+		// it is cheaper than a stream that says a run failed and then says
+		// nothing.
+		diagnostic(w, severityError, emptyMessage)
+
+		return
+	}
+
+	for _, d := range found {
+		reportDiagnostic(w, d)
+	}
+}
+
+// reportDiagnostic writes one fault: where it is, what it is, and every further
+// place it implicates.
+//
+//	error: orders.sexpr:22:9: ORDER-DETAIL declares no item OD-QTY
+//	  cpy/orders.cpy:41:8: it declares OD-QUANTITY and OD-PRICE
+//
+// The span leads the message because docs/cli/SPEC.md requires it to, in
+// `file:line:column` form — or the file alone where a line number would point
+// at nothing, which is [diag.Span.String]'s to decide rather than this
+// function's.
+//
+// A message that arrived with newlines in it — a wrapped error, most likely —
+// has its remaining lines written as `note:` diagnostics, so that a fault
+// cannot put a line on standard error that no severity opens. They come after
+// the continuation lines because the continuations belong to the fault the
+// first line states, while a second line of a message is a second thing to say
+// about it.
+func reportDiagnostic(w io.Writer, d diag.Diagnostic) {
+	message := d.Message
 	if strings.TrimSpace(message) == "" {
-		// A bare `error: ` says nothing anybody can act on. An error with no
-		// message is a bug in this program, and it is reported as one rather
-		// than as silence beside a non-zero exit.
-		message = "cpybkc failed and said nothing about why, which is a bug in cpybkc"
+		message = emptyMessage
 	}
 
 	lines := strings.Split(message, "\n")
 
-	diagnostic(w, severityError, lines[0])
+	head := lines[0]
+	if len(d.Spans) > 0 && d.Spans[0].Stated() {
+		head = d.Spans[0].String() + severitySeparator + head
+	}
+
+	diagnostic(w, severityError, head)
+
+	if len(d.Spans) > 1 {
+		for _, span := range d.Spans[1:] {
+			continuation(w, span)
+		}
+	}
 
 	for _, line := range lines[1:] {
 		diagnostic(w, severityNote, line)
 	}
 }
 
-// diagnostic writes one line.
+// continuation writes one further place a fault implicates: the place, what is
+// at it, or — where there is nowhere to name — what it has to say and nothing
+// else.
+//
+// Each line of it is indented separately. A note that arrived carrying a
+// newline is still one continuation, and writing its second line unindented
+// would put a line on this stream that reads as neither a diagnostic nor part
+// of one.
+func continuation(w io.Writer, span diag.Span) {
+	text := span.Note
+
+	if span.Stated() {
+		text = span.String()
+
+		if span.Note != "" {
+			text += severitySeparator + span.Note
+		}
+	}
+
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimRight(line, " \t")
+		if line == "" {
+			continue
+		}
+
+		_, _ = fmt.Fprint(w, continuationIndent+line+"\n")
+	}
+}
+
+// diagnostic writes one line cpybkc wrote itself, which is why it carries no
+// origin: docs/cli/SPEC.md makes the absence of a name what says a line is
+// cpybkc's own.
 //
 // The write is unchecked because there is nowhere left to report a failure to
 // write to the diagnostic channel to — the exit status is what the caller

--- a/cmd/cpybkc/diagnostic_test.go
+++ b/cmd/cpybkc/diagnostic_test.go
@@ -1,0 +1,250 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+	"github.com/Zaba505/cpybkc/internal/layout"
+	"github.com/Zaba505/cpybkc/internal/layoutmodel"
+	"github.com/Zaba505/cpybkc/internal/manifest"
+)
+
+// reported is what a caller holding err and a terminal sees.
+func reported(err error) string {
+	var stderr bytes.Buffer
+
+	report(&stderr, err)
+
+	return stderr.String()
+}
+
+// The goldens below are written out in full rather than assembled, because what
+// they pin is the shape of the stream and not the wording of any one message.
+// docs/cli/SPEC.md says as much: the wording is explicitly not a covered
+// guarantee and the format around it is, so a golden built from the messages
+// would agree with itself whatever the format became.
+
+// brokenManifest is a manifest with three independent faults in it, in three
+// different places: a field no manifest has, a list written as a single string,
+// and a required field that is not there at all.
+//
+// Nothing here depends on any two of them, which is the point — a manifest is
+// written by hand and gets three things wrong at once, and a reader that
+// stopped at the first would be a reader the adopter ran three times.
+const brokenManifest = `{
+  "output": "gen",
+  "inputs": ["cpy/orders.cpy"],
+  "generators": [
+    {"name": "go", "out": "gen/orders", "options": "verbose=true"}
+  ]
+}`
+
+// goldenManifest is what a malformed manifest reads as.
+//
+// Every line names the manifest, the line and the column, and all three faults
+// are there: docs/cli/SPEC.md requires more than one fault found in one pass to
+// be reported together rather than one per run.
+const goldenManifest = `error: cpybkc.json:2:3: a manifest has no field named "output"; it carries inputs, layout and generators
+error: cpybkc.json:5:52: generators[0].options is an object of generator options, and this one is text
+error: cpybkc.json:1:1: a manifest carries no layout; a project resolves its records against exactly one
+`
+
+// TestAMalformedManifestReportsEveryFaultWithItsPlace is the golden for the
+// first of the four failures docs/cli/SPEC.md's stream has to carry.
+func TestAMalformedManifestReportsEveryFaultWithItsPlace(t *testing.T) {
+	t.Parallel()
+
+	m, err := manifest.Read(manifest.Name, strings.NewReader(brokenManifest))
+	if err == nil {
+		t.Fatalf("the reader accepted a manifest with three faults in it: %+v", m)
+	}
+
+	if got := reported(err); got != goldenManifest {
+		t.Errorf("standard error is not the golden\n got:\n%s\nwant:\n%s", got, goldenManifest)
+	}
+}
+
+// brokenLayout is one layout with two independent faults in two places: a
+// charset nobody has a table for, and an override naming no axis at all.
+const brokenLayout = `(encoding
+  (charset cp999)
+  (sign-convention ebcdic)
+  (byte-order big-endian)
+  (float-format ieee-754))
+(encoding-override (item ORDER-HEADER OH-AMOUNT))`
+
+// goldenLayout is what an invalid layout reads as.
+const goldenLayout = `error: orders.sexpr:2:12: charset is one of cp037, cp500, cp1047, cp1140 or ascii, and this one says "cp999"
+error: orders.sexpr:6:1: the override on (item ORDER-HEADER OH-AMOUNT) states no axis; an override states at least one of charset, sign-convention, byte-order or float-format
+`
+
+// TestAnInvalidLayoutReportsTheSpanTheReaderResolved is the golden for the
+// second, and it is the half of #31 this story is the last mile of: the span a
+// reader computed is what lands on the terminal, in `file:line:column` form,
+// rather than a description of where the fault is.
+func TestAnInvalidLayoutReportsTheSpanTheReaderResolved(t *testing.T) {
+	t.Parallel()
+
+	file, err := layout.Parse("orders.sexpr", strings.NewReader(brokenLayout))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	profile, err := layoutmodel.ReadProfile(file)
+	if err == nil {
+		t.Fatalf("the reader accepted a layout with two faults in it: %+v", profile)
+	}
+
+	if got := reported(err); got != goldenLayout {
+		t.Errorf("standard error is not the golden\n got:\n%s\nwant:\n%s", got, goldenLayout)
+	}
+}
+
+// crossFile is the fault #31 exists for: one raised in the layout, about a
+// copybook, with a place in each.
+var crossFile = &diag.UndeclaredItemError{
+	Pos:      diag.Span{File: "orders.sexpr", Line: 22, Column: 9},
+	Path:     "cpy/orders.cpy",
+	Item:     "ORDER-DETAIL",
+	Copybook: diag.Span{File: "cpy/orders.cpy", Line: 41, Column: 8},
+	Declares: []string{"OD-QUANTITY", "OD-PRICE"},
+}
+
+// goldenCrossFile is the shape docs/cli/SPEC.md writes out by hand: the fault
+// under the place it is at, and the second file on a continuation line opening
+// with exactly two spaces and carrying no severity of its own.
+const goldenCrossFile = `error: orders.sexpr:22:9: the copybook "cpy/orders.cpy" declares no ORDER-DETAIL
+  cpy/orders.cpy:41:8: it declares OD-QUANTITY and OD-PRICE
+`
+
+// TestACrossFileFaultCarriesBothPlaces is the criterion that a validation
+// error's spans reach the terminal across a layout that references copybooks,
+// and not just the one span the message leads with.
+func TestACrossFileFaultCarriesBothPlaces(t *testing.T) {
+	t.Parallel()
+
+	if got := reported(crossFile); got != goldenCrossFile {
+		t.Errorf("standard error is not the golden\n got:\n%s\nwant:\n%s", got, goldenCrossFile)
+	}
+}
+
+// TestAContinuationLineIsNotADiagnostic holds the one rule that tells the two
+// apart. A reader scanning a column of faults reads the unindented lines and
+// finds one per thing to fix; a script matching `^error: ` has to find the same
+// number.
+func TestAContinuationLineIsNotADiagnostic(t *testing.T) {
+	t.Parallel()
+
+	stderr := reported(crossFile)
+
+	for _, line := range strings.Split(strings.TrimRight(stderr, "\n"), "\n") {
+		if strings.HasPrefix(line, continuationIndent) {
+			for _, severity := range []string{severityError, severityWarning, severityNote} {
+				if strings.HasPrefix(strings.TrimLeft(line, " "), severity+severitySeparator) {
+					t.Errorf("the continuation line %q carries a severity of its own", line)
+				}
+			}
+
+			continue
+		}
+
+		if !strings.HasPrefix(line, severityError+severitySeparator) {
+			t.Errorf("%q opens with neither a severity nor the continuation indent", line)
+		}
+	}
+}
+
+// TestEveryFaultOfAJoinedErrorIsReported is the criterion stated against the
+// shape the readers actually hand back: [errors.Join], which is what a reader
+// that kept going after a fault returns.
+func TestEveryFaultOfAJoinedErrorIsReported(t *testing.T) {
+	t.Parallel()
+
+	joined := errors.Join(
+		&manifest.NotFoundError{Path: "cpybkc.json"},
+		crossFile,
+		errors.New("something with no diagnostic of its own"),
+	)
+
+	stderr := reported(joined)
+
+	if got, want := strings.Count(stderr, severityError+severitySeparator), 3; got != want {
+		t.Errorf("reported %d faults, want %d:\n%s", got, want, stderr)
+	}
+
+	if !strings.Contains(stderr, "something with no diagnostic of its own") {
+		t.Errorf("the fault carrying no diagnostic was dropped:\n%s", stderr)
+	}
+}
+
+// TestTheSameFailureIsReportedByteForByte is docs/cli/SPEC.md's determinism
+// rule for this stream, asserted where it can be: one stage's faults, reported
+// twice.
+func TestTheSameFailureIsReportedByteForByte(t *testing.T) {
+	t.Parallel()
+
+	m, err := manifest.Read(manifest.Name, strings.NewReader(brokenManifest))
+	if err == nil {
+		t.Fatalf("the reader accepted a manifest with three faults in it: %+v", m)
+	}
+
+	first := reported(err)
+
+	for range 8 {
+		if got := reported(err); got != first {
+			t.Fatalf("the same failure reported differently\nfirst:\n%s\nthen:\n%s", first, got)
+		}
+	}
+}
+
+// TestAFaultWithNoPlaceIsReportedWithoutOne covers the span a diagnostic has
+// not got. An invented `0:0` is a position a reader would try to open, so a
+// fault that names nowhere says what it has to say and nothing else.
+func TestAFaultWithNoPlaceIsReportedWithoutOne(t *testing.T) {
+	t.Parallel()
+
+	want := severityError + severitySeparator + "the run was cancelled\n"
+
+	if got := reported(errors.New("the run was cancelled")); got != want {
+		t.Errorf("report wrote %q, want %q", got, want)
+	}
+}
+
+// TestAContinuationWithNoPlaceCarriesOnlyItsNote is the second half of the
+// continuation form docs/cli/SPEC.md fixes: a fault implicating something with
+// no place to name still says what it has to say, indented, and still carries
+// no severity.
+func TestAContinuationWithNoPlaceCarriesOnlyItsNote(t *testing.T) {
+	t.Parallel()
+
+	err := &fault{diag.Diagnostic{
+		Message: "the generator \"go\" was terminated by signal 9 (killed)",
+		Spans: []diag.Span{
+			{},
+			{Note: "a generator that is killed is usually the machine running out of memory"},
+		},
+	}}
+
+	want := severityError + severitySeparator + "the generator \"go\" was terminated by signal 9 (killed)\n" +
+		continuationIndent + "a generator that is killed is usually the machine running out of memory\n"
+
+	if got := reported(err); got != want {
+		t.Errorf("report wrote %q, want %q", got, want)
+	}
+}
+
+// fault is an error carrying whatever diagnostic a test needs, for the shapes
+// no reader in this repository happens to raise today.
+type fault struct{ diagnostic diag.Diagnostic }
+
+func (f *fault) Error() string { return f.diagnostic.String() }
+
+func (f *fault) Diagnostic() diag.Diagnostic { return f.diagnostic }

--- a/cmd/cpybkc/main.go
+++ b/cmd/cpybkc/main.go
@@ -10,11 +10,19 @@
 //	cpybkc --help
 //
 // As it stands it is the outermost layer of that command and nothing behind it:
-// it parses the argument vector, answers --help and --version, and turns a
-// fault into an exit status. It reads no manifest, resolves no layout, emits no
-// descriptor and starts no generator, and a run that asks for any of that fails
-// with a diagnostic saying so. Finding the manifest and resolving it is #148,
-// --emit-ir is #149, and the diagnostics the stages owe are #150.
+// it parses the argument vector, answers --help and --version, turns a fault
+// into an exit status, and reports whatever failed. It reads no manifest,
+// resolves no layout, emits no descriptor and starts no generator, and a run
+// that asks for any of that fails with a diagnostic saying so. Finding the
+// manifest and resolving it is #148, and --emit-ir is #149.
+//
+// What those stages will have to say for themselves already has a stream and a
+// shape. Every fault reaches the user through [report], which renders the
+// [github.com/Zaba505/cpybkc/internal/diag] diagnostics the readers of this
+// repository raise — each under the file, line and column it is at, with the
+// second file a cross-file fault implicates on a continuation line, and all of
+// them rather than the first. A generator's own lines reach the same stream in
+// the same shape through [logger].
 //
 // docs/cli/SPEC.md is the contract, and this command implements it rather than
 // restating it. The command set, the argument vector, where the manifest is
@@ -46,6 +54,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 )
 
@@ -62,7 +71,12 @@ func main() {
 // That is why a failure is reported here, where both streams are in hand,
 // rather than by whatever raised it.
 func run(args []string, stdout, stderr io.Writer) status {
-	err := execute(args, stdout)
+	// The log a generator's output reaches this stream through is built here,
+	// beside the stream, because docs/cli/SPEC.md's rule is about standard
+	// error and not about any one stage: a generator's line and a layout's
+	// fault are the same stream in the same shape, and the place that knows
+	// which writer that is is the place that decides both.
+	err := execute(args, stdout, logger(stderr))
 	if err == nil {
 		return statusOK
 	}
@@ -88,7 +102,7 @@ func run(args []string, stdout, stderr io.Writer) status {
 
 // execute performs what the line asked for, and writes to standard output only
 // what was asked for by name.
-func execute(args []string, stdout io.Writer) error {
+func execute(args []string, stdout io.Writer, log *slog.Logger) error {
 	inv, err := parse(args)
 	if err != nil {
 		return err
@@ -104,7 +118,7 @@ func execute(args []string, stdout io.Writer) error {
 
 		return nil
 	case answerRun:
-		return perform(inv)
+		return perform(inv, log)
 	}
 
 	// Unreachable: parse returns one of the three answers above. It is a
@@ -122,7 +136,15 @@ func execute(args []string, stdout io.Writer) error {
 // run, so an unwired pipeline exiting 0 is indistinguishable from a project
 // whose generators all ran. Status 1 with a diagnostic naming the story is the
 // honest answer, and it is a status the document already enumerates.
-func perform(inv invocation) error {
+//
+// log is where a generator's output reaches standard error, in the form
+// docs/cli/SPEC.md fixes for a relayed line. It is
+// [github.com/Zaba505/cpybkc/internal/plugin.Runner]'s Log, and it arrives here
+// rather than being built where the runner is because the writer it renders to
+// is [run]'s standard error and not a stream this stage is entitled to choose.
+// Nothing in this build starts a generator, so nothing in this build writes
+// through it yet; #148 is what does.
+func perform(inv invocation, log *slog.Logger) error {
 	if inv.emitting() {
 		return fmt.Errorf("this build cannot write the %s descriptor %s asked for: it parses the command "+
 			"line and answers %s and %s, and it has not read %s (#149)",

--- a/cmd/cpybkc/main_test.go
+++ b/cmd/cpybkc/main_test.go
@@ -250,12 +250,12 @@ func TestEveryDiagnosticLineCarriesASeverity(t *testing.T) {
 
 	for _, line := range strings.Split(strings.TrimRight(diagnostics, "\n"), "\n") {
 		switch {
-		case strings.HasPrefix(line, "  "):
+		case strings.HasPrefix(line, continuationIndent):
 			// A continuation line carries no severity of its own, and the
 			// two-space indent is what tells the two apart.
 		case strings.HasPrefix(line, severityError+severitySeparator),
 			strings.HasPrefix(line, severityNote+severitySeparator),
-			strings.HasPrefix(line, "warning"+severitySeparator):
+			strings.HasPrefix(line, severityWarning+severitySeparator):
 		default:
 			t.Errorf("standard error carries %q, which opens with no severity", line)
 		}

--- a/cmd/cpybkc/relay.go
+++ b/cmd/cpybkc/relay.go
@@ -1,0 +1,196 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+)
+
+// generatorKey is the attribute
+// [github.com/Zaba505/cpybkc/internal/plugin.Runner] names a generator with,
+// and it is the name as the manifest spells it.
+//
+// It is a constant here and there rather than a shared one because the log is
+// the seam between the two: the runner decides what it records and this decides
+// what a record looks like on a terminal, and a package neither of them owns
+// holding the key would put a third party between them.
+const generatorKey = "generator"
+
+// relay is the [slog.Handler] a generator's output reaches standard error
+// through.
+//
+// docs/plugin/SPEC.md requires cpybkc to parse a generator's diagnostics into
+// its structured log at the corresponding level, to surface every other line
+// verbatim at warning, and to discard nothing. That parsing is
+// [github.com/Zaba505/cpybkc/internal/plugin]'s, and what arrives here is its
+// result: a record per line, at the level the severity named, attributed to the
+// generator that wrote it. docs/cli/SPEC.md fixes what that log looks like when
+// it comes out — the same `<severity>: <message>` form as cpybkc's own
+// diagnostics, with the generator's name standing between the severity and the
+// message.
+//
+// A handler rather than a wrapper around the runner because the level is where
+// the severity went. Reconstituting a severity from a rendered string would be
+// parsing back out what the contract just had a plugin write down, and the two
+// spellings would then be free to disagree.
+type relay struct {
+	// mu serialises the writes, so that a line arrives whole.
+	//
+	// Generators run concurrently (#42) and each has two streams being read at
+	// once, so without this a line could be interleaved with another mid-word.
+	// docs/cli/SPEC.md leaves the order of two generators' lines unspecified
+	// and says nothing that would permit half a line.
+	mu *sync.Mutex
+
+	// w is standard error.
+	w io.Writer
+
+	// name is the generator every record through this handler came from, taken
+	// from the attribute the runner attaches with [slog.Logger.With]. It is
+	// empty for a line cpybkc wrote itself, and the absence of a name is what
+	// docs/cli/SPEC.md makes that mean.
+	name string
+
+	// grouped records that a group is open, which stops [generatorKey] being
+	// read out of a record's attributes.
+	//
+	// Inside a group that key is a different key — `run.generator` is not
+	// `generator` — and attributing a line to whatever happened to be called
+	// `generator` in some nested group would put a name on a line no generator
+	// wrote.
+	grouped bool
+}
+
+// newRelay is the handler writing to w.
+func newRelay(w io.Writer) *relay {
+	return &relay{mu: new(sync.Mutex), w: w}
+}
+
+// Enabled implements [slog.Handler].
+//
+// Every level is enabled, because every level here is a line a generator wrote
+// and docs/plugin/SPEC.md says none of them is discarded. A threshold would be
+// a filter on somebody else's output; the one place that decides what reaches
+// this stream is the plugin contract, and it has already decided.
+func (r *relay) Enabled(context.Context, slog.Level) bool { return true }
+
+// Handle implements [slog.Handler].
+func (r *relay) Handle(_ context.Context, record slog.Record) error {
+	name := r.name
+
+	if !r.grouped {
+		record.Attrs(func(attr slog.Attr) bool {
+			if attr.Key == generatorKey {
+				name = attr.Value.String()
+			}
+
+			return true
+		})
+	}
+
+	severity := severityOf(record.Level)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// A record carrying a newline is a line long enough that the reader handed
+	// it over in pieces, or a plugin that wrote one where the contract says a
+	// diagnostic has none. Either way every piece of it is written at the
+	// severity the whole arrived at, because the alternative is a line on this
+	// stream that no severity opens.
+	for _, line := range strings.Split(record.Message, "\n") {
+		relayed(r.w, severity, name, line)
+	}
+
+	return nil
+}
+
+// WithAttrs implements [slog.Handler].
+//
+// Only [generatorKey] is kept. The runner's other attribute says which of the
+// generator's two streams a line came from, and docs/cli/SPEC.md has already
+// spent that: the stream is what decided the severity, so repeating it on the
+// line would be saying the same thing twice in a form a reader has to translate.
+func (r *relay) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return r
+	}
+
+	next := *r
+
+	if !next.grouped {
+		for _, attr := range attrs {
+			if attr.Key == generatorKey {
+				next.name = attr.Value.String()
+			}
+		}
+	}
+
+	return &next
+}
+
+// WithGroup implements [slog.Handler].
+func (r *relay) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return r
+	}
+
+	next := *r
+	next.grouped = true
+
+	return &next
+}
+
+// severityOf is the level a line arrived at, back in the words a reader sees.
+//
+// docs/plugin/SPEC.md maps `error:` to error, `warning:` to warning and `note:`
+// to info, and puts a line that is not a diagnostic at warning. This is that
+// mapping read the other way, so a generator's own severity reaches the user
+// rather than a summary of it — docs/cli/SPEC.md requires the severity never to
+// change on the way through.
+//
+// The comparisons are ordered rather than exact so that a level between two of
+// slog's named ones is reported at the milder of the two it sits between, which
+// is the only way to answer without inventing a fourth severity.
+func severityOf(level slog.Level) string {
+	switch {
+	case level >= slog.LevelError:
+		return severityError
+	case level >= slog.LevelWarn:
+		return severityWarning
+	default:
+		return severityNote
+	}
+}
+
+// relayed writes one line that came from a generator.
+//
+// Unlike [diagnostic] it writes a line with nothing in it rather than dropping
+// one: docs/plugin/SPEC.md says a generator's output is never discarded, and a
+// blank line a generator wrote is output. What it becomes is the severity and
+// the name with nothing after them, which is a line saying exactly that.
+func relayed(w io.Writer, severity, name, message string) {
+	text := message
+	if name != "" {
+		text = name + severitySeparator + message
+	}
+
+	line := strings.TrimRight(severity+severitySeparator+text, " \t")
+
+	_, _ = io.WriteString(w, line+"\n")
+}
+
+// logger is the log to hand to
+// [github.com/Zaba505/cpybkc/internal/plugin.Runner].
+//
+// It exists so that the one place that knows where diagnostics go is the one
+// place that builds the log they arrive in, rather than a stage further down
+// deciding for itself.
+func logger(w io.Writer) *slog.Logger { return slog.New(newRelay(w)) }

--- a/cmd/cpybkc/relay.go
+++ b/cmd/cpybkc/relay.go
@@ -172,17 +172,30 @@ func severityOf(level slog.Level) string {
 
 // relayed writes one line that came from a generator.
 //
-// Unlike [diagnostic] it writes a line with nothing in it rather than dropping
-// one: docs/plugin/SPEC.md says a generator's output is never discarded, and a
-// blank line a generator wrote is output. What it becomes is the severity and
-// the name with nothing after them, which is a line saying exactly that.
+// The message is written exactly as it arrived, which is not what [diagnostic]
+// does with a line of cpybkc's own: docs/plugin/SPEC.md requires a line that is
+// not a diagnostic to be surfaced verbatim, and trailing whitespace is part of
+// a line a generator wrote — a plugin emitting a padded column or a shell
+// tracing itself is saying something about how it writes, and cpybkc tidying
+// that away would be reporting output nobody produced.
+//
+// Unlike [diagnostic] it also writes a line with nothing in it rather than
+// dropping one, because a generator's output is never discarded and a blank
+// line it wrote is output. What that becomes is the severity and the name with
+// nothing after them: the separator's own trailing space goes, since it belongs
+// to this rendering rather than to the line, and there is no message left for
+// it to separate.
 func relayed(w io.Writer, severity, name, message string) {
-	text := message
+	line := severity + severitySeparator
 	if name != "" {
-		text = name + severitySeparator + message
+		line += name + severitySeparator
 	}
 
-	line := strings.TrimRight(severity+severitySeparator+text, " \t")
+	if message == "" {
+		line = strings.TrimSuffix(line, " ")
+	} else {
+		line += message
+	}
 
 	_, _ = io.WriteString(w, line+"\n")
 }

--- a/cmd/cpybkc/relay_test.go
+++ b/cmd/cpybkc/relay_test.go
@@ -303,6 +303,48 @@ echo 'ERROR: shouting' >&2`)
 	}
 }
 
+// TestALineThatIsNotADiagnosticIsRelayedVerbatim is docs/plugin/SPEC.md's rule
+// for the line cpybkc could not classify: it is surfaced verbatim and
+// attributed, and verbatim includes the whitespace a generator ended it with.
+//
+// An indented frame of a stack trace and a line of trailing padding are the two
+// this is about. Tidying either would report output the generator did not
+// produce, in the one situation — a generator failing in a way its author did
+// not anticipate — where what it actually wrote is all a reader has.
+func TestALineThatIsNotADiagnosticIsRelayedVerbatim(t *testing.T) {
+	t.Parallel()
+
+	stderr, _, err := generate(t, `printf 'at frame 3   \n' >&2
+printf '\tgoroutine 1 [running]:  \n' >&2`)
+	if err != nil {
+		t.Fatalf("a generator that exited zero failed the run: %v", err)
+	}
+
+	want := "warning: go: at frame 3   \n" +
+		"warning: go: \tgoroutine 1 [running]:  \n"
+
+	if stderr != want {
+		t.Errorf("standard error is %q, want %q", stderr, want)
+	}
+}
+
+// TestABlankLineIsRelayedAsTheSeverityAndTheNameAlone is the one line with
+// nothing to preserve. It is still relayed, because a generator's output is
+// never discarded, and the separator's trailing space goes with the message it
+// had nothing to separate.
+func TestABlankLineIsRelayedAsTheSeverityAndTheNameAlone(t *testing.T) {
+	t.Parallel()
+
+	stderr, _, err := generate(t, `echo '' >&2`)
+	if err != nil {
+		t.Fatalf("a generator that exited zero failed the run: %v", err)
+	}
+
+	if got, want := stderr, "warning: go:\n"; got != want {
+		t.Errorf("standard error is %q, want %q", got, want)
+	}
+}
+
 // TestALineCpybkcWroteItselfCarriesNoName is what the absence of a name means.
 // docs/cli/SPEC.md makes it the whole of how a reader tells cpybkc's own line
 // from a generator's, so a record with no generator attribute has to come out

--- a/cmd/cpybkc/relay_test.go
+++ b/cmd/cpybkc/relay_test.go
@@ -1,0 +1,375 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/plugin"
+	"github.com/Zaba505/cpybkc/irpb"
+)
+
+// The generators below are shell scripts, for the reason
+// internal/plugin/invoke_test.go gives: docs/plugin/SPEC.md makes one a
+// first-class plugin, and what is under test here is what a real process's
+// output looks like once it has been through the contract's parsing and out
+// onto this command's standard error. A fake would let this package agree with
+// itself about a stream neither half ever wrote to.
+
+// generatorName is what the manifest calls the generator every test below runs,
+// and it is the name docs/cli/SPEC.md puts between the severity and the message
+// on a relayed line.
+const generatorName = "go"
+
+// descriptor is the message a run hands over. It is the smallest whole one,
+// because what these tests are about is what came back out on standard error.
+func descriptor() *irpb.Descriptor {
+	return &irpb.Descriptor{
+		Version: irpb.IrVersion_IR_VERSION_1,
+		Nodes: []*irpb.Node{
+			{
+				Id: 1,
+				Kind: &irpb.Node_File{File: &irpb.File{
+					Framing:      &irpb.File_Unframed{Unframed: &irpb.Unframed{}},
+					StartStateId: 2,
+				}},
+			},
+			{
+				Id:   2,
+				Kind: &irpb.Node_State{State: &irpb.State{Accepts: true}},
+			},
+		},
+	}
+}
+
+// generate runs one generator whose body is body, with its output rendered the
+// way this command renders it, and hands back that standard error, the
+// executable it ran and the run's verdict.
+//
+// The path comes back because a fault naming it names one under a directory the
+// operating system chose; a golden carrying that would be a golden that passes
+// on one machine, so [anonymise] is what a golden is compared against.
+func generate(t *testing.T, body string) (stderr, executable string, err error) {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	path := filepath.Join(dir, plugin.Filename(generatorName))
+	if writeErr := os.WriteFile(path, []byte("#!/bin/sh\n"+body+"\n"), 0o755); writeErr != nil {
+		t.Fatalf("writing %s: %v", path, writeErr)
+	}
+
+	var out bytes.Buffer
+
+	runner := &plugin.Runner{
+		Log:     logger(&out),
+		TempDir: t.TempDir(),
+		// PATH is stated rather than inherited because Env is either the whole
+		// environment or nothing, and a shell script needs the commands it
+		// calls.
+		Env: []string{"PATH=" + os.Getenv("PATH")},
+	}
+
+	err = runner.Run(t.Context(), descriptor(), []plugin.Invocation{
+		{Name: generatorName, Path: path, Out: t.TempDir()},
+	})
+
+	return out.String(), path, err
+}
+
+// anonymise takes the executable's path back out of a stream, so that what a
+// golden pins is everything about the diagnostic except where a test happened
+// to put a file.
+func anonymise(stream, executable string) string {
+	return strings.ReplaceAll(stream, executable, "<generator>")
+}
+
+// chatty is a generator writing one line of every kind docs/cli/SPEC.md's relay
+// table has a row for, and then exiting zero.
+const chatty = `echo 'error: ORDER-DETAIL.OD-QTY: USAGE COMP-3 is not supported by this generator' >&2
+echo 'note: ORDER-DETAIL.OD-QTY: declared as PIC S9(5)V99' >&2
+echo 'warning: ORDER-TRAILER: no accessor was generated' >&2
+echo 'panic: runtime error: index out of range [3]' >&2
+echo 'wrote gen/orders/orders.go'`
+
+// goldenChatty is what the four lines [chatty] wrote to standard error read as
+// once they are cpybkc's, in the order that generator wrote them.
+//
+// The severity is never changed on the way through, the generator's name stands
+// between the severity and the message, and the line that was not a diagnostic
+// is relayed at the level docs/plugin/SPEC.md argues for rather than dropped:
+// an unrecognised line on standard error at warning, one level above the note a
+// plugin writes deliberately.
+const goldenChatty = `error: go: ORDER-DETAIL.OD-QTY: USAGE COMP-3 is not supported by this generator
+note: go: ORDER-DETAIL.OD-QTY: declared as PIC S9(5)V99
+warning: go: ORDER-TRAILER: no accessor was generated
+warning: go: panic: runtime error: index out of range [3]
+`
+
+// goldenChattyStdout is the one line [chatty] wrote to its standard output.
+//
+// It is held apart from the golden above because the two streams are read
+// concurrently, so where it lands among the others is not something
+// docs/cli/SPEC.md fixes. What it says is: standard output is untidiness rather
+// than breakage — the contract makes writing there a SHOULD NOT — so it is
+// relayed at note, verbatim, and attributed the same way.
+const goldenChattyStdout = "note: go: wrote gen/orders/orders.go"
+
+// TestAGeneratorsDiagnosticsAreRelayedNamedAndAtTheirOwnSeverity is the golden
+// for the third of the four failures docs/cli/SPEC.md's stream has to carry.
+func TestAGeneratorsDiagnosticsAreRelayedNamedAndAtTheirOwnSeverity(t *testing.T) {
+	t.Parallel()
+
+	stderr, _, err := generate(t, chatty)
+	if err != nil {
+		t.Fatalf("a generator that exited zero failed the run: %v", err)
+	}
+
+	// The standard output line is taken out and checked on its own; what is
+	// left is standard error, which is fixed line for line.
+	var fromStderr []string
+
+	found := false
+
+	for _, line := range lines(stderr) {
+		if line == goldenChattyStdout {
+			found = true
+
+			continue
+		}
+
+		fromStderr = append(fromStderr, line)
+	}
+
+	if !found {
+		t.Errorf("what the generator wrote to standard output was not relayed as %q:\n%s", goldenChattyStdout, stderr)
+	}
+
+	if got := strings.Join(fromStderr, "\n") + "\n"; got != goldenChatty {
+		t.Errorf("standard error is not the golden\n got:\n%s\nwant:\n%s", got, goldenChatty)
+	}
+}
+
+// TestNothingAGeneratorWroteIsRelayedToStandardOutput is the rule that keeps
+// `--emit-ir -` pipeable. A generator's output is surfaced on cpybkc's standard
+// error and nowhere else, because cpybkc's standard output belongs to whoever
+// is reading it.
+func TestNothingAGeneratorWroteIsRelayedToStandardOutput(t *testing.T) {
+	t.Parallel()
+
+	stderr, _, err := generate(t, chatty)
+	if err != nil {
+		t.Fatalf("a generator that exited zero failed the run: %v", err)
+	}
+
+	if !strings.Contains(stderr, "wrote gen/orders/orders.go") {
+		t.Errorf("a line the generator wrote to standard output reached neither stream:\n%s", stderr)
+	}
+}
+
+// TestARelayedErrorDoesNotFailARunAndAWarningDoesNotEither is the severity rule
+// docs/cli/SPEC.md states twice: an `error:` cpybkc wrote itself fails the run,
+// a `warning:` or a `note:` never changes the status, and a *relayed* `error:`
+// is the generator's explanation rather than its verdict — the exit status is
+// the verdict.
+func TestARelayedErrorDoesNotFailARunAndAWarningDoesNotEither(t *testing.T) {
+	t.Parallel()
+
+	stderr, _, err := generate(t, `echo 'error: ORDER-DETAIL: nothing was generated for this record' >&2
+echo 'warning: ORDER-TRAILER: no accessor was generated' >&2
+exit 0`)
+	if err != nil {
+		t.Fatalf("a generator that exited zero after an error diagnostic failed the run: %v", err)
+	}
+
+	if statusOf(err) != statusOK {
+		t.Errorf("a generator's error diagnostic changed the exit status to %d", statusOf(err))
+	}
+
+	for _, want := range []string{
+		"error: go: ORDER-DETAIL: nothing was generated for this record",
+		"warning: go: ORDER-TRAILER: no accessor was generated",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("standard error does not carry %q:\n%s", want, stderr)
+		}
+	}
+}
+
+// goldenCrash is what a generator that explains itself and then dies reads as:
+// its own lines first, at its own severities, and then cpybkc's verdict on the
+// invocation with the executable that was running named on a continuation line.
+const goldenCrash = `error: go: ORDER-DETAIL.OD-QTY: USAGE COMP-3 is not supported by this generator
+warning: go: panic: runtime error: index out of range [3]
+error: the generator "go" failed: it exited 2
+  <generator>: this is the executable that ran
+`
+
+// TestAGeneratorCrashIsReportedWithWhatItSaidFirst is the golden for the fourth
+// failure, and it is the one that shows the two halves of this stream in one
+// place: a generator's lines are written as they arrive rather than held until
+// it exits, so the explanation reaches the user above the verdict on it.
+func TestAGeneratorCrashIsReportedWithWhatItSaidFirst(t *testing.T) {
+	t.Parallel()
+
+	stderr, executable, err := generate(t, `echo 'error: ORDER-DETAIL.OD-QTY: USAGE COMP-3 is not supported by this generator' >&2
+echo 'panic: runtime error: index out of range [3]' >&2
+exit 2`)
+	if err == nil {
+		t.Fatal("a generator that exited 2 did not fail the run")
+	}
+
+	if statusOf(err) != statusFailed {
+		t.Errorf("a crashed generator exited %d, want %d", statusOf(err), statusFailed)
+	}
+
+	got := anonymise(stderr+reported(err), executable)
+	if got != goldenCrash {
+		t.Errorf("standard error is not the golden\n got:\n%s\nwant:\n%s", got, goldenCrash)
+	}
+}
+
+// TestAGeneratorKilledIsDistinguishableFromOneThatExited is docs/cli/SPEC.md's
+// requirement that the two be told apart in the diagnostic, where the
+// difference is actionable: a non-zero exit is a bug in the generator and a
+// signal is usually a cancelled run or a machine out of memory.
+func TestAGeneratorKilledIsDistinguishableFromOneThatExited(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := generate(t, `kill -TERM $$; sleep 30`)
+	if err == nil {
+		t.Fatal("a generator killed by SIGTERM did not fail the run")
+	}
+
+	stderr := reported(err)
+
+	if !strings.Contains(stderr, "terminated by signal") {
+		t.Errorf("a killed generator was not reported as killed:\n%s", stderr)
+	}
+
+	if strings.Contains(stderr, "it exited") {
+		t.Errorf("a killed generator was reported as having exited:\n%s", stderr)
+	}
+
+	// The reason it is worth telling apart is on a continuation line, which
+	// names no place at all — there is nowhere to point at, and an invented one
+	// would be a position a reader would try to open.
+	if !strings.Contains(stderr, "\n"+continuationIndent+"a generator that is killed is usually") {
+		t.Errorf("the fault implicates nothing a reader can act on:\n%s", stderr)
+	}
+}
+
+// TestEveryRelayedLineOpensWithASeverity is the invariant a script reading this
+// stream depends on, asserted against output nobody wrote for it: a generator
+// writing blank lines, indented lines, a bare severity and a severity with no
+// space after it.
+//
+// docs/plugin/SPEC.md puts the last three on the text side of the line and says
+// none of them is discarded, so each has to come out carrying a severity of
+// cpybkc's choosing rather than not coming out at all.
+func TestEveryRelayedLineOpensWithASeverity(t *testing.T) {
+	t.Parallel()
+
+	stderr, _, err := generate(t, `echo '' >&2
+echo 'error: ' >&2
+echo 'error:something' >&2
+echo '    at frame 3' >&2
+echo 'ERROR: shouting' >&2`)
+	if err != nil {
+		t.Fatalf("a generator that exited zero failed the run: %v", err)
+	}
+
+	written := lines(stderr)
+	if len(written) != 5 {
+		t.Fatalf("five lines were written and %d came out:\n%s", len(written), stderr)
+	}
+
+	for _, line := range written {
+		switch {
+		case strings.HasPrefix(line, severityError+severitySeparator),
+			strings.HasPrefix(line, severityWarning+severitySeparator),
+			strings.HasPrefix(line, severityNote+severitySeparator):
+		default:
+			t.Errorf("standard error carries %q, which opens with no severity", line)
+		}
+	}
+}
+
+// TestALineCpybkcWroteItselfCarriesNoName is what the absence of a name means.
+// docs/cli/SPEC.md makes it the whole of how a reader tells cpybkc's own line
+// from a generator's, so a record with no generator attribute has to come out
+// with nothing standing between the severity and the message.
+func TestALineCpybkcWroteItselfCarriesNoName(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+
+	log := logger(&out)
+
+	log.Warn("the run is taking longer than usual")
+	log.With(slog.String(generatorKey, "go")).Warn("this one is the generator's")
+
+	want := "warning: the run is taking longer than usual\n" +
+		"warning: go: this one is the generator's\n"
+
+	if out.String() != want {
+		t.Errorf("the log rendered as %q, want %q", out.String(), want)
+	}
+}
+
+// TestAGroupedAttributeIsNotAGeneratorName covers the one way a name could be
+// invented. Inside a group `generator` is a different key, and a line
+// attributed to whatever happened to be called that in some nested group would
+// name a generator that wrote nothing.
+func TestAGroupedAttributeIsNotAGeneratorName(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+
+	logger(&out).WithGroup("run").With(slog.String(generatorKey, "go")).Error("something failed")
+
+	if got, want := out.String(), "error: something failed\n"; got != want {
+		t.Errorf("the log rendered as %q, want %q", got, want)
+	}
+}
+
+// TestEveryLevelMapsOntoTheClosedSetOfThree holds the mapping in both
+// directions: docs/plugin/SPEC.md sends `error:` to error, `warning:` to
+// warning and `note:` to info, and this is what a reader sees when each of them
+// comes back.
+func TestEveryLevelMapsOntoTheClosedSetOfThree(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		level slog.Level
+		want  string
+	}{
+		{slog.LevelError, severityError},
+		{slog.LevelError + 4, severityError},
+		{slog.LevelWarn, severityWarning},
+		{slog.LevelInfo, severityNote},
+		{slog.LevelDebug, severityNote},
+	} {
+		if got := severityOf(tc.level); got != tc.want {
+			t.Errorf("level %v renders as %q, want %q", tc.level, got, tc.want)
+		}
+	}
+}
+
+// lines is a stream as a reader reads it, with the trailing newline dropped.
+func lines(stream string) []string {
+	stream = strings.TrimSuffix(stream, "\n")
+	if stream == "" {
+		return nil
+	}
+
+	return strings.Split(stream, "\n")
+}


### PR DESCRIPTION
Closes #150

Makes cpybkc's failures readable to the person who caused them: the spans the
readers of this repository already compute now reach a terminal, in the form
`docs/cli/SPEC.md` fixes, and a generator's own lines reach the same stream in
the same shape.

## What changed

- `cmd/cpybkc/diagnostic.go` — `report` walks the error with
  `diag.Diagnostics` instead of splitting a message on newlines. Each fault
  leads with `Spans[0]` in `file:line:column` form (or the file alone where a
  line number would point at nothing), and every further place it implicates
  follows on a line indented by exactly two spaces, carrying no severity.
- `cmd/cpybkc/relay.go` — a `slog.Handler` that renders the structured log
  `internal/plugin` surfaces a generator's output into. The severity is the
  level read back the way `docs/plugin/SPEC.md` mapped it, and the generator's
  name stands between the severity and the message. Writes are serialised, so a
  line arrives whole while generators run concurrently.
- `cmd/cpybkc/main.go` — `run` builds that log beside the stream it renders to
  and threads it to `perform`, which is where `#148` hands it to
  `plugin.Runner.Log`. Nothing in this build starts a generator yet.

## Acceptance criteria

- [x] **Diagnostics are written to stderr in the format `docs/cli/SPEC.md`
  specifies, never to stdout** — `report` and the relay both take the writer
  `run` gives them, which is standard error; `TestAUsageErrorExitsTwoAndSaysSoOnStandardError`
  and `TestARunFailsUntilThePipelineIsWired` assert standard output stays empty,
  and `TestEveryDiagnosticLineCarriesASeverity` holds every line to
  `<severity>: <message>` or the continuation indent.
- [x] **Validation errors carry their cross-file source spans through to the
  output — file, line, column — as resolved by #31** —
  `TestACrossFileFaultCarriesBothPlaces` pins the exact two lines a
  `diag.UndeclaredItemError` renders as, and
  `TestAnInvalidLayoutReportsTheSpanTheReaderResolved` pins a real
  `layoutmodel.ReadProfile` failure.
- [x] **More than one validation error in a single run is reported together** —
  `diag.Diagnostics` walks the `errors.Join` the readers return.
  `TestAMalformedManifestReportsEveryFaultWithItsPlace` (three faults),
  `TestAnInvalidLayoutReportsTheSpanTheReaderResolved` (two) and
  `TestEveryFaultOfAJoinedErrorIsReported` cover it.
- [x] **Plugin diagnostic lines are parsed per `docs/plugin/SPEC.md` and
  relayed into the same stream at the matching level, with the generator
  identified as their origin (#39, #46)** — `relay`, exercised end to end
  against real generator processes in `relay_test.go`. Every row of the
  document's relay table has a line in `TestAGeneratorsDiagnosticsAreRelayedNamedAndAtTheirOwnSeverity`.
- [x] **Severity levels are honoured: a warning does not change the exit code,
  an error does** — `TestARelayedErrorDoesNotFailARunAndAWarningDoesNotEither`
  runs a generator that prints `error:` and exits zero, and asserts the run
  succeeded with both lines on the stream. `statusOf` is unchanged and remains
  the one place a status is decided.
- [x] **Golden tests assert exact stderr output for a representative failure of
  each kind** — malformed manifest (`goldenManifest`), invalid layout with a
  span (`goldenLayout`, `goldenCrossFile`), generator diagnostic
  (`goldenChatty`), generator crash (`goldenCrash`, plus a killed generator
  told apart from one that exited).
- [x] **Output is deterministic: the same failing input produces byte-identical
  stderr** — `TestTheSameFailureIsReportedByteForByte`. The order is the order
  the faults were reported, which is `diag.List`'s.

## Judgment calls

- **A `slog.Handler`, not a wrapper around the runner.** The plugin contract's
  severity became a level on the way in, so rebuilding it from a rendered
  string would parse back out what a plugin had just written down, and the two
  spellings would then be free to disagree.
- **The `stream` attribute is dropped on the way out.** It is what decided the
  severity, so putting it on the line as well says the same thing twice.
- **A grouped `generator` attribute is not a generator name.** Inside a group
  the key is `run.generator`, and attributing a line to whatever is called
  `generator` in a nested group would name a generator that wrote nothing.
- **A blank line from a generator is relayed rather than dropped**, unlike an
  empty message of cpybkc's own: `docs/plugin/SPEC.md` says a generator's output
  is never discarded. It comes out as the severity and the name with nothing
  after them.
- **Continuation lines come before the `note:` lines** a multi-line message
  falls back to: the continuations belong to the fault the first line states.
- **`perform` takes the log it does not yet use.** The writer it renders to is
  `run`'s standard error, not a stream that stage is entitled to choose, so the
  log is built once beside the stream and passed down; `#148` is what writes
  through it.

## Verified

`dagger call ci` passes in the worktree. `go test -race ./cmd/cpybkc/` and
`go test -count=3 ./...` pass; the generator tests are real processes running
shell-script plugins, as `internal/plugin`'s are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)