### PR TITLE
story(container): publish tagged releases to ghcr.io

### DIFF
--- a/.dagger/dagger.gen.go
+++ b/.dagger/dagger.gen.go
@@ -454,6 +454,132 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Cpybkc).Provenance(&parent, ctx, gitDir, image, builder, version, tags, invocation)
+		case "Publish":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var address string
+			if inputArgs["address"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["address"]), &address)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg address", err))
+				}
+			}
+			var username string
+			if inputArgs["username"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["username"]), &username)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg username", err))
+				}
+			}
+			var password *dagger.Secret
+			if inputArgs["password"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["password"]), &password)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg password", err))
+				}
+			}
+			return (*Cpybkc).Publish(&parent, ctx, address, username, password)
+		case "Release":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var gitDir *dagger.Directory
+			if inputArgs["gitDir"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["gitDir"]), &gitDir)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg gitDir", err))
+				}
+			}
+			var repository string
+			if inputArgs["repository"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["repository"]), &repository)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg repository", err))
+				}
+			}
+			var username string
+			if inputArgs["username"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["username"]), &username)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg username", err))
+				}
+			}
+			var password *dagger.Secret
+			if inputArgs["password"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["password"]), &password)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg password", err))
+				}
+			}
+			var idTokenRequestUrl string
+			if inputArgs["idTokenRequestUrl"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["idTokenRequestUrl"]), &idTokenRequestUrl)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg idTokenRequestUrl", err))
+				}
+			}
+			var idTokenRequestToken *dagger.Secret
+			if inputArgs["idTokenRequestToken"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["idTokenRequestToken"]), &idTokenRequestToken)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg idTokenRequestToken", err))
+				}
+			}
+			var builder string
+			if inputArgs["builder"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["builder"]), &builder)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg builder", err))
+				}
+			}
+			var invocation string
+			if inputArgs["invocation"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["invocation"]), &invocation)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg invocation", err))
+				}
+			}
+			return (*Cpybkc).Release(&parent, ctx, gitDir, repository, username, password, idTokenRequestUrl, idTokenRequestToken, builder, invocation)
+		case "ReleaseNotes":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var gitDir *dagger.Directory
+			if inputArgs["gitDir"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["gitDir"]), &gitDir)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg gitDir", err))
+				}
+			}
+			var notes *dagger.File
+			if inputArgs["notes"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["notes"]), &notes)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg notes", err))
+				}
+			}
+			var repository string
+			if inputArgs["repository"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["repository"]), &repository)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg repository", err))
+				}
+			}
+			return (*Cpybkc).ReleaseNotes(&parent, ctx, gitDir, notes, repository)
+		case "ReleaseNotesContract":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Cpybkc).ReleaseNotesContract(&parent)
 		case "Sbom":
 			var parent Cpybkc
 			err = json.Unmarshal(parentJSON, &parent)
@@ -468,6 +594,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Cpybkc).Sbom(&parent, ctx, platform)
+		case "TagScheme":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Cpybkc).TagScheme(&parent)
 		case "Test":
 			var parent Cpybkc
 			err = json.Unmarshal(parentJSON, &parent)

--- a/.dagger/dagger.gen.go
+++ b/.dagger/dagger.gen.go
@@ -495,6 +495,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg gitDir", err))
 				}
 			}
+			var tag string
+			if inputArgs["tag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["tag"]), &tag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg tag", err))
+				}
+			}
 			var repository string
 			if inputArgs["repository"] != nil {
 				err = json.Unmarshal([]byte(inputArgs["repository"]), &repository)
@@ -544,7 +551,7 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg invocation", err))
 				}
 			}
-			return (*Cpybkc).Release(&parent, ctx, gitDir, repository, username, password, idTokenRequestUrl, idTokenRequestToken, builder, invocation)
+			return (*Cpybkc).Release(&parent, ctx, gitDir, tag, repository, username, password, idTokenRequestUrl, idTokenRequestToken, builder, invocation)
 		case "ReleaseNotes":
 			var parent Cpybkc
 			err = json.Unmarshal(parentJSON, &parent)
@@ -556,6 +563,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				err = json.Unmarshal([]byte(inputArgs["gitDir"]), &gitDir)
 				if err != nil {
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg gitDir", err))
+				}
+			}
+			var tag string
+			if inputArgs["tag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["tag"]), &tag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg tag", err))
 				}
 			}
 			var notes *dagger.File
@@ -572,7 +586,7 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg repository", err))
 				}
 			}
-			return (*Cpybkc).ReleaseNotes(&parent, ctx, gitDir, notes, repository)
+			return (*Cpybkc).ReleaseNotes(&parent, ctx, gitDir, tag, notes, repository)
 		case "ReleaseNotesContract":
 			var parent Cpybkc
 			err = json.Unmarshal(parentJSON, &parent)

--- a/.dagger/image.go
+++ b/.dagger/image.go
@@ -193,6 +193,75 @@ func (m *Cpybkc) Image(
 	return m.image(p), nil
 }
 
+// Publish pushes the image, as a multi-platform index over every platform this
+// project ships for, and returns the digest-qualified reference the registry
+// stored it under:
+//
+//	dagger call publish --address=ghcr.io/zaba505/cpybkc:v0.2.0 \
+//	  --username=… --password=env://REGISTRY_PASSWORD
+//
+// One index rather than one push per platform, because docs/container/SPEC.md
+// promises that every published tag resolves to a multi-platform index: a
+// consumer's `FROM` line names a tag and their runtime picks the manifest for the
+// architecture it is on.
+//
+// The variants are image's own containers, so what is published is what
+// ImageContract checked rather than a second build that agrees with it today.
+//
+// It is a function of its own, and not folded into Release, so that pushing to a
+// test registry by hand is something a person can do — a publish path only ever
+// exercised by a release is one whose first real invocation is the one nobody
+// can retry.
+//
+// The digest in the returned reference is what a release signs. Nothing here
+// resolves a tag afterwards to find it: what gets signed has to be what was
+// pushed.
+func (m *Cpybkc) Publish(
+	ctx context.Context,
+	// The full image reference to push, including the tag.
+	address string,
+	// The registry username to authenticate as. Both this and password are
+	// needed for a registry that requires authentication, which is every
+	// registry this project publishes to.
+	// +optional
+	username string,
+	// The registry password or token to authenticate with.
+	// +optional
+	password *dagger.Secret,
+) (string, error) {
+	if address == "" {
+		return "", errors.New("address is required: it is the full image reference to push, including the tag")
+	}
+
+	// Half a credential is refused rather than quietly dropped. Skipping the
+	// authentication because one of the two is missing turns a typo into an
+	// anonymous push, which fails at the registry with a message about
+	// permissions rather than about the argument that was actually wrong — and on
+	// a registry that happened to allow it, would not fail at all.
+	switch {
+	case username != "" && password == nil:
+		return "", errors.New("username was given without password: both are needed to authenticate, and " +
+			"publishing with neither pushes anonymously")
+	case username == "" && password != nil:
+		return "", errors.New("password was given without username: both are needed to authenticate, and " +
+			"publishing with neither pushes anonymously")
+	}
+
+	platforms := imagePlatforms()
+
+	variants := make([]*dagger.Container, 0, len(platforms))
+	for _, p := range platforms {
+		variants = append(variants, m.image(p))
+	}
+
+	c := dag.Container()
+	if username != "" {
+		c = c.WithRegistryAuth(address, username, password)
+	}
+
+	return c.Publish(ctx, address, dagger.ContainerPublishOpts{PlatformVariants: variants})
+}
+
 // ImageContract checks the built image against every promise
 // docs/container/SPEC.md makes about it (#55).
 //

