### PR TITLE
story(container): ship the IR proto and FileDescriptorSet in the image

### DIFF
--- a/.dagger/image.go
+++ b/.dagger/image.go
@@ -49,6 +49,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"path"
 	"slices"
 	"strconv"
 	"strings"
@@ -88,6 +89,17 @@ const (
 	// ordinary.
 	executableMode = 0o755
 
+	// dataMode is the mode every shipped data file has: readable by everybody
+	// and writable by nobody but root.
+	//
+	// Both halves are promises docs/container/SPEC.md makes about the IR schema
+	// below. World-readable is what makes `--user $(id -u):$(id -g)` an ordinary
+	// configuration for a generator that reads the descriptor set, since the
+	// running UID is a number this image has never heard of. Writable only by
+	// root is what makes "a derived image may copy it out, and MUST NOT modify
+	// it in place" hold for the running process rather than only on paper.
+	dataMode = 0o644
+
 	// dirMode is the mode of every directory in the image.
 	dirMode = 0o755
 
@@ -103,6 +115,35 @@ const (
 	// and the one that keeps working when a caller overrides the UID.
 	tmpDir     = "/tmp"
 	tmpDirMode = 0o1777
+
+	// irDir is where the IR schema ships, and the two paths under it are the
+	// ones docs/container/SPEC.md fixes for a consumer (#57).
+	//
+	// /usr/local/share for the same reason the plugin directory is
+	// /usr/local/bin: it is the conventional destination for architecture-
+	// independent data belonging to a locally installed program, so a reader who
+	// has never opened that document guesses it correctly, and a `COPY --from`
+	// naming it reads naturally. The cpybkc component is what keeps a derived
+	// image's own share of that directory from colliding with this one's.
+	irDir = "/usr/local/share/cpybkc"
+
+	// irDescriptorSetFile is the protobuf FileDescriptorSet describing
+	// cpybkc.ir.v1.Descriptor, under the name the release asset already has —
+	// they are two ways of getting one artifact rather than two artifacts, and a
+	// second name for it would be the first step towards two.
+	irDescriptorSetFile = "ir.binpb"
+
+	// irProtoDirName is the schema sources, and it is a directory rather than an
+	// archive because it is an include root: every file sits at the path its
+	// protobuf package requires, so `protoc -I` is pointed straight at it.
+	irProtoDirName = "proto"
+
+	irDescriptorSetPath = irDir + "/" + irDescriptorSetFile
+	irProtoDir          = irDir + "/" + irProtoDirName
+
+	// protoSource is the schema root in this repository, which is what both
+	// shipped forms are cut from.
+	protoSource = "proto"
 )
 
 // imagePlatforms is the set of platforms the image is published for, and the
@@ -125,8 +166,9 @@ func imagePlatforms() []dagger.Platform {
 // It is the image docs/container/SPEC.md describes, and every promise that
 // document makes is made here: the CLI in /usr/local/bin with that directory on
 // PATH, the CLI as the entrypoint with an empty Cmd, UID and GID 65532 owning
-// the plugin directory and running the process, a writable temporary directory,
-// and nothing else in the filesystem at all.
+// the plugin directory and running the process, the IR schema under
+// /usr/local/share/cpybkc in both published forms, a writable temporary
+// directory, and nothing else in the filesystem at all.
 //
 // No generator is in it, and that absence is a promise rather than an omission:
 // cpybkc-gen-go (#48-#53) reaches a user the way a stranger's generator does, as
@@ -164,10 +206,13 @@ func (m *Cpybkc) Image(
 //   - The OCI configuration — Entrypoint, Cmd, User and PATH. WorkingDir is not
 //     among them, because that document explicitly does not cover it: a caller
 //     passes their own, and the invocation the document gives them says so.
-//   - The filesystem, as an exact list of every path in it with its owner and
-//     its mode. Exact rather than a spot check, because "the base is scratch
-//     plus the files this document names" is the promise, and it is the same
-//     assertion as no shell, no libc and no package manager.
+//   - The filesystem, as an exact list of every path in it with its kind, its
+//     owner and its mode. Exact rather than a spot check, because "the base is
+//     scratch plus the files this document names" is the promise, and it is the
+//     same assertion as no shell, no libc and no package manager.
+//   - The IR schema it ships, byte for byte against the artifacts a release
+//     publishes. The listing above says those paths are world-readable regular
+//     files; this says they are the right bytes.
 //   - How the executable in it was built, read out of the binary itself: CGO
 //     off, -trimpath on, and the GOOS and GOARCH of the platform whose image it
 //     landed in.
@@ -231,6 +276,14 @@ func (m *Cpybkc) image(platform dagger.Platform) *dagger.Container {
 		WithDirectory(pluginDir, cli, dagger.ContainerWithDirectoryOpts{
 			Owner: imageUser,
 		}).
+		// The IR schema, in both the forms a release publishes: the
+		// FileDescriptorSet a plugin author decodes a descriptor against with no
+		// codegen in their build, and the .proto sources for the build that
+		// would rather compile them. Root-owned, unlike the plugin directory —
+		// these are read-only data, and the running user having no way to
+		// rewrite them is what makes "MUST NOT modify it in place" true of the
+		// filesystem rather than only of the document.
+		WithDirectory(irDir, m.irDirectory()).
 		// A temporary directory, because cpybkc writes each invocation's
 		// descriptor into one. Not owned by the image's user: 1777 is what makes
 		// it usable by whichever UID the container is actually running as.
@@ -291,17 +344,81 @@ func (m *Cpybkc) tmpDirectory() *dagger.Directory {
 		Directory(staging)
 }
 
+// irDirectory is the contents of irDir: the FileDescriptorSet beside an include
+// root holding the schema sources.
+//
+// The descriptor set is IrDescriptorSet's file — the same node the release
+// workflow exports and attaches — rather than a second recipe producing bytes
+// that agree today. That is the whole of what makes docs/container/SPEC.md's
+// "byte-identical to the ir.binpb asset on the matching release" a property of
+// the build instead of a promise somebody has to keep, and it is why the same
+// bytes land in every platform's image: a FileDescriptorSet is a function of the
+// schema and knows nothing about an architecture.
+//
+// Only .proto files are copied, naming what goes in rather than what stays out,
+// which is the rule internal/tools/ir-protos already applies to the archive for
+// the same reason: a generated file or an editor's leavings appearing under
+// proto/ would otherwise be published as part of the contract.
+//
+// The modes are set here rather than inherited from the checkout because
+// ImageContract's listing is exhaustive down to the mode, and a file's mode in a
+// git checkout is the contributor's umask. Without the chmod the image would be
+// a function of whose machine built it, and the contract check would fail for
+// somebody whose umask is not 022 — on a file they had not touched. u=rwX,go=rX
+// leaves directories traversable and files world-readable, which is what dataMode
+// and dirMode say and what the promise about an overridden UID rests on.
+func (m *Cpybkc) irDirectory() *dagger.Directory {
+	const staging = "/staging"
+
+	return dag.Go().
+		Container(m.Source).
+		WithFile(staging+"/"+irDescriptorSetFile, m.IrDescriptorSet()).
+		WithDirectory(staging+"/"+irProtoDirName, m.Source.Directory(protoSource),
+			dagger.ContainerWithDirectoryOpts{Include: []string{"**/*.proto"}}).
+		WithExec([]string{"chmod", "-R", "u=rwX,go=rX", staging}).
+		Directory(staging)
+}
+
+// shippedProtos is every .proto the image carries, as a path relative to the
+// include root, sorted.
+//
+// Read out of the source tree rather than listed here, so that a second .proto
+// arrives in the image and in the contract at once. The alternative — a constant
+// naming ir.proto — would make the exhaustive listing fail on the commit that
+// added a schema file rather than on the one that shipped it wrongly, which is a
+// check that punishes the wrong change.
+func (m *Cpybkc) shippedProtos(ctx context.Context) ([]string, error) {
+	names, err := m.Source.Directory(protoSource).Glob(ctx, "**/*.proto")
+	if err != nil {
+		return nil, fmt.Errorf("listing the schema sources under %s/: %w", protoSource, err)
+	}
+
+	if len(names) == 0 {
+		return nil, fmt.Errorf("no .proto files under %s/: the image would ship an empty include root", protoSource)
+	}
+
+	slices.Sort(names)
+
+	return names, nil
+}
+
 // imageContractOn checks one platform's image.
 //
 // Every group is run and every failure collected rather than stopping at the
 // first: a change that broke the entrypoint most likely broke the user and the
 // plugin directory too, and one run should say so.
 func (m *Cpybkc) imageContractOn(ctx context.Context, platform dagger.Platform) error {
+	protos, err := m.shippedProtos(ctx)
+	if err != nil {
+		return err
+	}
+
 	image := m.image(platform)
 
 	errs := m.checkImageConfig(ctx, image)
-	errs = append(errs, m.checkImageContents(ctx, image, baseImageContents())...)
+	errs = append(errs, m.checkImageContents(ctx, image, baseImageContents(protos))...)
 	errs = append(errs, m.checkImageBuild(ctx, image, platform)...)
+	errs = append(errs, m.checkShippedIr(ctx, image)...)
 	errs = append(errs, m.checkImageIsTheCLI(ctx, image)...)
 
 	return errors.Join(errs...)
@@ -490,6 +607,50 @@ func (m *Cpybkc) checkImageBuild(
 	return errs
 }
 
+// checkShippedIr compares the IR schema in the image, byte for byte, against the
+// artifacts a release publishes.
+//
+// docs/container/SPEC.md promises the descriptor set in the image is identical
+// to the ir.binpb asset on the matching release — two ways of getting one
+// artifact rather than two artifacts — and the same of the sources against the
+// tree ir-protos.tar.gz is cut from. That promise is what lets a build fetch
+// whichever is cheaper and stop; two artifacts that merely agreed today would
+// make the choice a gamble on nobody having changed one recipe.
+//
+// The listing check beside this one is about the modes and owners of those
+// paths, and it would pass on a stale descriptor set with the right mode. This
+// one is about the bytes, and it would pass on a correct file nobody could read.
+// Neither subsumes the other.
+//
+// `diff --recursive --brief` rather than a comparison per file, because "Only in
+// …" is the finding for a schema file the image gained or lost, and a
+// file-by-file loop would only ever check the files somebody remembered to name.
+// It runs in the toolchain container over the image's filesystem mounted as
+// data: the image has no shell, and the executable being compared may be for
+// another architecture, which is irrelevant to a byte comparison.
+func (m *Cpybkc) checkShippedIr(ctx context.Context, image *dagger.Container) []error {
+	const (
+		mountedAt = "/image"
+		wantAt    = "/want"
+	)
+
+	_, err := dag.Go().
+		Container(m.Source).
+		WithMountedDirectory(mountedAt, image.Rootfs()).
+		WithFile(wantAt+"/"+irDescriptorSetFile, m.IrDescriptorSet()).
+		WithDirectory(wantAt+"/"+irProtoDirName, m.Source.Directory(protoSource),
+			dagger.ContainerWithDirectoryOpts{Include: []string{"**/*.proto"}}).
+		WithExec([]string{"diff", "--recursive", "--brief", wantAt, mountedAt + irDir}).
+		Sync(ctx)
+	if err != nil {
+		return []error{fmt.Errorf("the IR schema under %s is not the artifacts this repository publishes; the "+
+			"descriptor set in the image and the ir.binpb asset on a release are one artifact reachable two ways, "+
+			"and the sources are the tree ir-protos.tar.gz is cut from: %w", irDir, err)}
+	}
+
+	return nil
+}
+
 // buildSettings reads `go version -m` output into the settings it reports.
 //
 // Every line but the first is a tab-indented `<key>\t<value>` pair, and the ones
@@ -524,7 +685,10 @@ func buildSettings(out string) map[string]string {
 //
 // The parent directories are root-owned and that is intentional — only the
 // plugin directory is promised to the image's user, and a root-owned parent at
-// 0755 is what stops the running user replacing the tree above it.
+// 0755 is what stops the running user replacing the tree above it. The IR
+// schema is root-owned for the stronger form of the same reason: it is data a
+// derived image may copy out and must not modify, and 0644 owned by root is
+// that sentence enforced rather than asserted.
 //
 // Listing /tmp here does not make it a covered guarantee, and the two are not
 // the same kind of statement. Covered is about what a *consumer* may depend on,
@@ -537,16 +701,34 @@ func buildSettings(out string) map[string]string {
 // moved the temporary directory would edit this line in the same commit, which
 // is the difference between changing an implementation detail and changing it
 // without noticing.
-func baseImageContents() map[string]imageEntry {
-	contents := map[string]imageEntry{
-		"/usr":       {0, 0, dirMode},
-		"/usr/local": {0, 0, dirMode},
-		pluginDir:    {imageUID, imageGID, dirMode},
-		tmpDir:       {0, 0, tmpDirMode},
+// protos is every schema source the image carries, relative to the include root
+// — shippedProtos' answer, read out of the tree rather than named here.
+func baseImageContents(protos []string) map[string]imageEntry {
+	contents := map[string]imageEntry{}
+
+	for _, name := range []string{"/usr", "/usr/local", "/usr/local/share", irDir, irProtoDir} {
+		contents[name] = imageEntry{kindDir, 0, 0, dirMode}
 	}
 
+	contents[pluginDir] = imageEntry{kindDir, imageUID, imageGID, dirMode}
+	contents[tmpDir] = imageEntry{kindDir, 0, 0, tmpDirMode}
+	contents[irDescriptorSetPath] = imageEntry{kindFile, 0, 0, dataMode}
+
 	for _, name := range baseImageExecutables() {
-		contents[pluginDir+"/"+name] = imageEntry{imageUID, imageGID, executableMode}
+		contents[pluginDir+"/"+name] = imageEntry{kindFile, imageUID, imageGID, executableMode}
+	}
+
+	// Every directory a schema file's own package puts it in, so that the
+	// include root is listed the way it is shipped: cpybkc/ir/v1/ir.proto brings
+	// three directories with it, and a flattened copy would be a file whose
+	// FileDescriptorProto names a path this project does not publish.
+	for _, name := range protos {
+		full := irProtoDir + "/" + name
+		contents[full] = imageEntry{kindFile, 0, 0, dataMode}
+
+		for dir := path.Dir(full); dir != irProtoDir && dir != "/" && dir != "."; dir = path.Dir(dir) {
+			contents[dir] = imageEntry{kindDir, 0, 0, dirMode}
+		}
 	}
 
 	return contents
@@ -577,15 +759,31 @@ func baseImageExecutablePaths() []string {
 	return paths
 }
 
-// imageEntry is one path's expected ownership and mode.
+// imageEntry is one path's expected kind, ownership and mode.
 type imageEntry struct {
+	kind string
 	uid  int
 	gid  int
 	mode int
 }
 
+// The kinds `find -printf %y` reports for what this image is allowed to hold. A
+// third — `l`, a symbolic link — is deliberately not here: docs/container/SPEC.md
+// requires the files it names to be regular files, because a `COPY --from`
+// naming a symlink copies the link and a runtime resolving one inside an image
+// that has nothing else in it resolves a dangling name.
+const (
+	kindFile = "f"
+	kindDir  = "d"
+)
+
 func (e imageEntry) String() string {
-	return fmt.Sprintf("%d:%d %04o", e.uid, e.gid, e.mode)
+	kind := e.kind
+	if kind == "" {
+		kind = "?"
+	}
+
+	return fmt.Sprintf("%s %d:%d %04o", kind, e.uid, e.gid, e.mode)
 }
 
 // checkImageContents compares every path in an image against a listing of what
@@ -612,10 +810,15 @@ func (m *Cpybkc) checkImageContents(
 	// Numeric %U and %G rather than %u and %g: the listing container has no
 	// passwd entry for 65532, so the symbolic forms would print the number
 	// anyway on a good day and a name on a bad one.
+	//
+	// %y is the entry's kind, and it is here because "a regular file" is one of
+	// the promises: find reports a symbolic link as `l` and does not follow it,
+	// so a shipped file replaced by a link to one is a kind mismatch naming the
+	// path rather than a mode that happens not to match.
 	listing, err := dag.Go().
 		Container(m.Source).
 		WithMountedDirectory(mountedAt, image.Rootfs()).
-		WithExec([]string{"find", mountedAt, "-mindepth", "1", "-printf", `%U %G %m %p\n`}).
+		WithExec([]string{"find", mountedAt, "-mindepth", "1", "-printf", `%U %G %m %y %p\n`}).
 		Stdout(ctx)
 	if err != nil {
 		return []error{fmt.Errorf("listing the image filesystem: %w", err)}
@@ -664,11 +867,11 @@ func (m *Cpybkc) checkImageContents(
 	return errs
 }
 
-// parseFindLine reads one `%U %G %m %p` line and strips the mount prefix, so
+// parseFindLine reads one `%U %G %m %y %p` line and strips the mount prefix, so
 // that the paths compared are the paths inside the image.
 func parseFindLine(line, prefix string) (imageEntry, string, error) {
 	fields := strings.Fields(line)
-	if len(fields) != 4 {
+	if len(fields) != 5 {
 		return imageEntry{}, "", fmt.Errorf("unreadable listing line %q", line)
 	}
 
@@ -687,7 +890,7 @@ func parseFindLine(line, prefix string) (imageEntry, string, error) {
 		return imageEntry{}, "", fmt.Errorf("unreadable mode in %q: %w", line, err)
 	}
 
-	return imageEntry{uid, gid, int(mode)}, strings.TrimPrefix(fields[3], prefix), nil
+	return imageEntry{fields[3], uid, gid, int(mode)}, strings.TrimPrefix(fields[4], prefix), nil
 }
 
 // derivedImageContents is the base image's listing plus one file copied into the
@@ -699,8 +902,8 @@ func parseFindLine(line, prefix string) (imageEntry, string, error) {
 // stage only copies" becomes an assertion rather than a claim: a RUN that had
 // somehow worked, or a second file nobody mentioned, is a path in the listing
 // that nothing accounts for.
-func derivedImageContents(path string, entry imageEntry) map[string]imageEntry {
-	contents := maps.Clone(baseImageContents())
+func derivedImageContents(base map[string]imageEntry, path string, entry imageEntry) map[string]imageEntry {
+	contents := maps.Clone(base)
 	contents[path] = entry
 
 	return contents

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -204,7 +204,7 @@ func New(
 // the Z5Labs standard defines them, over each of this repository's two Go
 // modules, plus `buf lint` over the IR schema, a build of the CLI itself, a
 // build of the three artifacts a release publishes, the published base image on
-// every platform it ships for, and the worked example docs/container/SPEC.md
+// every platform it ships for, and the worked examples docs/container/SPEC.md
 // hands an adopter. This is the single entrypoint — CI is one `dagger call ci`
 // and stays one, because a workflow step that reran any of these stages would be
 // a second definition of them.
@@ -393,10 +393,11 @@ func (m *Cpybkc) ProtoGen() *dagger.Directory {
 //
 //	dagger call ir-descriptor-set export --path=ir.binpb
 //
-// It is what the release workflow attaches to a release, and what the base image
-// will copy in at the path docs/container/SPEC.md fixes (#57). Both forms are
-// two ways of getting one artifact rather than two artifacts, which only holds
-// while there is one recipe; this is it.
+// It is what the release workflow attaches to a release, and — the same node,
+// not a second build of it — what image.go copies into the published image at
+// /usr/local/share/cpybkc/ir.binpb (#57). Both forms are two ways of getting one
+// artifact rather than two artifacts, which only holds while there is one
+// recipe; this is it, and ImageContract compares the two on every run.
 //
 // It is a function on this module rather than steps in a workflow for the reason
 // .github/workflows/ci.yaml already gives: repo-specific work lands here and is
@@ -432,6 +433,11 @@ func (m *Cpybkc) IrDescriptorSet() *dagger.File {
 // IrDescriptorSet is not for: the one whose build can run protoc and would
 // rather generate bindings than decode dynamically. internal/tools/ir-protos
 // carries the argument for why it is an archive and not the one .proto file.
+//
+// The published image carries the same sources unpacked, under
+// /usr/local/share/cpybkc/proto/ (#57) — an archive would be one a stage with no
+// shell could not open, and the layout inside it is exactly the include root the
+// image needs anyway.
 //
 // Its bytes are a function of the schema too — every tar field the filesystem
 // could have supplied is a constant and the entries are sorted — so the same

--- a/.dagger/worked_example.go
+++ b/.dagger/worked_example.go
@@ -1,6 +1,7 @@
-// This file checks docs/container/SPEC.md's worked example: the multi-stage
-// Dockerfile a stranger copies out of that document to add a generator cpybkc
-// has never heard of (#54).
+// This file checks docs/container/SPEC.md's worked examples: the multi-stage
+// Dockerfiles a stranger copies out of that document to add a generator cpybkc
+// has never heard of (#54), and to read the IR out of the descriptor set the
+// image ships (#57).
 //
 // # Why the pipeline reads a document
 //
@@ -61,10 +62,20 @@ const (
 	// Dockerfile it builds.
 	containerSpec = "docs/container/SPEC.md"
 
-	// workedExampleHeading is the section the Dockerfile is taken from, matched
-	// as a whole line. It is the fenced block a stranger is given; a second
-	// fenced Dockerfile elsewhere in the document is not this check's business.
-	workedExampleHeading = "## Worked example: adding a generator"
+	// The sections a Dockerfile is taken from, each matched as a whole line. The
+	// fenced block under one of these is a block a stranger is handed and runs;
+	// a fenced Dockerfile anywhere else in the document is an illustration and
+	// not this check's business.
+	//
+	// The first adds a generator cpybkc has never heard of, which is the
+	// extension mechanism. The second reads the IR out of the descriptor set the
+	// image ships, which is the other thing a plugin author has to be able to do
+	// with the image alone (#57) — and it is a worked example rather than a
+	// paragraph for the same reason the first one is: the claim is that the
+	// shipped file is sufficient, and only a program that decoded a descriptor
+	// with nothing else makes it.
+	addAGeneratorHeading = "## Worked example: adding a generator"
+	readTheIrHeading     = "## Worked example: reading the IR without generated code"
 
 	// publishedBaseImage is the repository half of the reference the final stage
 	// is required to name — without a tag, because which tag the document tells
@@ -83,12 +94,59 @@ const (
 	// against the one plugin whose absence from the base image nobody would
 	// notice.
 	ownGenerator = "go"
+
+	// minimalDescriptor is a cpybkc IR descriptor in the protobuf wire format,
+	// written out by hand: tag byte 0x08 is field 1 as a varint — Descriptor's
+	// version — and 0x01 is IR_VERSION_1. Nothing else, because a descriptor
+	// stating a version and carrying no nodes is the smallest one the IR permits
+	// and every obligation the example generator has attaches to the version.
+	//
+	// By hand rather than by importing irpb and marshalling one, which would be
+	// two lines shorter. The example exists to show that the shipped descriptor
+	// set is *sufficient* — that a consumer with no generated code can decode —
+	// and a check that built its input out of the generated types would be
+	// resting the whole demonstration on the tier the demonstration is about
+	// avoiding. Two bytes anybody can verify against proto/cpybkc/ir/v1/ir.proto
+	// is the input that keeps that honest.
+	minimalDescriptor = "\x08\x01"
+
+	// irVersionName is what the example generator has to get out of those two
+	// bytes: not the number 1, which it could have printed without reading
+	// anything, but the enum value's name — which exists only in the descriptor
+	// set the image ships and nowhere in the descriptor it was handed.
+	irVersionName = "IR_VERSION_1"
 )
 
-// WorkedExample is docs/container/SPEC.md's worked example checked rather than
-// read (#54): it extracts the Dockerfile from that document, builds its build
-// stage against an empty build context, and reads its final stage for the
-// promises the document makes about one.
+// workedExampleChecks is the set of examples this check reads out of the
+// document, and what each one earns beyond the common three groups.
+//
+// extra is nil where the example makes no claim past building and extending the
+// image, and it is deliberately per-example rather than a flag: the IR reader's
+// extra claim is that it *works*, which is a different kind of assertion from
+// anything the Dockerfile's shape can carry.
+func workedExampleChecks() []workedExampleCheck {
+	return []workedExampleCheck{
+		{heading: addAGeneratorHeading},
+		{heading: readTheIrHeading, extra: (*Cpybkc).checkReadsTheShippedIr},
+	}
+}
+
+// workedExampleCheck is one section of the document and the checks it earns.
+type workedExampleCheck struct {
+	heading string
+	extra   func(m *Cpybkc, ctx context.Context, e *workedExample, derived *dagger.Container) error
+}
+
+// WorkedExample is docs/container/SPEC.md's worked examples checked rather than
+// read (#54, #57): for each one it extracts the Dockerfile from that document,
+// builds its build stage against an empty build context, and reads its final
+// stage for the promises the document makes about one.
+//
+// Two examples, and they demonstrate the two halves of what the image is for: a
+// generator cpybkc has never heard of arriving on PATH, and the IR being decoded
+// out of the descriptor set the image ships. The second earns one check the
+// first does not — it is run, because "the shipped file is sufficient" is a
+// claim only a program that used it can make. See checkReadsTheShippedIr.
 //
 // Three groups, and each one is a sentence in that document that would otherwise
 // only be a sentence:
@@ -121,18 +179,123 @@ const (
 // +check
 // +cache="session"
 func (m *Cpybkc) WorkedExample(ctx context.Context) error {
-	example, err := m.workedExample(ctx)
+	var errs []error
+
+	// Every example, and every one of them reported: two examples that stopped
+	// building are one edit to the document and not two visits to CI.
+	for _, check := range workedExampleChecks() {
+		if err := m.workedExampleAt(ctx, check); err != nil {
+			errs = append(errs, fmt.Errorf("%q: %w", check.heading, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// workedExampleAt runs one section's checks.
+//
+// checkExtendsTheImage hands back the derived image it assembled so that extra
+// runs against the same container the contract passed over, rather than against
+// a second assembly of it that could differ.
+func (m *Cpybkc) workedExampleAt(ctx context.Context, check workedExampleCheck) error {
+	example, err := m.workedExample(ctx, check.heading)
 	if err != nil {
 		return err
 	}
 
 	built := example.build()
 
-	return errors.Join(
+	derived, extendsErr := m.checkExtendsTheImage(ctx, example, built)
+
+	errs := []error{
 		example.rules(),
 		example.checkBuilds(ctx, built),
-		m.checkExtendsTheImage(ctx, example, built),
+		extendsErr,
+	}
+
+	// Only against an image that was actually assembled: an example whose COPY
+	// could not be replayed has already been reported, and running a generator
+	// that is not in the image would bury that finding under a second one.
+	if check.extra != nil && derived != nil {
+		errs = append(errs, check.extra(m, ctx, example, derived))
+	}
+
+	return errors.Join(errs...)
+}
+
+// checkReadsTheShippedIr runs the example generator inside the derived image and
+// requires it to have decoded a descriptor through the shipped descriptor set
+// alone (#57).
+//
+// This is the claim the Dockerfile's shape cannot make. Everything else about
+// this example is identical to the first one — two stages, one static executable
+// copied into the plugin directory — and all of that would pass on a generator
+// that read the descriptor set's path and ignored it. What separates them is
+// whether the file at /usr/local/share/cpybkc/ir.binpb is present, readable and
+// sufficient, and the only thing that answers is a program that used it.
+//
+// Three promises fall out of the one exec:
+//
+//   - The descriptor set is sufficient. The generator was built with no
+//     dependency on this repository's Go module, so the message type it decodes
+//     with came out of the shipped file or it did not exist. The output has to
+//     name the IR version, which is an enum value name that appears in the
+//     descriptor set and not in the two bytes the generator was handed.
+//   - It is readable by an overridden UID. The exec runs as an arbitrary other
+//     user, which is the invocation docs/container/SPEC.md recommends whenever
+//     output lands in a bind mount, and a shipped file readable only by 65532
+//     would fail here rather than in an adopter's pipeline.
+//   - The output directory works. It is created under the image's temporary
+//     directory, owned by the running user, which is the arrangement cpybkc
+//     itself makes for a generator.
+func (m *Cpybkc) checkReadsTheShippedIr(
+	ctx context.Context,
+	e *workedExample,
+	derived *dagger.Container,
+) error {
+	const (
+		descriptor = tmpDir + "/descriptor.binpb"
+		out        = tmpDir + "/out"
 	)
+
+	generator := e.copies[0].operands[1]
+
+	// Not through the entrypoint: cpybkc is what would normally exec a
+	// generator, and what is under test is the generator reading the image's own
+	// files, so it is run directly at the path the document's COPY put it.
+	ran := derived.
+		WithUser(overrideUser).
+		WithNewFile(descriptor, minimalDescriptor, dagger.ContainerWithNewFileOpts{
+			Permissions: dataMode,
+		}).
+		WithDirectory(out, dag.Directory(), dagger.ContainerWithDirectoryOpts{
+			Owner: overrideUser,
+		}).
+		WithExec([]string{generator, "--descriptor", descriptor, "--out", out})
+
+	written, err := ran.Directory(out).Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("running %s in the derived image as user %s, against a descriptor stating %s: %w",
+			generator, overrideUser, irVersionName, err)
+	}
+
+	if len(written) != 1 {
+		return fmt.Errorf("%s wrote %d files under its output directory (%v); the example writes one, and a "+
+			"generator that wrote none decoded nothing", generator, len(written), written)
+	}
+
+	got, err := ran.File(path.Join(out, written[0])).Contents(ctx)
+	if err != nil {
+		return fmt.Errorf("reading what %s wrote: %w", generator, err)
+	}
+
+	if !strings.Contains(got, irVersionName) {
+		return fmt.Errorf("%s wrote %q, which does not name %s; that name is in the descriptor set the image "+
+			"ships and not in the descriptor the generator was handed, so output without it is output the "+
+			"shipped file was not read for", generator, got, irVersionName)
+	}
+
+	return nil
 }
 
 // workedExample is the document's Dockerfile, parsed and judged.
@@ -202,48 +365,49 @@ func (c copyInstruction) owner() (int, int, error) {
 	return uid, gid, nil
 }
 
-// workedExample reads the Dockerfile out of the document and parses it.
-func (m *Cpybkc) workedExample(ctx context.Context) (*workedExample, error) {
+// workedExample reads the Dockerfile out of the document's named section and
+// parses it.
+func (m *Cpybkc) workedExample(ctx context.Context, heading string) (*workedExample, error) {
 	spec, err := m.Source.File(containerSpec).Contents(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %w", containerSpec, err)
 	}
 
-	dockerfile, err := workedExampleDockerfile(spec)
+	dockerfile, err := workedExampleDockerfile(spec, heading)
 	if err != nil {
 		return nil, err
 	}
 	return parseWorkedExample(dockerfile)
 }
 
-// workedExampleDockerfile returns the fenced dockerfile block under the worked
-// example heading, verbatim.
-func workedExampleDockerfile(spec string) (string, error) {
+// workedExampleDockerfile returns the fenced dockerfile block under the given
+// heading, verbatim.
+func workedExampleDockerfile(spec, heading string) (string, error) {
 	lines := strings.Split(spec, "\n")
 
 	i := 0
 	for ; i < len(lines); i++ {
-		if strings.TrimRight(lines[i], " ") == workedExampleHeading {
+		if strings.TrimRight(lines[i], " ") == heading {
 			break
 		}
 	}
 	if i == len(lines) {
 		return "", fmt.Errorf("%s: no %q heading; this check reads the Dockerfile out of that section",
-			containerSpec, workedExampleHeading)
+			containerSpec, heading)
 	}
 
 	for ; i < len(lines); i++ {
 		if lines[i] == "```dockerfile" {
 			break
 		}
-		if strings.HasPrefix(lines[i], "## ") && strings.TrimRight(lines[i], " ") != workedExampleHeading {
+		if strings.HasPrefix(lines[i], "## ") && strings.TrimRight(lines[i], " ") != heading {
 			return "", fmt.Errorf("%s: %q holds no ```dockerfile block; the worked example is what this check builds",
-				containerSpec, workedExampleHeading)
+				containerSpec, heading)
 		}
 	}
 	if i == len(lines) {
 		return "", fmt.Errorf("%s: %q holds no ```dockerfile block; the worked example is what this check builds",
-			containerSpec, workedExampleHeading)
+			containerSpec, heading)
 	}
 
 	i++
@@ -513,10 +677,14 @@ fi`, source)
 //
 // The fifth, CGO_ENABLED=0, is checkBuilds' — a property of the file, checked
 // where it is produced.
-func (m *Cpybkc) checkExtendsTheImage(ctx context.Context, e *workedExample, built *dagger.Container) error {
+func (m *Cpybkc) checkExtendsTheImage(
+	ctx context.Context,
+	e *workedExample,
+	built *dagger.Container,
+) (*dagger.Container, error) {
 	if len(e.copies) != 1 || len(e.copies[0].operands) != 2 {
 		// rules has already reported this; there is no COPY to replay.
-		return nil
+		return nil, nil
 	}
 	copied := e.copies[0]
 	source, destination := copied.operands[0], copied.operands[1]
@@ -527,11 +695,11 @@ func (m *Cpybkc) checkExtendsTheImage(ctx context.Context, e *workedExample, bui
 	// check invented would be a promise the document did not make.
 	mode, err := copied.mode()
 	if err != nil {
-		return nil
+		return nil, nil
 	}
 	uid, gid, err := copied.owner()
 	if err != nil {
-		return nil
+		return nil, nil
 	}
 
 	// The engine's own platform: the build stage compiled the generator for the
@@ -539,7 +707,12 @@ func (m *Cpybkc) checkExtendsTheImage(ctx context.Context, e *workedExample, bui
 	// copied onto. Which platforms the base is published for is ImageContract's.
 	platform, err := dag.DefaultPlatform(ctx)
 	if err != nil {
-		return fmt.Errorf("reading the engine's platform: %w", err)
+		return nil, fmt.Errorf("reading the engine's platform: %w", err)
+	}
+
+	protos, err := m.shippedProtos(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	derived := m.image(platform).WithFile(destination, built.File(source), dagger.ContainerWithFileOpts{
@@ -547,12 +720,14 @@ func (m *Cpybkc) checkExtendsTheImage(ctx context.Context, e *workedExample, bui
 		Permissions: mode,
 	})
 
-	errs := m.checkImageContents(ctx, derived, derivedImageContents(destination, imageEntry{uid, gid, mode}))
+	want := derivedImageContents(baseImageContents(protos), destination, imageEntry{kindFile, uid, gid, mode})
+
+	errs := m.checkImageContents(ctx, derived, want)
 	errs = append(errs, m.checkImageIsTheCLI(ctx, derived)...)
 
 	if err := errors.Join(errs...); err != nil {
-		return fmt.Errorf("%s: the worked example's final stage, built onto the image this pipeline produces: %w",
-			containerSpec, err)
+		return derived, fmt.Errorf("%s: the worked example's final stage, built onto the image this pipeline "+
+			"produces: %w", containerSpec, err)
 	}
-	return nil
+	return derived, nil
 }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,10 +43,12 @@ jobs:
   # version inside it rather than in its name, so that a file downloaded on its
   # own still says which version of the format it describes.
   #
-  # The same ir.binpb bytes will ship inside the published image (#57). That is
-  # two ways of getting one artifact rather than two artifacts, and what keeps it
-  # so is that both come from `dagger call ir-descriptor-set` rather than from
-  # two recipes that agree today.
+  # The same ir.binpb bytes ship inside the published image, at
+  # /usr/local/share/cpybkc/ir.binpb, and the same sources ship unpacked beside
+  # them (#57). That is two ways of getting one artifact rather than two
+  # artifacts, and what keeps it so is that the image copies in the file
+  # `dagger call ir-descriptor-set` produces rather than building its own —
+  # `dagger call image-contract` compares the two on every pull request.
   artifacts:
     name: Release artifacts
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,9 +100,10 @@ repository says `FROM ghcr.io/zaba505/cpybkc:v0` and names a path inside it, so
 [the base-image contract](docs/container/SPEC.md) is a document strangers depend
 on and `image-contract` is that document's compatibility guarantees table
 executed rather than read: the entrypoint, `Cmd`, the user, `PATH`, an exhaustive
-listing of every path in the filesystem with its owner and mode, the build
-settings the executable itself reports, and the entrypoint answering `--version`
-as the image's own user and as an overridden one.
+listing of every path in the filesystem with its kind, owner and mode, the build
+settings the executable itself reports, a byte comparison of the IR schema the
+image ships against the artifacts a release attaches, and the entrypoint
+answering `--version` as the image's own user and as an overridden one.
 
 It runs on every platform the image is published for, and reports each platform's
 failures separately — "it holds on amd64 and not on arm64" is the finding. The
@@ -336,6 +337,15 @@ Three properties are worth knowing before you touch any of them:
   by Go tests, in `irpb` and beside each tool under `internal/tools/`; the
   pipeline stages only check that the commands run to completion and leave a file
   behind.
+- **Both IR artifacts also ship inside the image**, at
+  `/usr/local/share/cpybkc/ir.binpb` and `/usr/local/share/cpybkc/proto/`, so
+  that a plugin author building `FROM` the image needs no download at all. They
+  are the same nodes — `image` copies in the file `ir-descriptor-set` produces,
+  rather than building its own — and `image-contract` compares the image's copy
+  against a fresh build byte for byte. That is what makes [the base-image
+  contract](docs/container/SPEC.md#these-are-the-release-assets-not-copies-of-them)'s
+  "two ways of getting one artifact, not two artifacts" a property of the
+  pipeline rather than a promise somebody has to keep.
 
 A `.proto` added under `proto/` that nothing reachable from
 `cpybkc.ir.v1.Descriptor` imports fails `TestPublishedFileDescriptorSetCoversTheSchema`.

--- a/cmd/cpybkc/generate_test.go
+++ b/cmd/cpybkc/generate_test.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/Zaba505/cpybkc/internal/generate"
@@ -77,9 +78,31 @@ func install(t *testing.T, bin, name, body string) {
 	t.Helper()
 
 	path := filepath.Join(bin, plugin.Filename(name))
-	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+	if err := writeGenerator(path, body); err != nil {
 		t.Fatalf("writing %s: %v", path, err)
 	}
+}
+
+// writeGenerator writes an executable plugin, under [syscall.ForkLock] held for
+// reading.
+//
+// The lock is the whole point of this function existing rather than the
+// [os.WriteFile] it wraps, and internal/generate/generate_test.go's generator
+// carries the same treatment for the same reason: a fork made anywhere in this
+// process while the script is open for writing hands the child a copy of that
+// descriptor, and the child holds it until it execs — so an exec of the script
+// inside that window fails with ETXTBSY (golang/go#22315).
+//
+// Every test in this package writes a generator and runs one, so the window is
+// real, and it is CI — more tests running than the machine has cores — that
+// finds it. Seen as `fork/exec …/cpybkc-gen-go: text file busy` from a
+// generator the run had just installed, which reads like a fault in the code
+// under test and is a fault in the test's own setup.
+func writeGenerator(path, body string) error {
+	syscall.ForkLock.RLock()
+	defer syscall.ForkLock.RUnlock()
+
+	return os.WriteFile(path, []byte(body), 0o755)
 }
 
 // projectIn writes a whole project — the manifest, the layout it names and the

--- a/cmd/cpybkc/relay_test.go
+++ b/cmd/cpybkc/relay_test.go
@@ -63,7 +63,7 @@ func runGenerator(t *testing.T, body string) (stderr, executable string, err err
 	dir := t.TempDir()
 
 	path := filepath.Join(dir, plugin.Filename(generatorName))
-	if writeErr := os.WriteFile(path, []byte("#!/bin/sh\n"+body+"\n"), 0o755); writeErr != nil {
+	if writeErr := writeGenerator(path, "#!/bin/sh\n"+body+"\n"); writeErr != nil {
 		t.Fatalf("writing %s: %v", path, writeErr)
 	}
 

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -232,14 +232,24 @@ network at build time, and no arrangement with this repository at all (#57):
 | `/usr/local/share/cpybkc/ir.binpb` | the protobuf `FileDescriptorSet` describing `cpybkc.ir.v1.Descriptor` and the transitive closure of its imports | a generator whose build has no protobuf code generation in it, decoding dynamically |
 | `/usr/local/share/cpybkc/proto/` | the `.proto` sources, each file at the path its protobuf package requires | a build that would rather run a compiler and generate bindings |
 
-Both **MUST** exist. Each **MUST** be a **regular file** — not a symbolic link,
-not a directory where a file is named — because a `COPY --from` naming one
-copies what is there, and a link copies as a link into an image whose target
-does not exist. Both **MUST** be readable by the [image's user](#the-user) *and*
-by any UID a caller overrides it with: a generator run under
-`--user $(id -u):$(id -g)` reads the same file as one run under 65532, and a
-file readable only by the image's own user would make that recommended
-invocation fail on the one thing the image exists to hand it.
+Both **MUST** exist, and they are not the same shape:
+`/usr/local/share/cpybkc/ir.binpb` **MUST** be a **regular file**, and
+`/usr/local/share/cpybkc/proto/` **MUST** be a **directory** whose every entry
+is a directory or a regular file.
+
+**Nothing under either path may be a symbolic link.** A `COPY --from` naming a
+link copies the link, into an image where its target does not exist, and a
+runtime resolving one inside a filesystem that holds nothing else resolves a
+dangling name. So what a consumer copies out is bytes, whichever of the two
+paths they name.
+
+Both **MUST** be readable by the [image's user](#the-user) *and* by any UID a
+caller overrides it with — for the directory, that means traversable as well, so
+that reaching a file inside it is not a privilege the image's own user has and
+a caller's does not. A generator run under `--user $(id -u):$(id -g)` reads the
+same schema as one run under 65532, and a copy readable only by the image's own
+user would make the recommended invocation fail on the one thing the image
+exists to hand it.
 
 `/usr/local/share/cpybkc/proto` is an **include root**. Every file under it sits
 at the path its protobuf package requires, so a compiler is pointed straight at
@@ -915,7 +925,7 @@ change to any of them is a breaking change:
 | [The entrypoint](#the-entrypoint) | Is the cpybkc CLI, and takes its arguments |
 | [The user](#the-user) | UID 65532, GID 65532, non-root, overridable |
 | [The IR `FileDescriptorSet`](#the-ir-schema-in-the-image) | `/usr/local/share/cpybkc/ir.binpb`, a world-readable regular file, byte-identical to the release asset |
-| [The IR `.proto` sources](#the-ir-schema-in-the-image) | `/usr/local/share/cpybkc/proto/`, an include root of world-readable regular files, byte-identical to the release archive's contents |
+| [The IR `.proto` sources](#the-ir-schema-in-the-image) | `/usr/local/share/cpybkc/proto/`, a world-traversable include root of world-readable regular files, byte-identical to the release archive's contents |
 | [Shell or no shell](#shell-or-no-shell) | Absent; extension is `COPY`-only |
 | [Platforms](#why-the-platform-set-is-the-two-it-is) | `linux/amd64` and `linux/arm64` |
 | [Tags](#tags-and-what-pinning-one-buys) | A published full-version tag never moves |

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -26,7 +26,8 @@ it goes belongs here.
 In scope: what the published image guarantees to an image built `FROM` it — the
 directory a generator is copied into, the entrypoint, the user and UID the
 process runs as and the guidance for overriding it with
-`--user $(id -u):$(id -g)`, whether a shell is present and what follows if it is
+`--user $(id -u):$(id -g)`, the paths the IR schema ships at and what a
+consumer may do with them, whether a shell is present and what follows if it is
 not, the tags a derived image may pin to, and which of these are covered by a
 compatibility guarantee and which are implementation detail that may change
 without notice.
@@ -218,6 +219,117 @@ find. An overridden UID is an ordinary configuration and not a workaround.
 The default exists for the case where no host user is involved — a CI runner, a
 Kubernetes job, a Dagger pipeline — where running as a pinned non-root UID is
 what a policy wants to see.
+
+## The IR schema in the image
+
+A generator is handed a `cpybkc.ir.v1.Descriptor` and has to decode it. The
+schema that says how is **in the image**, at two paths, so that a plugin author
+building `FROM` it needs nothing else from this project — no download, no
+network at build time, and no arrangement with this repository at all (#57):
+
+| Path | What it is | Who it is for |
+| --- | --- | --- |
+| `/usr/local/share/cpybkc/ir.binpb` | the protobuf `FileDescriptorSet` describing `cpybkc.ir.v1.Descriptor` and the transitive closure of its imports | a generator whose build has no protobuf code generation in it, decoding dynamically |
+| `/usr/local/share/cpybkc/proto/` | the `.proto` sources, each file at the path its protobuf package requires | a build that would rather run a compiler and generate bindings |
+
+Both **MUST** exist. Each **MUST** be a **regular file** — not a symbolic link,
+not a directory where a file is named — because a `COPY --from` naming one
+copies what is there, and a link copies as a link into an image whose target
+does not exist. Both **MUST** be readable by the [image's user](#the-user) *and*
+by any UID a caller overrides it with: a generator run under
+`--user $(id -u):$(id -g)` reads the same file as one run under 65532, and a
+file readable only by the image's own user would make that recommended
+invocation fail on the one thing the image exists to hand it.
+
+`/usr/local/share/cpybkc/proto` is an **include root**. Every file under it sits
+at the path its protobuf package requires, so a compiler is pointed straight at
+the directory:
+
+```console
+$ protoc -I /usr/local/share/cpybkc/proto --python_out=. cpybkc/ir/v1/ir.proto
+```
+
+That layout is the reason it is a directory and not one flattened `ir.proto`. A
+`.proto`'s path is part of its identity — it is the name a `FileDescriptorProto`
+carries and the string another schema's `import` resolves — so a file moved out
+of its package's directory compiles into descriptors naming a path this project
+does not publish.
+
+### These are the release assets, not copies of them
+
+The bytes at `/usr/local/share/cpybkc/ir.binpb` **MUST** be identical to the
+`ir.binpb` asset attached to the matching release, and the files under
+`/usr/local/share/cpybkc/proto/` **MUST** be identical to the contents of that
+release's `ir-protos.tar.gz`. They are **two ways of getting one artifact, not
+two artifacts.**
+
+This is the guarantee that lets a build stop after the cheaper one. A pipeline
+that already pulls the image reads the file out of it and never touches the
+release page; a pipeline that does not want a container image downloads the
+asset. Neither has any reason to fetch both, and neither has to diff them to
+find out whether it should have. Two files that merely agreed today would make
+that a gamble on nobody having changed one of the two recipes, so there is one
+recipe: `dagger call ir-descriptor-set` produces the file the release attaches
+*and* the file the image carries, and the pipeline compares them on every pull
+request.
+
+For the same reason the bytes are identical across the platforms of one release.
+A `FileDescriptorSet` is a function of the schema and knows nothing about an
+architecture, so `linux/amd64` and `linux/arm64` carry the same file and a build
+that reads it out of either gets the same answer.
+
+### What a derived image may do with them
+
+A derived image **MAY** copy either path out — into a builder stage that runs
+`protoc`, or into a distroless image of its own:
+
+```dockerfile
+FROM ghcr.io/zaba505/cpybkc:v0 AS cpybkc
+
+FROM python:3.13
+COPY --from=cpybkc /usr/local/share/cpybkc/ir.binpb /opt/ir.binpb
+```
+
+A derived image **MUST NOT** modify either in place. An image that rewrote the
+descriptor set would be publishing a cpybkc whose shipped schema no longer
+describes the descriptors its own CLI emits, and every generator in it would
+decode against a contract the entrypoint does not implement. The files are
+root-owned and mode `0644`, so the running user cannot do it by accident; the
+requirement is on the build that could.
+
+### Their size, which is not a guarantee
+
+Descriptive, and stated because *"ships a protobuf descriptor set"* otherwise
+means anything from two kilobytes to a hundred megabytes, which is the
+difference between `COPY --from`-ing it into a distroless image without thinking
+and not doing it at all: `ir.binpb` is roughly **five kilobytes** and the
+sources are roughly **forty-five**, so the whole of
+`/usr/local/share/cpybkc` is tens of kilobytes.
+
+Those numbers are **not covered**. They move with the schema, and a release that
+added a message would change both without changing anything a consumer depends
+on. What is covered is that the paths are there, are regular files, are readable
+and are the release's own bytes.
+
+### Why both, when the descriptor set alone would do
+
+The descriptor set is the one that serves the consumer with the least: a runtime
+that can load a `FileDescriptorSet` — which is every protobuf runtime — needs no
+compiler, no build step and no generated code. If only one form could ship, it
+would be that one.
+
+The sources ship as well because the consumer who *can* run a compiler is not
+served by it. Generating bindings from a `.proto` gives them named types, their
+language's own field accessors and their own build's error messages, and asking
+them to reconstruct a `.proto` from a descriptor set to get there is asking them
+to write a decompiler. The two are alternatives rather than a fallback pair, and
+[`ir/SPEC.md`](../ir/SPEC.md#reading-a-descriptor-without-generated-code) is
+normative for what each contains.
+
+There is a third way to read a descriptor and it ships nothing, because it needs
+nothing: cpybkc renders one as JSON on request, and the entrypoint is already in
+the image. That is the [IR specification's](../ir/SPEC.md#a-descriptor-is-readable-by-a-person),
+and it is a CLI flag rather than a file.
 
 ## Shell or no shell
 
@@ -570,6 +682,228 @@ than the ones this document permits is an error naming it, rather than a line
 that quietly goes unchecked. A worked example that grows an `ENV` teaches the
 pipeline what an `ENV` means before CI accepts it.
 
+## Worked example: reading the IR without generated code
+
+The example above put a generator on `PATH` and said nothing about how it reads
+what cpybkc hands it. This one is the other half, and it is the reason [the IR
+schema](#the-ir-schema-in-the-image) is in the image at all: a generator that
+decodes a descriptor using **only the `FileDescriptorSet` at
+`/usr/local/share/cpybkc/ir.binpb`**. Nothing in its build context is generated
+from cpybkc's schema, nothing in its `go.mod` comes from this repository, and it
+never downloads anything — the schema arrives with the base image.
+
+It is written in Go because the final stage has [no
+shell](#shell-or-no-shell) and every plugin is a static executable, but nothing
+below is Go-specific: the four calls are `decode a FileDescriptorSet`, `build a
+registry`, `look up a message by name`, `decode into a dynamic message of that
+type`, and every protobuf runtime has them. [`ir/SPEC.md`, *Reading a descriptor
+without generated code*](../ir/SPEC.md#reading-a-descriptor-without-generated-code)
+is normative for them.
+
+```dockerfile
+# syntax=docker/dockerfile:1
+
+FROM golang:1.25 AS build
+WORKDIR /src
+
+COPY <<'EOF' go.mod
+module example.com/cpybkc-gen-irdump
+
+go 1.24
+EOF
+
+COPY <<'EOF' main.go
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+// Everything this generator knows about the IR comes out of the image it is
+// running in. There is no import of cpybkc's Go module here and no ir.proto in
+// the build context; the schema is the file below.
+const (
+	shippedDescriptorSet = "/usr/local/share/cpybkc/ir.binpb"
+	descriptorMessage    = "cpybkc.ir.v1.Descriptor"
+
+	// The one IR version this generator implements, by name. A generator built
+	// against generated code compares an enum constant; one that decodes
+	// dynamically has the value's name and nothing else, and the name is in the
+	// descriptor set above.
+	irVersion     = "IR_VERSION_1"
+	pluginVersion = "0.1.0"
+)
+
+func main() {
+	descriptor, out := "", ""
+
+	args := os.Args[1:]
+	for len(args) > 0 && args[0] != "--" {
+		if len(args) < 2 {
+			fail("%s: missing value", args[0])
+		}
+		flag, value := args[0], args[1]
+		args = args[2:]
+		switch flag {
+		case "--descriptor":
+			descriptor = value
+		case "--out":
+			out = value
+		default:
+			fail("%s: unrecognised flag", flag)
+		}
+	}
+	if descriptor == "" || out == "" {
+		fail("--descriptor and --out are both required")
+	}
+
+	// The schema, read out of the image.
+	schema, err := os.ReadFile(shippedDescriptorSet)
+	if err != nil {
+		fail("%v", err)
+	}
+
+	var set descriptorpb.FileDescriptorSet
+	if err := proto.Unmarshal(schema, &set); err != nil {
+		fail("%s is not a FileDescriptorSet: %v", shippedDescriptorSet, err)
+	}
+
+	// A registry of every file in it, and the one message a generator is
+	// handed. Both come from the shipped bytes; neither needs a compiler.
+	files, err := protodesc.NewFiles(&set)
+	if err != nil {
+		fail("%s does not build a registry: %v", shippedDescriptorSet, err)
+	}
+
+	found, err := files.FindDescriptorByName(descriptorMessage)
+	if err != nil {
+		fail("%s describes no %s: %v", shippedDescriptorSet, descriptorMessage, err)
+	}
+
+	message, ok := found.(protoreflect.MessageDescriptor)
+	if !ok {
+		fail("%s is not a message", descriptorMessage)
+	}
+
+	encoded, err := os.ReadFile(descriptor)
+	if err != nil {
+		fail("%v", err)
+	}
+
+	root := dynamicpb.NewMessage(message)
+	if err := proto.Unmarshal(encoded, root); err != nil {
+		fail("the descriptor is not a %s: %v", descriptorMessage, err)
+	}
+
+	// The version before anything else in the message, and a refusal rather
+	// than a walk. That obligation binds a consumer that decoded dynamically
+	// exactly as it binds one with generated code — more visibly, if anything,
+	// since nothing here would have failed to compile against a newer IR.
+	field := message.Fields().ByName("version")
+	stated := field.Enum().Values().ByNumber(root.Get(field).Enum())
+	if stated == nil || string(stated.Name()) != irVersion {
+		fail("descriptor IR version %v; cpybkc-gen-irdump %s implements %s",
+			root.Get(field), pluginVersion, irVersion)
+	}
+
+	// A descriptor is a flat list of nodes, and a record names itself through a
+	// Names message. Reading either by field name is the whole of what the
+	// descriptor set bought.
+	report := &strings.Builder{}
+	fmt.Fprintf(report, "ir version: %s\n", stated.Name())
+
+	nodes := root.Get(message.Fields().ByName("nodes")).List()
+	fmt.Fprintf(report, "nodes: %d\n", nodes.Len())
+
+	for i := range nodes.Len() {
+		node := nodes.Get(i).Message()
+
+		kind := node.WhichOneof(node.Descriptor().Oneofs().ByName("kind"))
+		if kind == nil || kind.Name() != "record" {
+			continue
+		}
+
+		record := node.Get(kind).Message()
+		names := record.Get(record.Descriptor().Fields().ByName("names")).Message()
+
+		fmt.Fprintf(report, "record: %s\n",
+			names.Get(names.Descriptor().Fields().ByName("original")).String())
+	}
+
+	name := filepath.Join(out, "ir.txt")
+	if err := os.WriteFile(name, []byte(report.String()), 0o644); err != nil {
+		fail("%v", err)
+	}
+}
+
+func fail(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "error: "+format+"\n", args...)
+	os.Exit(1)
+}
+EOF
+
+RUN go mod tidy \
+ && CGO_ENABLED=0 go build -trimpath -o /out/cpybkc-gen-irdump .
+
+FROM ghcr.io/zaba505/cpybkc:v0
+COPY --from=build --chown=65532:65532 --chmod=0755 \
+     /out/cpybkc-gen-irdump /usr/local/bin/cpybkc-gen-irdump
+```
+
+Build it and run cpybkc against a project whose `cpybkc.json` names the
+`irdump` generator, and `ir.txt` names the IR version and every record in the
+descriptor:
+
+```console
+$ docker build -t cpybkc-irdump .
+$ docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/src" -w /src \
+    cpybkc-irdump <arguments>
+$ cat out/ir.txt
+ir version: IR_VERSION_1
+nodes: 42
+record: CUSTOMER-RECORD
+```
+
+Three things in it are the contract rather than the example:
+
+- `/usr/local/share/cpybkc/ir.binpb` is a path, written into the program, with
+  no fetch behind it. That is what [the IR schema in the
+  image](#the-ir-schema-in-the-image) guarantees, and it is why this Dockerfile
+  has no `ADD`, no `curl` and no build argument naming a release.
+- The file is opened by a process running as whatever UID the caller passed.
+  The `--user "$(id -u):$(id -g)"` above is the recommended invocation and it is
+  an ordinary one here too, because the shipped file is world-readable.
+- Nothing past the argument parsing knows the schema at compile time. Swap
+  `--python_out` for `go build` and the same four calls are the same four calls;
+  the only thing that would change is which of the two shipped forms the build
+  reaches for.
+
+### This example is built and run by the pipeline
+
+`dagger call worked-example` checks this Dockerfile exactly as it checks the
+[first one](#this-example-is-built-by-the-pipeline) — the build stage handed to
+the builder as committed, the final stage replayed onto the base image the
+pipeline just built — and then does one thing more: it **runs the generator**
+inside that derived image, as an overridden UID, against a descriptor stating an
+IR version and nothing else, and requires the output to name the version.
+
+That last step is the only thing that can tell this example from a program which
+merely mentions the path. Everything else about it — two stages, one static
+executable, one `COPY` into the plugin directory — would pass on a generator
+that never opened the file. The claim being checked is that the shipped
+descriptor set is *sufficient*: the version's name, `IR_VERSION_1`, appears in
+`ir.binpb` and nowhere in the bytes the generator was handed, so output carrying
+it is output that read the image's own copy of the schema.
+
 ## Compatibility guarantees
 
 **Covered.** Within a major version of the image each of these holds, and a
@@ -580,6 +914,8 @@ change to any of them is a breaking change:
 | [The plugin directory](#the-plugin-directory) | `/usr/local/bin`, on `PATH`, existing and owned by the image's user |
 | [The entrypoint](#the-entrypoint) | Is the cpybkc CLI, and takes its arguments |
 | [The user](#the-user) | UID 65532, GID 65532, non-root, overridable |
+| [The IR `FileDescriptorSet`](#the-ir-schema-in-the-image) | `/usr/local/share/cpybkc/ir.binpb`, a world-readable regular file, byte-identical to the release asset |
+| [The IR `.proto` sources](#the-ir-schema-in-the-image) | `/usr/local/share/cpybkc/proto/`, an include root of world-readable regular files, byte-identical to the release archive's contents |
 | [Shell or no shell](#shell-or-no-shell) | Absent; extension is `COPY`-only |
 | [Platforms](#why-the-platform-set-is-the-two-it-is) | `linux/amd64` and `linux/arm64` |
 | [Tags](#tags-and-what-pinning-one-buys) | A published full-version tag never moves |
@@ -603,6 +939,13 @@ depending on something that may change in a patch release, with no notice:
 - Layer count, layer ordering, image size, build timestamps, and every other
   label or annotation on the manifest.
 - Which UID owns a file that is not in the plugin directory.
+- The **size** of either IR artifact, and the number of files under
+  `/usr/local/share/cpybkc/proto/`. Both move with the schema; [the figures
+  given](#their-size-which-is-not-a-guarantee) are a description of one release
+  and not a promise about the next.
+- Anything else appearing under `/usr/local/share/cpybkc/`. The two paths named
+  above are the contract; a third file arriving beside them is not one to depend
+  on until this document names it.
 
 ### Why the platform set is the two it is
 
@@ -711,7 +1054,8 @@ Go install with no document that applies to them.
 | [This example is built by the pipeline](#this-example-is-built-by-the-pipeline) | #54 `container` for the build stage and the reading of the final one, #55 `container` for replaying that stage onto a base image of this pipeline's own |
 | [Compatibility guarantees](#compatibility-guarantees) | #54, #58 `container` |
 | [Why the platform set is the two it is](#why-the-platform-set-is-the-two-it-is) | #54 `container` decides it, #55 `container` builds it, #56 `container` retires the third leg it once had |
-| The IR proto shipped in the image — a consumer-visible file, sized here | #57 `container` |
+| [The IR schema in the image](#the-ir-schema-in-the-image) | #57 `container` |
+| [Worked example: reading the IR without generated code](#worked-example-reading-the-ir-without-generated-code) | #57 `container`; #19 `ir` for what the descriptor set contains |
 | The multi-platform build itself — out of scope, see above | #55 `container` |
 | The Dagger module's default image tag — out of scope, see above | #104 `dagger` settles it in [CONTRIBUTING.md](../../CONTRIBUTING.md#the-companion-dagger-module); #61 `dagger` carries it onto the constructor |
 | Signing, provenance and SBOM — verifiable, so the tags section cites them | #58 `container` |

--- a/docs/ir/SPEC.md
+++ b/docs/ir/SPEC.md
@@ -3123,10 +3123,13 @@ compiler and no build step to decode a descriptor.
 The schema sources are published beside it, as **`ir-protos.tar.gz`**, each file
 at the path its protobuf package requires. That is for the consumer whose build
 *can* run a compiler and would rather generate bindings; the two are
-alternatives, and neither is derived from the other. The published image
-carries the same `ir.binpb` bytes at a path the [container
-contract](../container/SPEC.md) fixes (#57) — one artifact reachable two ways,
-not two artifacts.
+alternatives, and neither is derived from the other. The published image carries
+both, at paths the [container contract](../container/SPEC.md#the-ir-schema-in-the-image)
+fixes: the same `ir.binpb` bytes at `/usr/local/share/cpybkc/ir.binpb`, and the
+same sources, unpacked, under `/usr/local/share/cpybkc/proto/` (#57). Each is
+one artifact reachable two ways, not two artifacts, and that document's worked
+example is a generator decoding a descriptor with nothing but the first of
+them.
 
 ### What the set contains
 


### PR DESCRIPTION
Closes #57

A plugin author building `FROM` the published image can now reach the IR schema in all the tiers the image can serve, without a download, a build argument or any arrangement with this project.

## Acceptance criteria

- [x] **`.proto` sources and the `FileDescriptorSet` present at documented paths inside the image** — `/usr/local/share/cpybkc/ir.binpb` and `/usr/local/share/cpybkc/proto/`, assembled in `.dagger/image.go`'s `irDirectory` and grafted onto the base by `image`.
- [x] **Paths documented in the base-image contract** — a new `## The IR schema in the image` section in `docs/container/SPEC.md`, two rows in the compatibility guarantees table, matching entries under *Not covered*, and the appendix mapping.
- [x] **A worked example reads the IR dynamically using only the shipped descriptor set** — `## Worked example: reading the IR without generated code`, built *and run* by `dagger call worked-example`.
- [x] **Artifacts also attached to GitHub releases** — already true, in `.github/workflows/release.yaml`'s `artifacts` job. What this PR adds is the guarantee that ties the two together: the image's copy is byte-identical to the asset, checked on every run.

## Judgment calls that shaped the public contract

**`/usr/local/share/cpybkc`, and a directory rather than a tarball for the sources.** `/usr/local/share` for the reason the plugin directory is `/usr/local/bin`: it is the conventional destination, so a reader guesses it without opening the spec. The sources ship unpacked because they are an *include root* — `protoc -I /usr/local/share/cpybkc/proto cpybkc/ir/v1/ir.proto` works directly — and because a stage built `FROM` this image has no shell to unpack an archive with.

**Both forms, where avroc ships only the descriptor set.** The issue flagged this as a deliberate divergence. The descriptor set serves the consumer with the least; the sources serve the one who *can* run a compiler and would otherwise have to reconstruct a `.proto` from a descriptor set to get named types. The spec section carries the argument.

**Root-owned, mode `0644`, rather than owned by the image's user.** World-readable is what makes `--user $(id -u):$(id -g)` ordinary for a generator that reads the descriptor set. Root-owned is what turns *"a derived image MAY copy it out and MUST NOT modify it in place"* into something the filesystem enforces for the running process rather than something the document merely asks for.

**The size is stated and explicitly not covered.** ~5 KB for `ir.binpb`, ~45 KB for the sources. Stated because *"ships a protobuf descriptor set"* otherwise spans four orders of magnitude, which is the difference between `COPY --from`-ing it into a distroless image without thinking and not doing it at all; not covered because it moves with the schema.

## How it is verified

`dagger call ci` — green locally, including the run after the final doc-comment edits.

Three checks are new or newly load-bearing:

- **`checkShippedIr`** compares the IR schema in the image against a fresh `ir-descriptor-set` build and against `proto/`, with `diff --recursive --brief`. The image copies in the *same node* the release workflow exports, so byte-identity is a property of the build rather than a promise; this is the assertion that keeps it so.
- **The exhaustive filesystem listing now carries each path's kind** (`find -printf %y`), so *"a regular file, not a symbolic link"* is checked for every path rather than incidentally caught by a mode mismatch.
- **The dynamic worked example is run**, not just built: inside the derived image, as UID 1234, against a two-byte descriptor stating an IR version and nothing else. Its output must name `IR_VERSION_1` — a name that appears in the shipped descriptor set and nowhere in the bytes the generator was handed, so output carrying it is output that read the image's own copy of the schema.

The descriptor the check feeds is hand-written wire bytes (`0x08 0x01`) rather than one marshalled with `irpb`. The example exists to show the shipped descriptor set is *sufficient*, and building its input out of the generated types would rest the demonstration on the tier it is about avoiding.

Both new assertions were confirmed to fail when they should: expecting mode `0600` produced `is f 0:0 0644, want f 0:0 0600` for both shipped paths, and feeding a descriptor stating IR version 7 produced `error: descriptor IR version 7; cpybkc-gen-irdump 0.1.0 implements IR_VERSION_1` — from the generator, in the derived image, having resolved the enum out of the shipped file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)