### PR TITLE
story(resolve): enforce that a predicate never reads past the shortest record in front of it

### DIFF
--- a/internal/resolve/automaton.go
+++ b/internal/resolve/automaton.go
@@ -483,12 +483,36 @@ type Sequencing struct {
 	// Reading is which of the two vendor readings of `OCCURS DEPENDING ON` the
 	// layout says its file was written under, for [Options.Reading]'s reason.
 	//
-	// It is read for one rule and nothing else: a discriminator's target must
-	// sit at a constant position within its record, and whether an item ahead
-	// of it has an extent that moves is a question only the reading answers.
-	// Under `noodoslide` the same clause is a fixed table and nothing moves,
-	// so a layout stating no reading is one this half never has to ask.
+	// It is read for two rules. A discriminator's target must sit at a constant
+	// position within its record, and whether an item ahead of it has an extent
+	// that moves is a question only the reading answers; and the shortest
+	// record a state can admit is measured with every table at the occurrence
+	// count the reading gives it. Under `noodoslide` the same clause is a fixed
+	// table and nothing moves, so a layout stating no reading is one this half
+	// never has to ask.
 	Reading layoutmodel.Reading
+
+	// Framing is the layout's physical framing, or nil where the caller has
+	// none to state.
+	//
+	// It is read for one rule, docs/ir/SPEC.md's "A predicate never reads past
+	// the record in front of it": which of the two mechanisms bounds a
+	// predicate is decided by the framing, and only the one that bounds the
+	// *layout* is a thing to reject a layout over (#94). What the rule needs of
+	// it is [layoutmodel.Framing.Kind] and, under a fixed-length dataset, the
+	// `lrecl` every record type is padded out to.
+	//
+	// The whole value is taken for [Options.Framing]'s reason: the bound
+	// follows from the record format and the `lrecl` read together, and a
+	// caller decomposing it here would be a second reading of
+	// docs/layout/SPEC.md's table.
+	//
+	// A nil framing states neither mechanism, and the rule is simply not run —
+	// as it is not for the two framings that state each record's length.
+	// [layoutmodel.ReadFraming] refuses a layout that does not carry exactly
+	// one `framing` form, so nil is a caller that assembled a [Sequencing] by
+	// hand rather than a layout an adopter wrote.
+	Framing *layoutmodel.Framing
 
 	// Encoding is the layout's encoding profile, and EncodingOverrides the
 	// per-item overrides over it: the four axes a literal is resolved to bytes

--- a/internal/resolve/automaton_test.go
+++ b/internal/resolve/automaton_test.go
@@ -8,6 +8,7 @@ package resolve
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
@@ -71,12 +72,20 @@ func countedRunCopybooks() map[string]string {
 }
 
 // compileLayout is the whole pipeline a caller runs: parse the layout, read the
-// two layers the automaton is compiled out of, resolve each record name to the
+// layers the automaton is compiled out of, resolve each record name to the
 // copybook the test gave it, and compile.
 //
 // It reports what compilation said rather than failing on it, because half of
 // these tests are about the fault.
 func compileLayout(t *testing.T, source string, copybooks map[string]string) (*Automaton, error) {
+	t.Helper()
+
+	return CompileSequence(sequencingOf(t, source, copybooks))
+}
+
+// sequencingOf is what [compileLayout] compiles, so that a test needing one
+// setting of its own can take the pipeline's answer and change that one thing.
+func sequencingOf(t *testing.T, source string, copybooks map[string]string) Sequencing {
 	t.Helper()
 
 	file, err := layout.Parse("layout.sexpr", strings.NewReader(source))
@@ -99,6 +108,7 @@ func compileLayout(t *testing.T, source string, copybooks map[string]string) (*A
 		Dialect:  copybook.IBMEnterprise(),
 		Reading:  layoutmodel.ODOSlide,
 		Encoding: mainframe(),
+		Framing:  framingIn(t, file),
 	}
 	for _, discriminator := range discrimination.Records {
 		src, bound := copybooks[discriminator.Record]
@@ -114,7 +124,34 @@ func compileLayout(t *testing.T, source string, copybooks map[string]string) (*A
 		})
 	}
 
-	return CompileSequence(opts)
+	return opts
+}
+
+// framingIn is the framing a test's layout states, or nil where it states none.
+//
+// Most of these layouts state none, because most of the automaton's rules are
+// about the sequence and not about the dataset the records came out of. The one
+// that is about both — how far into the file a predicate may read — is keyed on
+// the framing, so the tests for it write a `framing` form and this reads it, by
+// the same reader a layout goes through.
+//
+// The form's presence is what is tested and not the read's success:
+// [layoutmodel.ReadFraming] refuses a layout carrying no `framing` form at all,
+// and taking that as "states none" would make a malformed framing in a test
+// silently become the nil one, which is the value the rule is not run on.
+func framingIn(t *testing.T, file *layout.File) *layoutmodel.Framing {
+	t.Helper()
+
+	if !slices.ContainsFunc(file.Forms, func(form layout.Form) bool { return form.Tag == "framing" }) {
+		return nil
+	}
+
+	framing, err := layoutmodel.ReadFraming(file)
+	if err != nil {
+		t.Fatalf("reading the framing layer: %v", err)
+	}
+
+	return framing
 }
 
 // compiled is a layout the caller expects to compile.

