### PR TITLE
story(cli): decide what a generator's own inputs mean for the descriptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,11 @@ laptop as in CI:
 
 ```json
 {
-  "inputs": ["cpy/orders.cpy"],
   "layout": "orders.sexpr",
   "generators": [
     {
       "name": "go",
       "out": "gen",
-      "inputs": ["cpy/orders-go.cpy"],
       "options": {"package_name": "orders", "receiver": "o"}
     },
     {
@@ -73,13 +71,24 @@ laptop as in CI:
 
 | Field | Scope | Required | What it is |
 |---|---|---|---|
-| `inputs` | top-level | no | The copybooks every generator reads. |
 | `layout` | top-level | yes | The [layout file](docs/layout/SPEC.md) the run resolves against. There is one of it: a project resolving against two layouts is two runs. |
 | `generators` | top-level | yes | The generators to run, in order, at least one of them. |
 | `name` | generator | yes | Resolves to the `cpybkc-gen-<name>` executable on `PATH`. It is the whole of how a generator is identified — there is no `source` and no `version` beside it. |
 | `out` | generator | yes | The directory this generator's output lands in. |
-| `inputs` | generator | no | Copybooks this generator reads **in addition to** the top-level `inputs`; a path named in both is read once. |
 | `options` | generator | no | The generator's own options, each handed to it as one `--opt k=v`, **in the order this object writes them**. A key carries no `=`; a value is text, and may be empty. |
+
+**A manifest does not list copybooks.** Which copybooks a run reads is the
+layout's to say — a `record` form names the file its record is in — and cpybkc
+opens those and no others. A generator never sees a copybook at all: it is
+handed the resolved descriptor, an output directory and its options, and the IR
+carries no path back to the file an item came from. So there is no top-level
+`inputs` and no per-generator `inputs`; a manifest carrying either is reported
+as the unknown field it is, with the line and column it is at. [Which descriptor
+is emitted](docs/cli/SPEC.md#which-descriptor-is-emitted) is where that is
+settled, and [Finding the
+inputs](docs/cli/SPEC.md#finding-the-inputs) is why the manifest does not get a
+say. The point of both is one sentence: a run has **one** descriptor, and every
+generator in it — and `--emit-ir` — is handed the same bytes.
 
 Four rules are worth knowing before a manifest is written, because each of them
 is a fault rather than something cpybkc works around:
@@ -87,8 +96,8 @@ is a fault rather than something cpybkc works around:
 - **An unknown field is reported, never ignored.** A manifest is a file a person
   wrote, so a misspelled field is a typo they want told about rather than a line
   that reads as configuration and silently does nothing. The same goes for a
-  field written twice, a copybook named twice in one list, and an empty string
-  where a path or a name belongs.
+  field written twice, an option key written twice, and an empty string where a
+  path or a name belongs.
 - **A path is used as written.** cpybkc resolves nothing against anything on
   your behalf; a relative path is relative to the manifest.
 - **Every fault is reported at once**, each with the line and column in

--- a/cmd/cpybkc/diagnostic_test.go
+++ b/cmd/cpybkc/diagnostic_test.go
@@ -33,15 +33,14 @@ func reported(err error) string {
 // would agree with itself whatever the format became.
 
 // brokenManifest is a manifest with three independent faults in it, in three
-// different places: a field no manifest has, a list written as a single string,
-// and a required field that is not there at all.
+// different places: a field no manifest has, an option set written as a single
+// string, and a required field that is not there at all.
 //
 // Nothing here depends on any two of them, which is the point — a manifest is
 // written by hand and gets three things wrong at once, and a reader that
 // stopped at the first would be a reader the adopter ran three times.
 const brokenManifest = `{
   "output": "gen",
-  "inputs": ["cpy/orders.cpy"],
   "generators": [
     {"name": "go", "out": "gen/orders", "options": "verbose=true"}
   ]
@@ -52,8 +51,8 @@ const brokenManifest = `{
 // Every line names the manifest, the line and the column, and all three faults
 // are there: docs/cli/SPEC.md requires more than one fault found in one pass to
 // be reported together rather than one per run.
-const goldenManifest = `error: cpybkc.json:2:3: a manifest has no field named "output"; it carries inputs, layout and generators
-error: cpybkc.json:5:52: generators[0].options is an object of generator options, and this one is text
+const goldenManifest = `error: cpybkc.json:2:3: a manifest has no field named "output"; it carries layout and generators
+error: cpybkc.json:4:52: generators[0].options is an object of generator options, and this one is text
 error: cpybkc.json:1:1: a manifest carries no layout; a project resolves its records against exactly one
 `
 

--- a/docs/cli/SPEC.md
+++ b/docs/cli/SPEC.md
@@ -244,9 +244,8 @@ which is the same standard the manifest itself is held to (#40).
 One rule covers every path in a run, and it has two halves:
 
 - A relative path **stated in a file** is resolved against the directory of
-  that file. A manifest's `layout`, `inputs` and `out` are relative to the
-  manifest (#40); a layout's `copybook` path is relative to the layout
-  (#148).
+  that file. A manifest's `layout` and `out` are relative to the manifest
+  (#40); a layout's `copybook` path is relative to the layout (#148).
 - A relative path **typed on the command line** — `--manifest`, `--emit-ir` —
   is resolved against the working directory, because that is the directory the
   person typing it was standing in.
@@ -266,7 +265,9 @@ cannot afford.
 ### Finding the inputs
 
 [`layout/SPEC.md`](../layout/SPEC.md) hands two questions to the CLI by name,
-and this section is the answer to both.
+and this section answers both — and then the third, which nothing had asked
+until a manifest and a layout each looked like a place a copybook could be
+named from.
 
 **Where a copybook is looked for.** At the path its layout states, resolved as
 above, and nowhere else. cpybkc **MUST NOT** search a list of directories:
@@ -279,6 +280,29 @@ code compiles, and the offsets are wrong.
 **Where a layout's forms are read from.** From the one file the manifest's
 `layout` names. A layout has no include form and needs none (`layout/SPEC.md`),
 and cpybkc composes nothing: two files are two layouts and two runs.
+
+**Which copybooks a run reads**, and the answer #157 owed this section: exactly
+the ones its layout's `record` forms name, and no others. The manifest does not
+list them. It names the layout, the generators and their options — the things a
+layout has no opinion about — and it carries no `inputs` (#40), so there is no
+set a layout may not name a copybook outside of, and no diagnostic for naming
+one. The only fault about a copybook is the one above, a path cpybkc cannot
+open.
+
+That is a decision against the alternative and not an omission. A manifest that
+listed the copybooks a run may read would be a second statement of what the
+layout already says, in a file that is checked in beside it and diffable in the
+same review — right up until the two disagreed, at which point the layout would
+still be the one that named the item each record is. Worse, enforcing the list
+would mean deciding whether two spellings name one file: a manifest's paths
+resolve against the manifest and a layout's against the layout ([A path is
+relative to the file that states it](#a-path-is-relative-to-the-file-that-states-it)),
+so the same copybook is written two ways, and `layout/SPEC.md` hands "whether
+two paths name one copybook" to the CLI as a question about the files rather
+than the spellings. Behind a symlink, a bind mount or a case-insensitive
+filesystem there is no comparison that is right every time — and a check that
+fails a correct run is worse than no check, because the run it rejects is one
+the adopter cannot fix by changing anything that is wrong.
 
 A copybook cpybkc cannot open **MUST** be reported with a diagnostic that names
 the path **as the layout spells it** and, additionally, the absolute path
@@ -341,14 +365,31 @@ about the emission alone.
 
 A run resolves **one** descriptor, from the layout the manifest names and the
 copybooks that layout names, and `--emit-ir` writes that one. No flag selects
-among descriptors, because there is one.
+among descriptors, because there is one — and nothing a project can write makes
+there be two. A manifest names exactly one layout, a layout names the copybooks
+its records are in, and those two facts are the whole of what the descriptor is
+a function of.
 
-That statement is true of the pipeline as it stands (#43, #148) and is the
-narrow half of an open question this document could not settle on its own: the
-manifest also gives each generator its own `inputs`, and copybooks that differ
-per generator would mean a descriptor that differs per generator, which
-`--emit-ir` would then have to be told to choose between. #157 decides it, and
-this section is what changes if the answer is the other one.
+That was an open question when this document was written, and #157 settled it by
+changing the manifest rather than by giving the flag a selector. A generator
+entry used to carry its own `inputs` — "copybooks this generator reads in
+addition to the top-level `inputs`" — which read as though two generators could
+be resolved against two different sets of copybooks and therefore handed two
+different descriptors. They never could. A generator is invoked with
+`--descriptor`, `--out` and its options and nothing else ([Invocation](../plugin/SPEC.md#invocation)),
+no copybook path is among them, and the IR carries none either, so a list of
+copybooks attached to a generator named files that generator never opened. Both
+lists are gone from `cpybkc.json` (#40), and which copybooks a run reads is
+settled where it was always decided — in the layout.
+
+So the equality the plugin contract rests reproducibility on holds in its strong
+form, and cpybkc **MUST** meet it that way: every generator of one run is handed
+**the same bytes**, and they are the bytes `--emit-ir` writes for that run. Not
+"a descriptor equivalent to" and not "a descriptor assembled the same way" — the
+same bytes, because there is one descriptor and one encoder (#20). A plugin
+contract statement of the same rule is at [The
+descriptor](../plugin/SPEC.md#the-descriptor), and it is asserted by a test over
+a real generator process rather than claimed by either document (#157).
 
 ## Standard output
 
@@ -634,7 +675,7 @@ to any of them is a breaking change:
 | [The flags](#the-argument-vector) | The five above: each keeps its name, its value, its default and its meaning |
 | [Manifest discovery](#finding-the-manifest) | `--manifest`, else `cpybkc.json` in the working directory, and no search |
 | [Path resolution](#a-path-is-relative-to-the-file-that-states-it) | A path in a file is relative to that file; a path on the command line is relative to the working directory |
-| [`--emit-ir`](#emitting-the-ir) | Replaces generation; writes the same bytes a generator is handed |
+| [`--emit-ir`](#emitting-the-ir) | Replaces generation; writes the run's one descriptor, which is the same bytes every generator of that run is handed |
 | [Standard output](#standard-output) | Carries only what was asked for by name, and nothing during a generation run |
 | [The diagnostic format](#standard-error-diagnostics) | The severity set, the separator, the generator's name, the two-space continuation indent, and the stream all of it goes to |
 | [Exit codes](#exit-codes) | `0`, `1`, `2`, and no other value |
@@ -760,9 +801,9 @@ which is a property of the project.
 | [The argument vector](#the-argument-vector) | #147 `cli` |
 | [Finding the manifest](#finding-the-manifest) | #148 `cli`, over the manifest reader #40 `plugin` |
 | [A path is relative to the file that states it](#a-path-is-relative-to-the-file-that-states-it) | #148 `cli` |
-| [Finding the inputs](#finding-the-inputs) | #148 `cli`; the diagnostics it owes, #31 `resolve` and #150 `cli` |
+| [Finding the inputs](#finding-the-inputs) | #148 `cli`; the diagnostics it owes, #31 `resolve` and #150 `cli`; which copybooks a run reads, and that the manifest does not list them, #157 `cli` |
 | [Emitting the IR](#emitting-the-ir) | #149 `cli`, over the encoders #20 and #21 `ir` |
-| [Which descriptor is emitted](#which-descriptor-is-emitted) | #157 `cli` decides it; #148 `cli` assembles whatever it decides |
+| [Which descriptor is emitted](#which-descriptor-is-emitted) | #157 `cli` decided it — one descriptor per run, and the manifest's `inputs` removed to keep it true; #148 `cli` assembles it, #149 `cli` writes it |
 | [Standard output](#standard-output) | #147 `cli` for the version and usage, #149 `cli` for `--emit-ir -` |
 | [Standard error: diagnostics](#standard-error-diagnostics) | #150 `cli`, over `internal/diag` and the spans of #31 `resolve` |
 | [A relayed generator line](#a-relayed-generator-line) | #150 `cli`, over the classification #42 `plugin` already performs, against the format #39 `plugin` fixes |

--- a/docs/plugin/SPEC.md
+++ b/docs/plugin/SPEC.md
@@ -228,6 +228,16 @@ equality is what makes a failing invocation reproducible: an author emits the
 descriptor, saves it, and re-runs the generator against it by hand, and the
 second run is the same invocation rather than an approximation of it.
 
+A run has **one** descriptor, and every generator of that run is handed the same
+bytes (#157). A plugin **MUST NOT** read anything into having been given a
+descriptor of its own: the *file* is private to the invocation ([The
+descriptor's location and lifetime](#the-descriptors-location-and-lifetime)) and
+its *contents* are not. Nothing in a descriptor is selected for the generator
+receiving it, no option a generator declared has changed what is in it, and a
+plugin that behaved differently for having been run alongside another would be
+depending on something no descriptor states. What a generator does with the one
+descriptor is the whole of what makes its output its own.
+
 A plugin **MUST** read the descriptor and **MUST NOT** write to it, rename it,
 or delete it. It **MUST NOT** derive anything from the file's name or its
 directory — the path is a temporary location cpybkc chose, not a place a plugin
@@ -669,7 +679,7 @@ build-configuration format in front of the one reader with no use for it.
 | [Host platform](#host-platform) | #39 `plugin` — decided here; nothing in the backlog had committed either way, and the container contract is Linux-only |
 | [Discovery](#discovery) | #41 `plugin` |
 | [Invocation](#invocation) | #42 `plugin`; the option order, and the manifest it comes from, #40 `plugin` |
-| [The descriptor](#the-descriptor) | #17 `ir` for the message, #20 `ir` for the bytes `--emit-ir` writes, #42 `plugin` for the file handed over |
+| [The descriptor](#the-descriptor) | #17 `ir` for the message, #20 `ir` for the bytes `--emit-ir` writes, #42 `plugin` for the file handed over, #157 `cli` for there being one descriptor per run and the test that asserts every generator gets its bytes |
 | [The output directory](#the-output-directory) | #43, #44, #45 `plugin` |
 | [Exit codes and diagnostics](#exit-codes-and-diagnostics) | #42 `plugin` |
 | [Determinism](#determinism) | #47 `plugin` |

--- a/internal/manifest/doc.go
+++ b/internal/manifest/doc.go
@@ -5,14 +5,12 @@
 
 // Package manifest reads the cpybkc.json a project is driven by.
 //
-// A manifest names the layout a project resolves against, the copybooks a run
-// reads, and the generators to run over them. It is checked in beside them, so
-// that generator selection and options are diffable, reviewable and the same on
-// a laptop and in CI — which is the whole reason the file exists rather than the
-// flags it would otherwise be:
+// A manifest names the layout a project resolves against and the generators to
+// run over it. It is checked in beside them, so that generator selection and
+// options are diffable, reviewable and the same on a laptop and in CI — which is
+// the whole reason the file exists rather than the flags it would otherwise be:
 //
 //	{
-//	  "inputs": ["cpy/orders.cpy"],
 //	  "layout": "orders.sexpr",
 //	  "generators": [
 //	    {
@@ -35,26 +33,43 @@
 //
 // # What a manifest carries
 //
-// Three fields at the top level. `layout` names the layout file, is required,
-// and there is one of it: docs/layout/SPEC.md is what the records of a run are
+// Two fields at the top level. `layout` names the layout file, is required, and
+// there is one of it: docs/layout/SPEC.md is what the records of a run are
 // framed by, and a project resolving against two of them is two runs.
 // `generators` is the list of generators to run and carries at least one entry,
-// because a manifest declaring none asks for nothing to happen. `inputs` is the
-// copybooks the run reads and is optional.
+// because a manifest declaring none asks for nothing to happen.
 //
-// A generator entry carries `name` and `out`, both required, and `inputs` and
-// `options`, both optional. `name` is the whole of how a generator is
-// identified — it resolves to the `cpybkc-gen-<name>` executable on PATH (#41)
-// — so there is no source and no version beside it, and nothing in this package
-// looks for the executable. `out` is where that generator's output lands, and
-// what happens between a generator's scratch directory and that directory is
-// #43's, #44's and #45's.
+// A generator entry carries `name` and `out`, both required, and `options`,
+// optional. `name` is the whole of how a generator is identified — it resolves
+// to the `cpybkc-gen-<name>` executable on PATH (#41) — so there is no source
+// and no version beside it, and nothing in this package looks for the
+// executable. `out` is where that generator's output lands, and what happens
+// between a generator's scratch directory and that directory is #43's, #44's
+// and #45's.
 //
 // A path is kept exactly as it was written. Resolving one — against the
-// manifest's own directory, against a copybook search path, into the absolute
-// path a plugin is handed (docs/plugin/SPEC.md, "Invocation") — belongs to the
-// stage that opens the file, and a reader that resolved paths would put a
-// second answer beside it.
+// manifest's own directory, into the absolute path a plugin is handed
+// (docs/plugin/SPEC.md, "Invocation") — belongs to the stage that opens the
+// file, and a reader that resolved paths would put a second answer beside it.
+//
+// # Why a manifest names no copybook
+//
+// It used to carry an `inputs` list, at the top level and again on each
+// generator entry, and #157 removed both. The reason is that neither could
+// affect anything: a run's descriptor is assembled from the layout and the
+// copybooks that layout's `record` forms name (docs/cli/SPEC.md, "Which
+// descriptor is emitted"), and a generator is invoked with a descriptor, an
+// output directory and its options and never with a copybook path at all
+// (docs/plugin/SPEC.md, "Invocation"). A per-generator list therefore promised
+// something the pipeline cannot do — two generators of one run reading two
+// different sets of copybooks, and so being handed two different descriptors —
+// and a top-level list restated what the layout already said, in a second file,
+// against a second base directory.
+//
+// A manifest still carrying one is not special-cased: `inputs` is an unknown
+// field, and [Read] reports it with the line and column it is at, which is the
+// migration an adopter can act on rather than a field that quietly stopped
+// meaning anything.
 //
 // # Why the options are a list and not a map
 //
@@ -84,10 +99,10 @@
 // message a **program** wrote, where an unknown field is a newer producer. Same
 // CLI, opposite rules, and the author is the reason.
 //
-// The same argument covers a field written twice, an input named twice in one
-// list, and an empty string where a path or a name belongs: each is something
-// the author did not mean, and none of them has a reading this package could
-// choose on their behalf.
+// The same argument covers a field written twice, an option key written twice,
+// and an empty string where a path or a name belongs: each is something the
+// author did not mean, and none of them has a reading this package could choose
+// on their behalf.
 //
 // # Why faults accumulate, and where they stop
 //

--- a/internal/manifest/errors.go
+++ b/internal/manifest/errors.go
@@ -79,9 +79,9 @@ func (e *SyntaxError) Diagnostic() diag.Diagnostic {
 // TypeError is a value written as the wrong kind of JSON.
 //
 // It says what the field is before saying what was found, because a manifest is
-// written by hand and the useful half is what belongs there — `"inputs": "a.cpy"`
-// is one path where a list of them belongs, and the fix is a pair of brackets
-// rather than a different path.
+// written by hand and the useful half is what belongs there —
+// `"generators": {"name": "go"}` is one entry where a list of them belongs, and
+// the fix is a pair of brackets rather than a different entry.
 type TypeError struct {
 	// Span is the value.
 	Span diag.Span
@@ -229,42 +229,6 @@ func (e *EmptyValueError) Diagnostic() diag.Diagnostic {
 	return diag.Diagnostic{
 		Message: fmt.Sprintf("%s is empty; %s", e.Field, e.Fault),
 		Spans:   []diag.Span{e.Span},
-	}
-}
-
-// RepeatedInputError is one copybook named twice in one list.
-//
-// Reading a copybook twice is not reading two copybooks, so the second mention
-// does nothing — and a line in a checked-in manifest that does nothing is the
-// same fault as an unknown field, met from the other side. A path that appears
-// in both the manifest's inputs and a generator's is a different thing and is
-// not this: there the shared list and the specific one each state it once, and
-// [Manifest.InputsFor] keeps it once.
-type RepeatedInputError struct {
-	// Span is the second mention.
-	Span diag.Span
-
-	// First is the one before it.
-	First diag.Span
-
-	// Path is what was named twice.
-	Path string
-
-	// Field is the list carrying both.
-	Field string
-}
-
-// Error implements the error interface.
-func (e *RepeatedInputError) Error() string { return e.Diagnostic().String() }
-
-// Diagnostic is what the error says, and where.
-func (e *RepeatedInputError) Diagnostic() diag.Diagnostic {
-	first := e.First
-	first.Note = "the first one is here"
-
-	return diag.Diagnostic{
-		Message: fmt.Sprintf("%s names %s twice", e.Field, quote(e.Path)),
-		Spans:   []diag.Span{e.Span, first},
 	}
 }
 

--- a/internal/manifest/errors_test.go
+++ b/internal/manifest/errors_test.go
@@ -34,7 +34,6 @@ func TestEveryFaultReadsTheSameThroughEitherEnd(t *testing.T) {
 		&RepeatedFieldError{Span: somewhere, First: somewhere, Field: "layout", In: manifestObject},
 		&MissingFieldError{Span: somewhere, Field: "layout", In: manifestObject, Fault: layoutFault},
 		&EmptyValueError{Span: somewhere, Field: "layout", Fault: layoutFault},
-		&RepeatedInputError{Span: somewhere, First: somewhere, Path: "cpy/orders.cpy", Field: "inputs"},
 		&GeneratorNameError{Span: somewhere, Name: "z5labs/go"},
 		&OptionKeyError{Span: somewhere, Key: "a=b"},
 	}
@@ -80,9 +79,9 @@ func TestListReadsAsASentence(t *testing.T) {
 	}{
 		{names: nil, want: ""},
 		{names: []string{"layout"}, want: "layout"},
-		{names: []string{"layout", "generators"}, want: "layout and generators"},
-		{names: manifestFields, want: "inputs, layout and generators"},
-		{names: generatorFields, want: "name, out, inputs and options"},
+		{names: []string{"layout", "generators", "extras"}, want: "layout, generators and extras"},
+		{names: manifestFields, want: "layout and generators"},
+		{names: generatorFields, want: "name, out and options"},
 	}
 
 	for _, test := range tests {

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"slices"
 
 	"github.com/Zaba505/cpybkc/internal/diag"
 )
@@ -35,47 +34,14 @@ type Manifest struct {
 	// diagnostic about it names.
 	File string
 
-	// Inputs are the copybooks every generator reads, in the order they were
-	// written. A manifest that names none is not a fault: which copybooks a
-	// record is in is the layout's to say (docs/layout/SPEC.md, "Binding a
-	// record to a copybook"), and this list is the project's statement of what
-	// a run reads.
-	Inputs []string
-
-	// Layout is the layout file the run resolves against.
+	// Layout is the layout file the run resolves against. There is one of it,
+	// and it is the whole of what the run's descriptor is resolved from: which
+	// copybooks a run reads is the layout's to say (docs/layout/SPEC.md,
+	// "Record definitions"), and a manifest states no copybook of its own.
 	Layout string
 
 	// Generators are the generators to run, in the order they were declared.
 	Generators []Generator
-}
-
-// InputsFor is every copybook g reads: the manifest's inputs, then g's own, in
-// the order they were written.
-//
-// The two are merged rather than the entry's replacing the manifest's, because
-// the top-level list is what a project shares and an entry's list is what one
-// generator needs beyond it — a generator that had to restate the shared list to
-// add one file would be a list kept in step by hand.
-//
-// A path named in both lists is kept once, at the position the first mention
-// gives it. Reading one copybook twice is not a second copybook, and the
-// duplicate is what a shared list plus a specific one produces honestly; a
-// repeat *within* one list is a different thing and is a fault [Read] reports.
-func (m *Manifest) InputsFor(g Generator) []string {
-	var merged []string
-
-	seen := make(map[string]struct{}, len(m.Inputs)+len(g.Inputs))
-
-	for _, path := range slices.Concat(m.Inputs, g.Inputs) {
-		if _, duplicate := seen[path]; duplicate {
-			continue
-		}
-
-		seen[path] = struct{}{}
-		merged = append(merged, path)
-	}
-
-	return merged
 }
 
 // Generator is one entry of a manifest's generators list.
@@ -95,11 +61,6 @@ type Generator struct {
 
 	// Out is the directory this generator's output lands in.
 	Out string
-
-	// Inputs are the copybooks this generator reads beyond the manifest's.
-	// [Manifest.InputsFor] is the merged list; this is what the entry itself
-	// declared.
-	Inputs []string
 
 	// Options are the generator's options, in the order the manifest declares
 	// them, which is the order docs/plugin/SPEC.md requires them to be passed
@@ -161,7 +122,7 @@ func parse(file string, src []byte) (*Manifest, error) {
 	if len(bytes.TrimSpace(src)) == 0 {
 		return nil, &SyntaxError{
 			Span:  p.spanAt(0),
-			Fault: "the manifest is empty; it is a JSON object naming the layout, the copybooks and the generators to run",
+			Fault: "the manifest is empty; it is a JSON object naming the layout and the generators to run",
 		}
 	}
 

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -30,16 +30,14 @@ func read(t *testing.T, source string) *Manifest {
 	return m
 }
 
-// worked is a manifest with one of everything in it: shared inputs, a layout,
-// two generators, one of them with inputs and options of its own.
+// worked is a manifest with one of everything in it: a layout, and two
+// generators, one of them with options of its own.
 const worked = `{
-  "inputs": ["cpy/orders.cpy", "cpy/common.cpy"],
   "layout": "orders.sexpr",
   "generators": [
     {
       "name": "go",
       "out": "gen",
-      "inputs": ["cpy/orders-go.cpy"],
       "options": {"package_name": "orders", "receiver": ""}
     },
     {
@@ -60,11 +58,6 @@ func TestReadTakesAManifestApart(t *testing.T) {
 		t.Errorf("the layout is %q, want %q", m.Layout, "orders.sexpr")
 	}
 
-	wantInputs := []string{"cpy/orders.cpy", "cpy/common.cpy"}
-	if !slices.Equal(m.Inputs, wantInputs) {
-		t.Errorf("the inputs are %q, want %q", m.Inputs, wantInputs)
-	}
-
 	if len(m.Generators) != 2 {
 		t.Fatalf("the manifest declares %d generators, want 2", len(m.Generators))
 	}
@@ -75,10 +68,6 @@ func TestReadTakesAManifestApart(t *testing.T) {
 		t.Errorf("the first generator is %q into %q, want %q into %q", first.Name, first.Out, "go", "gen")
 	}
 
-	if !slices.Equal(first.Inputs, []string{"cpy/orders-go.cpy"}) {
-		t.Errorf("the first generator reads %q, want %q", first.Inputs, []string{"cpy/orders-go.cpy"})
-	}
-
 	// An option value may be empty; docs/plugin/SPEC.md says so, and a manifest
 	// is where one is written.
 	wantOptions := []Option{{Key: "package_name", Value: "orders"}, {Key: "receiver", Value: ""}}
@@ -86,25 +75,64 @@ func TestReadTakesAManifestApart(t *testing.T) {
 		t.Errorf("the first generator's options are %v, want %v", first.Options, wantOptions)
 	}
 
-	// The merge, end to end: what the entry declared, behind what the manifest
-	// shares, in the order both were written.
-	wantMerged := []string{"cpy/orders.cpy", "cpy/common.cpy", "cpy/orders-go.cpy"}
-	if got := m.InputsFor(first); !slices.Equal(got, wantMerged) {
-		t.Errorf("the first generator reads %q in all, want %q", got, wantMerged)
-	}
-
-	if got := m.InputsFor(second); !slices.Equal(got, wantInputs) {
-		t.Errorf("the second generator reads %q in all, want %q", got, wantInputs)
-	}
-
 	if second.Name != "json-schema" || second.Out != "schema" {
 		t.Errorf("the second generator is %q into %q, want %q into %q",
 			second.Name, second.Out, "json-schema", "schema")
 	}
 
-	if second.Inputs != nil || second.Options != nil {
-		t.Errorf("the second generator declares inputs %q and options %v, want neither",
-			second.Inputs, second.Options)
+	if second.Options != nil {
+		t.Errorf("the second generator declares options %v, want none", second.Options)
+	}
+}
+
+// TestAManifestNamesNoCopybook is #157's half of the manifest: a run's
+// copybooks are the layout's to name, so `inputs` is not a field a manifest has
+// — at either level — and one written anyway is reported as the unknown field
+// it is rather than read and ignored.
+//
+// The pair is deliberate. Both spellings used to be admitted, so an adopter
+// migrating a manifest meets whichever one they wrote, at the line they wrote
+// it, instead of a run that quietly stopped reading a file it never read.
+func TestAManifestNamesNoCopybook(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"at the top level": `{
+  "inputs": ["cpy/orders.cpy"],
+  "layout": "orders.sexpr",
+  "generators": [{"name": "go", "out": "gen"}]
+}`,
+		"on a generator entry": `{
+  "layout": "orders.sexpr",
+  "generators": [{"name": "go", "out": "gen", "inputs": ["cpy/orders-go.cpy"]}]
+}`,
+	}
+
+	for name, source := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			m, err := Read(Name, strings.NewReader(source))
+			if err == nil {
+				t.Fatalf("a manifest naming copybooks was accepted: %+v", m)
+			}
+
+			var unknown *UnknownFieldError
+			if !errors.As(err, &unknown) {
+				t.Fatalf("naming copybooks gave %v, want an *UnknownFieldError", err)
+			}
+
+			if unknown.Field != "inputs" {
+				t.Errorf("the fault names the field %q, want %q", unknown.Field, "inputs")
+			}
+
+			// The fields it offers instead are the ones that are left, which is
+			// what tells the adopter the field was removed rather than
+			// misspelled.
+			if got := diag.Render(err); strings.Contains(got, "carries inputs") {
+				t.Errorf("the fault reads:\n%s\nwant inputs left out of the fields it offers", got)
+			}
+		})
 	}
 }
 
@@ -115,8 +143,8 @@ func TestAGeneratorKnowsWhereItWasWritten(t *testing.T) {
 	m := read(t, worked)
 
 	want := []diag.Span{
-		{File: Name, Line: 5, Column: 5},
-		{File: Name, Line: 11, Column: 5},
+		{File: Name, Line: 4, Column: 5},
+		{File: Name, Line: 9, Column: 5},
 	}
 
 	for i, generator := range m.Generators {
@@ -154,52 +182,6 @@ func TestOptionsKeepTheOrderTheManifestDeclaresThem(t *testing.T) {
 
 	if !slices.Equal(got, want) {
 		t.Errorf("the options are declared %q, want %q", got, want)
-	}
-}
-
-func TestInputsForMergesTheManifestsInputsWithAGenerators(t *testing.T) {
-	tests := []struct {
-		name      string
-		manifest  []string
-		generator []string
-		want      []string
-	}{
-		{
-			name: "neither states one",
-		},
-		{
-			name:     "the manifest alone",
-			manifest: []string{"cpy/orders.cpy"},
-			want:     []string{"cpy/orders.cpy"},
-		},
-		{
-			name:      "the generator alone",
-			generator: []string{"cpy/orders.cpy"},
-			want:      []string{"cpy/orders.cpy"},
-		},
-		{
-			name:      "the manifest's first, then the generator's",
-			manifest:  []string{"cpy/orders.cpy", "cpy/common.cpy"},
-			generator: []string{"cpy/orders-go.cpy"},
-			want:      []string{"cpy/orders.cpy", "cpy/common.cpy", "cpy/orders-go.cpy"},
-		},
-		{
-			name:      "a copybook both name is read once",
-			manifest:  []string{"cpy/orders.cpy", "cpy/common.cpy"},
-			generator: []string{"cpy/common.cpy", "cpy/orders-go.cpy"},
-			want:      []string{"cpy/orders.cpy", "cpy/common.cpy", "cpy/orders-go.cpy"},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			m := &Manifest{Inputs: test.manifest}
-
-			got := m.InputsFor(Generator{Inputs: test.generator})
-			if !slices.Equal(got, test.want) {
-				t.Errorf("the generator reads %q, want %q", got, test.want)
-			}
-		})
 	}
 }
 

--- a/internal/manifest/parse.go
+++ b/internal/manifest/parse.go
@@ -32,8 +32,8 @@ const (
 )
 
 var (
-	manifestFields  = []string{"inputs", "layout", "generators"}
-	generatorFields = []string{"name", "out", "inputs", "options"}
+	manifestFields  = []string{"layout", "generators"}
+	generatorFields = []string{"name", "out", "options"}
 )
 
 // What a message says a field is for, once, so that the sentence a missing
@@ -43,7 +43,6 @@ const (
 	generatorsFault = "there is nothing for a run to do without one"
 	nameFault       = "a generator is found on PATH as cpybkc-gen-<name>"
 	outFault        = "its output lands in the directory out names"
-	inputFault      = "every input names a copybook to read"
 )
 
 // parser walks a manifest as a stream of JSON tokens.
@@ -123,8 +122,6 @@ func (p *parser) manifest() (*Manifest, error) {
 		seen[key] = keySpan
 
 		switch key {
-		case "inputs":
-			m.Inputs, err = p.paths("inputs")
 		case "layout":
 			m.Layout, _, err = p.requiredText("layout", "the layout file written as text", layoutFault)
 		case "generators":
@@ -252,8 +249,6 @@ func (p *parser) generator(field string) (Generator, bool, error) {
 		case "out":
 			generator.Out, _, err = p.requiredText(
 				field+".out", "a directory path written as text", outFault)
-		case "inputs":
-			generator.Inputs, err = p.paths(field + ".inputs")
 		case "options":
 			generator.Options, err = p.options(field + ".options")
 		default:
@@ -341,53 +336,6 @@ func (p *parser) options(field string) ([]Option, error) {
 	}
 
 	return options, nil
-}
-
-// paths reads a list of copybook paths.
-func (p *parser) paths(field string) ([]string, error) {
-	open, span, err := p.token()
-	if err != nil {
-		return nil, err
-	}
-
-	if !isOpen(open, '[') {
-		p.faults.Fail(&TypeError{
-			Span: span, Field: field, Want: "a list of copybook paths", Found: found(open),
-		})
-
-		return nil, p.discardAfter(open)
-	}
-
-	var paths []string
-
-	seen := map[string]diag.Span{}
-
-	for index := 0; p.dec.More(); index++ {
-		path, pathSpan, err := p.requiredText(
-			fmt.Sprintf("%s[%d]", field, index), "a copybook path written as text", inputFault)
-		if err != nil {
-			return nil, err
-		}
-
-		if path == "" {
-			continue
-		}
-
-		if first, repeated := seen[path]; repeated {
-			p.faults.Fail(&RepeatedInputError{Span: pathSpan, First: first, Path: path, Field: field})
-
-			continue
-		}
-
-		seen[path] = pathSpan
-		paths = append(paths, path)
-	}
-
-	if _, _, err := p.token(); err != nil {
-		return nil, err
-	}
-
-	return paths, nil
 }
 
 // required reports every field of known that the object at span did not carry.

--- a/internal/manifest/parse_test.go
+++ b/internal/manifest/parse_test.go
@@ -52,7 +52,7 @@ func TestReadRefusesAManifestWithSomethingWrongWithIt(t *testing.T) {
   "generators": [{"name": "go", "out": "gen"}],
   "generatorz": []
 }`,
-			want: `cpybkc.json:4:3: a manifest has no field named "generatorz"; it carries inputs, layout and generators`,
+			want: `cpybkc.json:4:3: a manifest has no field named "generatorz"; it carries layout and generators`,
 		},
 		{
 			name: "a field no generator entry has",
@@ -63,7 +63,7 @@ func TestReadRefusesAManifestWithSomethingWrongWithIt(t *testing.T) {
   ]
 }`,
 			want: `cpybkc.json:4:34: a generator entry has no field named "version"; ` +
-				`it carries name, out, inputs and options`,
+				`it carries name, out and options`,
 		},
 		{
 			name: "a field written twice",
@@ -111,7 +111,7 @@ func TestReadRefusesAManifestWithSomethingWrongWithIt(t *testing.T) {
 			name: "a generator with no name and no out",
 			source: `{
   "layout": "orders.sexpr",
-  "generators": [{"inputs": ["cpy/orders.cpy"]}]
+  "generators": [{"options": {"package_name": "orders"}}]
 }`,
 			want: `cpybkc.json:3:18: a generator entry carries no name; a generator is found on PATH as cpybkc-gen-<name>
 cpybkc.json:3:18: a generator entry carries no out; its output lands in the directory out names`,
@@ -142,13 +142,12 @@ cpybkc.json:3:18: a generator entry carries no out; its output lands in the dire
 				`it resolves to, and "z5labs/go" contains a /`,
 		},
 		{
-			name: "one path where a list of them belongs",
+			name: "one generator where a list of them belongs",
 			source: `{
-  "inputs": "cpy/orders.cpy",
   "layout": "orders.sexpr",
-  "generators": [{"name": "go", "out": "gen"}]
+  "generators": {"name": "go", "out": "gen"}
 }`,
-			want: `cpybkc.json:2:13: inputs is a list of copybook paths, and this one is text`,
+			want: `cpybkc.json:3:17: generators is a list of generator entries, and this one is an object`,
 		},
 		{
 			name: "a layout written as a number",
@@ -198,25 +197,6 @@ cpybkc.json:3:18: a generator entry carries no out; its output lands in the dire
 			want: `cpybkc.json:4:46: an option key is empty, and a generator is handed each option as k=v`,
 		},
 		{
-			name: "a copybook named twice in one list",
-			source: `{
-  "inputs": ["cpy/orders.cpy", "cpy/common.cpy", "cpy/orders.cpy"],
-  "layout": "orders.sexpr",
-  "generators": [{"name": "go", "out": "gen"}]
-}`,
-			want: `cpybkc.json:2:50: inputs names "cpy/orders.cpy" twice
-  cpybkc.json:2:14: the first one is here`,
-		},
-		{
-			name: "an input with nothing in it",
-			source: `{
-  "inputs": ["cpy/orders.cpy", ""],
-  "layout": "orders.sexpr",
-  "generators": [{"name": "go", "out": "gen"}]
-}`,
-			want: `cpybkc.json:2:32: inputs[1] is empty; every input names a copybook to read`,
-		},
-		{
 			name: "a layout written as a boolean",
 			source: `{
   "layout": true,
@@ -225,13 +205,12 @@ cpybkc.json:3:18: a generator entry carries no out; its output lands in the dire
 			want: `cpybkc.json:2:13: layout is the layout file written as text, and this one is a boolean`,
 		},
 		{
-			name: "inputs written as nothing at all",
+			name: "generators written as nothing at all",
 			source: `{
-  "inputs": null,
   "layout": "orders.sexpr",
-  "generators": [{"name": "go", "out": "gen"}]
+  "generators": null
 }`,
-			want: `cpybkc.json:2:13: inputs is a list of copybook paths, and this one is null`,
+			want: `cpybkc.json:3:17: generators is a list of generator entries, and this one is null`,
 		},
 		{
 			name:   "a manifest that is not an object",
@@ -242,7 +221,7 @@ cpybkc.json:3:18: a generator entry carries no out; its output lands in the dire
 			name:   "a manifest that is empty",
 			source: "\n  \n",
 			want: `cpybkc.json:1:1: the manifest is empty; ` +
-				`it is a JSON object naming the layout, the copybooks and the generators to run`,
+				`it is a JSON object naming the layout and the generators to run`,
 		},
 		{
 			name:   "a manifest that is not JSON",
@@ -281,7 +260,6 @@ cpybkc.json:3:18: a generator entry carries no out; its output lands in the dire
 func TestReadStopsWhereverTheJSONDoes(t *testing.T) {
 	tests := map[string]string{
 		"before the first field":  `{`,
-		"in a list of copybooks":  `{"inputs": ["cpy/orders.cpy",`,
 		"in the generators list":  `{"layout": "orders.sexpr", "generators": [`,
 		"in a generator entry":    `{"layout": "orders.sexpr", "generators": [{`,
 		"in a generator's option": `{"layout": "o.sexpr", "generators": [{"name": "go", "options": {"a":`,
@@ -304,7 +282,7 @@ func TestReadStopsWhereverTheJSONDoes(t *testing.T) {
 // reporting one of them per run is a reader run once per fault.
 func TestReadReportsEveryFaultRatherThanTheFirst(t *testing.T) {
 	got := refuse(t, `{
-  "input": ["cpy/orders.cpy"],
+  "input": "cpy/orders.cpy",
   "layout": "orders.sexpr",
   "generators": [
     {"name": "go", "outt": "gen"},
@@ -312,8 +290,8 @@ func TestReadReportsEveryFaultRatherThanTheFirst(t *testing.T) {
   ]
 }`)
 
-	want := `cpybkc.json:2:3: a manifest has no field named "input"; it carries inputs, layout and generators
-cpybkc.json:5:20: a generator entry has no field named "outt"; it carries name, out, inputs and options
+	want := `cpybkc.json:2:3: a manifest has no field named "input"; it carries layout and generators
+cpybkc.json:5:20: a generator entry has no field named "outt"; it carries name, out and options
 cpybkc.json:5:5: a generator entry carries no out; its output lands in the directory out names
 cpybkc.json:6:14: generators[1].name is empty; a generator is found on PATH as cpybkc-gen-<name>`
 
@@ -332,7 +310,7 @@ func TestReadKeepsWhatItFoundBesideAFaultItCannotReadPast(t *testing.T) {
   "generators": [{"name": "go", "out" = "gen"}]
 }`)
 
-	want := `cpybkc.json:2:3: a manifest has no field named "layoutt"; it carries inputs, layout and generators
+	want := `cpybkc.json:2:3: a manifest has no field named "layoutt"; it carries layout and generators
 cpybkc.json:3:39: the manifest is not valid JSON: invalid character '=' after object key`
 
 	if got != want {
@@ -380,14 +358,14 @@ func TestAFaultIsAssertableByType(t *testing.T) {
 // rather than leaving the walk standing inside it.
 func TestReadSkipsPastAFieldItCannotUse(t *testing.T) {
 	got := refuse(t, `{
-  "inputs": {"first": ["cpy/orders.cpy"]},
+  "layoutt": {"first": ["cpy/orders.cpy"]},
   "layout": "orders.sexpr",
   "generators": [{"name": "go", "out": "gen"}],
   "generatorz": [[1, 2], {"a": {"b": []}}]
 }`)
 
-	want := `cpybkc.json:2:13: inputs is a list of copybook paths, and this one is an object
-cpybkc.json:5:3: a manifest has no field named "generatorz"; it carries inputs, layout and generators`
+	want := `cpybkc.json:2:3: a manifest has no field named "layoutt"; it carries layout and generators
+cpybkc.json:5:3: a manifest has no field named "generatorz"; it carries layout and generators`
 
 	if got != want {
 		t.Errorf("the manifest reads:\n%s\nwant:\n%s", got, want)

--- a/internal/manifest/testdata/cpybkc.json
+++ b/internal/manifest/testdata/cpybkc.json
@@ -1,5 +1,4 @@
 {
-  "inputs": ["cpy/orders.cpy"],
   "layout": "orders.sexpr",
   "generators": [
     {

--- a/internal/plugin/invoke_test.go
+++ b/internal/plugin/invoke_test.go
@@ -243,6 +243,67 @@ func TestTheDescriptorIsTheBytesEmitIRWrites(t *testing.T) {
 	}
 }
 
+// TestEveryGeneratorOfARunIsHandedTheBytesEmitIRWrites is the equality #157
+// settled, asserted where it can be broken.
+//
+// A run has one descriptor: the manifest names one layout, the layout names the
+// copybooks, and nothing a generator entry carries can change either — which is
+// what removing the manifest's per-generator `inputs` made true (docs/cli/SPEC.md,
+// "Which descriptor is emitted"). The observable consequence is this one, and it
+// is the one docs/plugin/SPEC.md rests reproducibility on: two generators of one
+// run, declaring different options, are handed the *same bytes*, and those bytes
+// are what `--emit-ir <path>` leaves on disk.
+//
+// The comparison is against [github.com/Zaba505/cpybkc/internal/emit.Write] and
+// a second generator rather than against a constant, because a constant would go
+// on agreeing with itself if a future run started tailoring a descriptor to the
+// generator receiving it — which is the failure this test exists to catch and
+// the one an author reproducing a generation by hand would meet as a descriptor
+// their generator never saw.
+func TestEveryGeneratorOfARunIsHandedTheBytesEmitIRWrites(t *testing.T) {
+	t.Parallel()
+
+	first, second := t.TempDir(), t.TempDir()
+
+	// The bodies are identical and the options are not: what differs between
+	// the two invocations is everything a generator entry can differ by.
+	capture := `cat "$2" > "$4/descriptor"`
+
+	go1 := generator(t, "go", capture, first)
+	go1.Options = []Option{{Key: "package_name", Value: "orders"}}
+
+	go2 := generator(t, "json-schema", capture, second)
+	go2.Options = []Option{{Key: "draft", Value: "2020-12"}, {Key: "flatten", Value: ""}}
+
+	if err := run(t, go1, go2); err != nil {
+		t.Fatalf("running two generators: %v", err)
+	}
+
+	// What --emit-ir <path> leaves on disk, written by the function the flag
+	// writes with, in the format it defaults to.
+	emitted := filepath.Join(t.TempDir(), "ir.binpb")
+	if err := emit.Write(emitted, nil, descriptor(), emit.FormatBinary); err != nil {
+		t.Fatalf("emitting the descriptor: %v", err)
+	}
+
+	want, err := os.ReadFile(emitted)
+	if err != nil {
+		t.Fatalf("reading the emitted descriptor: %v", err)
+	}
+
+	for _, out := range []string{first, second} {
+		handed, err := os.ReadFile(filepath.Join(out, "descriptor"))
+		if err != nil {
+			t.Fatalf("reading what the generator in %s was handed: %v", out, err)
+		}
+
+		if !bytes.Equal(handed, want) {
+			t.Errorf("the generator in %s was handed %d bytes and --emit-ir writes %d, and they differ",
+				out, len(handed), len(want))
+		}
+	}
+}
+
 func TestEachGeneratorGetsItsOwnDescriptorFile(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #157

`docs/cli/SPEC.md` said a run assembles **one** descriptor and `--emit-ir` writes that one, while `README.md` gave each generator entry its own `inputs` — "copybooks this generator reads in addition to the top-level `inputs`". Two generators declaring different `inputs` would be resolved against different copybooks, and a descriptor from a different set of copybooks is a different descriptor. This settles which of the two was wrong.

## The decision: one descriptor per run

A run's descriptor is a function of the layout the manifest names — of which there is exactly one — and the copybooks that layout's `record` forms name. Nothing a generator entry carries is in that function, and nothing could be:

- a generator is invoked with `--descriptor <path> --out <dir> [--opt k=v ...]` and nothing else (`docs/plugin/SPEC.md`, "Invocation"), so no copybook path reaches it;
- the IR carries no copybook path either, so it cannot find one that way;
- `assemble.Assemble` takes the framing, the automaton, the resolved records and the renames — all of them the layout's — and `generate.Runner.Run(ctx, d, generators)` takes one descriptor for the whole run.

So a per-generator copybook list named files that generator never opened. `--emit-ir` gains no selector; the manifest loses the field instead.

## What changed in the manifest

Both `inputs` lists are gone — the top-level one and the per-generator one. `inputs` is now an unknown field, which `internal/manifest` already reports with the line and column it is at, so a manifest carrying one meets a diagnostic rather than a field that quietly stopped meaning anything.

## The second half: layout copybooks versus the manifest

A run reads exactly the copybooks its layout names, and no others. The manifest constrains nothing, so there is no set a layout may not name a copybook outside of and no diagnostic for naming one; the only fault about a copybook is one cpybkc cannot open, which was already specified.

That is a decision, not an omission. A manifest that listed the readable copybooks would restate what the layout already says in a file checked in beside it — until the two disagreed, at which point the layout is still the one that named the item each record is. And enforcing membership means deciding whether a manifest-relative spelling and a layout-relative spelling name one file, which `docs/layout/SPEC.md` hands to the CLI as a question about the files rather than the spellings. Behind a symlink, a bind mount or a case-insensitive filesystem no comparison is right every time, and a guardrail that fails a correct run is worse than none — the adopter cannot fix it by changing anything that is wrong.

## Acceptance criteria

- [x] **Settled whether a run assembles one descriptor or one per generator** — one per run; `docs/cli/SPEC.md` "Which descriptor is emitted" states it, and states why the manifest was changed rather than the flag.
- [x] **If one per generator, `--emit-ir` gains a selector** — does not apply. No selector, no new flag, and the Compatibility guarantees table's `--emit-ir` row now reads "writes the run's one descriptor, which is the same bytes every generator of that run is handed".
- [x] **If one per run, the meaning of a generator's own `inputs` is settled, and `README.md` says which** — removed, at both levels. `README.md`'s manifest table drops both rows and a new paragraph, "A manifest does not list copybooks", says what happened and links the two spec sections.
- [x] **The relationship between the copybooks a layout names and `inputs` is stated, including whether a layout may name one the manifest does not list and what the CLI reports** — `docs/cli/SPEC.md` "Finding the inputs" gains a third question and its answer: the manifest lists none, a layout may name any copybook, and the only diagnostic is the existing one for a copybook that cannot be opened.
- [x] **`docs/plugin/SPEC.md`'s equality holds, and a test asserts it rather than a document claiming it** — `TestEveryGeneratorOfARunIsHandedTheBytesEmitIRWrites` in `internal/plugin` runs two real generator processes declaring different options, and asserts both were handed the bytes `emit.Write` leaves on disk for the same descriptor. The plugin contract now also states the strong form: every generator of one run is handed the same bytes, and a plugin **MUST NOT** read anything into having been given a descriptor of its own.
- [x] **#148 and #149 updated to match** — both issue bodies amended.

## Judgment calls

- **Removed rather than redefined.** `inputs` could have been kept as a declared set the CLI enforces. That was rejected for the path-identity reason above, and because `README.md`'s own rule — a line that reads as configuration and silently does nothing is a fault — leaves no room for a field that decides nothing.
- **The removal is unguarded.** No deprecation window, because the CLI has no generation pipeline yet (#148 is open), so there is no adopter whose manifest works today.
- **The test compares to `emit.Write`, not `emit.Marshal`.** `Write` to a path is what `--emit-ir <dest>` does; comparing against the lower-level function would leave the flag's own encoding step untested.

## Verified

`dagger call ci` — fmt, vet, lint and `go test -race` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)