--- a/.dagger/image.go
+++ b/.dagger/image.go
@@ -216,6 +216,15 @@ func (m *Cpybkc) Image(
 // The digest in the returned reference is what a release signs. Nothing here
 // resolves a tag afterwards to find it: what gets signed has to be what was
 // pushed.
+//
+// Uncached, like Release, and for a reason that bites hardest on the path this
+// function exists for. This is the call that mutates a registry, and a cached
+// result would hand a second invocation the reference the first one resolved
+// without anything having been pushed — so retrying a release that failed
+// halfway would report success over a tag that is still missing at the
+// destination. A push is an effect, and an effect is not a value to memoise.
+//
+// +cache="never"
 func (m *Cpybkc) Publish(
 	ctx context.Context,
 	// The full image reference to push, including the tag.

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -13,21 +13,32 @@
 // nobody wrote down. Wrapping costs one dependency and keeps that impossible.
 //
 // GoLib rather than GoApp, even now that cmd/cpybkc-gen-go is a main package
-// (#48) and the image is built (#55). What GoApp adds over GoLib is a
-// multi-platform image build and the publish half of the standard, and this
-// story expected to reach the image by switching factories. It did not, and
-// image.go's own comment says why at length: GoApp publishes one image per
-// binary, and cpybkc publishes a *base* — a directory on PATH that other
-// people's images copy into, owned by a pinned non-root user. Four of the six
-// promises docs/container/SPEC.md makes are that shape rather than settings
-// GoApp is missing.
+// (#48), the image is built (#55) and it is published (#59). What GoApp adds
+// over GoLib is a multi-platform image build and the publish half of the
+// standard, and the image story expected to reach the image by switching
+// factories. It did not, and image.go's own comment says why at length: GoApp
+// publishes one image per binary, and cpybkc publishes a *base* — a directory on
+// PATH that other people's images copy into, owned by a pinned non-root user.
+// Four of the six promises docs/container/SPEC.md makes are that shape rather
+// than settings GoApp is missing.
 //
 // So the factory stays GoLib, and the four check stages still gate a pull
 // request and still cover cmd/ because they run over ./... . The image is built
-// by this module in image.go — the shape avroc arrived at for the same reason
-// (avroc#166). What is left for GoApp is the publish half, which is #59's, and
-// which it will be able to take or leave on its own merits rather than because
-// the image came attached to it.
+// by this module in image.go and published by it in release.go — the shape avroc
+// arrived at for the same reason (avroc#166, avroc#168). The publish half went
+// the same way as the image half once the image did: what a release pushes is
+// the base this module assembles, under tags this module derives, and GoApp has
+// no notion of either.
+//
+// # Why the release is decided here too
+//
+// release.go decides whether a commit is a release, which tags it carries and
+// what its notes say about the image (#59). That decision is in the module and
+// not in .github/workflows/release.yaml because the alternative is the tag scheme
+// written down a second time, in a file that runs once per release and is
+// exercised nowhere else. TagScheme and ReleaseNotesContract are in Ci for the
+// same reason the artifact builds are: a recipe whose first real run is on a tag
+// is one whose failure is a release that did not happen.
 //
 // # Why the stage functions exist alongside it
 //
@@ -219,12 +230,12 @@ func New(
 // modules, plus `buf lint` over the IR schema, a build of the CLI itself, a
 // build of the three artifacts a release publishes, the published base image on
 // every platform it ships for, the worked examples docs/container/SPEC.md hands
-// an adopter, and the attestations a release attaches to what it publishes. This
-// is the single entrypoint — CI is one `dagger call ci` and stays one, because a
-// workflow step that reran any of these stages would be a second definition of
-// them.
+// an adopter, the attestations a release attaches to what it publishes, and the
+// tag scheme and release notes a release is published under. This is the single
+// entrypoint — CI is one `dagger call ci` and stays one, because a workflow step
+// that reran any of these stages would be a second definition of them.
 //
-// The nine parts run concurrently and all are reported, for the reason the
+// The eleven parts run concurrently and all are reported, for the reason the
 // standard runs its own four that way: waiting on a Go stage to learn that the
 // schema is unlintable, or the reverse, is a second push to find out about the
 // second failure.
@@ -233,9 +244,10 @@ func New(
 // +cache="session"
 func (m *Cpybkc) Ci(ctx context.Context) error {
 	var goErr, irErr, protoErr, buildErr, artifactErr, layoutErr, imageErr, exampleErr, attestErr error
+	var tagErr, notesErr error
 
 	var wg sync.WaitGroup
-	wg.Add(9)
+	wg.Add(11)
 
 	go func() {
 		defer wg.Done()
@@ -287,9 +299,20 @@ func (m *Cpybkc) Ci(ctx context.Context) error {
 		attestErr = m.Attestations(ctx)
 	}()
 
+	go func() {
+		defer wg.Done()
+		tagErr = m.TagScheme()
+	}()
+
+	go func() {
+		defer wg.Done()
+		notesErr = m.ReleaseNotesContract()
+	}()
+
 	wg.Wait()
 
-	return errors.Join(goErr, irErr, protoErr, buildErr, artifactErr, layoutErr, imageErr, exampleErr, attestErr)
+	return errors.Join(goErr, irErr, protoErr, buildErr, artifactErr, layoutErr, imageErr, exampleErr, attestErr,
+		tagErr, notesErr)
 }
 
 // IrCi runs the same standard pipeline over irpb/, the published IR module.
@@ -567,16 +590,34 @@ func (m *Cpybkc) Binary() *dagger.File {
 // +check
 // +cache="session"
 func (m *Cpybkc) Build(ctx context.Context) error {
+	line, err := m.versionLine(ctx)
+	if err != nil {
+		return err
+	}
+
+	return checkVersionLine(line)
+}
+
+// versionLine runs `cpybkc --version` in an image holding nothing but the
+// binary, and returns what it wrote.
+//
+// Two callers want it for different reasons and one recipe serves both: Build
+// wants to know that the binary starts at all in an image with no loader and no
+// libc, and release.go's irVersion wants the IR version off the line, which is
+// the number the release notes state. Reading that number out of the artifact is
+// the whole point — a constant in the pipeline would be a second statement of
+// what the assembler stamps.
+func (m *Cpybkc) versionLine(ctx context.Context) (string, error) {
 	line, err := dag.Container().
 		WithFile(cliBinaryPath, m.Binary(), dagger.ContainerWithFileOpts{Permissions: 0o755}).
 		WithExec([]string{cliBinaryPath, "--version"}).
 		Stdout(ctx)
 	if err != nil {
-		return fmt.Errorf("cpybkc does not run in an image holding nothing but itself, which is the image it "+
+		return "", fmt.Errorf("cpybkc does not run in an image holding nothing but itself, which is the image it "+
 			"ships in: %w", err)
 	}
 
-	return checkVersionLine(line)
+	return line, nil
 }
 
 // checkVersionLine reports whether line is what `cpybkc --version` writes.

--- a/.dagger/release.go
+++ b/.dagger/release.go
@@ -1,6 +1,6 @@
-// This file publishes a release: it decides from the refs at HEAD whether there
-// is one, works out which tags it carries, pushes the multi-platform image under
-// every one of them, hands the digest it resolved to sign.go's Attest, and
+// This file publishes a release: it decides from the release's own tag whether
+// there is one, works out which tags it carries, pushes the multi-platform image
+// under every one of them, hands the digest it resolved to sign.go's Attest, and
 // renders the block of release notes that says which IR version the image just
 // published speaks (#59).
 //
@@ -15,13 +15,15 @@
 // and both are discovered by somebody whose `FROM` line resolved to an image
 // they did not ask for.
 //
-// So the module reads the refs at HEAD and everything downstream of that reading
-// is a function of them. TagScheme runs the same derivation over a table of
-// cases on every pull request, which is what makes the scheme something this
-// repository checks rather than something it intends. What is left to the
-// workflow is *where* — the registry repository and the credentials — which
-// genuinely is a property of the deployment rather than of the release, and is
-// the reason docs/container/SPEC.md keeps the registry out of the contract.
+// So the module is handed the release's tag, and everything downstream is a
+// function of that tag and the refs at HEAD. TagScheme runs the same derivation
+// over a table of cases on every pull request, which is what makes the scheme
+// something this repository checks rather than something it intends. What is
+// left to the workflow is *which release* — the tag of the object that triggered
+// it — and *where* — the registry repository and the credentials. Both are
+// genuinely properties of the deployment and of the event rather than of the tag
+// scheme, and the second is why docs/container/SPEC.md keeps the registry out of
+// the contract.
 //
 // # The three edge cases the plan settles
 //
@@ -41,11 +43,13 @@
 //     should follow has no defensible answer, and a pipeline that picked one
 //     would repoint a moving tag on a coin toss.
 //
-// A commit carrying no version tag at all is none of those: it publishes nothing
-// and succeeds, because "this commit is not a release" is an answer rather than
-// a fault. That is what lets the release workflow fire on every published
-// release — including the IR module's `irpb/vX.Y.Z`, which is not a release of
-// the image — without a filter naming tag shapes in YAML.
+// A release whose own tag is not a canonical version is none of those: it
+// publishes nothing and succeeds, because "this is not a release of the image"
+// is an answer rather than a fault. That is what lets the release workflow fire
+// on every published release — including the IR module's `irpb/vX.Y.Z` — without
+// a filter naming tag shapes in YAML, and it holds even when the two modules are
+// cut from one commit, because what decides is the tag of the release object
+// rather than whatever else points at the same tree.
 //
 // # Why re-running a release is safe
 //
@@ -128,6 +132,13 @@ func (m *Cpybkc) Release(
 	// this commit is a release, so a checkout without tags publishes nothing.
 	// +defaultPath="/.git"
 	gitDir *dagger.Directory,
+	// The tag of the release being published — `github.event.release.tag_name`
+	// on GitHub Actions. It is what decides whether this release is a release of
+	// the image: a canonical `vX.Y.Z` is one, and the IR module's `irpb/vX.Y.Z`
+	// is not. Given none, the refs at HEAD decide instead, which is what a run by
+	// hand against a checkout wants.
+	// +optional
+	tag string,
 	// The image's repository, without a tag — `ghcr.io/zaba505/cpybkc`.
 	repository string,
 	// The registry username to authenticate as.
@@ -150,20 +161,18 @@ func (m *Cpybkc) Release(
 	// +optional
 	invocation string,
 ) (string, error) {
-	plan, refs, err := m.releasePlan(ctx, gitDir)
-	if err != nil {
-		return "", err
-	}
-
-	if plan.version == "" {
-		return fmt.Sprintf("no version tag points at HEAD (refs: %s); nothing published",
-			strings.Join(refs, ", ")), nil
-	}
-
-	// Every credential the run needs is checked before the first byte moves. A
+	// Every credential the run needs is checked before the first byte moves, and
+	// before the run has worked out whether there is anything to publish. A
 	// publish that reached the registry and then found it had no way to sign
 	// would leave a tag pointing at an unattested image, and this project's
 	// contract says a published version tag is never repointed to correct that.
+	//
+	// Ahead of the decision rather than after it, so that the configuration is
+	// checked by every run of this job and not only by the ones that publish. A
+	// dropped `id-token: write`, an empty repository or a rotated secret would
+	// otherwise pass green on every `irpb` release and be discovered by the
+	// release that was supposed to push — which is the same "first real run is on
+	// a tag" failure this file is written against.
 	switch {
 	case repository == "":
 		return "", errors.New("repository is required: it is the image's full repository, without a tag")
@@ -173,6 +182,16 @@ func (m *Cpybkc) Release(
 		return "", errors.New("idTokenRequestUrl and idTokenRequestToken are both required: every published digest is signed, and signing exchanges a workload identity token")
 	case builder == "":
 		return "", errors.New("builder is required: the provenance predicate names what ran the release, and this module cannot know that")
+	}
+
+	plan, refs, err := m.releasePlan(ctx, gitDir, tag)
+	if err != nil {
+		return "", err
+	}
+
+	if plan.version == "" {
+		return fmt.Sprintf("%s is not a release of the image (refs at HEAD: %s); nothing published",
+			releaseName(tag), strings.Join(refs, ", ")), nil
 	}
 
 	digest, err := m.publishTags(ctx, repository, plan.tags, username, password)
@@ -211,11 +230,13 @@ func (m *Cpybkc) Release(
 // a version the image does not produce.
 //
 // The tags come from the same derivation Release publishes under, and the
-// decision about whether this commit is a release at all comes from the same
-// refs. A tagged commit that is not a release of the image — `irpb/v0.1.0`, the
-// IR module's own tag — leaves the notes exactly as they were, which is what lets
-// the release workflow run this step on every release without a filter naming
-// tag shapes in YAML.
+// decision about whether this release is a release of the image at all is made
+// from the same input — the release's own tag. A release that is not one of the
+// image — `irpb/v0.1.0`, the IR module's own tag — leaves the notes exactly as
+// they were, which is what lets the release workflow run this step on every
+// release without a filter naming tag shapes in YAML. Passing the same tag here
+// as to Release is what keeps the two from disagreeing: the block is spliced
+// into the notes of the release it describes, and into no other.
 //
 // repository is optional, for the same reason it is Release's argument rather
 // than a constant: where the image is published is a property of the deployment.
@@ -227,6 +248,11 @@ func (m *Cpybkc) ReleaseNotes(
 	// is.
 	// +defaultPath="/.git"
 	gitDir *dagger.Directory,
+	// The tag of the release whose notes these are — the same one Release was
+	// given. It decides whether this release is a release of the image; given
+	// none, the refs at HEAD decide.
+	// +optional
+	tag string,
 	// The notes the release carries now. Empty is a release whose notes are
 	// still to be written.
 	// +optional
@@ -236,7 +262,7 @@ func (m *Cpybkc) ReleaseNotes(
 	// +optional
 	repository string,
 ) (string, error) {
-	plan, _, err := m.releasePlan(ctx, gitDir)
+	plan, _, err := m.releasePlan(ctx, gitDir, tag)
 	if err != nil {
 		return "", err
 	}
@@ -283,6 +309,7 @@ func (m *Cpybkc) ReleaseNotes(
 func (m *Cpybkc) TagScheme() error {
 	cases := []struct {
 		refs    []string
+		tag     string
 		version string
 		tags    []string
 		fails   bool
@@ -320,27 +347,86 @@ func (m *Cpybkc) TagScheme() error {
 		// rejected: the release workflow fires on every published release, and
 		// this is the one that must pass through it publishing nothing.
 		{refs: []string{"refs/tags/irpb/v0.1.0"}},
+		// A canonical tag beside the remote refs a fetched checkout carries still
+		// publishes: everything that is not a version tag is ignored rather than
+		// treated as evidence of a mistake.
+		{
+			refs:    []string{"refs/tags/v0.2.0", "refs/heads/main", "refs/remotes/origin/main"},
+			version: "v0.2.0",
+			tags:    []string{"v0.2.0", "v0.2", "v0", "latest"},
+		},
+		// Both modules cut from one tree, which is the shape that decides whether
+		// the release workflow's claim about `irpb/vX.Y.Z` is true. The refs are
+		// identical in all three cases below and the answers are not, because what
+		// decides is the release object's own tag rather than what else happens to
+		// point at the same commit.
+		{
+			refs:    []string{"refs/tags/v0.2.0", "refs/tags/irpb/v0.1.0", "refs/heads/main"},
+			tag:     "v0.2.0",
+			version: "v0.2.0",
+			tags:    []string{"v0.2.0", "v0.2", "v0", "latest"},
+		},
+		// The IR module's release reaches this and publishes nothing, rather than
+		// finding the CLI's tag at HEAD and republishing the image under it.
+		{
+			refs: []string{"refs/tags/v0.2.0", "refs/tags/irpb/v0.1.0", "refs/heads/main"},
+			tag:  "irpb/v0.1.0",
+		},
+		// With no tag given the refs decide, which is a run by hand rather than a
+		// release object.
+		{
+			refs:    []string{"refs/tags/v0.2.0", "refs/tags/irpb/v0.1.0", "refs/heads/main"},
+			version: "v0.2.0",
+			tags:    []string{"v0.2.0", "v0.2", "v0", "latest"},
+		},
+		// A release whose tag is not the one this checkout is at would publish
+		// bytes that tag was never cut from.
+		{refs: []string{"refs/tags/v0.2.0", "refs/heads/main"}, tag: "v0.3.0", fails: true},
 		// Build metadata cannot be spelled in an OCI tag, so a version carrying
-		// it is refused rather than silently mangled into one that can.
+		// it is refused rather than silently mangled into one that can — and a
+		// prerelease carrying it is refused too, rather than taking the
+		// prerelease's early return before the metadata is ever looked at.
 		{refs: []string{"refs/tags/v0.2.0+build.5"}, fails: true},
+		{refs: []string{"refs/tags/v0.3.0-rc.1+build.5"}, fails: true},
 		// Two version tags at HEAD: which of them `latest` should follow is not a
 		// question with a defensible answer, so it is an error and not a choice.
+		// Naming one of them as the release does not settle it, because the moving
+		// tags are shared between the two.
 		{refs: []string{"refs/tags/v0.2.0", "refs/tags/v0.3.0"}, fails: true},
+		{refs: []string{"refs/tags/v0.2.0", "refs/tags/v0.3.0"}, tag: "v0.3.0", fails: true},
 	}
 
 	var errs []error
+
 	for _, c := range cases {
-		plan, err := planRelease(c.refs)
-		switch {
-		case c.fails && err == nil:
-			errs = append(errs, fmt.Errorf("%v: planned %v, want an error", c.refs, plan.tags))
-		case c.fails:
-		case err != nil:
-			errs = append(errs, fmt.Errorf("%v: %w", c.refs, err))
-		case plan.version != c.version:
-			errs = append(errs, fmt.Errorf("%v: version is %q, want %q", c.refs, plan.version, c.version))
-		case !slices.Equal(plan.tags, c.tags):
-			errs = append(errs, fmt.Errorf("%v: tags are %v, want %v", c.refs, plan.tags, c.tags))
+		plan, err := planRelease(c.refs, c.tag)
+
+		if c.fails {
+			if err == nil {
+				errs = append(errs, fmt.Errorf("%v (release %q): planned %v, want an error",
+					c.refs, releaseName(c.tag), plan.tags))
+			}
+
+			continue
+		}
+
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%v (release %q): %w", c.refs, releaseName(c.tag), err))
+
+			continue
+		}
+
+		// Two independent assertions rather than a chain: a case that got both
+		// the version and the tags wrong should say so twice, and the tags are the
+		// half a reader of this table came for.
+		if plan.version != c.version {
+			errs = append(errs, fmt.Errorf("%v (release %q): version is %q, want %q",
+				c.refs, releaseName(c.tag), plan.version, c.version))
+		}
+
+		if !slices.Equal(plan.tags, c.tags) {
+			errs = append(errs, fmt.Errorf("%v (release %q): tags are %v, want %v",
+				c.refs, releaseName(c.tag), plan.tags, c.tags))
 		}
 	}
 
@@ -371,8 +457,23 @@ func (m *Cpybkc) ReleaseNotesContract() error {
 
 	const irVersion = 7
 
-	release := releasePlan{version: "v0.2.0", tags: []string{"v0.2.0", "v0.2", "v0", "latest"}}
-	prerelease := releasePlan{version: "v0.3.0-rc.1", tags: []string{"v0.3.0-rc.1"}}
+	// Both plans go through versionTags rather than being written out as literals,
+	// so that what the block says about a release is checked against the tags that
+	// release would actually publish. A hand-built plan would let the block call a
+	// stable release a prerelease, or the reverse, and nothing here would notice.
+	plan := func(version string) releasePlan {
+		tags, err := versionTags(version)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("deriving the tags for %s: %w", version, err))
+
+			return releasePlan{version: version}
+		}
+
+		return releasePlan{version: version, tags: tags}
+	}
+
+	release := plan("v0.2.0")
+	prerelease := plan("v0.3.0-rc.1")
 
 	block := releaseNotesBlock(release, irVersion, "ghcr.io/zaba505/cpybkc")
 	for _, want := range []string{
@@ -389,12 +490,24 @@ func (m *Cpybkc) ReleaseNotesContract() error {
 	// A prerelease's block has to say that it moves nothing, because a reader who
 	// sees a release published and assumes `v0` followed it is exactly who this
 	// sentence is for.
+	//
+	// Two independent assertions and not a chain: a block that both mentions
+	// `latest` and fails to say it is a prerelease is wrong twice, and a chain
+	// would report one of them and hide the other — including the case where the
+	// first fires spuriously and silently retires the second.
 	pre := releaseNotesBlock(prerelease, irVersion, "")
-	switch {
-	case strings.Contains(pre, "`latest`"):
+	if strings.Contains(pre, "`latest`") {
 		errs = append(errs, fmt.Errorf("a prerelease's notes mention `latest`, which it does not move:\n%s", pre))
-	case !strings.Contains(pre, "prerelease"):
+	}
+
+	if !strings.Contains(pre, "prerelease") {
 		errs = append(errs, fmt.Errorf("a prerelease's notes do not say so:\n%s", pre))
+	}
+
+	// And the stable release must not call itself one, which is the half a plan
+	// built out of literals could never have caught.
+	if strings.Contains(block, "prerelease") {
+		errs = append(errs, fmt.Errorf("a stable release's notes call it a prerelease:\n%s", block))
 	}
 
 	// With no repository there is no reference to pull, and the block must not
@@ -469,13 +582,13 @@ type releasePlan struct {
 // releasePlan reads the refs at HEAD and plans the release they describe,
 // returning the refs alongside it so that a run publishing nothing can say what
 // it saw.
-func (m *Cpybkc) releasePlan(ctx context.Context, gitDir *dagger.Directory) (releasePlan, []string, error) {
+func (m *Cpybkc) releasePlan(ctx context.Context, gitDir *dagger.Directory, tag string) (releasePlan, []string, error) {
 	refs, err := headRefs(ctx, m.Source, gitDir)
 	if err != nil {
 		return releasePlan{}, nil, err
 	}
 
-	plan, err := planRelease(refs)
+	plan, err := planRelease(refs, tag)
 	if err != nil {
 		return releasePlan{}, refs, err
 	}
@@ -483,14 +596,54 @@ func (m *Cpybkc) releasePlan(ctx context.Context, gitDir *dagger.Directory) (rel
 	return plan, refs, nil
 }
 
-// planRelease reads the refs at HEAD and returns what to publish.
+// releaseName is how a run with nothing to publish refers to what it was asked
+// about, so that the report reads the same whether a tag was given or not.
+func releaseName(tag string) string {
+	if tag == "" {
+		return "HEAD"
+	}
+
+	return tag
+}
+
+// planRelease returns what to publish, from the tag the release carries and the
+// refs at HEAD.
+//
+// # Which of the two decides
+//
+// The tag is the release object that triggered the run, and where there is one it
+// is what decides: a release is a release of the image when its own tag is a
+// canonical version, and is not otherwise. Deciding from the refs at HEAD instead
+// would be a different question wearing the same answer, and the two come apart
+// exactly when one commit carries two releases — which this repository is built
+// to do, cutting `vX.Y.Z` for the CLI and `irpb/vX.Y.Z` for the IR module from
+// one tree. Publishing the IR module's release would then find the CLI's tag at
+// HEAD, republish the image under it at a second point in time, and splice the
+// image's notes into the IR module's release, which describes an image that
+// release did not publish.
+//
+// Given no tag the refs at HEAD decide, which is what `dagger call release` run
+// by hand against a checkout wants: there is no release object to name, and the
+// commit is the only thing that can say what it is.
 //
 // A ref counts only if it is a tag whose name is a canonical version. Everything
 // else — branches, remote refs, `refs/stash`, a tag named `nightly`, the IR
 // module's `irpb/vX.Y.Z` — is ignored rather than rejected, because a release
 // commit routinely carries several refs and none of the others is evidence of a
 // mistake.
-func planRelease(refs []string) (releasePlan, error) {
+//
+// # What is still an error
+//
+// Two canonical version tags at HEAD, whichever release triggered the run: which
+// of them the moving tags should follow has no defensible answer, and a run that
+// picked one would repoint a moving tag on a coin toss. The tag being given does
+// not settle it, because the moving tags are shared between both.
+//
+// A tag that does not point at HEAD, too. The image is built from this checkout,
+// so publishing it under a tag cut from somewhere else would put a name on bytes
+// that name was never given to — and a published version tag is never repointed
+// to take it back.
+func planRelease(refs []string, tag string) (releasePlan, error) {
 	var versions []string
 
 	for _, ref := range refs {
@@ -504,22 +657,47 @@ func planRelease(refs []string) (releasePlan, error) {
 		}
 	}
 
-	switch len(versions) {
-	case 0:
-		return releasePlan{}, nil
-	case 1:
-	default:
+	if len(versions) > 1 {
 		return releasePlan{}, fmt.Errorf("HEAD carries more than one version tag (%s): which release this is, and "+
 			"which of them the moving tags should follow, is not a question this pipeline can answer",
 			strings.Join(versions, ", "))
 	}
 
-	tags, err := versionTags(versions[0])
+	var version string
+
+	switch {
+	case tag == "":
+		if len(versions) == 1 {
+			version = versions[0]
+		}
+	default:
+		// The release that triggered this run is a release of something else —
+		// the IR module, most often. Publishing nothing is the answer rather than
+		// a fault, which is what lets the workflow fire on every release without
+		// a filter naming tag shapes in YAML.
+		if _, ok := parseVersion(tag); !ok {
+			return releasePlan{}, nil
+		}
+
+		if !slices.Contains(versions, tag) {
+			return releasePlan{}, fmt.Errorf("the release's tag %q does not point at HEAD (refs: %s): the image is "+
+				"built from this checkout, so publishing it under that tag would name bytes the tag was never cut from",
+				tag, strings.Join(refs, ", "))
+		}
+
+		version = tag
+	}
+
+	if version == "" {
+		return releasePlan{}, nil
+	}
+
+	tags, err := versionTags(version)
 	if err != nil {
 		return releasePlan{}, err
 	}
 
-	return releasePlan{version: versions[0], tags: tags}, nil
+	return releasePlan{version: version, tags: tags}, nil
 }
 
 // semver is a parsed canonical version tag.
@@ -566,6 +744,24 @@ func parseVersion(tag string) (semver, bool) {
 // that do: the minor tag, the major tag and the rolling tag. A prerelease
 // publishes its own tag and nothing else, for the reason this file's comment
 // gives.
+//
+// # What a pure function of one version cannot see
+//
+// The moving tags follow *this* release, because that is what
+// docs/container/SPEC.md's table says they do — the minor tag moves on each
+// patch, the major tag and the rolling tag on each release. Releasing out of
+// order therefore walks them backwards: a backport `v0.1.5` cut after `v0.2.0`
+// has shipped publishes `v0.1.5, v0.1, v0, latest`, and `v0` and `latest` land
+// back on the older image. `v0` is the tag CONTRIBUTING.md tells a derived
+// Dockerfile to pin, so that is not a small blast radius.
+//
+// Nothing here can catch it: this is a function of one version, and TagScheme
+// runs it over refs rather than over a registry, so neither sees what is already
+// published. Making the moving tags follow the *highest* released version rather
+// than the most recent one is a change to the published tag table and not an
+// implementation detail, so it belongs in that document before it belongs here.
+// Until then the constraint is on the releaser: cut releases in ascending order,
+// and cut a backport before the release that supersedes it.
 func versionTags(tag string) ([]string, error) {
 	v, ok := parseVersion(tag)
 	if !ok {
@@ -691,7 +887,14 @@ func releaseNotesBlock(plan releasePlan, irVersion int, repository string) strin
 		quoted = append(quoted, "`"+tag+"`")
 	}
 
-	if len(plan.tags) == 1 {
+	// Read off the version rather than inferred from the number of tags. That the
+	// two agree is a property of versionTags today and not a fact about a
+	// release, and this block is the one artifact a reader cannot check against
+	// anything else — so it says "prerelease" when the version is one, and not
+	// when the tag list happens to have a single entry.
+	v, _ := parseVersion(plan.version)
+
+	if v.prerelease != "" {
 		fmt.Fprintf(&b, "This is a **prerelease**. It publishes %s and moves none of the tags a derived Dockerfile\n"+
 			"pins to pick up fixes: a release candidate is not a fix anybody consented to be given.\n\n", quoted[0])
 	} else {

--- a/.dagger/release.go
+++ b/.dagger/release.go
@@ -1,0 +1,776 @@
+// This file publishes a release: it decides from the refs at HEAD whether there
+// is one, works out which tags it carries, pushes the multi-platform image under
+// every one of them, hands the digest it resolved to sign.go's Attest, and
+// renders the block of release notes that says which IR version the image just
+// published speaks (#59).
+//
+// # Why the decision is here and not an `if:` on a job
+//
+// A workflow that decided would have to write the tag scheme down to do it — a
+// `for tag in "$VERSION" "${VERSION%.*}" …` line, or a job-level `if:` naming
+// the ref shape that counts as a release. That is a second place the scheme
+// lives, beside docs/container/SPEC.md's tag table, in a file that runs once per
+// release and is exercised nowhere else. The two drift in the direction nobody
+// notices: a prerelease moves `latest`, or a patch release forgets to move `v0`,
+// and both are discovered by somebody whose `FROM` line resolved to an image
+// they did not ask for.
+//
+// So the module reads the refs at HEAD and everything downstream of that reading
+// is a function of them. TagScheme runs the same derivation over a table of
+// cases on every pull request, which is what makes the scheme something this
+// repository checks rather than something it intends. What is left to the
+// workflow is *where* — the registry repository and the credentials — which
+// genuinely is a property of the deployment rather than of the release, and is
+// the reason docs/container/SPEC.md keeps the registry out of the contract.
+//
+// # The three edge cases the plan settles
+//
+// Each of these is a question a release workflow otherwise discovers in
+// production, at the one moment where this project's own contract forbids the
+// obvious fix:
+//
+//   - A **prerelease** publishes its own full version tag and moves none of the
+//     other three. `v0`, `v0.2` and `latest` are what a derived Dockerfile pins
+//     to pick up fixes without an edit, and a release candidate is not a fix
+//     anybody consented to be given.
+//   - A version carrying **`+build` metadata** is refused rather than mangled.
+//     An OCI tag is `[A-Za-z0-9_.-]`, which has no `+` in it, so dropping the
+//     metadata would publish `v0.2.0` and `v0.2.0+build.5` under one tag — and a
+//     published full version tag is never repointed.
+//   - **Two version tags on one commit** is an error. Which of them `latest`
+//     should follow has no defensible answer, and a pipeline that picked one
+//     would repoint a moving tag on a coin toss.
+//
+// A commit carrying no version tag at all is none of those: it publishes nothing
+// and succeeds, because "this commit is not a release" is an answer rather than
+// a fault. That is what lets the release workflow fire on every published
+// release — including the IR module's `irpb/vX.Y.Z`, which is not a release of
+// the image — without a filter naming tag shapes in YAML.
+//
+// # Why re-running a release is safe
+//
+// docs/container/SPEC.md says a published full version tag is never repointed,
+// and that sits oddly beside a job somebody may have to run twice. Both hold at
+// once because the image is a function of the source: the binary is built
+// -trimpath and CGO-free, the IR artifacts are byte-deterministic, and the image
+// is assembled from those alone. A second run at the same tag therefore pushes
+// the same bytes, the registry stores one manifest, and every tag lands back on
+// the digest it already named — a repoint of a tag onto itself, which is no
+// repoint at all. publishTags asserts exactly that, by requiring every tag of one
+// release to resolve to one digest.
+//
+// What a re-run does add is another signature and another set of attestations on
+// that digest. Those are additive by design — cosign attaches rather than
+// replaces, and a consumer verifying finds more than one valid statement rather
+// than a conflict — so a re-run costs a transparency log entry and nothing else.
+//
+// The notes block is the one part that would otherwise accumulate, since
+// appending twice would say everything twice. It is delimited and regenerated
+// rather than appended, so splicing it into a body that already carries one is a
+// fixed point.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+
+	"dagger/cpybkc/internal/dagger"
+)
+
+const (
+	// rollingTag is docs/container/SPEC.md's rolling tag, the one that moves on
+	// every release.
+	rollingTag = "latest"
+
+	// notesOpen and notesClose delimit the block Release Notes maintains inside a
+	// release's body. They are HTML comments because GitHub renders release notes
+	// as Markdown and a comment is the one thing that survives rendering without
+	// appearing in it.
+	//
+	// A delimited block is what makes the step idempotent: the notes are
+	// regenerated between the markers rather than appended after whatever is
+	// there, so a release job run twice produces one block and not two.
+	notesOpen  = "<!-- cpybkc:image -->"
+	notesClose = "<!-- /cpybkc:image -->"
+)
+
+// Release publishes the base image for the release at HEAD, signs the digest it
+// resolved to and attaches its provenance and SBOMs (#59).
+//
+// Whether there is a release at all is decided here, from the refs at HEAD: a
+// single canonical version tag pointing at HEAD is a release, and anything else
+// — a branch alone, no tag, a tag that is not a version — is not. A run with no
+// release publishes nothing and succeeds; a run with two version tags fails, for
+// the reason this file's comment gives.
+//
+// repository is where to publish, without a tag — `ghcr.io/zaba505/cpybkc`. It
+// is the caller's because a mirror or an internal registry serves the same
+// release, and docs/container/SPEC.md holds the registry out of the contract for
+// the same reason. Which tags exist is not the caller's, and is not spelled
+// anywhere but versionTags.
+//
+// Signing goes through Attest rather than through a signing path of this
+// function's own, so what a release signs is what `dagger call attestations`
+// checks the shape of on every pull request.
+//
+// It returns a report naming the repository, the digest and the tags now
+// pointing at it.
+//
+// +cache="never"
+func (m *Cpybkc) Release(
+	ctx context.Context,
+	// The repository's git metadata. The refs at HEAD are what decide whether
+	// this commit is a release, so a checkout without tags publishes nothing.
+	// +defaultPath="/.git"
+	gitDir *dagger.Directory,
+	// The image's repository, without a tag — `ghcr.io/zaba505/cpybkc`.
+	repository string,
+	// The registry username to authenticate as.
+	username string,
+	// The registry password or token to authenticate with.
+	password *dagger.Secret,
+	// The CI provider's OIDC token request endpoint —
+	// `ACTIONS_ID_TOKEN_REQUEST_URL` on GitHub Actions. Signing is keyless, and
+	// cosign exchanges a token from it for the certificate that signs.
+	idTokenRequestUrl string,
+	// The bearer token for that endpoint — `ACTIONS_ID_TOKEN_REQUEST_TOKEN` on
+	// GitHub Actions. A secret, because it mints identity tokens.
+	idTokenRequestToken *dagger.Secret,
+	// What ran this release, for the provenance predicate's builder — the
+	// workflow reference on GitHub Actions. This module cannot know what invoked
+	// it, and provenance that guessed would be provenance about nothing.
+	builder string,
+	// The run this release came from — a URL to the workflow run on GitHub
+	// Actions.
+	// +optional
+	invocation string,
+) (string, error) {
+	plan, refs, err := m.releasePlan(ctx, gitDir)
+	if err != nil {
+		return "", err
+	}
+
+	if plan.version == "" {
+		return fmt.Sprintf("no version tag points at HEAD (refs: %s); nothing published",
+			strings.Join(refs, ", ")), nil
+	}
+
+	// Every credential the run needs is checked before the first byte moves. A
+	// publish that reached the registry and then found it had no way to sign
+	// would leave a tag pointing at an unattested image, and this project's
+	// contract says a published version tag is never repointed to correct that.
+	switch {
+	case repository == "":
+		return "", errors.New("repository is required: it is the image's full repository, without a tag")
+	case username == "" || password == nil:
+		return "", errors.New("username and password are both required: a release is pushed to a registry that authenticates")
+	case idTokenRequestUrl == "" || idTokenRequestToken == nil:
+		return "", errors.New("idTokenRequestUrl and idTokenRequestToken are both required: every published digest is signed, and signing exchanges a workload identity token")
+	case builder == "":
+		return "", errors.New("builder is required: the provenance predicate names what ran the release, and this module cannot know that")
+	}
+
+	digest, err := m.publishTags(ctx, repository, plan.tags, username, password)
+	if err != nil {
+		return "", err
+	}
+
+	attested, err := m.Attest(ctx, gitDir, repository+"@"+digest, username, password,
+		idTokenRequestUrl, idTokenRequestToken, builder, plan.version, plan.tags, invocation)
+	if err != nil {
+		return "", err
+	}
+
+	// Attest's own report is appended whole rather than merged into this one. It
+	// is what `dagger call attest` prints on its own, and a release reading
+	// differently from the function it called would be a second account of one
+	// event.
+	var report strings.Builder
+	fmt.Fprintf(&report, "%s\n  version:    %s\n  digest:     %s\n  tags:       %s\n\n",
+		repository, plan.version, digest, strings.Join(plan.tags, ", "))
+	report.WriteString(attested)
+
+	return report.String(), nil
+}
+
+// ReleaseNotes returns a release's notes with the block naming the published
+// image spliced into them (#59).
+//
+// The block states **which IR version the image speaks**, which is the one fact
+// about a release a reader cannot recover from the tag. A generator refuses a
+// descriptor written against an IR version it does not implement
+// (docs/plugin/SPEC.md), and the person reading that refusal has to decide
+// whether to upgrade the generator or pin the CLI — so the number the CLI in
+// this image writes belongs where somebody looking at the release will find it.
+// It is read out of the built CLI rather than restated here, so it cannot claim
+// a version the image does not produce.
+//
+// The tags come from the same derivation Release publishes under, and the
+// decision about whether this commit is a release at all comes from the same
+// refs. A tagged commit that is not a release of the image — `irpb/v0.1.0`, the
+// IR module's own tag — leaves the notes exactly as they were, which is what lets
+// the release workflow run this step on every release without a filter naming
+// tag shapes in YAML.
+//
+// repository is optional, for the same reason it is Release's argument rather
+// than a constant: where the image is published is a property of the deployment.
+// Given one, the block names the reference to pull; given none, it names the
+// tags alone.
+func (m *Cpybkc) ReleaseNotes(
+	ctx context.Context,
+	// The repository's git metadata, for the refs that decide what this release
+	// is.
+	// +defaultPath="/.git"
+	gitDir *dagger.Directory,
+	// The notes the release carries now. Empty is a release whose notes are
+	// still to be written.
+	// +optional
+	notes *dagger.File,
+	// The image's repository, without a tag — `ghcr.io/zaba505/cpybkc`. Empty
+	// leaves the pull reference out of the block.
+	// +optional
+	repository string,
+) (string, error) {
+	plan, _, err := m.releasePlan(ctx, gitDir)
+	if err != nil {
+		return "", err
+	}
+
+	var body string
+	if notes != nil {
+		body, err = notes.Contents(ctx)
+		if err != nil {
+			return "", fmt.Errorf("reading the notes the release carries now: %w", err)
+		}
+	}
+
+	// Not a release of the image: the notes come back untouched, so the step that
+	// writes them back is a no-op rather than an error.
+	if plan.version == "" {
+		return body, nil
+	}
+
+	irVersion, err := m.irVersion(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return spliceNotes(body, releaseNotesBlock(plan, irVersion, repository))
+}
+
+// TagScheme is docs/container/SPEC.md's tag table executed rather than read.
+//
+// The table is the part of a release that cannot be checked by releasing. A tag
+// that moved when it should not have is discovered by a consumer whose `FROM`
+// line resolved to something they did not ask for, and by then the tag has been
+// published and this project's own contract says it is never repointed. So the
+// derivation is a pure function of the refs, and this runs it over the cases that
+// matter — including the ones with no release in them, since "publishes nothing"
+// is as much a promise as "publishes four tags".
+//
+// Every expected tag below is a literal, never one of this file's own constants.
+// A table written in terms of rollingTag would move with it and pass on a release
+// that had quietly started publishing something else under a different name,
+// which is the one failure this check exists to catch.
+//
+// +check
+// +cache="session"
+func (m *Cpybkc) TagScheme() error {
+	cases := []struct {
+		refs    []string
+		version string
+		tags    []string
+		fails   bool
+	}{
+		// A release: the full version tag, plus the three that move.
+		{
+			refs:    []string{"refs/tags/v0.2.0", "refs/heads/main"},
+			version: "v0.2.0",
+			tags:    []string{"v0.2.0", "v0.2", "v0", "latest"},
+		},
+		{
+			refs:    []string{"refs/tags/v1.10.3"},
+			version: "v1.10.3",
+			tags:    []string{"v1.10.3", "v1.10", "v1", "latest"},
+		},
+		// A prerelease publishes itself and moves nothing: `v0`, `v0.2` and
+		// `latest` are what a derived Dockerfile pins to get fixes, and a release
+		// candidate is not a fix anybody asked to be given.
+		{
+			refs:    []string{"refs/tags/v0.3.0-rc.1"},
+			version: "v0.3.0-rc.1",
+			tags:    []string{"v0.3.0-rc.1"},
+		},
+		// Not a release of the image. A branch, no refs at all, a tag that is not
+		// a version, and three tags that look like versions and are not canonical
+		// all publish nothing rather than publishing something surprising.
+		{refs: []string{"refs/heads/main"}},
+		{refs: []string{}},
+		{refs: []string{"refs/tags/nightly", "refs/heads/main"}},
+		{refs: []string{"refs/tags/0.2.0"}},
+		{refs: []string{"refs/tags/v0.2"}},
+		{refs: []string{"refs/tags/v01.2.0"}},
+		// The IR module's own tag, which is a release of something this pipeline
+		// does not publish an image for. It has to be ignored rather than
+		// rejected: the release workflow fires on every published release, and
+		// this is the one that must pass through it publishing nothing.
+		{refs: []string{"refs/tags/irpb/v0.1.0"}},
+		// Build metadata cannot be spelled in an OCI tag, so a version carrying
+		// it is refused rather than silently mangled into one that can.
+		{refs: []string{"refs/tags/v0.2.0+build.5"}, fails: true},
+		// Two version tags at HEAD: which of them `latest` should follow is not a
+		// question with a defensible answer, so it is an error and not a choice.
+		{refs: []string{"refs/tags/v0.2.0", "refs/tags/v0.3.0"}, fails: true},
+	}
+
+	var errs []error
+	for _, c := range cases {
+		plan, err := planRelease(c.refs)
+		switch {
+		case c.fails && err == nil:
+			errs = append(errs, fmt.Errorf("%v: planned %v, want an error", c.refs, plan.tags))
+		case c.fails:
+		case err != nil:
+			errs = append(errs, fmt.Errorf("%v: %w", c.refs, err))
+		case plan.version != c.version:
+			errs = append(errs, fmt.Errorf("%v: version is %q, want %q", c.refs, plan.version, c.version))
+		case !slices.Equal(plan.tags, c.tags):
+			errs = append(errs, fmt.Errorf("%v: tags are %v, want %v", c.refs, plan.tags, c.tags))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// ReleaseNotesContract checks the block a release's notes carry, and the splice
+// that puts it there (#59).
+//
+// Two things, and each is a failure a release would otherwise ship once and
+// never take back:
+//
+//   - The block says what it is for. It names the IR version the image speaks —
+//     the fact a reader cannot recover from the tag — and every tag the release
+//     publishes, and it says of a prerelease that it moves none of them.
+//   - Splicing is idempotent. A release job re-run appends nothing: splicing into
+//     a body that already carries a block replaces that block, leaving everything
+//     around it alone, and a second splice is a fixed point.
+//
+// What it does not check is the number itself against a constant. The IR version
+// is read out of the built CLI at release time precisely so that there is one
+// statement of it, and a literal here would be the second.
+//
+// +check
+// +cache="session"
+func (m *Cpybkc) ReleaseNotesContract() error {
+	var errs []error
+
+	const irVersion = 7
+
+	release := releasePlan{version: "v0.2.0", tags: []string{"v0.2.0", "v0.2", "v0", "latest"}}
+	prerelease := releasePlan{version: "v0.3.0-rc.1", tags: []string{"v0.3.0-rc.1"}}
+
+	block := releaseNotesBlock(release, irVersion, "ghcr.io/zaba505/cpybkc")
+	for _, want := range []string{
+		"IR version 7",
+		"v0.2.0", "`v0.2`", "`v0`", "`latest`",
+		"ghcr.io/zaba505/cpybkc:v0.2.0",
+		notesOpen, notesClose,
+	} {
+		if !strings.Contains(block, want) {
+			errs = append(errs, fmt.Errorf("the release notes block does not mention %q:\n%s", want, block))
+		}
+	}
+
+	// A prerelease's block has to say that it moves nothing, because a reader who
+	// sees a release published and assumes `v0` followed it is exactly who this
+	// sentence is for.
+	pre := releaseNotesBlock(prerelease, irVersion, "")
+	switch {
+	case strings.Contains(pre, "`latest`"):
+		errs = append(errs, fmt.Errorf("a prerelease's notes mention `latest`, which it does not move:\n%s", pre))
+	case !strings.Contains(pre, "prerelease"):
+		errs = append(errs, fmt.Errorf("a prerelease's notes do not say so:\n%s", pre))
+	}
+
+	// With no repository there is no reference to pull, and the block must not
+	// invent one.
+	if strings.Contains(pre, "ghcr.io") {
+		errs = append(errs, fmt.Errorf("a block rendered without a repository names one anyway:\n%s", pre))
+	}
+
+	// The splice, over the three bodies a release's notes can be in.
+	for _, c := range []struct {
+		name string
+		body string
+	}{
+		{"notes nobody has written yet", ""},
+		{"notes somebody wrote", "## What changed\n\n- the parser got faster\n"},
+		{"notes ending without a newline", "## What changed"},
+	} {
+		once, err := spliceNotes(c.body, block)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", c.name, err))
+
+			continue
+		}
+
+		if c.body != "" && !strings.Contains(once, strings.TrimSpace(c.body)) {
+			errs = append(errs, fmt.Errorf("%s: the splice dropped what was already there:\n%s", c.name, once))
+		}
+
+		if !strings.Contains(once, block) {
+			errs = append(errs, fmt.Errorf("%s: the splice did not add the block:\n%s", c.name, once))
+		}
+
+		// The property the release job rests on: running it again changes
+		// nothing. The second splice is given a *different* block, so a fixed
+		// point cannot be reached by the block happening to be identical.
+		twice, err := spliceNotes(once, releaseNotesBlock(prerelease, irVersion, ""))
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s, spliced twice: %w", c.name, err))
+
+			continue
+		}
+
+		if strings.Count(twice, notesOpen) != 1 || strings.Count(twice, notesClose) != 1 {
+			errs = append(errs, fmt.Errorf("%s: splicing twice left %d blocks, want 1:\n%s",
+				c.name, strings.Count(twice, notesOpen), twice))
+		}
+
+		if strings.Contains(twice, "v0.2.0") {
+			errs = append(errs, fmt.Errorf("%s: splicing twice kept the first block's content:\n%s", c.name, twice))
+		}
+	}
+
+	// A body carrying an opening marker with no closing one is refused rather
+	// than appended to. Appending would leave two openings, and the next release
+	// would splice over the wrong region — which is a release's notes rewritten
+	// by a bug nobody could see coming.
+	if _, err := spliceNotes("## What changed\n\n"+notesOpen+"\nhalf a block\n", block); err == nil {
+		errs = append(errs, errors.New("a body with an unterminated block was spliced into rather than refused"))
+	}
+
+	return errors.Join(errs...)
+}
+
+// releasePlan is what the refs at HEAD decided: the version being released, and
+// every tag that ends up pointing at it. A zero value is "this commit is not a
+// release of the image".
+type releasePlan struct {
+	version string
+	tags    []string
+}
+
+// releasePlan reads the refs at HEAD and plans the release they describe,
+// returning the refs alongside it so that a run publishing nothing can say what
+// it saw.
+func (m *Cpybkc) releasePlan(ctx context.Context, gitDir *dagger.Directory) (releasePlan, []string, error) {
+	refs, err := headRefs(ctx, m.Source, gitDir)
+	if err != nil {
+		return releasePlan{}, nil, err
+	}
+
+	plan, err := planRelease(refs)
+	if err != nil {
+		return releasePlan{}, refs, err
+	}
+
+	return plan, refs, nil
+}
+
+// planRelease reads the refs at HEAD and returns what to publish.
+//
+// A ref counts only if it is a tag whose name is a canonical version. Everything
+// else — branches, remote refs, `refs/stash`, a tag named `nightly`, the IR
+// module's `irpb/vX.Y.Z` — is ignored rather than rejected, because a release
+// commit routinely carries several refs and none of the others is evidence of a
+// mistake.
+func planRelease(refs []string) (releasePlan, error) {
+	var versions []string
+
+	for _, ref := range refs {
+		name, ok := strings.CutPrefix(strings.TrimSpace(ref), "refs/tags/")
+		if !ok {
+			continue
+		}
+
+		if _, ok := parseVersion(name); ok {
+			versions = append(versions, name)
+		}
+	}
+
+	switch len(versions) {
+	case 0:
+		return releasePlan{}, nil
+	case 1:
+	default:
+		return releasePlan{}, fmt.Errorf("HEAD carries more than one version tag (%s): which release this is, and "+
+			"which of them the moving tags should follow, is not a question this pipeline can answer",
+			strings.Join(versions, ", "))
+	}
+
+	tags, err := versionTags(versions[0])
+	if err != nil {
+		return releasePlan{}, err
+	}
+
+	return releasePlan{version: versions[0], tags: tags}, nil
+}
+
+// semver is a parsed canonical version tag.
+type semver struct {
+	major      string
+	minor      string
+	patch      string
+	prerelease string
+	build      string
+}
+
+// parseVersion reads a canonical `vMAJOR.MINOR.PATCH` tag, with the optional
+// prerelease and build parts semantic versioning allows.
+//
+// Canonical is meant strictly: `0.2.0` without the `v`, `v0.2` without the patch
+// and `v01.2.0` with a leading zero are none of them versions, and a commit
+// tagged with one of them publishes nothing. That is the safe direction — a tag
+// this function does not recognise costs a release nobody meant to make, where
+// one it recognised too eagerly would move `latest` onto something that was never
+// a release.
+func parseVersion(tag string) (semver, bool) {
+	// Compiled per call rather than kept as package state: this runs a handful of
+	// times per release and once per case in TagScheme, and a package-level
+	// variable is a piece of shared state to reason about for no measurable gain.
+	re := regexp.MustCompile(`^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$`)
+
+	fields := re.FindStringSubmatch(tag)
+	if fields == nil {
+		return semver{}, false
+	}
+
+	return semver{
+		major:      fields[1],
+		minor:      fields[2],
+		patch:      fields[3],
+		prerelease: fields[4],
+		build:      fields[5],
+	}, true
+}
+
+// versionTags is docs/container/SPEC.md's tag table, as a function.
+//
+// A release publishes the full version tag, which never moves, and the three
+// that do: the minor tag, the major tag and the rolling tag. A prerelease
+// publishes its own tag and nothing else, for the reason this file's comment
+// gives.
+func versionTags(tag string) ([]string, error) {
+	v, ok := parseVersion(tag)
+	if !ok {
+		return nil, fmt.Errorf("%q is not a canonical version tag", tag)
+	}
+
+	// An OCI tag is [A-Za-z0-9_.-], which has no `+` in it. Refusing is the only
+	// honest answer: mangling the metadata away would publish `v0.2.0` and
+	// `v0.2.0+build.5` under one name, and this project's contract says a
+	// published version tag is never repointed.
+	if v.build != "" {
+		return nil, fmt.Errorf("version tag %q carries build metadata, which cannot be spelled in an OCI tag: "+
+			"release it under a version without one", tag)
+	}
+
+	if v.prerelease != "" {
+		return []string{tag}, nil
+	}
+
+	return []string{
+		tag,
+		"v" + v.major + "." + v.minor,
+		"v" + v.major,
+		rollingTag,
+	}, nil
+}
+
+// publishTags pushes the image under every tag the release carries and returns
+// the digest they all point at.
+//
+// Every tag is a separate push of the same content, so the registry stores one
+// manifest and the tags are names for it. The digests are required to agree,
+// which is the machine-checkable form of the promise the tag table makes: `v0.2`
+// and `v0.2.0` are the same image, or one of them is lying. It is also what makes
+// a re-run visibly safe — the second run pushes the same bytes, so every tag
+// lands back on the digest it already named.
+func (m *Cpybkc) publishTags(
+	ctx context.Context,
+	repository string,
+	tags []string,
+	username string,
+	password *dagger.Secret,
+) (string, error) {
+	var digest string
+
+	for _, tag := range tags {
+		ref, err := m.Publish(ctx, repository+":"+tag, username, password)
+		if err != nil {
+			return "", fmt.Errorf("publishing %s:%s: %w", repository, tag, err)
+		}
+
+		_, pushed, ok := strings.Cut(ref, "@")
+		if !ok {
+			return "", fmt.Errorf("publishing %s:%s returned %q, which is not digest-qualified",
+				repository, tag, ref)
+		}
+
+		switch {
+		case digest == "":
+			digest = pushed
+		case pushed != digest:
+			return "", fmt.Errorf("%s:%s published as %s but %s:%s published as %s: every tag of one release "+
+				"names one image", repository, tag, pushed, repository, tags[0], digest)
+		}
+	}
+
+	return digest, nil
+}
+
+// irVersion is the IR version the published image speaks, read out of the CLI
+// that image ships.
+//
+// Out of the artifact rather than out of the source: `cpybkc --version` names
+// the version its assembler stamps into every descriptor it writes, which is the
+// number a plugin's refusal quotes. A constant here would be a second statement
+// of it, and the day the two disagreed the release notes would be the ones that
+// lied.
+func (m *Cpybkc) irVersion(ctx context.Context) (int, error) {
+	line, err := m.versionLine(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	fields := regexp.MustCompile(`IR version (\d+)`).FindStringSubmatch(line)
+	if fields == nil {
+		return 0, fmt.Errorf("cpybkc --version wrote %q, which names no IR version", line)
+	}
+
+	version, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return 0, fmt.Errorf("cpybkc --version wrote %q, whose IR version is not a number: %w", line, err)
+	}
+
+	return version, nil
+}
+
+// releaseNotesBlock renders the block a release's notes carry.
+//
+// It is a pure function of the plan, the IR version and where the image was
+// published, so ReleaseNotesContract can read it back without a registry, a git
+// checkout or a release.
+//
+// repository empty leaves the pull reference out rather than guessing one: where
+// the image lives is a property of the deployment, and a block naming `ghcr.io`
+// on a mirror's release would be telling a reader to pull from somewhere this
+// release did not go.
+func releaseNotesBlock(plan releasePlan, irVersion int, repository string) string {
+	var b strings.Builder
+
+	b.WriteString(notesOpen)
+	b.WriteString("\n## The image this release publishes\n\n")
+
+	if repository != "" {
+		fmt.Fprintf(&b, "```console\n$ docker pull %s:%s\n```\n\n", repository, plan.version)
+	}
+
+	fmt.Fprintf(&b, "**This image speaks IR version %d.** Every descriptor the `cpybkc` in it writes carries that\n"+
+		"version, and a generator that implements a lower one refuses the descriptor rather than guessing — so a\n"+
+		"plugin used beside this image has to implement IR version %d or higher.\n\n", irVersion, irVersion)
+
+	quoted := make([]string, 0, len(plan.tags))
+	for _, tag := range plan.tags {
+		quoted = append(quoted, "`"+tag+"`")
+	}
+
+	if len(plan.tags) == 1 {
+		fmt.Fprintf(&b, "This is a **prerelease**. It publishes %s and moves none of the tags a derived Dockerfile\n"+
+			"pins to pick up fixes: a release candidate is not a fix anybody consented to be given.\n\n", quoted[0])
+	} else {
+		fmt.Fprintf(&b, "It is a multi-platform index over %s, published under %s. Only the first of those never\n"+
+			"moves; the other three follow releases, which is what they are for.\n\n",
+			strings.Join(platformNames(), " and "), strings.Join(quoted, ", "))
+	}
+
+	b.WriteString("What pinning each of those buys, and how to verify the signature and attestations on the digest\n" +
+		"they resolve to, is in [the base-image contract](docs/container/SPEC.md).\n")
+	b.WriteString(notesClose)
+
+	return b.String()
+}
+
+// platformNames is the published platform set as a consumer reads it.
+func platformNames() []string {
+	names := make([]string, 0, len(imagePlatforms()))
+	for _, p := range imagePlatforms() {
+		names = append(names, string(p))
+	}
+
+	return names
+}
+
+// spliceNotes puts the block into a release's notes: replacing the one already
+// there, or adding it at the end.
+//
+// Replacing rather than appending is the whole of why a release job can be run
+// twice. Everything outside the markers is left exactly as it was, because the
+// text around the block is somebody's release notes and this function is a
+// pipeline step.
+//
+// A body carrying an opening marker with no closing one is refused. Appending to
+// it would leave two openings, and the next release would splice over a region
+// starting at the first — which is a release's notes rewritten by a bug that
+// showed up one release after the one that caused it.
+func spliceNotes(body, block string) (string, error) {
+	open := strings.Index(body, notesOpen)
+	closing := strings.Index(body, notesClose)
+
+	switch {
+	case open < 0 && closing < 0:
+		trimmed := strings.TrimRight(body, "\n")
+		if trimmed == "" {
+			return block + "\n", nil
+		}
+
+		return trimmed + "\n\n" + block + "\n", nil
+	case open < 0:
+		return "", fmt.Errorf("the notes carry %q with no %q in front of it: the block cannot be replaced without "+
+			"guessing where it starts", notesClose, notesOpen)
+	case closing < 0:
+		return "", fmt.Errorf("the notes carry %q with no %q after it: the block cannot be replaced without "+
+			"guessing where it ends", notesOpen, notesClose)
+	case closing < open:
+		return "", fmt.Errorf("the notes carry %q before %q: the block cannot be replaced without guessing which "+
+			"is which", notesClose, notesOpen)
+	}
+
+	return body[:open] + block + body[closing+len(notesClose):], nil
+}
+
+// headRefs is every ref pointing at HEAD, as git reports them.
+func headRefs(ctx context.Context, source, gitDir *dagger.Directory) ([]string, error) {
+	out, err := gitContainer(source, gitDir).
+		WithExec([]string{"git", "for-each-ref", "--points-at", "HEAD", "--format=%(refname)"}).
+		Stdout(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("reading the refs at HEAD: %w", err)
+	}
+
+	var refs []string
+
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if ref := strings.TrimSpace(line); ref != "" {
+			refs = append(refs, ref)
+		}
+	}
+
+	return refs, nil
+}

--- a/.dagger/sign.go
+++ b/.dagger/sign.go
@@ -57,8 +57,9 @@
 // valid document per executable per platform tied to that platform's own binary.
 //
 // What is left unchecked until a release runs is the signing itself, and that is
-// stated rather than papered over: #59 is what first calls Attest with something
-// published, and the first release is where a wrong flag would show up.
+// stated rather than papered over: release.go's Release is what calls Attest
+// with something published (#59), and the first release is where a wrong flag
+// would show up.
 package main
 
 import (
@@ -207,10 +208,10 @@ func (m *Cpybkc) Provenance(
 // Attest signs a published image digest with cosign and attaches its provenance
 // and SBOMs (#58).
 //
-// It is the seam #59's release publishing comes through: that story resolves
+// It is the seam release publishing comes through: release.go's Release resolves
 // which tags a release carries and pushes them, and hands the digest they all
-// point at to this function. Nothing here decides what to publish or where —
-// where to publish is a property of the deployment, and a mirror or an internal
+// point at to this function (#59). Nothing here decides what to publish or where
+// — where to publish is a property of the deployment, and a mirror or an internal
 // registry serves the same release.
 //
 // The signature comes first and the attestations follow, deliberately. The

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,11 +6,11 @@ on:
     branches:
       - main
     # A release is a tag push and nothing else. The tag is here so the pipeline
-    # runs on one at all; whether that run publishes anything is the module's
-    # decision, made from the refs at HEAD, not this list and not an `if:` on a
-    # job. Today the answer is always no — the module builds a library, so there
-    # is nothing to publish yet — and that is a fact about which archetype
-    # .dagger/main.go calls rather than about this file.
+    # runs on one at all; this workflow publishes nothing under any of them, and
+    # never will. What a release publishes is release.yaml's, fired by a
+    # published release rather than by a pushed tag, and which tags it publishes
+    # under is the module's decision from the refs at HEAD (#59) — not this list
+    # and not an `if:` on a job.
     #
     # Two patterns because this repository publishes two modules. The CLI's
     # releases are vX.Y.Z; the IR module's are irpb/vX.Y.Z, which is not a prefix

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,8 +88,12 @@ jobs:
       # never been run against — which is the difference between this repository
       # and every other one that the module exists to prevent. It is the same
       # command CONTRIBUTING.md gives contributors, for the same reason.
+      # set -euo pipefail because a `run:` block is `bash -e` without it: a
+      # failed download would otherwise leave `sh` reading empty input and
+      # exiting 0, and the step would pass with no Dagger installed.
       - name: Install the Dagger CLI
         run: |
+          set -euo pipefail
           curl -fsSL https://dl.dagger.io/dagger/install.sh \
             | DAGGER_VERSION="$(jq -r .engineVersion dagger.json | tr -d v)" \
               BIN_DIR="$HOME/.local/bin" sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,8 +20,10 @@ name: Release
 #
 # The image job below has no filter either, and for a stronger reason: whether a
 # release is a release of the image is a question the Dagger module answers from
-# the refs at HEAD, and answering it here as well would put the tag scheme in two
-# places. An `irpb/vX.Y.Z` release reaches that job and publishes nothing.
+# the release's tag, and answering it here as well would put the tag scheme in
+# two places. An `irpb/vX.Y.Z` release reaches that job and publishes nothing —
+# including when the same commit also carries the CLI's own version tag, because
+# the module is told which release this is rather than left to guess from HEAD.
 on:
   release:
     types: [published]
@@ -77,6 +79,7 @@ jobs:
       # reason, as ci.yaml's.
       - name: Install the Dagger CLI
         run: |
+          set -euo pipefail
           curl -fsSL https://dl.dagger.io/dagger/install.sh \
             | DAGGER_VERSION="$(jq -r .engineVersion dagger.json | tr -d v)" \
               BIN_DIR="$HOME/.local/bin" sh
@@ -121,12 +124,32 @@ jobs:
   #
   # That is also why this job carries no tag filter. This repository publishes two
   # tag schemes, and `irpb/vX.Y.Z` is a release of the IR module rather than of
-  # the image: the module sees no canonical version tag at HEAD, publishes
-  # nothing, leaves the notes untouched and succeeds. A filter here would be the
-  # same decision made twice, in the place that is hardest to test.
+  # the image: the module is handed that tag, sees it is not a canonical version,
+  # publishes nothing, leaves the notes untouched and succeeds. A filter here
+  # would be the same decision made twice, in the place that is hardest to test.
+  #
+  # The tag is passed in rather than left to be inferred from the refs at HEAD,
+  # because the two answer differently exactly when this repository does what it
+  # is built to do: cut `vX.Y.Z` and `irpb/vX.Y.Z` from one commit. Inferring
+  # would find the CLI's tag while publishing the IR module's release, republish
+  # the image under it, and splice the image's notes into the wrong release.
   image:
     name: Image
     runs-on: ubuntu-latest
+    # Two releases published moments apart — a batch, or a draft released just
+    # after another — would otherwise race on `latest`, `vMAJOR` and the minor
+    # tag, and the winner would be whichever run happened to push last rather
+    # than whichever release is newer. That would make the tag table's "moves on
+    # each release" true only up to a scheduling accident. The two runs also
+    # read-modify-write release bodies, which does not survive being interleaved
+    # either.
+    #
+    # cancel-in-progress is false deliberately: a release cancelled midway
+    # through publishing its tags is the outcome this job least wants, since a
+    # published version tag is never repointed to tidy it up.
+    concurrency:
+      group: release-image
+      cancel-in-progress: false
     permissions:
       # Reading the source, writing the package, writing the release's notes, and
       # minting the OIDC token that signs. All four are here rather than at the
@@ -158,6 +181,7 @@ jobs:
 
       - name: Install the Dagger CLI
         run: |
+          set -euo pipefail
           curl -fsSL https://dl.dagger.io/dagger/install.sh \
             | DAGGER_VERSION="$(jq -r .engineVersion dagger.json | tr -d v)" \
               BIN_DIR="$HOME/.local/bin" sh
@@ -198,8 +222,11 @@ jobs:
       - name: Publish, sign and attest the image
         env:
           REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
         run: |
+          set -euo pipefail
           dagger call release \
+            --tag "$TAG" \
             --repository "$IMAGE_REPOSITORY" \
             --username "${{ github.actor }}" \
             --password env://REGISTRY_PASSWORD \
@@ -222,8 +249,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.event.release.tag_name }}
         run: |
+          set -euo pipefail
           gh release view "$TAG" --json body --jq .body > "$RUNNER_TEMP/notes.md"
           dagger call release-notes \
+            --tag "$TAG" \
             --notes "$RUNNER_TEMP/notes.md" \
             --repository "$IMAGE_REPOSITORY" > "$RUNNER_TEMP/notes.new.md"
           gh release edit "$TAG" --notes-file "$RUNNER_TEMP/notes.new.md"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,10 +1,11 @@
 name: Release
 
 # A published release is the trigger, not a pushed tag. The distinction matters
-# for what this workflow does: it uploads assets onto a release object, and a
-# release object only exists once somebody has published one. Firing on the tag
-# would mean racing the person who is about to create the release, and losing
-# that race means uploading to a release that is not there yet.
+# for what this workflow does: it uploads assets onto a release object and edits
+# that object's notes, and a release object only exists once somebody has
+# published one. Firing on the tag would mean racing the person who is about to
+# create the release, and losing that race means uploading to a release that is
+# not there yet.
 #
 # `published` covers both a release created straight away and a draft released
 # later, which is the shape a release with notes to write actually takes.
@@ -16,11 +17,16 @@ name: Release
 # release carried, and a reader who has found a release has them one download
 # away without having to know which of the two schemes is the one that publishes
 # them.
+#
+# The image job below has no filter either, and for a stronger reason: whether a
+# release is a release of the image is a question the Dagger module answers from
+# the refs at HEAD, and answering it here as well would put the tag scheme in two
+# places. An `irpb/vX.Y.Z` release reaches that job and publishes nothing.
 on:
   release:
     types: [published]
 
-# The floor for every job. The one job that has to write says so itself.
+# The floor for every job. The jobs that have to write say so themselves.
 permissions:
   contents: read
 
@@ -98,3 +104,126 @@ jobs:
             "$RUNNER_TEMP/ir-protos.tar.gz" \
             "$RUNNER_TEMP/layout-schema.sexpr" \
             --clobber
+
+  # The published base image (#55) — the one docs/container/SPEC.md describes and
+  # strangers' Dockerfiles say FROM — pushed under every tag that document's tag
+  # table gives this release, signed, attested, and named in the release's own
+  # notes (#59).
+  #
+  # Which tags exist, and whether this release is a release of the image at all,
+  # is decided by the module from the refs at HEAD — not by an `if:` here and not
+  # by a tag assembled in the steps below. A workflow that decided would have to
+  # write the tag scheme down to do it, in a file that runs once per release and
+  # is exercised nowhere else, while `dagger call tag-scheme` runs the same
+  # derivation on every pull request. What is left here is *where* to publish and
+  # what credentials to publish with, which genuinely are properties of this
+  # deployment rather than of the release.
+  #
+  # That is also why this job carries no tag filter. This repository publishes two
+  # tag schemes, and `irpb/vX.Y.Z` is a release of the IR module rather than of
+  # the image: the module sees no canonical version tag at HEAD, publishes
+  # nothing, leaves the notes untouched and succeeds. A filter here would be the
+  # same decision made twice, in the place that is hardest to test.
+  image:
+    name: Image
+    runs-on: ubuntu-latest
+    permissions:
+      # Reading the source, writing the package, writing the release's notes, and
+      # minting the OIDC token that signs. All four are here rather than at the
+      # top of the file because this is the only job that pushes or signs
+      # anything, and a grant held in advance is one nothing accounts for.
+      #
+      # `id-token: write` is what lets the run ask GitHub for the workload
+      # identity token cosign exchanges for a short-lived certificate, and it is
+      # also what puts ACTIONS_ID_TOKEN_REQUEST_URL and
+      # ACTIONS_ID_TOKEN_REQUEST_TOKEN in the step environment below.
+      contents: write
+      packages: write
+      id-token: write
+    steps:
+      # At the release's tag, for the same reason the assets above are built
+      # there: the image is a function of the source, and one built from a
+      # different commit would be a different program wearing the tag.
+      #
+      # With full history and tags, because the module reads the refs at HEAD to
+      # decide what this release is. A shallow checkout without tags has no
+      # version tag pointing at HEAD, so the release step would correctly conclude
+      # there is nothing to publish and push nothing at all.
+      - name: Check out the release's tag
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Install the Dagger CLI
+        run: |
+          curl -fsSL https://dl.dagger.io/dagger/install.sh \
+            | DAGGER_VERSION="$(jq -r .engineVersion dagger.json | tr -d v)" \
+              BIN_DIR="$HOME/.local/bin" sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # ghcr.io is a registry, and a registry's repository path is lowercase. The
+      # owner of this repository is not, so `ghcr.io/${{ github.repository }}` is
+      # a reference no registry will accept — a failure that would first appear
+      # halfway through a release, after the contract check had passed. It is
+      # lowercased once, here, and read from a variable everywhere below so the
+      # publish and the notes cannot disagree about where the image went.
+      - name: Resolve where the image is published
+        run: echo "IMAGE_REPOSITORY=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
+      # The same contract check CI runs on every pull request, run once more
+      # against the tag before anything is pushed. A published version tag is
+      # never repointed, so this is the last moment at which a broken promise
+      # costs nothing.
+      - name: Check the image against its contract
+        run: dagger call image-contract
+
+      # One call publishes the image as a multi-platform index under every tag
+      # this release carries, then signs the digest it resolved to and attaches
+      # the provenance statement and the SBOMs (#58).
+      #
+      # It is safe to re-run. The image is a function of the source, so a second
+      # run pushes the same bytes and every tag lands back on the digest it
+      # already named; .dagger/release.go's comment carries the argument, and the
+      # publish asserts it by requiring every tag of one release to resolve to one
+      # digest.
+      #
+      # The two ACTIONS_ID_TOKEN_REQUEST_* variables are put in the environment by
+      # `id-token: write` above. They are the workload identity exchange: cosign
+      # trades a token minted from them for a short-lived sigstore certificate, so
+      # the signature says which workflow at which ref produced the image rather
+      # than which key somebody is holding. The token is passed as a secret
+      # because it mints identity tokens for this repository.
+      - name: Publish, sign and attest the image
+        env:
+          REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          dagger call release \
+            --repository "$IMAGE_REPOSITORY" \
+            --username "${{ github.actor }}" \
+            --password env://REGISTRY_PASSWORD \
+            --id-token-request-url "$ACTIONS_ID_TOKEN_REQUEST_URL" \
+            --id-token-request-token env://ACTIONS_ID_TOKEN_REQUEST_TOKEN \
+            --builder "${{ github.server_url }}/${{ github.workflow_ref }}" \
+            --invocation "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      # The one fact about a release a reader cannot recover from its tag: which
+      # IR version the image speaks. A generator refuses a descriptor written
+      # against an IR version it does not implement, and the person reading that
+      # refusal has to decide whether to upgrade the generator or pin the CLI.
+      #
+      # After the publish, so the notes describe an image that exists. The block
+      # is delimited and regenerated rather than appended, so a re-run rewrites it
+      # instead of saying everything twice — which is the other half of what makes
+      # this job safe to run again.
+      - name: State what the image speaks in the release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          gh release view "$TAG" --json body --jq .body > "$RUNNER_TEMP/notes.md"
+          dagger call release-notes \
+            --notes "$RUNNER_TEMP/notes.md" \
+            --repository "$IMAGE_REPOSITORY" > "$RUNNER_TEMP/notes.new.md"
+          gh release edit "$TAG" --notes-file "$RUNNER_TEMP/notes.new.md"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -412,15 +412,31 @@ Publish a GitHub release whose tag is a canonical `vX.Y.Z`.
 above, pushes the image, signs the digest, and writes into the release's notes
 which IR version that image speaks.
 
-Nothing else is a step. There is no version constant to bump — `cmd/cpybkc`'s
-`version` is a constant in the tree and `internal/assemble.Version` is the IR
-version, and neither is stamped at release time — and no tag to push by hand
-beyond the one the release object carries.
+Nothing else is a step, after the first one. There is no version constant to
+bump — `cmd/cpybkc`'s `version` is a constant in the tree and
+`internal/assemble.Version` is the IR version, and neither is stamped at release
+time — and no tag to push by hand beyond the one the release object carries.
+
+**The first release needs one manual step, once.** A package that
+`secrets.GITHUB_TOKEN` creates on ghcr.io is private, and nothing the workflow
+can do with the default token makes it public. Until somebody sets the package's
+visibility to public in its settings on GitHub, every `FROM
+ghcr.io/zaba505/cpybkc:v0` in [the base-image contract](docs/container/SPEC.md)
+gets a 401 — which is the whole point of the image, so it is worth doing before
+announcing the release rather than after the first bug report. The same page is
+where a user-namespace package is given the repository write access the workflow
+pushes with. Every release after that one is the paragraph above.
+
+Releases are also expected to be cut in ascending version order. The moving tags
+follow the release being published rather than the highest version ever
+published, so a backport cut *after* the release that supersedes it would land
+`v0` and `latest` back on the older image — see `versionTags` in
+[`.dagger/release.go`](.dagger/release.go).
 
 ### Which tags a release publishes is a function, not a step
 
-[`.dagger/release.go`](.dagger/release.go) reads the refs at HEAD and derives the
-tag list from them, and [the base-image
+[`.dagger/release.go`](.dagger/release.go) is handed the release's tag, checks it
+against the refs at HEAD and derives the tag list from it, and [the base-image
 contract](docs/container/SPEC.md#tags-and-what-pinning-one-buys) is the table it
 implements: the full version tag never moves, the minor tag moves on each patch,
 the **moving major tag** moves on each release in that major, and `latest` moves

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,8 +180,9 @@ directory on `PATH` that other people's images copy into, owned by a pinned
 non-root user. Teaching the archetype that shape would be teaching it this
 repository's plugin model. So the image is assembled in
 [`.dagger/image.go`](.dagger/image.go), the four check stages gate a pull request
-exactly as before, and what is left for `GoApp` is the publish half, which the
-publishing story can take or leave on its own merits.
+exactly as before, and the publish half went the same way once the image did:
+[`.dagger/release.go`](.dagger/release.go) pushes the base this module assembles,
+under tags this module derives, and `GoApp` has no notion of either.
 
 Both dependencies in `dagger.json` are pinned to one `devex` commit, so a bump
 has to move them together.
@@ -379,8 +380,8 @@ dagger call attestations                                # the check `ci` runs
 ```
 
 `attest` is the third, and it is the one that needs a release: it signs a
-published digest and attaches the predicate and the SBOMs to it. #59 is what
-calls it, with the digest its publish returned.
+published digest and attaches the predicate and the SBOMs to it. `release` is
+what calls it, with the digest its publish returned.
 
 Four things about it are worth knowing before changing any of it:
 
@@ -403,6 +404,86 @@ Four things about it are worth knowing before changing any of it:
   real signature needs an OIDC token, a registry and a public transparency log,
   none of which a pull request has, and a check that faked one would be checking
   the fake. The signing flow is first exercised by a release.
+
+## Making a release
+
+Publish a GitHub release whose tag is a canonical `vX.Y.Z`.
+`.github/workflows/release.yaml` does the rest: it attaches the three artifacts
+above, pushes the image, signs the digest, and writes into the release's notes
+which IR version that image speaks.
+
+Nothing else is a step. There is no version constant to bump — `cmd/cpybkc`'s
+`version` is a constant in the tree and `internal/assemble.Version` is the IR
+version, and neither is stamped at release time — and no tag to push by hand
+beyond the one the release object carries.
+
+### Which tags a release publishes is a function, not a step
+
+[`.dagger/release.go`](.dagger/release.go) reads the refs at HEAD and derives the
+tag list from them, and [the base-image
+contract](docs/container/SPEC.md#tags-and-what-pinning-one-buys) is the table it
+implements: the full version tag never moves, the minor tag moves on each patch,
+the **moving major tag** moves on each release in that major, and `latest` moves
+on each release. The major tag is the one a derived Dockerfile should usually
+pin — it picks up every fix inside the compatibility guarantees — and it is what
+the [companion Dagger module's default](#the-default-image-tag-is-the-moving-major-tag)
+resolves through.
+
+```sh
+dagger call tag-scheme             # the derivation, over the cases that matter
+dagger call release-notes-contract # the block a release's notes carry
+```
+
+Both are in `ci`, so the scheme is checked on every pull request rather than
+discovered at a release. Three edge cases are settled there rather than in
+production:
+
+- A **prerelease** publishes its own full version tag and moves none of the other
+  three. A release candidate is not a fix anybody consented to be given.
+- A version carrying **`+build` metadata** is refused rather than mangled. An OCI
+  tag has no `+` in it, and dropping the metadata would publish two releases
+  under one name.
+- **Two version tags on one commit** is an error, because which of them `latest`
+  should follow has no defensible answer.
+
+A commit with no version tag publishes nothing and succeeds — which is what lets
+the workflow fire on the IR module's `irpb/vX.Y.Z` releases without a filter
+naming tag shapes in YAML.
+
+### Re-running a release is safe
+
+The job can be re-run, and this project's contract still holds that a published
+full version tag is never repointed. Both are true because the image is a
+function of the source: the binary is built `-trimpath` and CGO-free, the IR
+artifacts are byte-deterministic, and the image is assembled from those alone. A
+second run pushes the same bytes, so every tag lands back on the digest it
+already named. `release` asserts it by requiring every tag of one release to
+resolve to one digest, and refusing the release if they do not.
+
+The asset uploads use `--clobber`, the signature and the attestations are
+additive rather than replacing, and the notes block is delimited and regenerated
+rather than appended — so a second run leaves one block, not two.
+
+Correcting a *broken* release is the case none of that covers, and the answer is
+a new version number. Repointing `v0.2.0` at different bytes is the one thing
+[the contract](docs/container/SPEC.md#tags-and-what-pinning-one-buys) forbids
+outright.
+
+### Publishing somewhere else
+
+Where the image goes is an argument, not a constant: `release` takes the
+repository, and `publish` pushes one multi-platform index to any registry you can
+authenticate against.
+
+```sh
+dagger call publish --address=localhost:5000/cpybkc:v0 \
+  --username=… --password=env://REGISTRY_PASSWORD
+```
+
+That is deliberate — [the base-image
+contract](docs/container/SPEC.md#also-out-of-scope) holds the registry out of
+what it promises, because a mirror serving the same digest satisfies it
+identically. What is *not* an argument is which tags exist, for the reason above.
 
 ## The companion Dagger module
 
@@ -538,10 +619,11 @@ is not a weaker check — it is a claim that something is being verified. So the
 story is closed as unnecessary rather than carried against a premise this
 decision removed.
 
-What survives of it is the one thing the default depends on. #59 publishes the
-moving major tag; if that ever stopped being published, this decision is what
-would have to be reopened, rather than the default quietly patched at the call
-site.
+What survives of it is the one thing the default depends on. Every release
+[publishes the moving major tag](#which-tags-a-release-publishes-is-a-function-not-a-step)
+(#59), and `dagger call tag-scheme` is what says so on every pull request; if
+that ever stopped being published, this decision is what would have to be
+reopened, rather than the default quietly patched at the call site.
 
 ## The conformance corpus
 

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -429,6 +429,14 @@ example](#worked-example-adding-a-generator) uses. A **prerelease** —
 the other three, because a release candidate is not a fix anybody consented to
 be given (#59).
 
+The three that move follow **the release being published**, not the highest
+version ever published. For releases cut in ascending order — which is how this
+project cuts them — the two are the same thing. They come apart only if a
+backport is released after the version that supersedes it, which would land `v0`
+and `latest` back on the older image; that is a constraint on the releaser
+rather than a licence for a consumer to see the moving tags go backwards, and
+the full version tag and the digest are unaffected either way.
+
 A digest is the only reference that pins the bytes rather than a promise about
 them, and it is what to use when reproducibility is the requirement — the
 position the plugin contract takes under [Plugin


### PR DESCRIPTION
Closes #59

Releases the image and the schema artifacts together, so a given image tag always has a matching `.proto`, descriptor set and layout schema available.

## Acceptance criteria

- [x] **A release workflow publishes the multi-platform image on a git tag.** `.github/workflows/release.yaml` gains an `image` job that publishes the base image as one multi-platform index over `linux/amd64` and `linux/arm64`, then signs the digest and attaches the provenance and SBOMs through the existing `attest` (#58). It runs the same `image-contract` CI runs, once more against the tag, before anything is pushed — a published version tag is never repointed, so that is the last moment at which a broken promise costs nothing.
- [x] **Tag scheme documented, including a moving major tag.** [`docs/container/SPEC.md`](docs/container/SPEC.md#tags-and-what-pinning-one-buys) already carried the table; this adds the producing side. `dagger call tag-scheme` is that table executed rather than read, and CONTRIBUTING.md gains a *Making a release* section pointing at both — including why `v0` is the right pin for a derived Dockerfile and what the [companion module's default](CONTRIBUTING.md#the-default-image-tag-is-the-moving-major-tag) depends on.
- [x] **Releases also attach the layout schema, the `.proto` set and the `FileDescriptorSet`.** The `artifacts` job already did all three; the new job publishes the image beside it, and `image-contract` compares the descriptor set and sources in the image byte for byte against those same assets, so they stay one artifact reachable two ways.
- [x] **Publishing is idempotent and safely re-runnable.** See below.
- [x] **Release notes state the IR version the image speaks.** `dagger call release-notes` splices a delimited block into the release's body naming the IR version, read out of the built CLI's `--version` line rather than restated as a constant.

## The three edge cases, settled in code

`planRelease` answers them once, and `tag-scheme` runs it over a table on every pull request rather than leaving them to be discovered at a release:

- a **prerelease** publishes its own full version tag and moves none of the other three — a release candidate is not a fix anybody consented to be given;
- a version carrying **`+build` metadata** is refused rather than mangled, since `+` cannot be spelled in an OCI tag and dropping it would publish two releases under one name;
- **two version tags on one commit** is an error, because which of them `latest` follows has no defensible answer.

A commit with no canonical version tag publishes nothing and succeeds. That is what lets the workflow fire on the IR module's `irpb/vX.Y.Z` releases with no filter naming tag shapes in YAML — the decision stays in one place, and the place it stays is the one that is exercised on every pull request.

## Why re-running is safe, given that a published tag is never repointed

Both hold at once because the image is a function of the source: the binary is built `-trimpath` and CGO-free, the IR artifacts are byte-deterministic, and the image is assembled from those alone. A second run pushes the same bytes, so every tag lands back on the digest it already named — a repoint onto itself. `publishTags` asserts it by requiring every tag of one release to resolve to one digest and failing the release if they do not.

The signature and attestations are additive, the asset uploads already use `--clobber`, and the notes block is delimited and regenerated rather than appended. `release-notes-contract` checks that splicing is a fixed point: splicing a *different* block into a body that already carries one leaves exactly one block, with the surrounding notes untouched.

## Judgment calls that shaped the public API

- **`repository` is an argument; the tag list is not.** Where the image goes is a property of the deployment — `docs/container/SPEC.md` holds the registry out of the contract because a mirror serving the same digest satisfies it identically — so `release` and `publish` take it. Which tags exist is not the caller's, and is spelled only in `versionTags`.
- **`publish` is its own function.** Pushing one multi-platform index to a registry is something a person can do by hand against a test registry. A publish path only ever exercised by a release is one whose first real invocation is the one nobody can retry.
- **The IR version is read out of the artifact.** `versionLine` was factored out of `build` so that `irVersion` reads the same `cpybkc --version` line. A constant in the pipeline would be a second statement of what the assembler stamps, and the day the two disagreed the release notes would be the ones that lied.
- **The notes block is delimited by HTML comments and omits the digest.** It names the version, the tags, the platforms and the IR version — all functions of the plan and the build — so the notes step does not have to parse the publish step's output to run.
- **The workflow lowercases the repository owner.** `ghcr.io/${{ github.repository }}` is `ghcr.io/Zaba505/cpybkc`, which no registry accepts; it is lowercased once into `IMAGE_REPOSITORY` so the publish and the notes cannot disagree about where the image went.

## Verified

`dagger call ci` passes locally — now eleven parts, with `tag-scheme` and `release-notes-contract` added to it. `dagger develop` was re-run and the regenerated bindings are in the same commit.

The signing half is still first exercised by a real release, as `.dagger/sign.go` already says: producing a signature needs an OIDC token, a registry and a public transparency log, none of which a pull request has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)