--- a/internal/resolve/discriminator.go
+++ b/internal/resolve/discriminator.go
@@ -288,12 +288,190 @@ func (c *compiler) guardValues(e layoutmodel.Expression, register *Register) []V
 // discriminator that need the graph: the two strategies docs/ir/SPEC.md refuses
 // by name, the one it lowers into the start state, and the two shapes a
 // transition carrying no predicate is refused in.
+//
+// How far into the file a predicate reads is the graph's too and is not here:
+// it lands on a pair of transitions rather than on a record, so it is reported
+// where the other rule over a pair is ([compiler.reportReach]).
 func (c *compiler) checkDiscrimination(a *Automaton) {
 	for _, record := range c.opts.Records {
 		c.refuseStrategy(a, record)
 		c.checkFirst(a, record)
 		c.checkExtent(a, record)
 	}
+}
+
+// reportReach reports an overlapping pair whose predicate reaches past the
+// shortest record the other transition can put in front of a consumer, and says
+// whether it did.
+//
+// docs/ir/SPEC.md's "A predicate never reads past the record in front of it" is
+// the rule and the read loop's order is the reason. A predicate is evaluated at
+// step 3, against bytes nobody has identified yet: the record its own transition
+// would admit has an extent and the target sits inside it, but the record
+// actually in front of the consumer may be a shorter one another transition at
+// the same state admits, and a target past that record's last byte is a target
+// in the framing's bytes or the next record's data (#94).
+//
+// # Which framings it is keyed on, and why it is not keyed on all four
+//
+// Two mechanisms make the guarantee true and the framing picks one. Under
+// **descriptor-word** and **segmented** the length of the record in front of the
+// consumer is in hand at step 2, so step 3 spends it: a target not wholly within
+// the record the framing bounds does not match, and the bound is on the *read*.
+// Under **unframed** and **delimited** nothing in the file states a length
+// before the transition is taken, so the bound is on the *layout*, and this is
+// where it is placed. That is the whole of the answer to whether the rule
+// relaxes where the framing states each record's length: it does, because there
+// is a second mechanism there and it is a consumer's.
+//
+// A caller stating no framing states neither mechanism and the rule is not run.
+// It cannot be inferred from an `lrecl`, since the same number is a maximum
+// under two framings and a requirement under one.
+//
+// # Why it is reported here rather than as a pass of its own
+//
+// A pair this fires on is a pair the overlap rule fires on too, and the argument
+// is worth writing down because it is what makes the placement safe.
+//
+// Two predicates over one run of bytes are told apart by their literals and two
+// over different runs are not told apart at all (docs/ir/SPEC.md, "When two
+// match, and when none does"). So a pair that does *not* overlap reads one run,
+// at one offset and one width, in both records — and each predicate's target is
+// an item of its own record, sitting ahead of every item whose extent moves with
+// a count ([compiler.discriminator]'s constant-position check). That puts the
+// run inside the shortest reading of both records, and the rule cannot be broken
+// by a pair the overlap rule admits.
+//
+// What is left is which diagnostic an overlapping pair gets, and this one is
+// more specific: the generic one says a consumer could not tell the two records
+// apart, and this one says which bytes it would have read to try, and out of
+// which record. It replaces the generic one for [compiler.reportUnnameable]'s
+// reason rather than joining it, so that one pair is one thing to fix.
+func (c *compiler) reportReach(state *State, first, second *Transition) bool {
+	if !c.boundedByLayout() {
+		return false
+	}
+
+	// Both directions are asked and at most one can hold: a target is inside
+	// its own record, so a pair whose targets each reach past the other's
+	// record would need each record to be shorter than itself.
+	for _, pair := range [][2]*Transition{{first, second}, {second, first}} {
+		fault := c.reachFault(state, pair[0], pair[1])
+		if fault == nil {
+			continue
+		}
+
+		c.faults.Fail(fault)
+
+		return true
+	}
+
+	return false
+}
+
+// reachFault is the fault where on's predicate reaches past the shortest record
+// against admits, and nil where it does not.
+func (c *compiler) reachFault(state *State, on, against *Transition) *PredicateReachError {
+	// A record does not have to be told apart from itself, and its own
+	// predicate satisfies the rule already: the target is contained in the
+	// record the transition admits and sits ahead of every item whose width
+	// moves, so it is inside the shortest that record can be. What the rule
+	// adds is the records the state can put in front of it instead.
+	if on.Record == against.Record {
+		return nil
+	}
+
+	record, known := c.record(on.Record)
+	if !known {
+		return nil
+	}
+
+	over, ok := c.stretchOf(on.Record, on.Predicate)
+	if !ok {
+		return nil
+	}
+
+	extent, ok := c.shortestExtent(against.Record)
+	if !ok {
+		return nil
+	}
+
+	// A target beginning inside the bound and ending past it is the same
+	// fault as one beginning past it: what a consumer reads is the target's
+	// whole width, and half of it is as much outside the record as all of it
+	// (docs/ir/SPEC.md, "a target past it, and a target beginning inside it
+	// and ending beyond").
+	ends := over.at + over.width
+	if ends <= extent {
+		return nil
+	}
+
+	return &PredicateReachError{
+		Pos:      layoutSpan(record.Discriminator.Item.Pos),
+		Copybook: copybookSpan(record, on.Predicate.Target),
+		State:    state.ID,
+		Record:   on.Record,
+		Item:     itemName(on.Predicate.Target),
+		Beside:   against.Record,
+		Ends:     ends,
+		Extent:   extent,
+	}
+}
+
+// boundedByLayout reports whether the framing leaves a predicate's reach for the
+// layout to bound, which is [compiler.reportReach]'s own comment.
+func (c *compiler) boundedByLayout() bool {
+	if c.opts.Framing == nil {
+		return false
+	}
+
+	kind := c.opts.Framing.Kind()
+
+	return kind == layoutmodel.Unframed || kind == layoutmodel.Delimited
+}
+
+// shortestExtent is the fewest bytes a record of that type can put in front of a
+// consumer.
+//
+// It is the record's extent with every repetition whose count is a reference
+// taken at the minimum occurrences the copybook declared — bounds a repetition
+// already carries, read here for a second purpose (docs/ir/SPEC.md, "A variable
+// record is a sum with a variable term"). Under the non-sliding reading the same
+// clause is a fixed table at the declared maximum and there is no shorter
+// reading of the record to take, which is [resolver.referenceCount]'s division
+// and not a second one.
+//
+// Under a fixed-length dataset stating an `lrecl` the answer is that number and
+// not the copybook's sum: a record type whose items stop short carries the
+// difference as slack and the bytes are in the file whatever the copybook says
+// ([resolver.frame], #34). Reading the copybook's sum instead would refuse a
+// layout whose records the dataset has already made one length — which is
+// docs/ir/SPEC.md's reason for saying **unframed** carries the rule and rarely
+// pays for it. A record type longer than `lrecl` is [LRECLExtentError]'s and is
+// not narrowed here, since padding never takes bytes away.
+func (c *compiler) shortestExtent(record string) (int, bool) {
+	known, ok := c.record(record)
+	if !ok {
+		return 0, false
+	}
+
+	built := c.layoutOf(known)
+	if built == nil {
+		return 0, false
+	}
+
+	extent := built.MaxLength
+	if built.Variable && c.opts.Reading.Slides() {
+		extent = built.MinLength
+	}
+
+	if framing := c.opts.Framing; framing != nil && framing.LRECLBound() == layoutmodel.LRECLExact {
+		if lrecl := int(framing.LRECL.Value); lrecl > extent {
+			extent = lrecl
+		}
+	}
+
+	return extent, true
 }
 
 // refuseStrategy reports the strategies that name neither a field nor nothing.

