### PR TITLE
story(container): build the multi-platform image

### DIFF
--- a/.dagger/dagger.gen.go
+++ b/.dagger/dagger.gen.go
@@ -230,6 +230,34 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Cpybkc).Fmt(&parent, ctx)
+		case "Image":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var platform string
+			if inputArgs["platform"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["platform"]), &platform)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg platform", err))
+				}
+			}
+			return (*Cpybkc).Image(&parent, ctx, platform)
+		case "ImageContract":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var platform string
+			if inputArgs["platform"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["platform"]), &platform)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg platform", err))
+				}
+			}
+			return nil, (*Cpybkc).ImageContract(&parent, ctx, platform)
 		case "IrArtifacts":
 			var parent Cpybkc
 			err = json.Unmarshal(parentJSON, &parent)

--- a/.dagger/image.go
+++ b/.dagger/image.go
@@ -525,6 +525,18 @@ func buildSettings(out string) map[string]string {
 // The parent directories are root-owned and that is intentional — only the
 // plugin directory is promised to the image's user, and a root-owned parent at
 // 0755 is what stops the running user replacing the tree above it.
+//
+// Listing /tmp here does not make it a covered guarantee, and the two are not
+// the same kind of statement. Covered is about what a *consumer* may depend on,
+// and docs/container/SPEC.md keeps the temporary directory out of that
+// deliberately: its path and its mode may change in a patch release. This map
+// is what *this repository* expects its own build to produce, and it has to be
+// exhaustive or the promise it exists to check — scratch plus the files that
+// document names, so no shell, no libc and no package manager — degrades into a
+// spot check that a busybox under another name would pass. A patch release that
+// moved the temporary directory would edit this line in the same commit, which
+// is the difference between changing an implementation detail and changing it
+// without noticing.
 func baseImageContents() map[string]imageEntry {
 	contents := map[string]imageEntry{
 		"/usr":       {0, 0, dirMode},

--- a/.dagger/image.go
+++ b/.dagger/image.go
@@ -1,0 +1,711 @@
+// This file builds the published base image — the one docs/container/SPEC.md
+// describes and strangers' Dockerfiles name paths inside — and checks it against
+// every promise that document makes about one (#55).
+//
+// # Why the image is built here rather than by the GoApp archetype
+//
+// .dagger/main.go's package comment expected this story to be a change of
+// factory: GoLib to GoApp, and the multi-platform image build arrives with it.
+// It is not, and the reason is what GoApp's image *is*. That archetype produces
+// one image per binary — a scratch image holding one executable at a path of its
+// own choosing, with that path as the entrypoint and nothing else set: no PATH,
+// no user, no second directory, no notion of an image built FROM it.
+//
+// cpybkc publishes a base. Four of the six promises docs/container/SPEC.md makes
+// — the plugin directory, its membership of PATH, its ownership and the non-root
+// user the process runs as — are not settings GoApp is missing so much as a
+// different shape of image, and teaching it that shape would be teaching it this
+// repository's plugin model, which is a contract in docs/ and belongs nowhere
+// else. avroc reached the same conclusion for the same reason and built its
+// image in its own module (avroc#166); what is left once the customization is
+// taken out is the handful of Container calls below.
+//
+// What is *not* rebuilt here is anything about what "checked" means. fmt, vet,
+// lint and `go test -race` still route through the Z5Labs standard by way of Ci,
+// and the executable is still built by the shared devex Go module's Build — with
+// the platform and CGO switches that module already takes. This file adds only
+// the image layout the standard has no opinion about, which is why no upstream
+// change was needed to reach it and why main.go's factory is still GoLib.
+//
+// # Why the contract is a check rather than a comment
+//
+// Every promise docs/container/SPEC.md makes is a field of an OCI image
+// configuration or a file in the filesystem it describes, so every one of them
+// is machine-checkable — and each is the kind of promise that breaks silently
+// here and loudly somewhere else. An image whose PATH lost /usr/local/bin runs
+// cpybkc perfectly and fails only in a stranger's repository, at the point where
+// their generator is not found. ImageContract is that document's compatibility
+// guarantees table executed rather than read.
+//
+// The images built FROM this one are not this repository's to write — that is
+// the whole of #48's argument for shipping cpybkc-gen-go as a separate image —
+// but one of them is: docs/container/SPEC.md's worked example, which
+// worked_example.go now assembles onto the image this file produces rather than
+// interpreting its final stage against a published tag.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"strconv"
+	"strings"
+
+	"dagger/cpybkc/internal/dagger"
+)
+
+// The published image's contract, as constants. Each one is a row of
+// docs/container/SPEC.md's compatibility guarantees table, and changing one here
+// without changing it there is the drift ImageContract exists to catch.
+const (
+	// pluginDir is the plugin directory: the one path in the image a derived
+	// Dockerfile writes to, and the one directory on PATH.
+	pluginDir = "/usr/local/bin"
+
+	// imageUID and imageGID are the pinned non-root identity the image runs as.
+	// They are numbers rather than a name because the image has no /etc/passwd
+	// for a name to resolve against, and because a derived Dockerfile's
+	// COPY --chown and a Kubernetes securityContext are both written against
+	// the number.
+	imageUID = 65532
+	imageGID = 65532
+
+	// imageUser is that identity in the form the OCI configuration's User field,
+	// Dagger's owner arguments and a COPY --chown all take.
+	imageUser = "65532:65532"
+
+	// overrideUser is an arbitrary other identity, used to check the promise
+	// that the image does not require its own: a caller writing output into a
+	// bind mount is told to pass `--user $(id -u):$(id -g)`, and that has to be
+	// an ordinary configuration rather than a workaround.
+	overrideUser = "1234:1234"
+
+	// executableMode is the mode every executable in the plugin directory has:
+	// readable and executable by the image's user and by any UID a caller
+	// overrides it with, which is the other half of what makes that override
+	// ordinary.
+	executableMode = 0o755
+
+	// dirMode is the mode of every directory in the image.
+	dirMode = 0o755
+
+	// tmpDir is a writable temporary directory, and it is the one thing in the
+	// image that docs/container/SPEC.md deliberately does not cover — it lists
+	// the directory under implementation detail rather than as a guarantee.
+	//
+	// It is here because cpybkc writes each invocation's descriptor into a
+	// directory it creates under os.TempDir, and hands each generator an output
+	// directory it created the same way, so a scratch image without one fails
+	// every generation with an error naming /tmp. tmpDirMode is 1777 —
+	// root-owned, world-writable and sticky — which is the ordinary arrangement
+	// and the one that keeps working when a caller overrides the UID.
+	tmpDir     = "/tmp"
+	tmpDirMode = 0o1777
+)
+
+// imagePlatforms is the set of platforms the image is published for, and the
+// single definition of it in this module.
+//
+// Two, and the same two avroc publishes. cpybkc runs on the machines a modern
+// codebase is developed on; it is not deployed to the mainframe whose files it
+// reads, which is what #56 settled when it was closed as not planned, and
+// docs/container/SPEC.md's platform table says the same. Big-endian *files* stay
+// fully in scope — that fork is a property of the data, not of the host — and
+// they are decoded by the test suite on the platforms below.
+func imagePlatforms() []dagger.Platform {
+	return []dagger.Platform{"linux/amd64", "linux/arm64"}
+}
+
+// Image builds the published base image for one platform:
+//
+//	dagger call image --platform=linux/arm64 export --path=cpybkc.tar
+//
+// It is the image docs/container/SPEC.md describes, and every promise that
+// document makes is made here: the CLI in /usr/local/bin with that directory on
+// PATH, the CLI as the entrypoint with an empty Cmd, UID and GID 65532 owning
+// the plugin directory and running the process, a writable temporary directory,
+// and nothing else in the filesystem at all.
+//
+// No generator is in it, and that absence is a promise rather than an omission:
+// cpybkc-gen-go (#48-#53) reaches a user the way a stranger's generator does, as
+// an image built FROM this one. A base carrying its own generator would publish
+// the same bytes and quietly stop testing the extension mechanism.
+//
+// platform defaults to the engine's own, which is what makes `dagger call image`
+// useful from a checkout; a value must be one of the published platforms, so a
+// typo is an error rather than an image nobody publishes.
+func (m *Cpybkc) Image(
+	ctx context.Context,
+	// Build for this platform, as `GOOS/GOARCH` — one of the published
+	// platforms. Empty builds for the engine's own platform.
+	// +optional
+	platform string,
+) (*dagger.Container, error) {
+	p, err := imagePlatform(ctx, platform)
+	if err != nil {
+		return nil, err
+	}
+
+	return m.image(p), nil
+}
+
+// ImageContract checks the built image against every promise
+// docs/container/SPEC.md makes about it (#55).
+//
+// It is a check rather than a paragraph because each promise is depended on from
+// a repository this project cannot see and breaks without breaking anything
+// here: an image whose PATH lost the plugin directory runs cpybkc perfectly and
+// fails at the point where somebody else's generator is not found.
+//
+// Four groups, all on the real image rather than on a description of it:
+//
+//   - The OCI configuration — Entrypoint, Cmd, User and PATH. WorkingDir is not
+//     among them, because that document explicitly does not cover it: a caller
+//     passes their own, and the invocation the document gives them says so.
+//   - The filesystem, as an exact list of every path in it with its owner and
+//     its mode. Exact rather than a spot check, because "the base is scratch
+//     plus the files this document names" is the promise, and it is the same
+//     assertion as no shell, no libc and no package manager.
+//   - How the executable in it was built, read out of the binary itself: CGO
+//     off, -trimpath on, and the GOOS and GOARCH of the platform whose image it
+//     landed in.
+//   - The entrypoint being the CLI, by running it — twice, as the image's own
+//     user and as an arbitrary other one.
+//
+// platform restricts the check to one of the published platforms; empty runs
+// every one of them, and every failure is reported rather than the first,
+// because "it holds on amd64 and not on arm64" is the finding.
+//
+// +check
+// +cache="session"
+func (m *Cpybkc) ImageContract(
+	ctx context.Context,
+	// Run the check on this platform alone, as `GOOS/GOARCH` — one of the
+	// published platforms. Empty covers all of them.
+	// +optional
+	platform string,
+) error {
+	platforms := imagePlatforms()
+	if platform != "" {
+		if !slices.Contains(platforms, dagger.Platform(platform)) {
+			return fmt.Errorf("platform %q is not one this repository publishes: %v", platform, platforms)
+		}
+
+		platforms = []dagger.Platform{dagger.Platform(platform)}
+	}
+
+	var errs []error
+	for _, p := range platforms {
+		if err := m.imageContractOn(ctx, p); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", p, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// image is the base image for one platform, and the one definition of it: Image,
+// ImageContract and the worked example's final stage all come through here, so
+// there is no arrangement in which the image a check passed is not the image
+// somebody publishes, nor one in which a derived image is built on a base
+// nobody checked.
+//
+// The order of the calls below is the order docs/container/SPEC.md states the
+// promises in, which is not an accident worth preserving so much as one worth
+// not breaking: WithEntrypoint clears Cmd, so it comes before the
+// WithoutDefaultArgs that asserts Cmd is empty rather than after it.
+func (m *Cpybkc) image(platform dagger.Platform) *dagger.Container {
+	cli := dag.Directory().WithFile(
+		cliBinary,
+		m.binary(platform),
+		dagger.DirectoryWithFileOpts{Permissions: executableMode},
+	)
+
+	return dag.Container(dagger.ContainerOpts{Platform: platform}).
+		// The plugin directory, owned by the image's user so that a generator
+		// copied in by a derived image lands somewhere that user can execute
+		// from. The CLI goes here too; its own path is explicitly not part of
+		// the contract, and this is simply the one directory the image has.
+		WithDirectory(pluginDir, cli, dagger.ContainerWithDirectoryOpts{
+			Owner: imageUser,
+		}).
+		// A temporary directory, because cpybkc writes each invocation's
+		// descriptor into one. Not owned by the image's user: 1777 is what makes
+		// it usable by whichever UID the container is actually running as.
+		WithDirectory("/", m.tmpDirectory()).
+		// PATH is set outright rather than appended to, because a scratch image
+		// has no PATH to append to. Only the guarantee that it contains the
+		// plugin directory is covered; the rest of the value is not.
+		WithEnvVariable("PATH", pluginDir).
+		WithUser(imageUser).
+		WithEntrypoint([]string{pluginDir + "/" + cliBinary}).
+		WithoutDefaultArgs()
+}
+
+// binary builds the CLI for one platform.
+//
+// It is what Binary calls with no platform at all, so the executable a
+// contributor exports and the one that lands in every published image are the
+// same build with one argument different — including the CGO and -trimpath
+// switches, whose reasons are Binary's doc comment and whose effect
+// checkImageBuild reads back out of the artifact.
+//
+// The platform is a cross-compile by the toolchain container rather than a
+// build under emulation. Nothing about a Go build needs the target's
+// architecture to be executable, and paying qemu for every compile to learn
+// what `go build` already knows would be minutes per platform per run.
+func (m *Cpybkc) binary(platform dagger.Platform) *dagger.File {
+	return dag.Go().
+		Build(m.Source, dagger.GoBuildOpts{
+			Pkg:          cliPackage,
+			ArtifactName: cliBinary,
+			Trimpath:     true,
+			DisableCgo:   true,
+			Platform:     string(platform),
+		}).
+		File(cliBinary)
+}
+
+// tmpDirectory is a directory holding nothing but `tmp`, with mode 1777, for
+// grafting onto the image's root.
+//
+// It is staged by a real mkdir in a container that has one rather than by
+// WithDirectory's permissions argument, because that argument sets the mode of
+// the files written *into* a directory and not the mode of the directory
+// itself — which would leave /tmp root-owned at 0755, and every generation
+// failing with `permission denied` the moment the process is not root. That is
+// a fault the filesystem listing catches and no configuration check would.
+//
+// The toolchain container is the one dag.Go() already builds from this
+// repository's go.mod, rather than an image of this file's choosing: it is
+// pulled by every other stage anyway, so staging one directory costs nothing
+// beyond the exec.
+func (m *Cpybkc) tmpDirectory() *dagger.Directory {
+	const staging = "/staging"
+
+	return dag.Go().
+		Container(m.Source).
+		WithExec([]string{"install", "-d", "-m", "1777", staging + tmpDir}).
+		Directory(staging)
+}
+
+// imageContractOn checks one platform's image.
+//
+// Every group is run and every failure collected rather than stopping at the
+// first: a change that broke the entrypoint most likely broke the user and the
+// plugin directory too, and one run should say so.
+func (m *Cpybkc) imageContractOn(ctx context.Context, platform dagger.Platform) error {
+	image := m.image(platform)
+
+	errs := m.checkImageConfig(ctx, image)
+	errs = append(errs, m.checkImageContents(ctx, image, baseImageContents())...)
+	errs = append(errs, m.checkImageBuild(ctx, image, platform)...)
+	errs = append(errs, m.checkImageIsTheCLI(ctx, image)...)
+
+	return errors.Join(errs...)
+}
+
+// checkImageConfig checks the fields of the OCI image configuration a derived
+// image inherits.
+func (m *Cpybkc) checkImageConfig(ctx context.Context, image *dagger.Container) []error {
+	var errs []error
+
+	// The structural half of the entrypoint guarantee. Exactly one element,
+	// because "the arguments a caller passes to docker run are cpybkc's
+	// arguments" is only true when there is nothing in Entrypoint for them to
+	// arrive after; and that element has to be an executable the image actually
+	// ships, because Entrypoint is otherwise free to name a path that is not
+	// there and fail at run time in somebody else's pipeline.
+	//
+	// It is deliberately not compared to a literal, since the CLI's own path is
+	// implementation detail and pinning it here would make a promise this
+	// project has explicitly not made. What pins the entrypoint to the CLI is
+	// behaviour rather than shape, in checkImageIsTheCLI.
+	//
+	// The base image's executables rather than the checked image's, because this
+	// runs on derived images too and a derived image inherits its Entrypoint: an
+	// image whose Entrypoint had become the generator it copied in would be a
+	// different program wearing cpybkc's filesystem, which is exactly the edit
+	// docs/container/SPEC.md forbids.
+	executables := baseImageExecutablePaths()
+	entrypoint, err := image.Entrypoint(ctx)
+	switch {
+	case err != nil:
+		errs = append(errs, fmt.Errorf("reading Entrypoint: %w", err))
+	case len(entrypoint) == 0:
+		errs = append(errs, errors.New("the image's Entrypoint is empty: a derived image inherits no program"))
+	case len(entrypoint) > 1:
+		errs = append(errs, fmt.Errorf("the image's Entrypoint is %v, want exactly one element: a caller's "+
+			"arguments are cpybkc's arguments, and anything else here would come before them", entrypoint))
+	case !slices.Contains(executables, entrypoint[0]):
+		errs = append(errs, fmt.Errorf("the image's Entrypoint is %v, which is not one of the executables the "+
+			"image ships (%v)", entrypoint, executables))
+	}
+
+	args, err := image.DefaultArgs(ctx)
+	switch {
+	case err != nil:
+		errs = append(errs, fmt.Errorf("reading Cmd: %w", err))
+	case len(args) != 0:
+		errs = append(errs, fmt.Errorf("the image's Cmd is %v, want empty: a caller's arguments are cpybkc's "+
+			"arguments", args))
+	}
+
+	user, err := image.User(ctx)
+	switch {
+	case err != nil:
+		errs = append(errs, fmt.Errorf("reading User: %w", err))
+	case user != imageUser:
+		errs = append(errs, fmt.Errorf("the image's User is %q, want %q", user, imageUser))
+	}
+
+	path, err := image.EnvVariable(ctx, "PATH")
+	switch {
+	case err != nil:
+		errs = append(errs, fmt.Errorf("reading PATH: %w", err))
+	case !slices.Contains(strings.Split(path, ":"), pluginDir):
+		errs = append(errs, fmt.Errorf("PATH is %q, which does not contain the plugin directory %q", path,
+			pluginDir))
+	}
+
+	return errs
+}
+
+// checkImageIsTheCLI runs the entrypoint and requires cpybkc's version line
+// back, as the image's own user and then as an arbitrary other one.
+//
+// The behavioural half of the entrypoint guarantee: docs/container/SPEC.md
+// promises that a caller's arguments are cpybkc's arguments, and --version is
+// the one invocation docs/cli/SPEC.md requires to succeed without touching
+// anything — it contacts nothing, reads no manifest, writes one line and exits
+// 0. An entrypoint repointed at some other executable would answer differently
+// or not at all.
+//
+// The second run is the other promise in the same command. "The image MUST NOT
+// require its own UID" is what makes `--user $(id -u):$(id -g)` the recommended
+// invocation whenever output lands in a bind mount, and a plugin directory or an
+// executable readable only by 65532 would break it — which is a failure a
+// caller sees and this repository never would.
+func (m *Cpybkc) checkImageIsTheCLI(ctx context.Context, image *dagger.Container) []error {
+	var errs []error
+
+	for _, user := range []string{imageUser, overrideUser} {
+		line, err := image.
+			WithUser(user).
+			WithExec([]string{"--version"}, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
+			Stdout(ctx)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("running --version through the image's entrypoint as user %s: %w",
+				user, err))
+
+			continue
+		}
+
+		if err := checkVersionLine(line); err != nil {
+			errs = append(errs, fmt.Errorf("as user %s, %w", user, err))
+		}
+	}
+
+	return errs
+}
+
+// checkImageBuild reads the build settings out of the executable in the image
+// and requires the ones the contract rests on.
+//
+// `go version -m` is the binary describing its own build, so this is the claim
+// checked against the artifact rather than against the source of the pipeline
+// that produced it: a flag dropped from binary's GoBuildOpts fails here, and so
+// would one dropped upstream in the shared Go module.
+//
+// Three settings, and each one is a criterion of #55 that nothing else can see:
+//
+//   - CGO_ENABLED=0 is what makes the executable a single static file. The
+//     image has no loader and no libc, so a dynamically linked one does not
+//     start; Build already runs the engine-platform binary in an empty image,
+//     and this is the same claim for the platforms that cannot be run without
+//     emulation.
+//   - -trimpath=true is what makes the build reproducible. Without it the
+//     binary carries the directory it was compiled in, so two builds of one
+//     commit in two checkouts produce two different images.
+//   - GOOS and GOARCH are what makes the multi-platform index real. A
+//     cross-compile that silently fell back to the engine's own architecture
+//     would produce an index whose arm64 manifest holds an amd64 executable,
+//     which fails for the first person to pull it on the platform they asked
+//     for and for nobody here.
+func (m *Cpybkc) checkImageBuild(
+	ctx context.Context,
+	image *dagger.Container,
+	platform dagger.Platform,
+) []error {
+	const mountedAt = "/image"
+
+	goos, goarch, ok := strings.Cut(string(platform), "/")
+	if !ok {
+		return []error{fmt.Errorf("platform %q is not GOOS/GOARCH", platform)}
+	}
+
+	// Read in a container that has a Go toolchain, over the image's filesystem
+	// mounted as data. Nothing is run *in* the image, which is the point of the
+	// image having no shell — and the binary being read may be for another
+	// architecture, which `go version -m` does not care about because it reads
+	// the file rather than executing it.
+	out, err := dag.Go().
+		Container(m.Source).
+		WithMountedDirectory(mountedAt, image.Rootfs()).
+		WithExec([]string{"go", "version", "-m", mountedAt + pluginDir + "/" + cliBinary}).
+		Stdout(ctx)
+	if err != nil {
+		return []error{fmt.Errorf("reading the build settings of the executable in the image: %w", err)}
+	}
+
+	settings := buildSettings(out)
+
+	want := []struct {
+		setting string
+		value   string
+		why     string
+	}{
+		{"CGO_ENABLED", "0", "the image has no libc and no loader, so a dynamically linked cpybkc does not start"},
+		{"-trimpath", "true", "without it the binary carries the directory it was compiled in, and the image is " +
+			"no longer a function of the source alone"},
+		{"GOOS", goos, "the image would carry an executable for another operating system"},
+		{"GOARCH", goarch, "the index's manifest for this platform would carry an executable for another one"},
+	}
+
+	var errs []error
+	for _, w := range want {
+		got, ok := settings[w.setting]
+		switch {
+		case !ok:
+			errs = append(errs, fmt.Errorf("the executable in the image states no %s; it has to be %s, because %s",
+				w.setting, w.value, w.why))
+		case got != w.value:
+			errs = append(errs, fmt.Errorf("the executable in the image was built with %s=%s, want %s: %s",
+				w.setting, got, w.value, w.why))
+		}
+	}
+
+	return errs
+}
+
+// buildSettings reads `go version -m` output into the settings it reports.
+//
+// Every line but the first is a tab-indented `<key>\t<value>` pair, and the ones
+// this file wants are under the `build` key, each of them a single
+// `<setting>=<value>` field. A line shaped any other way is not a build setting
+// and is skipped rather than guessed at.
+func buildSettings(out string) map[string]string {
+	settings := map[string]string{}
+
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 || fields[0] != "build" {
+			continue
+		}
+
+		if setting, value, ok := strings.Cut(fields[1], "="); ok {
+			settings[setting] = value
+		}
+	}
+
+	return settings
+}
+
+// baseImageContents is every path the base image is allowed to contain, with the
+// owner and the mode each one must have.
+//
+// It is exhaustive on purpose. docs/container/SPEC.md's "Shell or no shell" says
+// the base is scratch plus the files that document names, and an exhaustive
+// listing is the only form of that claim which stays true when somebody adds a
+// file: a spot check for /bin/sh passes on an image carrying a busybox under
+// another name.
+//
+// The parent directories are root-owned and that is intentional — only the
+// plugin directory is promised to the image's user, and a root-owned parent at
+// 0755 is what stops the running user replacing the tree above it.
+func baseImageContents() map[string]imageEntry {
+	contents := map[string]imageEntry{
+		"/usr":       {0, 0, dirMode},
+		"/usr/local": {0, 0, dirMode},
+		pluginDir:    {imageUID, imageGID, dirMode},
+		tmpDir:       {0, 0, tmpDirMode},
+	}
+
+	for _, name := range baseImageExecutables() {
+		contents[pluginDir+"/"+name] = imageEntry{imageUID, imageGID, executableMode}
+	}
+
+	return contents
+}
+
+// baseImageExecutables is what ships in the base image's plugin directory: the
+// CLI, and nothing else.
+//
+// cpybkc's own generator is not here, and its absence is a promise
+// docs/container/SPEC.md makes outright. A base that carried cpybkc-gen-go would
+// make the generator image #48 ships decorative — the generator would be
+// reachable by a path nobody copied it to, which is precisely the private
+// arrangement that leaves an extension mechanism untested by its own author.
+func baseImageExecutables() []string {
+	return []string{cliBinary}
+}
+
+// baseImageExecutablePaths is baseImageExecutables where they land, which is
+// what an Entrypoint would have to name.
+func baseImageExecutablePaths() []string {
+	names := baseImageExecutables()
+	paths := make([]string, 0, len(names))
+
+	for _, name := range names {
+		paths = append(paths, pluginDir+"/"+name)
+	}
+
+	return paths
+}
+
+// imageEntry is one path's expected ownership and mode.
+type imageEntry struct {
+	uid  int
+	gid  int
+	mode int
+}
+
+func (e imageEntry) String() string {
+	return fmt.Sprintf("%d:%d %04o", e.uid, e.gid, e.mode)
+}
+
+// checkImageContents compares every path in an image against a listing of what
+// it is allowed to hold.
+//
+// The listing is produced by one `find` in a container that has one, over the
+// image's root filesystem mounted as data. It cannot be produced by running
+// anything *in* the image, which is the point of the image having no shell, and
+// a Dagger entries walk would report the paths without their owners — and
+// ownership is half of what is being checked.
+//
+// want is given outright rather than derived, because the worked example's
+// expected listing is a function of the document: that Dockerfile states the
+// owner and the mode of the file it copies in, and the check that builds it
+// reads both out of the committed text rather than assuming this file's
+// constants.
+func (m *Cpybkc) checkImageContents(
+	ctx context.Context,
+	image *dagger.Container,
+	want map[string]imageEntry,
+) []error {
+	const mountedAt = "/image"
+
+	// Numeric %U and %G rather than %u and %g: the listing container has no
+	// passwd entry for 65532, so the symbolic forms would print the number
+	// anyway on a good day and a name on a bad one.
+	listing, err := dag.Go().
+		Container(m.Source).
+		WithMountedDirectory(mountedAt, image.Rootfs()).
+		WithExec([]string{"find", mountedAt, "-mindepth", "1", "-printf", `%U %G %m %p\n`}).
+		Stdout(ctx)
+	if err != nil {
+		return []error{fmt.Errorf("listing the image filesystem: %w", err)}
+	}
+
+	var errs []error
+
+	got := make(map[string]imageEntry, len(want))
+	for _, line := range strings.Split(strings.TrimSpace(listing), "\n") {
+		if line == "" {
+			continue
+		}
+
+		entry, path, err := parseFindLine(line, mountedAt)
+		if err != nil {
+			errs = append(errs, err)
+
+			continue
+		}
+
+		got[path] = entry
+	}
+
+	for path, wantEntry := range want {
+		gotEntry, ok := got[path]
+		switch {
+		case !ok:
+			errs = append(errs, fmt.Errorf("%s: missing from the image", path))
+		case gotEntry != wantEntry:
+			errs = append(errs, fmt.Errorf("%s: is %v, want %v", path, gotEntry, wantEntry))
+		}
+	}
+
+	for path := range got {
+		if _, ok := want[path]; !ok {
+			errs = append(errs, fmt.Errorf("%s: present in the image and not in the contract; the base is scratch "+
+				"plus the files docs/container/SPEC.md names, plus whatever a derived image copied in, and nothing "+
+				"else", path))
+		}
+	}
+
+	// Sorted, because a map walk would order the failures differently on every
+	// run and make two reports of one break look like two breaks.
+	slices.SortFunc(errs, func(a, b error) int { return strings.Compare(a.Error(), b.Error()) })
+
+	return errs
+}
+
+// parseFindLine reads one `%U %G %m %p` line and strips the mount prefix, so
+// that the paths compared are the paths inside the image.
+func parseFindLine(line, prefix string) (imageEntry, string, error) {
+	fields := strings.Fields(line)
+	if len(fields) != 4 {
+		return imageEntry{}, "", fmt.Errorf("unreadable listing line %q", line)
+	}
+
+	uid, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return imageEntry{}, "", fmt.Errorf("unreadable uid in %q: %w", line, err)
+	}
+
+	gid, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return imageEntry{}, "", fmt.Errorf("unreadable gid in %q: %w", line, err)
+	}
+
+	mode, err := strconv.ParseInt(fields[2], 8, 32)
+	if err != nil {
+		return imageEntry{}, "", fmt.Errorf("unreadable mode in %q: %w", line, err)
+	}
+
+	return imageEntry{uid, gid, int(mode)}, strings.TrimPrefix(fields[3], prefix), nil
+}
+
+// derivedImageContents is the base image's listing plus one file copied into the
+// plugin directory, which is what an image built FROM this one is allowed to
+// hold.
+//
+// The difference between this and baseImageContents is exactly the set of files
+// somebody copied in, and checking a derived image against it is how "the final
+// stage only copies" becomes an assertion rather than a claim: a RUN that had
+// somehow worked, or a second file nobody mentioned, is a path in the listing
+// that nothing accounts for.
+func derivedImageContents(path string, entry imageEntry) map[string]imageEntry {
+	contents := maps.Clone(baseImageContents())
+	contents[path] = entry
+
+	return contents
+}
+
+// imagePlatform resolves the platform argument Image takes: empty is the
+// engine's own, and anything else has to be a platform this repository actually
+// publishes, so that a typo is an error rather than an image nobody ships.
+func imagePlatform(ctx context.Context, platform string) (dagger.Platform, error) {
+	if platform == "" {
+		return dag.DefaultPlatform(ctx)
+	}
+
+	platforms := imagePlatforms()
+	if !slices.Contains(platforms, dagger.Platform(platform)) {
+		return "", fmt.Errorf("platform %q is not one this repository publishes: %v", platform, platforms)
+	}
+
+	return dagger.Platform(platform), nil
+}

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -22,9 +22,9 @@
 // promises docs/container/SPEC.md makes are that shape rather than settings
 // GoApp is missing.
 //