--- a/internal/resolve/doc.go
+++ b/internal/resolve/doc.go
@@ -218,4 +218,43 @@
 //
 // Under the other three framings each record states its own length, so an
 // `lrecl` is a maximum that is checked and never padded to.
+//
+// # A predicate is bounded by the layout under two framings and by the read
+// under the other two
+//
+// A predicate is evaluated before the record in front of the consumer has been
+// identified, so a target past that record's last byte is a target in the
+// framing's bytes or the next record's data. docs/ir/SPEC.md's "A predicate
+// never reads past the record in front of it" makes that impossible two ways,
+// and which one applies is the framing's (#94).
+//
+// Under **descriptor-word** and **segmented** the length of the record in front
+// of the consumer is in hand before any predicate runs, so a target not wholly
+// within it does not match and the bound is on the read. `resolve` refuses
+// nothing there, and that is a decision rather than an omission: the strict form
+// applied to all four framings would refuse the layouts those two framings exist
+// to make expressible, a record told apart by a field the longer type has and
+// the shorter one does not.
+//
+// Under **unframed** and **delimited** nothing in the file states a length
+// before the transition is taken, so the bound is on the layout and
+// [CompileSequence] enforces it: every transition's target lies inside the
+// shortest record any transition leaving the same state can admit while this one
+// is eligible, measured over the transitions whose guards can hold at once and
+// with every table at its minimum occurrences. A layout breaking it is a
+// [PredicateReachError] naming the record the target is in, the target and the
+// shorter record it would be read past the end of.
+//
+// It is a diagnostic rather than a second gate, and knowing which it is matters
+// to anyone changing either rule. A layout that breaks it is one the overlap
+// rule refuses anyway — two predicates over different runs of bytes are told
+// apart by nothing — so what the reach rule adds is the message: which bytes a
+// consumer would have read and out of which record, in place of a report that
+// two discriminators could both match. [compiler.reportReach] carries the
+// argument that the two coincide, which is why the specific message replaces the
+// generic one rather than being reported beside it.
+//
+// [Sequencing.Framing] is what that is keyed on, and a caller stating no framing
+// states neither mechanism, so the rule is not run. It cannot be inferred from
+// an `lrecl`, which is a maximum under two framings and a requirement under one.
 package resolve

--- a/internal/resolve/predicate_errors.go
+++ b/internal/resolve/predicate_errors.go
@@ -16,14 +16,16 @@ import (
 // The faults compiling a discriminator into a predicate reports.
 //
 // Each names what docs/ir/SPEC.md asks it to name and refuses the generic
-// version, because a discriminator goes wrong in five ways that look alike from
-// a distance and send an adopter to five different files. A target in the wrong
+// version, because a discriminator goes wrong in six ways that look alike from a
+// distance and send an adopter to six different files. A target in the wrong
 // record is a layout mistake; a target inside a table is a copybook the adopter
 // may not own; a target behind an `OCCURS DEPENDING ON` is a rule about the read
-// loop's order; a literal that will not resolve is a spelling; and a strategy
-// this format refuses is a file shape the IR cannot describe. "rather than
-// reporting a generic reference error" is the spec's own phrase, and it appears
-// against three of these.
+// loop's order; a target reaching past a shorter record the same state admits is
+// a rule about the other records that state can put in front of a consumer; a
+// literal that will not resolve is a spelling; and a strategy this format
+// refuses is a file shape the IR cannot describe. "rather than reporting a
+// generic reference error" is the spec's own phrase, and it appears against four
+// of these.
 
 // PredicateTargetError is a discriminator whose item reference does not name one
 // item of the record it discriminates.
@@ -203,6 +205,73 @@ func (e *PredicateLiteralError) Diagnostic() diag.Diagnostic {
 			"%s compares %s against %s, and %s: a literal reaches a consumer as the bytes it compares, "+
 				"padded to the width of the item",
 			e.Subject, e.Item, e.Literal, e.Found),
+		Spans: spans(e.Pos, e.Copybook, "declared here"),
+	}
+}
+
+// PredicateReachError is a discriminator whose target reaches past the shortest
+// record its state can put in front of a consumer.
+//
+// docs/ir/SPEC.md's "A predicate never reads past the record in front of it" is
+// the rule and it is about the bytes in front of the consumer rather than about
+// which record they turn out to be. A predicate exists to be evaluated against
+// records its own transition does not admit — that is what selecting one is — so
+// what is refused is not reading another record's bytes but reading a byte no
+// record the state can admit covers (#94).
+//
+// Where the framing states each record's length the read is bounded instead and
+// this is not reported; it fires under **unframed** and **delimited**, where
+// nothing in the file states a length before the transition is taken.
+// [compiler.reportReach] is where that division is stated, and where the
+// argument is that a layout reaching this is one [SequenceAmbiguityError] would
+// otherwise report — this is the specific message in place of that generic one,
+// rather than a second thing wrong with the layout.
+//
+// It names the record the target is in, the target, and the shorter record it
+// would be read past the end of, rather than reporting a generic reference
+// error, because the two failures it prevents are files that are exactly right:
+// a well-formed short record on which a consumer reaches end of input inside
+// step 3 and condemns the file as truncated, and a predicate testing the *next*
+// record's bytes and matching them, which takes the wrong transition on the day
+// those bytes happen to hold the value it was looking for.
+type PredicateReachError struct {
+	// Pos is the item reference in the layout.
+	Pos diag.Span
+
+	// Copybook is the target's entry in the copybook.
+	Copybook diag.Span
+
+	// State is a state offering both records, and the one whose shorter
+	// record the numbers below are about.
+	State int
+
+	// Record is the record being discriminated, and Item the target.
+	Record string
+	Item   string
+
+	// Beside is the shorter record the state can put in front of a consumer
+	// instead.
+	Beside string
+
+	// Ends is the byte of a record the target ends at, counting from one: the
+	// bytes ahead of it in its own record plus its width. Extent is how many
+	// bytes Beside is at its shortest.
+	Ends   int
+	Extent int
+}
+
+// Error implements the error interface.
+func (e *PredicateReachError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *PredicateReachError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"the discriminator for record %s tests %s, whose last byte is byte %d of a record, and at state %d "+
+				"the sequence can put %s in front of a consumer instead, which is %s: the target ends %s past "+
+				"the end of it, and a predicate is evaluated before the record in front of it has been "+
+				"identified, so its target has to lie inside the shortest record its state can admit",
+			e.Record, e.Item, e.Ends, e.State, e.Beside, plural(e.Extent, "byte"), plural(e.Ends-e.Extent, "byte")),
 		Spans: spans(e.Pos, e.Copybook, "declared here"),
 	}
 }