-// So the factory stays GoLib, the four check stages still gate a pull request
-// and still cover cmd/ because they run over ./... , and the image is built by
-// this module in image.go — the shape avroc arrived at for the same reason
+// So the factory stays GoLib, and the four check stages still gate a pull
+// request and still cover cmd/ because they run over ./... . The image is built
+// by this module in image.go — the shape avroc arrived at for the same reason
 // (avroc#166). What is left for GoApp is the publish half, which is #59's, and
 // which it will be able to take or leave on its own merits rather than because
 // the image came attached to it.

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -13,15 +13,21 @@
 // nobody wrote down. Wrapping costs one dependency and keeps that impossible.
 //
 // GoLib rather than GoApp, even now that cmd/cpybkc-gen-go is a main package
-// (#48). What GoApp adds over GoLib is the multi-platform image build and the
-// publish half of the standard, and both of those are what #54 and #55 specify
-// and build — the base-image contract decides what is in the image, which
-// platforms it carries and where it is published, and switching factories ahead
-// of those stories would produce an image nothing had described and a publish
-// stage with nowhere to publish to. The four check stages are what gate a pull
-// request, and they cover cmd/ under either archetype because they run over
-// ./... . The move to GoApp lands with the image, in #55: a change to which
-// factory this file calls, not a change to what the pipeline is.
+// (#48) and the image is built (#55). What GoApp adds over GoLib is a
+// multi-platform image build and the publish half of the standard, and this
+// story expected to reach the image by switching factories. It did not, and
+// image.go's own comment says why at length: GoApp publishes one image per
+// binary, and cpybkc publishes a *base* — a directory on PATH that other
+// people's images copy into, owned by a pinned non-root user. Four of the six
+// promises docs/container/SPEC.md makes are that shape rather than settings
+// GoApp is missing.
+//
+// So the factory stays GoLib, the four check stages still gate a pull request
+// and still cover cmd/ because they run over ./... , and the image is built by
+// this module in image.go — the shape avroc arrived at for the same reason
+// (avroc#166). What is left for GoApp is the publish half, which is #59's, and
+// which it will be able to take or leave on its own merits rather than because
+// the image came attached to it.
 //
 // # Why the stage functions exist alongside it
 //
@@ -77,6 +83,15 @@
 // smallest thing that can tell a static binary from a dynamic one without
 // reading its headers. It lands with the CLI (#147) rather than with the image
 // (#55) because it is a claim about the binary, and the binary exists first.
+//
+// # Why the image is built here too
+//
+// ImageContract builds the published base image on every platform this project
+// ships for and checks it against docs/container/SPEC.md (#55). It is in Ci for
+// the reason the artifact builds are: the image is a public contract named by
+// path from repositories this project cannot see, so the pull request that moves
+// a path is where that has to fail. image.go carries the argument for why the
+// image is assembled in this module rather than by the standard's app archetype.
 //
 // # Why the release artifacts are built here
 //
@@ -188,12 +203,13 @@ func New(
 // Ci runs the whole pipeline: fmt, vet, golangci-lint and `go test -race`, as
 // the Z5Labs standard defines them, over each of this repository's two Go
 // modules, plus `buf lint` over the IR schema, a build of the CLI itself, a
-// build of the three artifacts a release publishes, and the worked example
-// docs/container/SPEC.md hands an adopter. This is the single entrypoint — CI
-// is one `dagger call ci` and stays one, because a workflow step that reran any
-// of these stages would be a second definition of them.
+// build of the three artifacts a release publishes, the published base image on
+// every platform it ships for, and the worked example docs/container/SPEC.md
+// hands an adopter. This is the single entrypoint — CI is one `dagger call ci`
+// and stays one, because a workflow step that reran any of these stages would be
+// a second definition of them.
 //
-// The seven parts run concurrently and all are reported, for the reason the
+// The eight parts run concurrently and all are reported, for the reason the
 // standard runs its own four that way: waiting on a Go stage to learn that the
 // schema is unlintable, or the reverse, is a second push to find out about the
 // second failure.
@@ -201,10 +217,10 @@ func New(
 // +check
 // +cache="session"
 func (m *Cpybkc) Ci(ctx context.Context) error {
-	var goErr, irErr, protoErr, buildErr, artifactErr, layoutErr, exampleErr error
+	var goErr, irErr, protoErr, buildErr, artifactErr, layoutErr, imageErr, exampleErr error
 
 	var wg sync.WaitGroup
-	wg.Add(7)
+	wg.Add(8)
 
 	go func() {
 		defer wg.Done()
@@ -240,12 +256,20 @@ func (m *Cpybkc) Ci(ctx context.Context) error {
 
 	go func() {
 		defer wg.Done()
+		// Every published platform, because the promise is about the index a
+		// consumer pulls from and not about the one architecture this run
+		// happens to be on.
+		imageErr = m.ImageContract(ctx, "")
+	}()
+
+	go func() {
+		defer wg.Done()
 		exampleErr = m.WorkedExample(ctx)
 	}()
 
 	wg.Wait()
 
-	return errors.Join(goErr, irErr, protoErr, buildErr, artifactErr, layoutErr, exampleErr)
+	return errors.Join(goErr, irErr, protoErr, buildErr, artifactErr, layoutErr, imageErr, exampleErr)
 }
 
 // IrCi runs the same standard pipeline over irpb/, the published IR module.
@@ -486,15 +510,13 @@ func (m *Cpybkc) IrArtifacts(ctx context.Context) error {
 // It is a function on this module rather than steps in a workflow for the
 // reason IrDescriptorSet is: a recipe that only ever ran inside a workflow
 // would be a build nobody can reproduce locally.
+//
+// The engine's own platform, because that is what a contributor exporting one
+// wants. Every published image carries the same build with a platform argument
+// (image.go's binary), so there is one recipe for the executable and not one per
+// destination.
 func (m *Cpybkc) Binary() *dagger.File {
-	return dag.Go().
-		Build(m.Source, dagger.GoBuildOpts{
-			Pkg:          cliPackage,
-			ArtifactName: cliBinary,
-			Trimpath:     true,
-			DisableCgo:   true,
-		}).
-		File(cliBinary)
+	return m.binary("")
 }
 
 // Build builds the CLI and runs it in an empty image.
@@ -528,9 +550,19 @@ func (m *Cpybkc) Build(ctx context.Context) error {
 			"ships in: %w", err)
 	}
 
-	// Only that it is the version line's shape. What the line says is
-	// cmd/cpybkc's own test's business, and asserting the version here would
-	// pin a release number in the pipeline.
+	return checkVersionLine(line)
+}
+
+// checkVersionLine reports whether line is what `cpybkc --version` writes.
+//
+// Only the line's shape. What it says is cmd/cpybkc's own test's business, and
+// asserting the version here would pin a release number in the pipeline.
+//
+// It is shared with the image contract, which runs the same invocation through
+// the published image's entrypoint (#55): what "this is cpybkc answering" means
+// is a property of the line rather than of which container it came out of, and a
+// second spelling would be a second, weaker answer.
+func checkVersionLine(line string) error {
 	if !strings.HasPrefix(line, cliBinary+" ") || !strings.Contains(line, "IR version") {
 		return fmt.Errorf("cpybkc --version wrote %q, and the line names the program, its version and the IR "+
 			"version this build produces", line)

--- a/.dagger/worked_example.go
+++ b/.dagger/worked_example.go
@@ -397,9 +397,18 @@ func (e *workedExample) rules() error {
 		errs = append(errs, fmt.Errorf("the final stage's COPY is --chown=%q; it has to be --chown=%s, "+
 			"the UID and GID the image runs as", chown, imageUser))
 	}
-	if mode, err := copied.mode(); err != nil || mode != executableMode {
-		errs = append(errs, fmt.Errorf("the final stage's COPY is --chmod=%q; it has to be --chmod=%04o, "+
-			"because cpybkc discovers only a file carrying an execute bit", copied.flags["chmod"], executableMode))
+	// The mode rather than its spelling: --chmod=755 and --chmod=0755 are the
+	// same instruction to a builder, and a rule that insisted on one of them
+	// would be this check having an opinion the document does not. What a
+	// malformed value earns is mode's own error, which names the value and says
+	// what was wrong with it, rather than being folded into the rule below.
+	switch mode, err := copied.mode(); {
+	case err != nil:
+		errs = append(errs, err)
+	case mode != executableMode:
+		errs = append(errs, fmt.Errorf("the final stage's COPY is --chmod=%q, which is mode %04o; it has to be "+
+			"%04o, because cpybkc discovers only a file carrying an execute bit",
+			copied.flags["chmod"], mode, executableMode))
 	}
 
 	if len(copied.operands) != 2 {

--- a/.dagger/worked_example.go
+++ b/.dagger/worked_example.go
@@ -20,27 +20,29 @@
 // the thing in the document is the thing people read, and the two would drift
 // exactly as far apart as nobody notices.
 //
-// # Why the final stage is read rather than built
+// # Why the final stage is replayed rather than built
 //
-// `FROM ghcr.io/zaba505/cpybkc:v0` names a *published* image. This repository
-// does not publish one yet — that is #55 — and even once it does, a pull request
-// has to check the base it just built rather than the one on the registry, and
-// there is no way to point a Dockerfile's FROM at a container that exists only
-// inside the pipeline.
+// `FROM ghcr.io/zaba505/cpybkc:v0` names a *published* image, and a pull request
+// has to check the base it just built rather than the one on the registry: the
+// published tag is last release's image, and a change that moved the plugin
+// directory would pass against it and break the first adopter to pull the next
+// release. There is no way to point a Dockerfile's FROM at a container that
+// exists only inside the pipeline.
 //
 // So the build stage — every line that compiles the generator, including the
 // heredocs that make the example runnable with an empty build context and the
 // CGO_ENABLED=0 that makes the result run in a scratch image — is handed to the
-// builder exactly as committed, and the final stage is *interpreted*: its FROM
-// is required to name the published base, and its COPY is read for the flags and
-// the paths the document itself wrote. Building that stage against a base image
-// of this pipeline's own is what #55 adds, when there is one to build against.
+// builder exactly as committed, and the final stage is *replayed*: its FROM is
+// required to name the published base, and its COPY is read for the flags and
+// the paths the document itself wrote and then applied to the base image
+// image.go builds (#55). What comes out is a real derived image, checked against
+// the base's own contract plus the one file that COPY moved.
 //
-// Interpreting is only honest if it cannot silently diverge, so the parser
-// refuses anything it does not know how to replay: an instruction other than
-// COPY in the final stage is an error naming it, rather than a line that quietly
-// goes unchecked. A worked example that grows an ENV has to teach this function
-// what an ENV means before CI will accept it.
+// Replaying is only honest if it cannot silently diverge, so the parser refuses
+// anything it does not know how to replay: an instruction other than COPY in the
+// final stage is an error naming it, rather than a line that quietly goes
+// unchecked. A worked example that grows an ENV has to teach this function what
+// an ENV means before CI will accept it.
 package main
 
 import (
@@ -48,6 +50,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"strconv"
 	"strings"
 
 	"dagger/cpybkc/internal/dagger"
@@ -69,10 +72,6 @@ const (
 	// fixed it here would fail the day that advice changed.
 	publishedBaseImage = "ghcr.io/zaba505/cpybkc"
 
-	// pluginDir is the plugin directory the document promises, and the only
-	// destination a copied generator may have.
-	pluginDir = "/usr/local/bin"
-
 	// generatorPrefix is what docs/plugin/SPEC.md's discovery rule makes of a
 	// generator's name, and so what the copied executable has to be called for
 	// cpybkc to find it at all.
@@ -84,14 +83,6 @@ const (
 	// against the one plugin whose absence from the base image nobody would
 	// notice.
 	ownGenerator = "go"
-
-	// imageUser is the UID:GID pair docs/container/SPEC.md pins, spelled the way
-	// a COPY --chown is spelled.
-	imageUser = "65532:65532"
-
-	// executableMode is the mode the copied generator has to land with. cpybkc
-	// discovers a candidate only if it carries an execute bit.
-	executableMode = "0755"
 )
 
 // WorkedExample is docs/container/SPEC.md's worked example checked rather than
@@ -116,11 +107,16 @@ const (
 //     bit, and is statically linked. That last one is the CGO_ENABLED=0 claim,
 //     and it is checked rather than grepped for, because what matters is the
 //     property of the file and not the spelling of the line that produced it.
+//   - The final stage assembles onto the image this pipeline builds (#55). What
+//     the document's COPY says — the path, the owner and the mode — is applied
+//     to the base image image.go produces, and the result is checked against the
+//     base's own contract plus that one file. This is the half that was
+//     interpreted rather than built while there was no base to build against.
 //
 // One platform — the engine's own. What is under test is a document, and the
 // document is platform-agnostic; the platform-specific claims are the image's,
-// and #55 is where they get checked on every platform this project publishes
-// for.
+// and ImageContract is where they get checked on every platform this project
+// publishes for.
 //
 // +check
 // +cache="session"
@@ -129,7 +125,14 @@ func (m *Cpybkc) WorkedExample(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return errors.Join(example.rules(), example.checkBuilds(ctx))
+
+	built := example.build()
+
+	return errors.Join(
+		example.rules(),
+		example.checkBuilds(ctx, built),
+		m.checkExtendsTheImage(ctx, example, built),
+	)
 }
 
 // workedExample is the document's Dockerfile, parsed and judged.
@@ -157,6 +160,46 @@ type workedExample struct {
 type copyInstruction struct {
 	flags    map[string]string
 	operands []string
+}
+
+// mode is the file mode --chmod names, read as octal the way a Dockerfile means
+// it.
+func (c copyInstruction) mode() (int, error) {
+	mode, err := strconv.ParseInt(c.flags["chmod"], 8, 32)
+	if err != nil {
+		return 0, fmt.Errorf("the final stage's COPY is --chmod=%q, which is not a file mode: %w",
+			c.flags["chmod"], err)
+	}
+
+	return int(mode), nil
+}
+
+// owner is the UID and GID --chown names.
+//
+// Numbers only, because the image has no /etc/passwd for a name to resolve
+// against — which is the reason docs/container/SPEC.md pins the identity as a
+// number in the first place, and why a `--chown=cpybkc` in the example would be
+// a line that fails in a stranger's build rather than in this one.
+func (c copyInstruction) owner() (int, int, error) {
+	chown := c.flags["chown"]
+
+	user, group, ok := strings.Cut(chown, ":")
+	if !ok {
+		return 0, 0, fmt.Errorf("the final stage's COPY is --chown=%q, which names no group; the image has no "+
+			"passwd file, so both halves are numbers", chown)
+	}
+
+	uid, err := strconv.Atoi(user)
+	if err != nil {
+		return 0, 0, fmt.Errorf("the final stage's COPY is --chown=%q, whose user is not a UID: %w", chown, err)
+	}
+
+	gid, err := strconv.Atoi(group)
+	if err != nil {
+		return 0, 0, fmt.Errorf("the final stage's COPY is --chown=%q, whose group is not a GID: %w", chown, err)
+	}
+
+	return uid, gid, nil
 }
 
 // workedExample reads the Dockerfile out of the document and parses it.
@@ -354,9 +397,9 @@ func (e *workedExample) rules() error {
 		errs = append(errs, fmt.Errorf("the final stage's COPY is --chown=%q; it has to be --chown=%s, "+
 			"the UID and GID the image runs as", chown, imageUser))
 	}
-	if chmod := copied.flags["chmod"]; chmod != executableMode {
-		errs = append(errs, fmt.Errorf("the final stage's COPY is --chmod=%q; it has to be --chmod=%s, "+
-			"because cpybkc discovers only a file carrying an execute bit", chmod, executableMode))
+	if mode, err := copied.mode(); err != nil || mode != executableMode {
+		errs = append(errs, fmt.Errorf("the final stage's COPY is --chmod=%q; it has to be --chmod=%04o, "+
+			"because cpybkc discovers only a file carrying an execute bit", copied.flags["chmod"], executableMode))
 	}
 
 	if len(copied.operands) != 2 {
@@ -389,19 +432,26 @@ func (e *workedExample) rules() error {
 	return errors.Join(errs...)
 }
 
-// checkBuilds hands the build half of the Dockerfile to the builder exactly as
-// committed, against a context holding nothing but that Dockerfile, and then
-// asks the result for the file the final stage copies out of it.
-func (e *workedExample) checkBuilds(ctx context.Context) error {
+// build hands the build half of the Dockerfile to the builder exactly as
+// committed, against a context holding nothing but that Dockerfile.
+//
+// One node, shared by every check that needs what it produced, so the executable
+// the final stage is assembled from is the same one the linking check passed
+// over rather than a second build of it.
+func (e *workedExample) build() *dagger.Container {
+	return dag.Directory().
+		WithNewFile("Dockerfile", e.buildStage).
+		DockerBuild(dagger.DirectoryDockerBuildOpts{Dockerfile: "Dockerfile"})
+}
+
+// checkBuilds asks the built stage for the file the final stage copies out of
+// it, and requires it to be a static executable.
+func (e *workedExample) checkBuilds(ctx context.Context, built *dagger.Container) error {
 	if len(e.copies) != 1 || len(e.copies[0].operands) != 2 {
 		// rules has already reported this; there is no source path to look for.
 		return nil
 	}
 	source := e.copies[0].operands[0]
-
-	built := dag.Directory().
-		WithNewFile("Dockerfile", e.buildStage).
-		DockerBuild(dagger.DirectoryDockerBuildOpts{Dockerfile: "Dockerfile"})
 
 	// One exec, so that a build stage which produced nothing reports that rather
 	// than three variations on it. ldd exits non-zero for a static executable and
@@ -419,6 +469,81 @@ fi`, source)
 
 	if _, err := built.WithExec([]string{"sh", "-c", script}).Sync(ctx); err != nil {
 		return fmt.Errorf("%s: the worked example: %w", containerSpec, err)
+	}
+	return nil
+}
+
+// checkExtendsTheImage assembles the final stage onto the base image this
+// pipeline builds, and checks what comes out (#55).
+//
+// This is the half the file comment above called interpreted rather than built.
+// `FROM ghcr.io/zaba505/cpybkc:v0` names a published image and a Dockerfile's
+// FROM cannot be pointed at a container that exists only inside the pipeline, so
+// the instruction is replayed instead: the COPY's own path, owner and mode are
+// applied to image.go's base, which is what a builder would do with them, and
+// the result is a real derived image to make assertions about. Replaying rather
+// than building is also why parseWorkedExample refuses an instruction it does
+// not know — a line that cannot be replayed is a line this check would otherwise
+// silently skip.
+//
+// A pull request checks the base it just built, not the one on the registry.
+// That is the whole reason this is worth doing at all: the published tag is
+// last release's image, and a change that moved the plugin directory would pass
+// against it and break the first adopter to pull the next release.
+//
+// Two assertions, and between them they are four of the five things
+// docs/container/SPEC.md calls the contract rather than the example:
+//
+//   - The derived image is the base plus exactly one file, at the path and with
+//     the owner and mode the document's COPY named. Exhaustive, so a stage that
+//     had somehow run something, or copied a second file, is a path nothing
+//     accounts for — which is the COPY-only rule as an assertion.
+//   - It is still cpybkc. The document says ENTRYPOINT is untouched, so the
+//     derived image answers --version exactly as the base does, as its own user
+//     and as an overridden one.
+//
+// The fifth, CGO_ENABLED=0, is checkBuilds' — a property of the file, checked
+// where it is produced.
+func (m *Cpybkc) checkExtendsTheImage(ctx context.Context, e *workedExample, built *dagger.Container) error {
+	if len(e.copies) != 1 || len(e.copies[0].operands) != 2 {
+		// rules has already reported this; there is no COPY to replay.
+		return nil
+	}
+	copied := e.copies[0]
+	source, destination := copied.operands[0], copied.operands[1]
+
+	// A --chmod or a --chown the document did not write properly is rules'
+	// finding — an unreadable mode fails its rule and so does any --chown that
+	// is not the image's user. There is nothing to replay here, and a value this
+	// check invented would be a promise the document did not make.
+	mode, err := copied.mode()
+	if err != nil {
+		return nil
+	}
+	uid, gid, err := copied.owner()
+	if err != nil {
+		return nil
+	}
+
+	// The engine's own platform: the build stage compiled the generator for the
+	// machine the pipeline is running on, so that is the only base it can be
+	// copied onto. Which platforms the base is published for is ImageContract's.
+	platform, err := dag.DefaultPlatform(ctx)
+	if err != nil {
+		return fmt.Errorf("reading the engine's platform: %w", err)
+	}
+
+	derived := m.image(platform).WithFile(destination, built.File(source), dagger.ContainerWithFileOpts{
+		Owner:       copied.flags["chown"],
+		Permissions: mode,
+	})
+
+	errs := m.checkImageContents(ctx, derived, derivedImageContents(destination, imageEntry{uid, gid, mode}))
+	errs = append(errs, m.checkImageIsTheCLI(ctx, derived)...)
+
+	if err := errors.Join(errs...); err != nil {
+		return fmt.Errorf("%s: the worked example's final stage, built onto the image this pipeline produces: %w",
+			containerSpec, err)
 	}
 	return nil
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,10 +3,11 @@
 ## The pipeline
 
 fmt, vet, golangci-lint, `go test -race`, `buf lint`, the three artifacts a
-release attaches and the worked example in the base-image contract are defined
-once, in the root Dagger module under [`.dagger/`](.dagger/). CI calls that
-module and so do you, which is the point: there is no arrangement of local
-commands that passes while CI fails, because they are the same functions.
+release attaches, the published base image and the worked example in the
+base-image contract are defined once, in the root Dagger module under
+[`.dagger/`](.dagger/). CI calls that module and so do you, which is the point:
+there is no arrangement of local commands that passes while CI fails, because
+they are the same functions.
 
 Run the whole thing before pushing:
 
@@ -18,8 +19,9 @@ That is the same call CI makes, with no arguments on either side. It runs the
 four Go stages in parallel and reports every failure, not just the first, and it
 runs the schema lint, the IR module's own stages, a build of [the CLI
 itself](#building-the-cli), a build of the [release
-artifacts](#the-release-artifacts) and a build of the [base-image
-contract](docs/container/SPEC.md)'s worked example alongside them.
+artifacts](#the-release-artifacts), a build of [the published
+image](#building-the-image) on every platform it ships for, and a build of the
+[base-image contract](docs/container/SPEC.md)'s worked example alongside them.
 
 ### Running one stage
 
@@ -36,6 +38,7 @@ dagger call ir-ci         # the whole standard again, over the irpb/ module
 dagger call build         # builds cpybkc CGO-free and runs it in an empty image
 dagger call ir-artifacts  # builds the two IR artifacts a release attaches
 dagger call layout-artifact  # builds the layout schema a release attaches
+dagger call image-contract   # builds the published image, checks its contract
 dagger call worked-example   # builds docs/container/SPEC.md's worked example
 ```
 
@@ -48,16 +51,18 @@ schema](#linting-the-ir-schema).
 
 `ir-ci` is not a stage but the whole standard a second time, over the second Go
 module; see [The IR module](#the-ir-module) for why there is one. `build`,
-`ir-artifacts` and `layout-artifact` are not stages either; see [Building the
-CLI](#building-the-cli) and [The release artifacts](#the-release-artifacts).
+`ir-artifacts`, `layout-artifact` and `image-contract` are not stages either; see
+[Building the CLI](#building-the-cli), [The release
+artifacts](#the-release-artifacts) and [Building the image](#building-the-image).
 
 `worked-example` is the odd one out: it builds a document. The multi-stage
 Dockerfile in [the base-image contract](docs/container/SPEC.md#worked-example-adding-a-generator)
 is the first thing an adopter runs and the last thing anybody here would notice
-had broken, since no other stage reads it, so `ci` extracts it from that file and
-builds it. Edit that example and this is the stage that will tell you about it.
+had broken, since no other stage reads it, so `ci` extracts it from that file,
+builds it, and replays its final stage onto the image `image-contract` just
+checked. Edit that example and this is the stage that will tell you about it.
 
-`dagger check` runs all eleven as a checklist, if you would rather see them
+`dagger check` runs all twelve as a checklist, if you would rather see them
 together than pick one.
 
 ### Building the CLI
@@ -80,6 +85,35 @@ So `build` compiles it CGO-free and runs `cpybkc --version` in an *empty* image.
 Nothing else is in there: a binary needing an interpreter or a libc does not
 start at all, and that failure is this check rather than an image somebody
 publishes.
+
+### Building the image
+
+```sh
+# the image itself, for one platform
+dagger call image --platform=linux/arm64 export --path=cpybkc.tar
+dagger call image-contract                         # the check `ci` runs
+dagger call image-contract --platform=linux/amd64  # one platform of it
+```
+
+The published image is a **public contract**. A Dockerfile in somebody else's
+repository says `FROM ghcr.io/zaba505/cpybkc:v0` and names a path inside it, so
+[the base-image contract](docs/container/SPEC.md) is a document strangers depend
+on and `image-contract` is that document's compatibility guarantees table
+executed rather than read: the entrypoint, `Cmd`, the user, `PATH`, an exhaustive
+listing of every path in the filesystem with its owner and mode, the build
+settings the executable itself reports, and the entrypoint answering `--version`
+as the image's own user and as an overridden one.
+
+It runs on every platform the image is published for, and reports each platform's
+failures separately — "it holds on amd64 and not on arm64" is the finding. The
+foreign-platform legs are cross-compiled by the toolchain container; only the
+runs *through* the entrypoint are emulated, and they are one `--version` each.
+
+The image is assembled in [`.dagger/image.go`](.dagger/image.go) rather than by
+the standard pipeline's app archetype, which publishes one image per binary and
+has no notion of a base other people build `FROM`. That file carries the whole
+argument, and `.dagger/main.go`'s package comment says why the factory this
+module calls is still `GoLib`.
 
 ### Getting the tools
 
@@ -135,15 +169,16 @@ wrote down. Wrapping costs one dependency and makes that impossible. The full
 reasoning, including why the stage functions are not a fork of it, is in
 [`.dagger/main.go`](.dagger/main.go)'s package comment.
 
-`GoLib` rather than `GoApp`, even now that `cmd/cpybkc-gen-go` is a main package.
-What `GoApp` adds is the multi-platform image build and the publish half of the
-standard, and both belong to the container stories: what is in the image, which
-platforms it carries and where it goes are the [base-image
-contract](docs/container/SPEC.md)'s, and switching factories ahead of them would
-build an image nothing had described. The four check stages gate a pull request
-under either archetype and they run over `./...`, so `cmd/` is checked today. The
-move lands with the image — a change to which factory the module calls, not a
-change to what the pipeline is.
+`GoLib` rather than `GoApp`, even now that `cmd/cpybkc-gen-go` is a main package
+and the image is built. What `GoApp` adds is a multi-platform image build and the
+publish half of the standard, and the image half of that turned out not to fit:
+`GoApp` publishes one image per binary, and cpybkc publishes a *base* — a
+directory on `PATH` that other people's images copy into, owned by a pinned
+non-root user. Teaching the archetype that shape would be teaching it this
+repository's plugin model. So the image is assembled in
+[`.dagger/image.go`](.dagger/image.go), the four check stages gate a pull request
+exactly as before, and what is left for `GoApp` is the publish half, which the
+publishing story can take or leave on its own merits.
 
 Both dependencies in `dagger.json` are pinned to one `devex` commit, so a bump
 has to move them together.

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -552,11 +552,18 @@ is what makes "runnable as written" something somebody measured rather than
 remembered — a heredoc that no longer parses, a Go program that no longer
 compiles, a module path that no longer resolves or a toolchain that has moved on
 all fail there, and so does an executable that comes out dynamically linked. The
-**final stage is interpreted rather than built**: `FROM ghcr.io/zaba505/cpybkc`
-names a published image, and its `FROM` line, its absence of a `RUN` and its
-`COPY` flags and paths are read and checked against the requirements above.
-Building that stage against the base image the pipeline itself produced is what
-#55 adds, when there is one to build it against.
+**final stage is replayed onto the image the pipeline just built** (#55): a
+`FROM` line cannot name a container that exists only inside a pipeline, so its
+`FROM` is required to name the published base and its `COPY` — the path, the
+`--chown` and the `--chmod` this document wrote — is applied to that base
+instead. What comes out is a real derived image, and it is checked against this
+document the same way the base is: the filesystem is the base's plus exactly the
+one file that was copied, and the entrypoint still answers as cpybkc.
+
+Checking against the base the pipeline built rather than against the published
+tag is the point. The tag is last release's image, so an edit that moved the
+plugin directory would pass against it and break the first adopter to pull the
+next release.
 
 The check refuses what it cannot replay: an instruction in the final stage other
 than the ones this document permits is an error naming it, rather than a line
@@ -574,7 +581,7 @@ change to any of them is a breaking change:
 | [The entrypoint](#the-entrypoint) | Is the cpybkc CLI, and takes its arguments |
 | [The user](#the-user) | UID 65532, GID 65532, non-root, overridable |
 | [Shell or no shell](#shell-or-no-shell) | Absent; extension is `COPY`-only |
-| [Platforms](#why-linuxs390x-is-inside-the-guarantee) | `linux/amd64`, `linux/arm64` and `linux/s390x` |
+| [Platforms](#why-the-platform-set-is-the-two-it-is) | `linux/amd64` and `linux/arm64` |
 | [Tags](#tags-and-what-pinning-one-buys) | A published full-version tag never moves |
 | [Signatures](#what-a-tag-carries-besides-the-image) | The published index and each manifest beneath it are signed; the index digest carries provenance and an SBOM |
 
@@ -597,34 +604,41 @@ depending on something that may change in a patch release, with no notice:
   label or annotation on the manifest.
 - Which UID owns a file that is not in the plugin directory.
 
-### Why `linux/s390x` is inside the guarantee
+### Why the platform set is the two it is
 
-The covered platform set is the deliberate part of that table, because it is the
-one place this contract does not follow the prior art it is otherwise modelled
-on: `avroc` publishes `linux/amd64` and `linux/arm64` and puts every further
-platform explicitly *outside* its guarantee.
+The covered platform set is the deliberate part of that table. An earlier draft
+of this document had a third entry, `linux/s390x`, on the reasoning that files
+composed of COBOL copybook records come from mainframes and that a shop with
+those files runs containers on Linux on Z. That reasoning was about the *files*
+and this table is about the *machine cpybkc executes on*, and the two are not
+the same place (#55, #56).
 
-cpybkc brings `linux/s390x` inside instead (#55, #56). The audience is the
-reason. Files composed of COBOL copybook records come from mainframes, and Linux
-on Z and z/OS Container Extensions are where a shop with those files already
-runs containers; a derived image that cannot be built for the machine holding
-the data is an extension mechanism that mostly works. It is also the only
-big-endian platform in the matrix, which makes it the leg that tests the
-[byte-order fork](https://github.com/Zaba505/cobol-go/blob/main/codec/SPEC.md)
-the generated code is written against rather than merely packaging for it — the
-class of bug that passes everywhere else (#56).
+cpybkc runs on developer machines. It is a code generator for a modern codebase
+that integrates with an existing mainframe ecosystem through a file format a
+copybook defines in part; it is not deployed to the mainframe, and nothing about
+using it requires it to run on one. So `linux/amd64` and `linux/arm64` are the
+platforms developers and their CI actually have, and a third leg would have been
+a published promise with no consumer behind it — which #56 said outright when it
+was closed as not planned.
 
-The cost is honest and small: CGO-free Go cross-compiles to it for nothing, and
-the emulated test leg (#56) is CI time rather than a promise. What putting it in
-the table buys is that a Dockerfile in a mainframe shop's repository may say
-`FROM` and mean it, and that dropping the platform later would be the breaking
-change it ought to be rather than a quiet change of mind.
+What this retires is a build target, and nothing else. The [byte-order
+fork](https://github.com/Zaba505/cobol-go/blob/main/codec/SPEC.md) the generated
+code is written against is a property of the **data being read**, not of the
+host CPU: big-endian files stay fully in scope, must decode correctly on both
+platforms above, and are tested there. A big-endian *host* is what is out of
+scope.
+
+Any platform beyond those two is explicitly outside this guarantee, which is the
+same position `avroc` takes for the same set. Adding one later is not a breaking
+change and needs no new major version; dropping one of these two is, and would
+go through [How a covered thing would change](#how-a-covered-thing-would-change)
+like any other covered value.
 
 The *set* is covered; the machinery that fills it is not. Which platforms a
 published index carries is something a consumer reads out of the index and
-builds against, so it is a guarantee. How each one is cross-compiled, tested
-under emulation or assembled is [out of
-scope](#how-the-image-is-built-and-published) like the rest of the build.
+builds against, so it is a guarantee. How each one is cross-compiled or
+assembled is [out of scope](#how-the-image-is-built-and-published) like the rest
+of the build.
 
 ### How a covered thing would change
 
@@ -644,8 +658,8 @@ deprecation notice somebody reads instead of a broken build somebody bisects.
 
 ### How the image is built and published
 
-The build, the platform matrix, emulated testing, signing, provenance and SBOM
-generation are **not specified here**.
+The build, the platform matrix, how each leg of it is cross-compiled or tested,
+signing, provenance and SBOM generation are **not specified here**.
 
 Reason: none of it is visible to a Dockerfile that says `FROM`. This document
 describes what an image consumer may depend on; the machinery producing it
@@ -694,11 +708,11 @@ Go install with no document that applies to them.
 | [Tags and what pinning one buys](#tags-and-what-pinning-one-buys) | #59 `container` |
 | [What a tag carries besides the image](#what-a-tag-carries-besides-the-image) | #58 `container` |
 | [Worked example: adding a generator](#worked-example-adding-a-generator) | #54 `container` |
-| [This example is built by the pipeline](#this-example-is-built-by-the-pipeline) | #54 `container` for the build stage and the reading of the final one, #55 `container` for building that stage against a base image of this pipeline's own |
+| [This example is built by the pipeline](#this-example-is-built-by-the-pipeline) | #54 `container` for the build stage and the reading of the final one, #55 `container` for replaying that stage onto a base image of this pipeline's own |
 | [Compatibility guarantees](#compatibility-guarantees) | #54, #58 `container` |
-| [Why `linux/s390x` is inside the guarantee](#why-linuxs390x-is-inside-the-guarantee) | #54 `container` decides it, #55, #56 `container` build and test it |
+| [Why the platform set is the two it is](#why-the-platform-set-is-the-two-it-is) | #54 `container` decides it, #55 `container` builds it, #56 `container` retires the third leg it once had |
 | The IR proto shipped in the image — a consumer-visible file, sized here | #57 `container` |
-| Multi-platform build and s390x testing — out of scope, see above | #55, #56 `container` |
+| The multi-platform build itself — out of scope, see above | #55 `container` |
 | The Dagger module's default image tag — out of scope, see above | #104 `dagger` settles it in [CONTRIBUTING.md](../../CONTRIBUTING.md#the-companion-dagger-module); #61 `dagger` carries it onto the constructor |
 | Signing, provenance and SBOM — verifiable, so the tags section cites them | #58 `container` |
 | This document | #54 `container`; its shape and the settled `Scope`, `Governing sources` and `Out of Scope`, #15 `setup` |


### PR DESCRIPTION
Closes #55

Builds the published base image [`docs/container/SPEC.md`](https://github.com/Zaba505/cpybkc/blob/main/docs/container/SPEC.md) describes, for `linux/amd64` and `linux/arm64`, and turns that document's compatibility guarantees table into a check the pipeline runs on every pull request.

## Acceptance criteria

- [x] **Image built for `linux/amd64` and `linux/arm64`** — `imagePlatforms()` is the single definition of the set; `ImageContract` fans across all of it and reports each platform's failures separately, and `Ci` calls it with no platform so a pull request covers both. `GOOS`/`GOARCH` are read back out of the executable that landed in each platform's image, so a cross-compile that silently fell back to the engine's architecture fails here rather than for whoever pulls that manifest.
- [x] **Built CGO-free** — `CGO_ENABLED=0` is asserted from the binary's own build settings on every platform, not just inferred from the flag the pipeline passed. `Build`'s existing "run it in an empty image" check still covers the engine platform behaviourally.
- [x] **Runs as the documented non-root UID** — `User` is the literal `65532:65532`, the plugin directory is owned by it, and the entrypoint is run twice: as that user and as `1234:1234`. The second run is the SPEC's "the image MUST NOT require its own UID", which is what makes `--user $(id -u):$(id -g)` an ordinary configuration.
- [x] **Plugin directory present and on `PATH`** — `/usr/local/bin` exists, is owned by the image's user, and `PATH` is checked to contain it.
- [x] **Entrypoint is the cpybkc CLI** — structurally (exactly one element, naming an executable the image ships) and behaviourally (`--version` through it returns the version line, checked by the same helper `Build` uses). `Cmd` is empty.
- [x] **Image builds reproducibly** — `-trimpath=true` is read back out of the binary, so a build that started depending on the directory it ran in fails; the base is `scratch`, and the filesystem listing is exhaustive, so the image is the executable plus four directory entries and nothing that could vary.

## What else is in here

**The worked example's final stage is now built, not only interpreted.** `docs/container/SPEC.md` said this is what #55 adds "when there is one to build it against". A Dockerfile's `FROM` cannot name a container that exists only inside the pipeline, so the `COPY` is *replayed*: its path, `--chown` and `--chmod` — read out of the committed document, not assumed — are applied to the base this pipeline just built, and the result is checked as the base's contents plus exactly that one file, with the entrypoint still answering as cpybkc. Checking against the built base rather than the published tag is the point: the tag is last release's image, so an edit that moved the plugin directory would pass against it and break the next release's first adopter.

**The platform set drops `linux/s390x`.** #56 closed as not planned and said explicitly that "#55's acceptance criteria rest on the same premise and should be revisited there". cpybkc runs on developer machines working on a modern codebase; it is not deployed to the mainframe whose files it reads, so a third leg would have been a published guarantee with no consumer. `cobol-go`'s byte-order fork is a property of the **data**, not of the host — big-endian files stay fully in scope and are decoded by the test suite on both platforms above. `Why linux/s390x is inside the guarantee` becomes `Why the platform set is the two it is`, and the compatibility table, the out-of-scope note and the story mapping move with it.

## Judgment calls that shaped the public surface

- **The image is assembled in `.dagger/image.go`, and the factory stays `GoLib`.** `.dagger/main.go` had anticipated reaching the image by switching to the standard's `GoApp` archetype. It does not fit: `GoApp` publishes one image per binary, and cpybkc publishes a *base* — a directory on `PATH` that other people's images copy into, owned by a pinned non-root user. Four of the six promises the SPEC makes are that shape rather than settings `GoApp` lacks, and teaching it that shape would be teaching it this repository's plugin model. avroc reached the same conclusion for the same reason ([avroc#166](https://github.com/z5labs/avroc/pull/166)). What is left for `GoApp` is the publish half, which is #59's to take or leave on its own merits.
- **No `Publish`.** Which tags exist and where they go is #59; this story stops at building and checking, so there is no credential handling in the module yet.
- **No `WorkingDir`, and no `/work`.** The SPEC lists `WorkingDir` and "the existence of any directory a caller mounts over" as explicitly *not covered* — a caller passes their own, as the documented `docker run` invocation does — so the image sets neither, and the filesystem stays scratch plus what is promised. This is the one place the layout deliberately diverges from the avroc prior art.
- **No IR `FileDescriptorSet` in the image.** That file and its path are #57's; adding it here would have shipped a consumer-visible path before the story that sizes it.
- **The entrypoint check runs `--version`, not `--help`.** The SPEC leaves usage wording explicitly uncovered, and the version line's shape is already what `Build` asserts — so the two now share one helper rather than two spellings of "this is cpybkc answering".

## Verification

`dagger call ci` passes locally, which is character-for-character what CI runs. `ImageContract` and the extended `WorkedExample` were each confirmed to be live rather than vacuous by temporarily inverting an expectation and watching them fail: a wrong `/tmp` mode reported `/tmp: is 0:0 1777, want 0:0 1755`, a `-trimpath=false` expectation reported the real setting back, and a wrong expected mode for the copied generator reported `/usr/local/bin/cpybkc-gen-hello: is 65532:65532 0755, want 65532:65532 0700`. `.dagger/dagger.gen.go` is regenerated and committed with the change, per CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)