--- a/internal/resolve/reach_test.go
+++ b/internal/resolve/reach_test.go
@@ -1,0 +1,341 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package resolve
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/layoutmodel"
+)
+
+// A predicate is evaluated against a record nobody has identified yet, so what
+// bounds it is not its own record's extent but the shortest record its state can
+// put in front of a consumer. These hold docs/ir/SPEC.md's "A predicate never
+// reads past the record in front of it" to that: the layouts it refuses, the
+// nearly identical one it admits, and the two framings it is not run under
+// because the file states each record's length there and the read is bounded
+// instead (#94).
+//
+// The shape throughout is the ordinary one rather than an exotic one: a header
+// whose type code is its first field beside a data record whose type code sits
+// behind an account key every record of that type carries. That is the shape a
+// worked example is built on, and the whole difficulty is that it looks right.
+//
+// Every one of these layouts is refused by the overlap rule as well, and that is
+// a property of the rule rather than of the tests — [compiler.reportReach] is
+// where the argument is. So what the rejecting tests assert is *which*
+// diagnostic an adopter gets, and they assert the generic one is not reported
+// beside it.
+
+// The copybooks these tests discriminate. `reachHeader` is ten bytes with its
+// type code at the front; `reachDetail` carries a twenty-byte key in front of
+// its own, which puts the target twelve bytes past the end of the header; and
+// `reachFront` is the same detail with the code moved to the front, which is the
+// fix the diagnostic asks for.
+const (
+	reachHeader = `01 H-REC.
+   05 H-TYPE PIC X(2).
+   05 H-DATE PIC X(8).
+`
+
+	reachDetail = `01 D-REC.
+   05 D-KEY PIC X(20).
+   05 D-TYPE PIC X(2).
+   05 D-AMOUNT PIC X(8).
+`
+
+	reachFront = `01 D-REC.
+   05 D-TYPE PIC X(2).
+   05 D-KEY PIC X(20).
+   05 D-AMOUNT PIC X(8).
+`
+
+	// reachStraddle puts the target across the header's last byte: it begins
+	// at byte 9 of a record and ends at byte 12, so eight of its bytes are
+	// inside the ten the header has and two are not.
+	reachStraddle = `01 D-REC.
+   05 D-KEY PIC X(8).
+   05 D-TYPE PIC X(4).
+   05 D-AMOUNT PIC X(8).
+`
+
+	// reachVariable is a record whose extent moves with a count: four bytes of
+	// fixed head and one to five four-byte cells, so eight bytes at its
+	// shortest and twenty-four at the storage a compiler reserves for it.
+	reachVariable = `01 V-REC.
+   05 V-TYPE PIC X(2).
+   05 V-N PIC 9(2).
+   05 V-CELL PIC X(4) OCCURS 1 TO 5 TIMES DEPENDING ON V-N.
+`
+
+	// reachBehindCell carries its type code at bytes 9 and 10 of a record,
+	// which is inside reachVariable at two cells and outside it at one.
+	reachBehindCell = `01 D-REC.
+   05 D-KEY PIC X(8).
+   05 D-TYPE PIC X(2).
+   05 D-AMOUNT PIC X(4).
+`
+)
+
+// The framings, in the spellings a layout writes them. The first two leave the
+// bound to the layout and the last two state each record's length.
+const (
+	delimitedFraming  = `(framing (recfm line-sequential) (delimiter (bytes "25")) (placement terminator))`
+	fixedFraming      = `(framing (recfm FB) (lrecl 30))`
+	descriptorFraming = `(framing (recfm VB) (lrecl 512))`
+	segmentedFraming  = `(framing (recfm VBS) (max-segment 4096))`
+)
+
+// reachLayout is a state admitting a header and a detail, under the framing the
+// caller names.
+func reachLayout(framing string) string {
+	return framing + `
+(record HEADER (copybook "header.cpy" H-REC))
+(record DETAIL (copybook "detail.cpy" D-REC))
+(discriminate HEADER (equals (item HEADER H-TYPE) "HD"))
+(discriminate DETAIL (equals (item DETAIL D-TYPE) "DT"))
+(sequence (* (alt HEADER DETAIL)))`
+}
+
+// reachCopybooks binds the two record names to the header and the detail the
+// caller chose.
+func reachCopybooks(detail string) map[string]string {
+	return map[string]string{"HEADER": reachHeader, "DETAIL": detail}
+}
+
+// reachFaultIn is the reach fault a compilation reported, and fails the test
+// where it reported none.
+func reachFaultIn(t *testing.T, err error) *PredicateReachError {
+	t.Helper()
+
+	var reach *PredicateReachError
+	if !errors.As(err, &reach) {
+		t.Fatalf("compiling reported %v, want a PredicateReachError", err)
+	}
+
+	return reach
+}
+
+// leftToTheOverlapRule asserts that a pair was reported as the ambiguity it also
+// is, and not as a reach fault.
+//
+// It is what the relaxations assert. The pair is refused either way — two
+// predicates over different runs of bytes are told apart by nothing — so what a
+// relaxation changes is the diagnostic, and a test asserting the compilation
+// failed would pass without the rule being relaxed at all.
+func leftToTheOverlapRule(t *testing.T, err error) {
+	t.Helper()
+
+	var reach *PredicateReachError
+	if errors.As(err, &reach) {
+		t.Fatalf("the reach rule was run: %v", reach)
+	}
+
+	var ambiguity *SequenceAmbiguityError
+	if !errors.As(err, &ambiguity) {
+		t.Fatalf("compiling reported %v, want the overlap rule's own fault", err)
+	}
+}
+
+// TestAPredicateReachingPastAShorterRecordAtTheSameStateIsRejected is the whole
+// rule, on the shape that makes it worth having.
+//
+// Both predicates are inside their own records and the layout is otherwise
+// unremarkable. What is wrong is that the state can put a ten-byte header in
+// front of a consumer while the detail's predicate is testing bytes 21 and 22 —
+// the delimiter's bytes, or the next record's data, and on a file whose bytes
+// happen to hold `DT` there the wrong transition is taken and a record that is
+// exactly right is reported malformed.
+func TestAPredicateReachingPastAShorterRecordAtTheSameStateIsRejected(t *testing.T) {
+	t.Parallel()
+
+	err := refused(t, reachLayout(delimitedFraming), reachCopybooks(reachDetail))
+	reach := reachFaultIn(t, err)
+
+	if reach.Record != "DETAIL" || reach.Item != "D-TYPE" || reach.Beside != "HEADER" {
+		t.Errorf("the fault is about %s's %s beside %s, want DETAIL's D-TYPE beside HEADER",
+			reach.Record, reach.Item, reach.Beside)
+	}
+	if reach.Ends != 22 || reach.Extent != 10 {
+		t.Errorf("the target ends at byte %d against a record of %d bytes, want byte 22 against 10",
+			reach.Ends, reach.Extent)
+	}
+
+	// The three things docs/ir/SPEC.md asks the diagnostic to name — the
+	// record the target is in, the target, and the shorter record it would be
+	// read past the end of — and how far past it reaches.
+	for _, want := range []string{"DETAIL", "D-TYPE", "HEADER", "12 bytes past"} {
+		if !strings.Contains(reach.Error(), want) {
+			t.Errorf("the diagnostic does not name %s: %s", want, reach.Error())
+		}
+	}
+
+	// Only the detail is at fault. The header's own target is inside every
+	// record the state can admit, and naming the pair rather than the record
+	// reaching would send an adopter to a copybook that is right.
+	if strings.Contains(err.Error(), "the discriminator for record HEADER") {
+		t.Errorf("the header is reported too, and its target is inside every record beside it: %v", err)
+	}
+
+	// And the generic fault is not reported beside the specific one: one pair
+	// is one thing to fix.
+	var ambiguity *SequenceAmbiguityError
+	if errors.As(err, &ambiguity) {
+		t.Errorf("the overlap rule reported the same pair as well: %v", ambiguity)
+	}
+}
+
+// TestAPredicateInsideTheShortestRecordIsAnOrdinaryLayout is the same file with
+// the type code moved to the front, which is where a type code usually is and is
+// the fix the diagnostic asks for.
+//
+// The accepted case is pinned beside the rejected one because the rule's whole
+// cost is this move, and a check that refused both would be one nobody could
+// satisfy under a delimited framing.
+func TestAPredicateInsideTheShortestRecordIsAnOrdinaryLayout(t *testing.T) {
+	t.Parallel()
+
+	a := compiled(t, reachLayout(delimitedFraming), reachCopybooks(reachFront))
+
+	if got := len(a.Start.Transitions); got != 2 {
+		t.Fatalf("the start state offers %d transitions, want the header and the detail", got)
+	}
+}
+
+// TestATargetStraddlingTheBoundIsRejectedOnTheSameFooting is docs/ir/SPEC.md's
+// "a target past it, and a target beginning inside it and ending beyond": what a
+// consumer reads is the target's whole width, so eight bytes inside the header
+// and two outside it is as much a read past the record as four bytes wholly
+// outside it.
+func TestATargetStraddlingTheBoundIsRejectedOnTheSameFooting(t *testing.T) {
+	t.Parallel()
+
+	reach := reachFaultIn(t, refused(t, reachLayout(delimitedFraming), reachCopybooks(reachStraddle)))
+
+	if reach.Ends != 12 || reach.Extent != 10 {
+		t.Errorf("the target ends at byte %d against a record of %d bytes, want byte 12 against 10",
+			reach.Ends, reach.Extent)
+	}
+	if !strings.Contains(reach.Error(), "2 bytes past") {
+		t.Errorf("the diagnostic does not say how far past the end it reaches: %s", reach.Error())
+	}
+}
+
+// TestTheRuleIsRelaxedWhereTheFramingStatesEachRecordsLength is the other half
+// of the answer, and the reason the check is keyed on the framing rather than
+// applied to every layout.
+//
+// Under **descriptor-word** and **segmented** the length of the record in front
+// of the consumer is in hand before any predicate runs, so a target outside it
+// does not match and no file is misread. The layout is still refused, because
+// two predicates over different runs of bytes are told apart by nothing — but it
+// is refused as the ambiguity it is, and not for a read that cannot happen
+// there.
+func TestTheRuleIsRelaxedWhereTheFramingStatesEachRecordsLength(t *testing.T) {
+	t.Parallel()
+
+	for name, framing := range map[string]string{
+		"descriptor-word": descriptorFraming,
+		"segmented":       segmentedFraming,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			leftToTheOverlapRule(t, refused(t, reachLayout(framing), reachCopybooks(reachDetail)))
+		})
+	}
+}
+
+// TestALayoutStatingNoFramingIsNotHeldToEitherMechanism, because which mechanism
+// bounds a predicate is the framing's answer and an `lrecl` is not a substitute
+// for it: the same number is a maximum under two framings and a requirement
+// under one.
+//
+// A layout read from a file always carries a `framing` form, so this is a caller
+// assembling a [Sequencing] by hand — which is the road every other test of this
+// package takes, and why the rule changes none of their answers.
+func TestALayoutStatingNoFramingIsNotHeldToEitherMechanism(t *testing.T) {
+	t.Parallel()
+
+	leftToTheOverlapRule(t, refused(t, reachLayout(""), reachCopybooks(reachDetail)))
+}
+
+// TestAFixedLengthDatasetBoundsThePredicateByItsLRECL is why docs/ir/SPEC.md
+// says **unframed** carries the rule and rarely pays for it.
+//
+// Every record type of a fixed-length dataset accounts for one LRECL, and a
+// record type whose items stop short carries the difference as slack — the bytes
+// are in the file whatever the copybook says. So the header is thirty bytes in
+// front of a consumer and not ten, and the detail's target at bytes 21 and 22 is
+// inside it. Measuring the copybook's sum instead would report a read past the
+// end of a record the dataset has already made long enough.
+func TestAFixedLengthDatasetBoundsThePredicateByItsLRECL(t *testing.T) {
+	t.Parallel()
+
+	leftToTheOverlapRule(t, refused(t, reachLayout(fixedFraming), reachCopybooks(reachDetail)))
+}
+
+// TestTheShortestRecordIsMeasuredAtTheMinimumOccurrences is the *shortest* in
+// the rule: a record whose extent moves with a count is as short as its
+// copybook's declared minimum allows, and not as long as the storage a compiler
+// reserves for it.
+//
+// The detail's target sits at bytes 9 and 10, which is inside the variable
+// record at two cells and outside it at one — and one is a count the copybook
+// admits, so a file holding one is a file the layout describes.
+func TestTheShortestRecordIsMeasuredAtTheMinimumOccurrences(t *testing.T) {
+	t.Parallel()
+
+	source := delimitedFraming + `
+(record VARIABLE (copybook "variable.cpy" V-REC))
+(record DETAIL (copybook "detail.cpy" D-REC))
+(discriminate VARIABLE (equals (item VARIABLE V-TYPE) "VR"))
+(discriminate DETAIL (equals (item DETAIL D-TYPE) "DT"))
+(sequence (* (alt VARIABLE DETAIL)))`
+
+	copybooks := map[string]string{"VARIABLE": reachVariable, "DETAIL": reachBehindCell}
+
+	reach := reachFaultIn(t, refused(t, source, copybooks))
+	if reach.Beside != "VARIABLE" || reach.Extent != 8 {
+		t.Errorf("the target is bounded by %s at %d bytes, want VARIABLE at 8 — the head and one cell",
+			reach.Beside, reach.Extent)
+	}
+
+	// Under the non-sliding reading the same clause is a fixed table at the
+	// declared maximum, so there is no shorter reading of the record to take
+	// and every record of that type is twenty-four bytes.
+	t.Run("under the non-sliding reading the table is fixed and nothing is short", func(t *testing.T) {
+		t.Parallel()
+
+		opts := sequencingOf(t, source, copybooks)
+		opts.Reading = layoutmodel.NoODOSlide
+
+		_, err := CompileSequence(opts)
+		leftToTheOverlapRule(t, err)
+	})
+}
+
+// TestRecordsAdmittedAtDifferentStatesAreNotPaired, because the rule is about
+// what one state can put in front of a consumer and not about what the file
+// contains: a detail that only ever follows a header is never a record a
+// consumer is choosing between, so nothing about the header bounds its
+// predicate.
+//
+// This is the pairing every rule about telling two records apart is over
+// (docs/ir/SPEC.md, "When two match, and when none does"), and a rule keyed on
+// the record set instead would refuse a layout no consumer can misread.
+func TestRecordsAdmittedAtDifferentStatesAreNotPaired(t *testing.T) {
+	t.Parallel()
+
+	compiled(t, delimitedFraming+`
+(record HEADER (copybook "header.cpy" H-REC))
+(record DETAIL (copybook "detail.cpy" D-REC))
+(discriminate HEADER (equals (item HEADER H-TYPE) "HD"))
+(discriminate DETAIL (equals (item DETAIL D-TYPE) "DT"))
+(sequence (seq HEADER (* DETAIL)))`, reachCopybooks(reachDetail))
+}

--- a/internal/resolve/reach_test.go
+++ b/internal/resolve/reach_test.go
@@ -56,7 +56,7 @@ const (
 `
 
 	// reachStraddle puts the target across the header's last byte: it begins
-	// at byte 9 of a record and ends at byte 12, so eight of its bytes are
+	// at byte 9 of a record and ends at byte 12, so two of its four bytes are
 	// inside the ten the header has and two are not.
 	reachStraddle = `01 D-REC.
    05 D-KEY PIC X(8).
@@ -209,9 +209,9 @@ func TestAPredicateInsideTheShortestRecordIsAnOrdinaryLayout(t *testing.T) {
 
 // TestATargetStraddlingTheBoundIsRejectedOnTheSameFooting is docs/ir/SPEC.md's
 // "a target past it, and a target beginning inside it and ending beyond": what a
-// consumer reads is the target's whole width, so eight bytes inside the header
-// and two outside it is as much a read past the record as four bytes wholly
-// outside it.
+// consumer reads is the target's whole width, so two bytes inside the header and
+// two outside it is as much a read past the record as four bytes wholly outside
+// it.
 func TestATargetStraddlingTheBoundIsRejectedOnTheSameFooting(t *testing.T) {
 	t.Parallel()
 

--- a/internal/resolve/sequence.go
+++ b/internal/resolve/sequence.go
@@ -600,6 +600,18 @@ func (c *compiler) checkAmbiguity(a *Automaton) {
 					continue
 				}
 
+				// A predicate reaching past the shortest record the
+				// state can put in front of a consumer is refused in
+				// its own words too, and for the same reason: the
+				// generic message says a consumer could not tell the
+				// two records apart, and that one says which bytes it
+				// would have read to try and out of which record
+				// (docs/ir/SPEC.md, "A predicate never reads past the
+				// record in front of it", #94).
+				if c.reportReach(state, first, second) {
+					continue
+				}
+
 				c.faults.Fail(&SequenceAmbiguityError{
 					Pos:       layoutSpan(c.positions[second.To.ID-1].pos),
 					First:     layoutSpan(c.positions[first.To.ID-1].pos),


### PR DESCRIPTION
Closes #151.

`docs/ir/SPEC.md`'s *A predicate never reads past the record in front of it*
read as specified and unenforced. `resolve` carried no extent reasoning about a
discriminator's target, and none of the twelve faults in
`internal/resolve/predicate_errors.go` was about a target reaching past the
shortest record a state can put in front of a consumer.

## Acceptance criteria

- [x] **`resolve` rejects a layout whose predicate target does not lie wholly
      inside the shortest record its state can admit, computed from the record
      extents the state's transitions carry rather than from any offset that
      reaches the IR.** `compiler.reachFault` computes the target's run from the
      record's own layout (`compiler.stretchOf`, the sum `docs/ir/SPEC.md`'s
      "Ordering and width, and no offset" already states) and the bound from
      `compiler.shortestExtent`. No node carries an offset and none is added.
- [x] **A distinct error type beside the other twelve.** `PredicateReachError`
      names the record being discriminated, the target item, the shorter record
      whose extent bounds it, the byte the target ends at and how far past the
      end it reaches — not a generic reference error.
- [x] **A target that begins inside the bound and ends past it is rejected on
      the same footing as one that begins past it.** The test is
      `at + width <= extent`, and `TestATargetStraddlingTheBoundIsRejectedOnTheSameFooting`
      pins it with a four-byte target that has eight bytes inside the bound and
      two outside.
- [x] **Settle whether the rule is relaxed where the framing states each
      record's length.** It is relaxed, following the spec's own division, and
      it is said in the package's docs (`doc.go`, "A predicate is bounded by the
      layout under two framings and by the read under the other two") as well as
      on `compiler.reportReach` and in a test.
- [x] **Tests over a state admitting two record types of different extents,
      including the header-plus-shared-key shape #145's example is built on, so
      the accepted case is pinned alongside the rejected one.**
      `internal/resolve/reach_test.go`.

## The judgment calls

**Which framings it is keyed on.** `docs/ir/SPEC.md` puts the bound on the
layout only where the file states no length before the transition is taken, so
the check runs under **unframed** and **delimited** and not under
**descriptor-word** or **segmented**, where a target outside the record the
framing bounds is a no-match at step 3. Applying the strict form to all four
would refuse the layouts those two framings exist to make expressible.
`Sequencing` gains a `Framing` field for it; a caller stating none is held to
neither mechanism, since the same `lrecl` is a maximum under two framings and a
requirement under one and the mechanism cannot be inferred from it.

**A fixed-length dataset is bounded by its `lrecl`, not by the copybook's sum.**
Every record type of an **unframed** dataset accounts for one LRECL and a
shorter one carries the difference as slack (#34), so the bytes are in the file
whatever the copybook says. Measuring the copybook's sum would report a read
past the end of a record the dataset has already made long enough — and is why
`docs/ir/SPEC.md` says **unframed** carries the rule and rarely pays for it.

**It replaces the ambiguity report rather than joining it.** A pair that breaks
this rule is a pair the overlap rule refuses anyway: two predicates over
different runs of bytes are told apart by nothing (`docs/ir/SPEC.md`, "When two
match, and when none does"), and a pair that does *not* overlap reads one run at
one offset in both records, which the constant-position rule already puts inside
the shortest reading of both. So the rule cannot fire on a layout the overlap
rule admits, and what it adds is the message: which bytes a consumer would have
read and out of which record, in place of a report that two discriminators could
both match. It is reported beside `compiler.reportUnnameable`, in that
function's own pattern — specific instead of generic, so one pair is one thing
to fix. The argument is written down on `compiler.reportReach`, because it is
what makes the placement safe and it is the thing that goes stale if either rule
moves. The tests therefore assert *which* diagnostic an adopter gets, and the
relaxations assert that the generic one is what is left.

## Verified

`dagger call ci` — green, from inside the worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)