### PR TITLE
story(dagger): expose Generate returning a Directory

### DIFF
--- a/.dagger/companion.go
+++ b/.dagger/companion.go
@@ -2,7 +2,7 @@
 // daggerverse/cpybkc that runs the published image for somebody else's pipeline
 // (#61). It is not that module; it is this pipeline's opinion about it.
 //
-// Two things are checked here, and they are separate because they fail for
+// Three things are checked here, and they are separate because they fail for
 // unrelated reasons and a run should say which.
 //
 // CompanionCi runs the standard Go pipeline over the module, exactly as IrCi
@@ -15,12 +15,25 @@
 // needs a check rather than a convention because the tool only catches half of
 // it — see the function's comment, which records what was measured rather than
 // what was assumed.
+//
+// CliSurface asserts the module has an answer for every flag the CLI accepts.
+// The module curates deliberately rather than mapping the flag table one-to-one
+// (#62), and a curated surface is only safe if adding a flag to the CLI forces
+// somebody to say which side of the curation it falls on.
 package main
 
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"maps"
+	"slices"
+	"strconv"
+	"strings"
 
 	"dagger/cpybkc/internal/dagger"
 )
@@ -134,4 +147,297 @@ func engineVersion(ctx context.Context, source *dagger.Directory, path string) (
 	}
 
 	return config.EngineVersion, nil
+}
+
+// generatedFile is the file `dagger develop` writes into a module, and the one
+// file in either module that is nobody's opinion about anything. CliSurface
+// skips it: it declares methods on the module's own type that the module's
+// author did not write, and counting those as functions covering a flag would
+// let the check pass on a name nobody chose.
+const generatedFile = "dagger.gen.go"
+
+// cliPackageDir is the CLI's own package. Its flag constants are the surface
+// CliSurface holds the companion module to, and it is a directory rather than a
+// file so that a flag introduced in a new file beside args.go is still seen.
+const cliPackageDir = "cmd/cpybkc"
+
+// companionCoverage is what the companion module answers each of the CLI's
+// flags with. It is the record the curation of #62 is worth having: the module
+// maps the run a caller almost always wants and hands the rest to one escape
+// hatch, and without a written record of which flag went where, "curated" and
+// "forgotten" are the same thing to read.
+//
+// Every value names a function on daggerverse/cpybkc's own type, checked to
+// exist rather than taken on trust. Run appears five times over because it is
+// the escape hatch and that is what an escape hatch looks like when it is
+// working; a flag moving from Run to a curated argument is an edit here in the
+// same commit that adds the argument.
+//
+// This is a table in the pipeline rather than a list in the module because it is
+// this repository's opinion about the module, in the file that already holds the
+// other two (#61). The module states the same split in prose, in its package
+// comment, where a caller reading `dagger call --help` will meet it.
+var companionCoverage = map[string]string{
+	// The one flag Generate maps by name: it says which project is being
+	// generated, which is the question a Dagger caller is already answering with
+	// --source.
+	"--manifest": "Generate",
+
+	// Terminal, and mutually constrained: --emit-ir replaces generation outright
+	// and --emit-ir-format is a usage error without it. A Directory-returning
+	// function cannot express either — the emission may go to standard output —
+	// and two Dagger arguments cannot express "one is only legal beside the
+	// other" at all.
+	"--emit-ir":        "Run",
+	"--emit-ir-format": "Run",
+
+	// Questions about the program rather than about a project, whose answer is a
+	// line on standard output. Image() reaches them too; Run is what reaches them
+	// with no project and no with-exec spelled out.
+	"--version": "Run",
+	"--help":    "Run",
+}
+
+// CliSurface checks that every flag the CLI accepts is one the companion module
+// has an answer for.
+//
+// docs/cli/SPEC.md fixes cpybkc as one command with no subcommands, so the
+// surface that can drift away from the module is the flag table rather than a
+// verb list: a flag added to the CLI is the event that would otherwise leave the
+// module quietly unable to express a run somebody can perform by hand. That is
+// what this fails on, in both directions — a flag no entry covers, and an entry
+// naming a flag the CLI no longer accepts.
+//
+// The CLI's side is read from the flag constants the parser matches on, not from
+// what `--help` prints and not from docs/cli/SPEC.md's table. The help text is
+// deliberately written out rather than assembled from those constants, because
+// what a flag is called is a covered guarantee and what usage says about it is
+// explicitly not one (cmd/cpybkc/usage.go); a check reading it would fail on a
+// rewording and pass on a flag the document forgot. The constants are what
+// decides whether an argument is accepted, which is the only reading that cannot
+// be true of the document and false of the program.
+//
+// It follows that a flag introduced *without* a constant — matched inline in a
+// string literal — would escape this check. That is a shape the parser does not
+// use and one the lint stage would have opinions about, and the alternative,
+// reading every string literal in the package, would fail on the diagnostics
+// that quote flags at the user. The compromise is stated here rather than left
+// as a surprise, and the empty case below is what stops the check degrading into
+// one that compares nothing.
+//
+// +check
+// +cache="session"
+func (m *Cpybkc) CliSurface(ctx context.Context) error {
+	flags, err := cliFlags(ctx, m.Source)
+	if err != nil {
+		return err
+	}
+
+	// A check that found no flags has not passed, it has stopped working: a
+	// renamed package, a parse that silently produced nothing, or a constant
+	// block written some other way would all read as "every flag is covered".
+	if len(flags) == 0 {
+		return fmt.Errorf(
+			"%s declares no flag constants, so this check compared the companion module against nothing; the CLI's "+
+				"flags are the constants cmd/cpybkc/args.go matches on, and a check that cannot find them is not a "+
+				"check that passed", cliPackageDir)
+	}
+
+	functions, err := companionFunctions(ctx, m.Source)
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+
+	for _, flag := range flags {
+		function, covered := companionCoverage[flag]
+		if !covered {
+			errs = append(errs, fmt.Errorf(
+				"the cpybkc CLI accepts %s and %s records nothing that covers it: add it to companionCoverage in "+
+					"this file, against the curated function that maps it or against Run, which is the escape hatch "+
+					"an uncurated flag reaches through (#62)",
+				flag, companionModuleDir))
+
+			continue
+		}
+
+		if !slices.Contains(functions, function) {
+			errs = append(errs, fmt.Errorf(
+				"%s is recorded as covered by %s's %s, and that module declares no such function; either the "+
+					"function was renamed and this table was not, or the flag now reaches the module some other way",
+				flag, companionModuleDir, function))
+		}
+	}
+
+	for _, flag := range slices.Sorted(maps.Keys(companionCoverage)) {
+		if !slices.Contains(flags, flag) {
+			errs = append(errs, fmt.Errorf(
+				"%s records %s as covered by %s and the cpybkc CLI no longer accepts that flag; a module argument "+
+					"is public API for as long as the published module ref exists, so a flag leaving the CLI is a "+
+					"decision about the module rather than a line to delete from this table without one",
+				companionModuleDir, flag, companionCoverage[flag]))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// cliFlags is every flag the CLI's parser matches on, read out of its own
+// constants.
+//
+// Two spellings are deliberately not flags here. The bare "--" is POSIX's end of
+// options rather than something a caller passes a value to, and "-h" is a
+// single-hyphen synonym docs/cli/SPEC.md requires to go undocumented — a module
+// covering "--help" covers it, and listing it would ask the coverage table to
+// record a spelling the CLI's own help text will not print.
+func cliFlags(ctx context.Context, source *dagger.Directory) ([]string, error) {
+	files, err := goFiles(ctx, source, cliPackageDir)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := map[string]bool{}
+	for path, contents := range files {
+		parsed, err := parser.ParseFile(token.NewFileSet(), path, contents, 0)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", path, err)
+		}
+
+		for _, value := range constantStrings(parsed) {
+			if strings.HasPrefix(value, "--") && value != "--" {
+				seen[value] = true
+			}
+		}
+	}
+
+	return slices.Sorted(maps.Keys(seen)), nil
+}
+
+// companionFunctions is every exported method the companion module declares on
+// its own type — which is exactly what Dagger publishes as the module's
+// functions, and so exactly what a coverage entry may name.
+func companionFunctions(ctx context.Context, source *dagger.Directory) ([]string, error) {
+	files, err := goFiles(ctx, source, companionModuleDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var functions []string
+	for path, contents := range files {
+		if strings.HasSuffix(path, generatedFile) {
+			continue
+		}
+
+		parsed, err := parser.ParseFile(token.NewFileSet(), path, contents, 0)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", path, err)
+		}
+
+		for _, decl := range parsed.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv == nil || len(fn.Recv.List) != 1 || !fn.Name.IsExported() {
+				continue
+			}
+
+			if receiverType(fn.Recv.List[0].Type) == companionType {
+				functions = append(functions, fn.Name.Name)
+			}
+		}
+	}
+
+	slices.Sort(functions)
+
+	return functions, nil
+}
+
+// companionType is the companion module's own type, whose exported methods are
+// the module's functions. It is the directory's name in Go's spelling, and the
+// two move together or the module does not build.
+const companionType = "Cpybkc"
+
+// receiverType names the type a method is declared on, with the pointer taken
+// off. A Dagger module's functions are conventionally declared on the pointer,
+// but a value receiver publishes the same function, so both are read.
+func receiverType(expr ast.Expr) string {
+	if star, ok := expr.(*ast.StarExpr); ok {
+		expr = star.X
+	}
+
+	ident, ok := expr.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+
+	return ident.Name
+}
+
+// constantStrings is every string a file declares as a constant.
+//
+// Constants only, and not every string literal in the file: a diagnostic that
+// quotes a flag back at the user is prose about the surface rather than part of
+// it, and reading those too would make the check fail on a reworded error
+// message.
+func constantStrings(file *ast.File) []string {
+	var values []string
+
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+
+		for _, spec := range gen.Specs {
+			value, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+
+			for _, expr := range value.Values {
+				literal, ok := expr.(*ast.BasicLit)
+				if !ok || literal.Kind != token.STRING {
+					continue
+				}
+
+				unquoted, err := strconv.Unquote(literal.Value)
+				if err != nil {
+					continue
+				}
+
+				values = append(values, unquoted)
+			}
+		}
+	}
+
+	return values
+}
+
+// goFiles reads a directory's Go source, keyed by path.
+//
+// Tests are skipped because a test's constants are its own fixtures: a table
+// driving the parser over "--jobs" to assert it is refused would otherwise read
+// as the CLI having grown a flag.
+func goFiles(ctx context.Context, source *dagger.Directory, dir string) (map[string]string, error) {
+	directory := source.Directory(dir)
+
+	entries, err := directory.Entries(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", dir, err)
+	}
+
+	files := map[string]string{}
+	for _, entry := range entries {
+		if !strings.HasSuffix(entry, ".go") || strings.HasSuffix(entry, "_test.go") {
+			continue
+		}
+
+		contents, err := directory.File(entry).Contents(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("reading %s/%s: %w", dir, entry, err)
+		}
+
+		files[dir+"/"+entry] = contents
+	}
+
+	return files, nil
 }

--- a/.dagger/companion.go
+++ b/.dagger/companion.go
@@ -27,15 +27,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"go/ast"
-	"go/parser"
-	"go/token"
 	"maps"
 	"slices"
-	"strconv"
 	"strings"
 
 	"dagger/cpybkc/internal/dagger"
+	"dagger/cpybkc/internal/surface"
 )
 
 // companionModuleDir is the companion module's directory, which is also its
@@ -157,8 +154,14 @@ func engineVersion(ctx context.Context, source *dagger.Directory, path string) (
 const generatedFile = "dagger.gen.go"
 
 // cliPackageDir is the CLI's own package. Its flag constants are the surface
-// CliSurface holds the companion module to, and it is a directory rather than a
-// file so that a flag introduced in a new file beside args.go is still seen.
+// CliSurface holds the companion module to.
+//
+// It is read as a tree rather than as one file or one directory's entries: a
+// flag introduced in a new file beside args.go counts, and so does one in a
+// subpackage a later refactor moves parsing into. Reading only the immediate
+// entries would lose the whole of cmd/cpybkc/internal/ while args.go still
+// declared enough flags for the check to look healthy, which is the partial
+// failure the empty-result guard below cannot catch.
 const cliPackageDir = "cmd/cpybkc"
 
 // companionCoverage is what the companion module answers each of the CLI's
@@ -167,11 +170,21 @@ const cliPackageDir = "cmd/cpybkc"
 // hatch, and without a written record of which flag went where, "curated" and
 // "forgotten" are the same thing to read.
 //
+// Be exact about what an entry claims, because it is less than it looks. It is a
+// person's assertion that they thought about this flag and decided where it
+// belongs — nothing here proves the named function can *reach* the flag, and
+// since Run forwards an arbitrary vector, every flag is reachable through Run by
+// construction. Deleting Generate's manifest argument would leave "--manifest"
+// pointing at a Generate that no longer maps it, and CliSurface would pass. What
+// the check buys is that the assertion has to be re-made by somebody whenever the
+// CLI's surface moves, which is exactly the moment it stops being true by
+// accident.
+//
 // Every value names a function on daggerverse/cpybkc's own type, checked to
-// exist rather than taken on trust. Run appears five times over because it is
-// the escape hatch and that is what an escape hatch looks like when it is
-// working; a flag moving from Run to a curated argument is an edit here in the
-// same commit that adds the argument.
+// exist rather than taken on trust. Run appears six times over because it is the
+// escape hatch and that is what an escape hatch looks like when it is working; a
+// flag moving from Run to a curated argument is an edit here in the same commit
+// that adds the argument.
 //
 // This is a table in the pipeline rather than a list in the module because it is
 // this repository's opinion about the module, in the file that already holds the
@@ -196,6 +209,13 @@ var companionCoverage = map[string]string{
 	// with no project and no with-exec spelled out.
 	"--version": "Run",
 	"--help":    "Run",
+
+	// The one single-hyphen spelling docs/cli/SPEC.md states. It is recorded
+	// rather than filtered out as "a synonym of a covered flag", because that
+	// reasoning is true of -h and of nothing else: filtering the whole class would
+	// let a future short flag that is nobody's synonym land with this check green,
+	// and an entry costs one line.
+	"-h": "Run",
 }
 
 // CliSurface checks that every flag the CLI accepts is one the companion module
@@ -205,8 +225,9 @@ var companionCoverage = map[string]string{
 // surface that can drift away from the module is the flag table rather than a
 // verb list: a flag added to the CLI is the event that would otherwise leave the
 // module quietly unable to express a run somebody can perform by hand. That is
-// what this fails on, in both directions — a flag no entry covers, and an entry
-// naming a flag the CLI no longer accepts.
+// what this fails on, in three directions — a flag no entry covers, an entry
+// naming a function the module does not declare, and an entry naming a flag the
+// CLI no longer accepts.
 //
 // The CLI's side is read from the flag constants the parser matches on, not from
 // what `--help` prints and not from docs/cli/SPEC.md's table. The help text is
@@ -217,25 +238,41 @@ var companionCoverage = map[string]string{
 // decides whether an argument is accepted, which is the only reading that cannot
 // be true of the document and false of the program.
 //
-// It follows that a flag introduced *without* a constant — matched inline in a
-// string literal — would escape this check. That is a shape the parser does not
-// use and one the lint stage would have opinions about, and the alternative,
-// reading every string literal in the package, would fail on the diagnostics
-// that quote flags at the user. The compromise is stated here rather than left
-// as a surprise, and the empty case below is what stops the check degrading into
-// one that compares nothing.
+// What that leaves outside is a flag matched inline on a string literal rather
+// than through a constant — a shape the parser does not use, and the one this
+// check cannot see. Everything else a constant can be written as is read:
+// package scope or a function body, one hyphen or two, a literal or one flag's
+// spelling built from another's. The rules are internal/surface's and each of
+// them is a test rather than a sentence here, because a drift guard's failure
+// mode is staying green and a sentence cannot fail.
+//
+// Two guards stop this degrading quietly. A read that finds no flags at all is a
+// failure rather than a pass, since a renamed package would otherwise read as
+// "every flag is covered". And a constant this check could not evaluate is
+// reported rather than dropped, because "I could not read this" and "this is not
+// a flag" are different things to have learned.
 //
 // +check
 // +cache="session"
 func (m *Cpybkc) CliSurface(ctx context.Context) error {
-	flags, err := cliFlags(ctx, m.Source)
+	cli, err := goFiles(ctx, m.Source, cliPackageDir)
 	if err != nil {
 		return err
 	}
 
-	// A check that found no flags has not passed, it has stopped working: a
-	// renamed package, a parse that silently produced nothing, or a constant
-	// block written some other way would all read as "every flag is covered".
+	flags, unreadable, err := surface.Flags(cli)
+	if err != nil {
+		return err
+	}
+
+	if len(unreadable) > 0 {
+		return fmt.Errorf(
+			"%s declares the constants %s with values this check cannot evaluate, so it cannot say whether they "+
+				"are flags; a flag's spelling is written as a literal or built from another flag's, and a value "+
+				"assembled some other way has to be read by a person instead",
+			cliPackageDir, strings.Join(unreadable, ", "))
+	}
+
 	if len(flags) == 0 {
 		return fmt.Errorf(
 			"%s declares no flag constants, so this check compared the companion module against nothing; the CLI's "+
@@ -243,7 +280,12 @@ func (m *Cpybkc) CliSurface(ctx context.Context) error {
 				"check that passed", cliPackageDir)
 	}
 
-	functions, err := companionFunctions(ctx, m.Source)
+	module, err := goFiles(ctx, m.Source, companionModuleDir)
+	if err != nil {
+		return err
+	}
+
+	functions, err := surface.Functions(module, companionType)
 	if err != nil {
 		return err
 	}
@@ -283,160 +325,41 @@ func (m *Cpybkc) CliSurface(ctx context.Context) error {
 	return errors.Join(errs...)
 }
 
-// cliFlags is every flag the CLI's parser matches on, read out of its own
-// constants.
-//
-// Two spellings are deliberately not flags here. The bare "--" is POSIX's end of
-// options rather than something a caller passes a value to, and "-h" is a
-// single-hyphen synonym docs/cli/SPEC.md requires to go undocumented — a module
-// covering "--help" covers it, and listing it would ask the coverage table to
-// record a spelling the CLI's own help text will not print.
-func cliFlags(ctx context.Context, source *dagger.Directory) ([]string, error) {
-	files, err := goFiles(ctx, source, cliPackageDir)
-	if err != nil {
-		return nil, err
-	}
-
-	seen := map[string]bool{}
-	for path, contents := range files {
-		parsed, err := parser.ParseFile(token.NewFileSet(), path, contents, 0)
-		if err != nil {
-			return nil, fmt.Errorf("parsing %s: %w", path, err)
-		}
-
-		for _, value := range constantStrings(parsed) {
-			if strings.HasPrefix(value, "--") && value != "--" {
-				seen[value] = true
-			}
-		}
-	}
-
-	return slices.Sorted(maps.Keys(seen)), nil
-}
-
-// companionFunctions is every exported method the companion module declares on
-// its own type — which is exactly what Dagger publishes as the module's
-// functions, and so exactly what a coverage entry may name.
-func companionFunctions(ctx context.Context, source *dagger.Directory) ([]string, error) {
-	files, err := goFiles(ctx, source, companionModuleDir)
-	if err != nil {
-		return nil, err
-	}
-
-	var functions []string
-	for path, contents := range files {
-		if strings.HasSuffix(path, generatedFile) {
-			continue
-		}
-
-		parsed, err := parser.ParseFile(token.NewFileSet(), path, contents, 0)
-		if err != nil {
-			return nil, fmt.Errorf("parsing %s: %w", path, err)
-		}
-
-		for _, decl := range parsed.Decls {
-			fn, ok := decl.(*ast.FuncDecl)
-			if !ok || fn.Recv == nil || len(fn.Recv.List) != 1 || !fn.Name.IsExported() {
-				continue
-			}
-
-			if receiverType(fn.Recv.List[0].Type) == companionType {
-				functions = append(functions, fn.Name.Name)
-			}
-		}
-	}
-
-	slices.Sort(functions)
-
-	return functions, nil
-}
-
 // companionType is the companion module's own type, whose exported methods are
 // the module's functions. It is the directory's name in Go's spelling, and the
 // two move together or the module does not build.
 const companionType = "Cpybkc"
 
-// receiverType names the type a method is declared on, with the pointer taken
-// off. A Dagger module's functions are conventionally declared on the pointer,
-// but a value receiver publishes the same function, so both are read.
-func receiverType(expr ast.Expr) string {
-	if star, ok := expr.(*ast.StarExpr); ok {
-		expr = star.X
-	}
-
-	ident, ok := expr.(*ast.Ident)
-	if !ok {
-		return ""
-	}
-
-	return ident.Name
-}
-
-// constantStrings is every string a file declares as a constant.
+// goFiles reads a directory tree's Go source, keyed by path.
 //
-// Constants only, and not every string literal in the file: a diagnostic that
-// quotes a flag back at the user is prose about the surface rather than part of
-// it, and reading those too would make the check fail on a reworded error
-// message.
-func constantStrings(file *ast.File) []string {
-	var values []string
-
-	for _, decl := range file.Decls {
-		gen, ok := decl.(*ast.GenDecl)
-		if !ok || gen.Tok != token.CONST {
-			continue
-		}
-
-		for _, spec := range gen.Specs {
-			value, ok := spec.(*ast.ValueSpec)
-			if !ok {
-				continue
-			}
-
-			for _, expr := range value.Values {
-				literal, ok := expr.(*ast.BasicLit)
-				if !ok || literal.Kind != token.STRING {
-					continue
-				}
-
-				unquoted, err := strconv.Unquote(literal.Value)
-				if err != nil {
-					continue
-				}
-
-				values = append(values, unquoted)
-			}
-		}
-	}
-
-	return values
-}
-
-// goFiles reads a directory's Go source, keyed by path.
+// The whole tree, because a package's flags do not all have to live in its top
+// directory and a check that read only the top one would go quiet about a
+// subpackage rather than fail about it.
 //
 // Tests are skipped because a test's constants are its own fixtures: a table
 // driving the parser over "--jobs" to assert it is refused would otherwise read
-// as the CLI having grown a flag.
+// as the CLI having grown a flag. The generated client is skipped for the reason
+// generatedFile gives.
 func goFiles(ctx context.Context, source *dagger.Directory, dir string) (map[string]string, error) {
 	directory := source.Directory(dir)
 
-	entries, err := directory.Entries(ctx)
+	paths, err := directory.Glob(ctx, "**/*.go")
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %w", dir, err)
 	}
 
 	files := map[string]string{}
-	for _, entry := range entries {
-		if !strings.HasSuffix(entry, ".go") || strings.HasSuffix(entry, "_test.go") {
+	for _, path := range paths {
+		if strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, generatedFile) {
 			continue
 		}
 
-		contents, err := directory.File(entry).Contents(ctx)
+		contents, err := directory.File(path).Contents(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("reading %s/%s: %w", dir, entry, err)
+			return nil, fmt.Errorf("reading %s/%s: %w", dir, path, err)
 		}
 
-		files[dir+"/"+entry] = contents
+		files[dir+"/"+path] = contents
 	}
 
 	return files, nil

--- a/.dagger/dagger.gen.go
+++ b/.dagger/dagger.gen.go
@@ -412,6 +412,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Cpybkc).Lint(&parent, ctx)
+		case "PipelineCi":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Cpybkc).PipelineCi(&parent, ctx)
 		case "ProtoGen":
 			var parent Cpybkc
 			err = json.Unmarshal(parentJSON, &parent)

--- a/.dagger/dagger.gen.go
+++ b/.dagger/dagger.gen.go
@@ -307,6 +307,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Cpybkc).Ci(&parent, ctx)
+		case "CliSurface":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Cpybkc).CliSurface(&parent, ctx)
 		case "CompanionCi":
 			var parent Cpybkc
 			err = json.Unmarshal(parentJSON, &parent)

--- a/.dagger/internal/dagger/companion.gen.go
+++ b/.dagger/internal/dagger/companion.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Companion
-func (r *Binding) AsCompanion() *Companion { // companion (../../../daggerverse/cpybkc/main.go:80:6)
+func (r *Binding) AsCompanion() *Companion { // companion (../../../daggerverse/cpybkc/main.go:124:6)
 	q := r.query.Select("asCompanion")
 
 	return &Companion{
@@ -24,7 +24,7 @@ func (r *Binding) AsCompanion() *Companion { // companion (../../../daggerverse/
 // A function on it is a builder returning a new Cpybkc, a terminal that runs
 // something, or an accessor handing back what was resolved, so a call chain
 // reads as the image being assembled and then used; nothing here mutates.
-type Companion struct { // companion (../../../daggerverse/cpybkc/main.go:80:6)
+type Companion struct { // companion (../../../daggerverse/cpybkc/main.go:124:6)
 	query *querybuilder.Selection
 
 	id *ID
@@ -32,6 +32,61 @@ type Companion struct { // companion (../../../daggerverse/cpybkc/main.go:80:6)
 
 func (r *Companion) WithGraphQLQuery(q *querybuilder.Selection) *Companion {
 	return &Companion{
+		query: q,
+	}
+}
+
+// CompanionGenerateOpts contains options for Companion.Generate
+type CompanionGenerateOpts struct {
+	//
+	// The project manifest to read, relative to the root of source.
+	//
+	// It defaults to nothing, which leaves cpybkc reading `cpybkc.json` at the
+	// root of the mounted project — the CLI's own default, applied by the CLI,
+	// against the working directory this module puts the project at. There is no
+	// upward search and no second manifest, so a project keeping its manifest
+	// somewhere else says so here.
+	//
+	// A relative path resolves against that project root, because that is the
+	// directory the CLI resolves a path typed on the command line against. It
+	// cannot be "-": a manifest's own paths are relative to the directory holding
+	// it, and a manifest arriving on a stream is in no directory.
+	//
+	Manifest string // companion (../../../daggerverse/cpybkc/main.go:295:2)
+}
+
+// Generate runs cpybkc over a project and hands back the project as it should
+// now be committed:
+//
+//	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+//	  generate --source . export --path .
+//
+// Nothing is written to the host. The Directory that comes back is a value like
+// any other, and exporting it is the caller's separate, explicit step — which is
+// also what disposes of the ownership problem a bind mount has, where generated
+// files land owned by whichever UID the container ran as and a host user who is
+// not that UID owns none of their own project. Dagger's export writes as the
+// person running it, so the image's pinned user never reaches the host.
+//
+// What comes back is the **whole project directory**, not only the files a
+// generator produced. A generator's output lands where the manifest says, which
+// is ordinarily inside the source tree, and a run also prunes what a previous
+// run generated and no longer would — so the generated files alone cannot
+// express half of what a run did. `generate --source . export --path .` is
+// therefore the ordinary use, and it is a full statement of the run rather than
+// an overlay that leaves deletions behind.
+func (r *Companion) Generate(source *Directory, opts ...CompanionGenerateOpts) *Directory { // companion (../../../daggerverse/cpybkc/main.go:272:1)
+	assertNotNil("source", source)
+	q := r.query.Select("generate")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `manifest` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Manifest) {
+			q = q.Arg("manifest", opts[i].Manifest)
+		}
+	}
+	q = q.Arg("source", source)
+
+	return &Directory{
 		query: q,
 	}
 }
@@ -102,8 +157,70 @@ func (r *Companion) UnmarshalJSON(bs []byte) error {
 // none of the signatures or attestations one does (docs/container/SPEC.md, "What
 // a tag carries besides the image"), because those are attached to the digest
 // this project published and not to the bytes.
-func (r *Companion) Image() *Container { // companion (../../../daggerverse/cpybkc/main.go:204:1)
+func (r *Companion) Image() *Container { // companion (../../../daggerverse/cpybkc/main.go:248:1)
 	q := r.query.Select("image")
+
+	return &Container{
+		query: q,
+	}
+}
+
+// CompanionRunOpts contains options for Companion.Run
+type CompanionRunOpts struct {
+	//
+	// The project to run over, mounted at /src and made the working directory.
+	//
+	// It is optional because half the reason this function exists is the
+	// invocations that have no project — `--version` and `--help` read nothing and
+	// contact nothing. With no source the container is the image as it was
+	// resolved, and cpybkc runs in whatever directory the image left it in.
+	//
+	Source *Directory // companion (../../../daggerverse/cpybkc/main.go:359:2)
+}
+
+// Run is the escape hatch: cpybkc invoked with an argument vector this module
+// has no opinion about, in a container handed back whole.
+//
+//	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+//	  run --source . --args=--emit-ir,- stdout
+//
+//	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+//	  run --args=--help stdout
+//
+// It exists so that Generate does not have to grow an argument every time
+// docs/cli/SPEC.md's flag table does. A flag that replaces the action rather
+// than configuring it (--emit-ir is terminal: no generator runs and nothing is
+// merged or pruned), one that may only appear beside another (--emit-ir-format
+// without --emit-ir is a usage error), and one that answers a question about the
+// program rather than about a project (--version, --help) are all things a
+// command line states plainly and a set of Dagger arguments states badly.
+//
+// A container rather than a directory, because the uncurated invocations are the
+// ones whose answer is not a tree. --emit-ir may write to standard output, and
+// --version and --help write nothing else at all; a Directory return would make
+// the escape hatch unable to reach exactly the flags it exists for. A caller who
+// does want the tree takes it from the container, where the project is still
+// mounted at /src:
+//
+//	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+//	  run --source . --args=--manifest,build/cpybkc.json \
+//	  directory --path=/src export --path .
+//
+// Nothing here is validated. A vector this module checked would be a second,
+// unversioned reading of a contract the CLI already implements, and its
+// diagnostics are better than anything guessed at from out here: what an
+// unrecognised flag is, whether a flag may repeat and what a usage error exits
+// with are all docs/cli/SPEC.md's, and the exec's failure carries them back
+// verbatim.
+func (r *Companion) Run(args []string, opts ...CompanionRunOpts) *Container { // companion (../../../daggerverse/cpybkc/main.go:346:1)
+	q := r.query.Select("run")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `source` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Source) {
+			q = q.Arg("source", opts[i].Source)
+		}
+	}
+	q = q.Arg("args", args)
 
 	return &Container{
 		query: q,
@@ -119,7 +236,7 @@ func (r *Companion) AsNode() Node {
 }
 
 // Create or update a binding of type Companion in the environment
-func (r *Env) WithCompanionInput(name string, value *Companion, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:80:6)
+func (r *Env) WithCompanionInput(name string, value *Companion, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:124:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withCompanionInput")
 	q = q.Arg("name", name)
@@ -132,7 +249,7 @@ func (r *Env) WithCompanionInput(name string, value *Companion, description stri
 }
 
 // Declare a desired Companion output to be assigned in the environment
-func (r *Env) WithCompanionOutput(name string, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:80:6)
+func (r *Env) WithCompanionOutput(name string, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:124:6)
 	q := r.query.Select("withCompanionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -156,7 +273,7 @@ type CompanionOpts struct {
 	//
 	//
 	// Default: "v0"
-	Version string // companion (../../../daggerverse/cpybkc/main.go:143:2)
+	Version string // companion (../../../daggerverse/cpybkc/main.go:187:2)
 	//
 	// The registry repository the image is pulled from, as `<host>/<path>` with no
 	// tag.
@@ -171,7 +288,7 @@ type CompanionOpts struct {
 	//
 	//
 	// Default: "ghcr.io/zaba505/cpybkc"
-	Repository string // companion (../../../daggerverse/cpybkc/main.go:156:2)
+	Repository string // companion (../../../daggerverse/cpybkc/main.go:200:2)
 	//
 	// Run in this container instead of pulling one, replacing it entirely.
 	//
@@ -186,7 +303,7 @@ type CompanionOpts struct {
 	// change to cpybkc before it ships, and how a build pins the image by digest —
 	// a reference no tag argument can express, and the only one that pins bytes.
 	//
-	Image *Container // companion (../../../daggerverse/cpybkc/main.go:170:2)
+	Image *Container // companion (../../../daggerverse/cpybkc/main.go:214:2)
 }
 
 // New selects the cpybkc release to run:
@@ -207,7 +324,7 @@ type CompanionOpts struct {
 // resolve companion images against (#63), which is why an air-gapped caller
 // passing a container from their own registry should pass --repository beside it
 // rather than instead of it.
-func (r *Query) Companion(opts ...CompanionOpts) *Companion { // companion (../../../daggerverse/cpybkc/main.go:132:1)
+func (r *Query) Companion(opts ...CompanionOpts) *Companion { // companion (../../../daggerverse/cpybkc/main.go:176:1)
 	q := r.query.Select("companion")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `version` optional argument

--- a/.dagger/internal/surface/surface.go
+++ b/.dagger/internal/surface/surface.go
@@ -1,0 +1,281 @@
+// Package surface reads a Go package's command-line surface out of its source:
+// the flags it declares as constants, and the exported methods it declares on a
+// type.
+//
+// It is a package of its own for the reason daggerverse/cpybkc's internal
+// packages are: the pipeline's own package main imports the generated Dagger
+// client, whose init panics without a session, so a test beside it cannot run
+// under plain `go test`. This package imports no Dagger and takes file contents
+// rather than a *dagger.Directory, so every rule below is pinned by a test
+// rather than asserted by a comment — which matters more here than anywhere
+// else in the pipeline, because what is built on it is a drift guard, and a
+// drift guard with a hole fails by staying green.
+package surface
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"maps"
+	"regexp"
+	"slices"
+	"strconv"
+)
+
+// flagToken is what a flag looks like when it is written on a command line: one
+// or two hyphens, then a letter, then letters, digits and hyphens.
+//
+// It is a shape test rather than a prefix test, and it does three jobs at once.
+// It admits a single-hyphen flag, so a short flag that is not a synonym of a
+// long one cannot slip past a guard built on this. It rejects "-" and "--",
+// which are POSIX's standard-stream operand and its end-of-options delimiter
+// rather than flags. And it rejects anything carrying a space, which is what
+// keeps a diagnostic or a wrapped usage line hoisted into a constant —
+// "--emit-ir-format may only be given beside --emit-ir" — from being read as a
+// flag nobody has covered, a red build whose suggested remedy would make things
+// worse.
+var flagToken = regexp.MustCompile(`^--?[A-Za-z][A-Za-z0-9-]*$`)
+
+// Flags is every flag the given Go sources declare as a string constant, sorted,
+// with the names of the constants whose value could not be evaluated.
+//
+// The keys of files are paths used in parse errors; the values are the sources.
+//
+// Constants only, and not every string literal: a diagnostic that quotes a flag
+// back at the user is prose about the surface rather than part of it, and
+// reading those too would make a guard built on this fail on a reworded error
+// message. Within that, every constant counts — one declared inside a function
+// body as much as one at package scope, because which of the two a contributor
+// reaches for is a style choice and not a statement about whether the flag is
+// real.
+//
+// The second return is what stops "I could not read this" being reported as
+// "this is not a flag". A constant whose value this package cannot evaluate but
+// which has a string literal somewhere inside it is named rather than dropped,
+// so a caller can refuse to draw a conclusion from a reading it knows is
+// incomplete. A value with no string literal in it is neither: it is arithmetic,
+// or an untyped number, and it was never a candidate.
+func Flags(files map[string]string) ([]string, []string, error) {
+	constants, err := stringConstants(files)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	values, unresolved := resolve(constants)
+
+	flags := map[string]bool{}
+	for _, value := range values {
+		if flagToken.MatchString(value) {
+			flags[value] = true
+		}
+	}
+
+	return slices.Sorted(maps.Keys(flags)), unresolved, nil
+}
+
+// Functions is every exported method the given Go sources declare on typeName,
+// sorted — which for a Dagger module's own type is exactly the set of functions
+// the module publishes.
+//
+// A pointer receiver and a value receiver both count: the pointer is the
+// convention, and a value receiver publishes the same function.
+func Functions(files map[string]string, typeName string) ([]string, error) {
+	names := map[string]bool{}
+
+	for _, path := range slices.Sorted(maps.Keys(files)) {
+		parsed, err := parser.ParseFile(token.NewFileSet(), path, files[path], 0)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", path, err)
+		}
+
+		for _, decl := range parsed.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv == nil || len(fn.Recv.List) != 1 || !fn.Name.IsExported() {
+				continue
+			}
+
+			if receiverType(fn.Recv.List[0].Type) == typeName {
+				names[fn.Name.Name] = true
+			}
+		}
+	}
+
+	return slices.Sorted(maps.Keys(names)), nil
+}
+
+// constant is one declared constant, kept unevaluated because a constant may be
+// written in terms of another declared later or in another file.
+type constant struct {
+	name string
+	expr ast.Expr
+}
+
+// stringConstants is every constant in the given sources whose value could be a
+// string — that is, every one with a string literal somewhere inside its value
+// expression.
+//
+// ast.Inspect rather than a walk of file.Decls, because a constant declared
+// inside a function body is a *ast.DeclStmt in that body and a walk of the
+// file's top-level declarations never reaches it.
+func stringConstants(files map[string]string) ([]constant, error) {
+	var constants []constant
+
+	for _, path := range slices.Sorted(maps.Keys(files)) {
+		parsed, err := parser.ParseFile(token.NewFileSet(), path, files[path], 0)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", path, err)
+		}
+
+		ast.Inspect(parsed, func(node ast.Node) bool {
+			decl, ok := node.(*ast.GenDecl)
+			if !ok || decl.Tok != token.CONST {
+				return true
+			}
+
+			for _, spec := range decl.Specs {
+				value, ok := spec.(*ast.ValueSpec)
+				if !ok || len(value.Values) != len(value.Names) {
+					// A spec with no values of its own is an iota repetition,
+					// which carries the previous spec's expression and never a
+					// string of its own.
+					continue
+				}
+
+				for at, expr := range value.Values {
+					if holdsAStringLiteral(expr) {
+						constants = append(constants, constant{name: value.Names[at].Name, expr: expr})
+					}
+				}
+			}
+
+			return true
+		})
+	}
+
+	return constants, nil
+}
+
+// resolve evaluates what it can, to a fixed point, and names what it cannot.
+//
+// A fixed point rather than one pass because a constant may be written in terms
+// of one declared further down the file or in another file of the package, and
+// declaration order is not evaluation order in Go. Each round resolves at least
+// one constant or the loop is over, so the number of rounds is bounded by the
+// number of constants.
+func resolve(constants []constant) (map[string]string, []string) {
+	values := map[string]string{}
+
+	for {
+		progressed := false
+
+		for _, c := range constants {
+			if _, done := values[c.name]; done {
+				continue
+			}
+
+			if value, ok := evaluate(c.expr, values); ok {
+				values[c.name] = value
+				progressed = true
+			}
+		}
+
+		if !progressed {
+			break
+		}
+	}
+
+	var unresolved []string
+	for _, c := range constants {
+		if _, done := values[c.name]; !done {
+			unresolved = append(unresolved, c.name)
+		}
+	}
+
+	slices.Sort(unresolved)
+
+	return values, slices.Compact(unresolved)
+}
+
+// evaluate reads a constant expression as a string.
+//
+// Literals, concatenation and references to constants already resolved, which is
+// the whole of what a flag spelling is ever written as: a literal, or one flag's
+// spelling built from another's — `emitIRFlag + "-format"`. Anything else — a
+// conversion, a call, a reference to something outside the package — is not
+// guessed at; it comes back false and its constant is named to the caller.
+func evaluate(expr ast.Expr, values map[string]string) (string, bool) {
+	switch expr := expr.(type) {
+	case *ast.BasicLit:
+		if expr.Kind != token.STRING {
+			return "", false
+		}
+
+		unquoted, err := strconv.Unquote(expr.Value)
+		if err != nil {
+			return "", false
+		}
+
+		return unquoted, true
+
+	case *ast.Ident:
+		value, ok := values[expr.Name]
+
+		return value, ok
+
+	case *ast.ParenExpr:
+		return evaluate(expr.X, values)
+
+	case *ast.BinaryExpr:
+		if expr.Op != token.ADD {
+			return "", false
+		}
+
+		left, ok := evaluate(expr.X, values)
+		if !ok {
+			return "", false
+		}
+
+		right, ok := evaluate(expr.Y, values)
+		if !ok {
+			return "", false
+		}
+
+		return left + right, true
+
+	default:
+		return "", false
+	}
+}
+
+// holdsAStringLiteral reports whether an expression has a string literal
+// anywhere inside it, which is what makes a constant a candidate for being a
+// flag at all. It is what keeps integer arithmetic out of the unresolved list.
+func holdsAStringLiteral(expr ast.Expr) bool {
+	found := false
+
+	ast.Inspect(expr, func(node ast.Node) bool {
+		if literal, ok := node.(*ast.BasicLit); ok && literal.Kind == token.STRING {
+			found = true
+		}
+
+		return !found
+	})
+
+	return found
+}
+
+// receiverType names the type a method is declared on, with the pointer taken
+// off.
+func receiverType(expr ast.Expr) string {
+	if star, ok := expr.(*ast.StarExpr); ok {
+		expr = star.X
+	}
+
+	ident, ok := expr.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+
+	return ident.Name
+}

--- a/.dagger/internal/surface/surface_test.go
+++ b/.dagger/internal/surface/surface_test.go
@@ -1,0 +1,242 @@
+// These tests are the whole reason this package exists apart from the pipeline
+// that uses it. What is built on it is CliSurface, a drift guard, and a drift
+// guard is the one kind of check whose failure mode is staying green — so every
+// shape it claims to see, and every shape it claims not to, is a row here rather
+// than a sentence in a doc comment.
+//
+// Each escape below was a real hole in the first version of the guard, found in
+// review: a flag written with one hyphen, a constant declared inside a function
+// body, a constant built by concatenating another, and a diagnostic hoisted to a
+// constant being read as a flag.
+
+package surface
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestFlagsFindsEveryShapeOfConstant(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		source string
+		want   []string
+	}{
+		{
+			name: "a package-level block, the ordinary case",
+			source: `package main
+const (
+	manifestFlag = "--manifest"
+	versionFlag  = "--version"
+)`,
+			want: []string{"--manifest", "--version"},
+		},
+		{
+			// A short flag that is not a synonym of a long one. A prefix test for
+			// "--" would let this reach the default branch with the guard green.
+			name: "a single-hyphen flag",
+			source: `package main
+const outFlag = "-o"`,
+			want: []string{"-o"},
+		},
+		{
+			// Hoisting a constant to package scope is a style choice, not a
+			// statement about whether the flag is real.
+			name: "a constant declared inside a function body",
+			source: `package main
+func parse(args []string) error {
+	const jobsFlag = "--jobs"
+	_ = jobsFlag
+	return nil
+}`,
+			want: []string{"--jobs"},
+		},
+		{
+			// The natural way to write a family: --emit-ir and --emit-ir-format.
+			name: "a constant built from another",
+			source: `package main
+const (
+	emitIRFlag       = "--emit-ir"
+	emitIRFormatFlag = emitIRFlag + "-format"
+)`,
+			want: []string{"--emit-ir", "--emit-ir-format"},
+		},
+		{
+			// Declaration order is not evaluation order, so the resolution has to
+			// reach a fixed point rather than make one pass.
+			name: "a constant built from one declared later",
+			source: `package main
+const derived = base + "-format"
+const base = "--emit-ir"`,
+			want: []string{"--emit-ir", "--emit-ir-format"},
+		},
+		{
+			name: "a parenthesised concatenation",
+			source: `package main
+const (
+	prefix = "--"
+	flag   = prefix + ("emit" + "-ir")
+)`,
+			want: []string{"--emit-ir"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			flags, unresolved, err := Flags(map[string]string{"args.go": tc.source})
+			if err != nil {
+				t.Fatalf("Flags: unexpected error: %v", err)
+			}
+			if len(unresolved) != 0 {
+				t.Errorf("Flags reported %q unresolved, want nothing unresolved", unresolved)
+			}
+			if !slices.Equal(flags, tc.want) {
+				t.Errorf("Flags = %q, want %q", flags, tc.want)
+			}
+		})
+	}
+}
+
+func TestFlagsRefusesWhatIsNotAFlag(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		source string
+	}{
+		{
+			// POSIX's end of options. cpybkc honours it and it takes no value.
+			name: "the end-of-options delimiter",
+			source: `package main
+const endOfOptions = "--"`,
+		},
+		{
+			// POSIX's standard-stream operand, which cpybkc reads as a destination
+			// rather than as a flag.
+			name: "a lone dash",
+			source: `package main
+const standardOutput = "-"`,
+		},
+		{
+			// The false positive that would produce a red build whose suggested
+			// remedy — "record this flag" — is not a thing anyone should do.
+			name: "a diagnostic that quotes a flag",
+			source: `package main
+const complaint = "--emit-ir-format may only be given beside --emit-ir"`,
+		},
+		{
+			name: "a whole usage block",
+			source: `package main
+const usage = ` + "`" + `Usage:
+  cpybkc [--manifest <path>]
+` + "`",
+		},
+		{
+			name: "an ordinary path",
+			source: `package main
+const defaultManifest = "cpybkc.json"`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			flags, unresolved, err := Flags(map[string]string{"args.go": tc.source})
+			if err != nil {
+				t.Fatalf("Flags: unexpected error: %v", err)
+			}
+			if len(unresolved) != 0 {
+				t.Errorf("Flags reported %q unresolved, want nothing unresolved", unresolved)
+			}
+			if len(flags) != 0 {
+				t.Errorf("Flags = %q, want nothing", flags)
+			}
+		})
+	}
+}
+
+func TestFlagsNamesWhatItCouldNotRead(t *testing.T) {
+	// A constant whose value has a string in it and cannot be evaluated is the
+	// one case where "not a flag" and "I could not tell" differ, and reporting it
+	// is what stops the second being read as the first.
+	source := `package main
+import "strings"
+const prefix = "--"
+var flags = []string{prefix}
+const derived = elsewhere + "-ir"
+const shouted = "--emit" + strings.ToUpper("x")`
+
+	flags, unresolved, err := Flags(map[string]string{"args.go": source})
+	if err != nil {
+		t.Fatalf("Flags: unexpected error: %v", err)
+	}
+	if len(flags) != 0 {
+		t.Errorf("Flags = %q, want nothing readable", flags)
+	}
+	if !slices.Equal(unresolved, []string{"derived", "shouted"}) {
+		t.Errorf("Flags reported %q unresolved, want [derived shouted]", unresolved)
+	}
+}
+
+func TestFlagsIgnoresArithmetic(t *testing.T) {
+	// Nothing here is a candidate, so nothing here is a complaint either: an
+	// unresolved integer constant reported as unreadable would make the guard
+	// noisy about code that was never about flags.
+	source := `package main
+const width = columns + 2
+const answer = 40 + 2`
+
+	flags, unresolved, err := Flags(map[string]string{"args.go": source})
+	if err != nil {
+		t.Fatalf("Flags: unexpected error: %v", err)
+	}
+	if len(flags) != 0 || len(unresolved) != 0 {
+		t.Errorf("Flags = %q, unresolved %q, want both empty", flags, unresolved)
+	}
+}
+
+func TestFlagsAcrossFiles(t *testing.T) {
+	// The guard reads a package, not a file: a flag introduced in a new file
+	// beside the parser, or in a subpackage the caller globbed in, has to count.
+	files := map[string]string{
+		"args.go": `package main
+const emitIRFlag = "--emit-ir"`,
+		"internal/flags/flags.go": `package flags
+const EmitIRFormatFlag = "--emit-ir" + "-format"`,
+	}
+
+	flags, _, err := Flags(files)
+	if err != nil {
+		t.Fatalf("Flags: unexpected error: %v", err)
+	}
+	if !slices.Equal(flags, []string{"--emit-ir", "--emit-ir-format"}) {
+		t.Errorf("Flags = %q, want [--emit-ir --emit-ir-format]", flags)
+	}
+}
+
+func TestFlagsReportsAParseError(t *testing.T) {
+	_, _, err := Flags(map[string]string{"broken.go": "package main\nconst = "})
+	if err == nil {
+		t.Fatal("Flags over unparseable source: want an error")
+	}
+	// Named, because a guard that could not read a file has to say which one.
+	if !strings.Contains(err.Error(), "broken.go") {
+		t.Errorf("Flags error = %q, want it to name the file", err)
+	}
+}
+
+func TestFunctions(t *testing.T) {
+	files := map[string]string{
+		"main.go": `package main
+type Cpybkc struct{}
+func (m *Cpybkc) Generate() {}
+func (m Cpybkc) Image() {}
+func (m *Cpybkc) project() {}
+func (m *Other) Generate() {}
+func New() *Cpybkc { return nil }`,
+	}
+
+	got, err := Functions(files, "Cpybkc")
+	if err != nil {
+		t.Fatalf("Functions: unexpected error: %v", err)
+	}
+	// Exported methods on the type, by pointer or by value; not its unexported
+	// ones, not another type's, and not a plain function.
+	if !slices.Equal(got, []string{"Generate", "Image"}) {
+		t.Errorf("Functions = %q, want [Generate Image]", got)
+	}
+}

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -230,12 +230,13 @@ func New(
 // modules, plus `buf lint` over the IR schema, a build of the CLI itself, a
 // build of the three artifacts a release publishes, the published base image on
 // every platform it ships for, the worked examples docs/container/SPEC.md hands
-// an adopter, the attestations a release attaches to what it publishes, and the
-// tag scheme and release notes a release is published under. This is the single
-// entrypoint — CI is one `dagger call ci` and stays one, because a workflow step
-// that reran any of these stages would be a second definition of them.
+// an adopter, the attestations a release attaches to what it publishes, the tag
+// scheme and release notes a release is published under, and the companion
+// module's coverage of the CLI's flags. This is the single entrypoint — CI is
+// one `dagger call ci` and stays one, because a workflow step that reran any of
+// these stages would be a second definition of them.
 //
-// The thirteen parts run concurrently and all are reported, for the reason the
+// The fourteen parts run concurrently and all are reported, for the reason the
 // standard runs its own four that way: waiting on a Go stage to learn that the
 // schema is unlintable, or the reverse, is a second push to find out about the
 // second failure.
@@ -244,10 +245,10 @@ func New(
 // +cache="session"
 func (m *Cpybkc) Ci(ctx context.Context) error {
 	var goErr, irErr, protoErr, buildErr, artifactErr, layoutErr, imageErr, exampleErr, attestErr error
-	var tagErr, notesErr, companionErr, engineErr error
+	var tagErr, notesErr, companionErr, engineErr, surfaceErr error
 
 	var wg sync.WaitGroup
-	wg.Add(13)
+	wg.Add(14)
 
 	go func() {
 		defer wg.Done()
@@ -319,10 +320,15 @@ func (m *Cpybkc) Ci(ctx context.Context) error {
 		engineErr = m.EngineLock(ctx)
 	}()
 
+	go func() {
+		defer wg.Done()
+		surfaceErr = m.CliSurface(ctx)
+	}()
+
 	wg.Wait()
 
 	return errors.Join(goErr, irErr, protoErr, buildErr, artifactErr, layoutErr, imageErr, exampleErr, attestErr,
-		tagErr, notesErr, companionErr, engineErr)
+		tagErr, notesErr, companionErr, engineErr, surfaceErr)
 }
 
 // IrCi runs the same standard pipeline over irpb/, the published IR module.

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -66,15 +66,18 @@
 // is the gate a contributor runs, and a check CI performs that the gate does
 // not is an arrangement of local commands that passes while CI fails.
 //
-// # Why the standard is invoked twice
+// # Why the standard is invoked four times
 //
-// This repository holds two Go modules: the CLI at the root and the published IR
-// module at irpb/. A nested go.mod is where `go test ./...` stops, so the source
-// directory that reaches one of them cannot reach the other, and IrCi is the
-// second invocation that covers the second module. It is the standard again and
-// not a variation on it — same archetype, same lint configuration — because the
-// module the third-party generators actually import is the last place this
-// repository should be checking something bespoke.
+// This repository holds four Go modules: the CLI at the root, the published IR
+// module at irpb/, the companion Dagger module at daggerverse/cpybkc/, and this
+// pipeline itself at .dagger/. A nested go.mod is where `go test ./...` stops,
+// so the source directory that reaches one of them reaches none of the others,
+// and IrCi, CompanionCi and PipelineCi are the three further invocations that
+// cover the three further modules. Each is the standard again and not a
+// variation on it — same archetype, same lint configuration — because the module
+// third-party generators import, the module strangers call, and the pipeline
+// that judges everything else are the last three places this repository should
+// be checking something bespoke.
 //
 // ProtoGen is the odd one out: it is not a check at all but the generator that
 // produces irpb/ir.pb.go, kept here because a generation recipe living anywhere
@@ -226,7 +229,7 @@ func New(
 }
 
 // Ci runs the whole pipeline: fmt, vet, golangci-lint and `go test -race`, as
-// the Z5Labs standard defines them, over each of this repository's two Go
+// the Z5Labs standard defines them, over each of this repository's four Go
 // modules, plus `buf lint` over the IR schema, a build of the CLI itself, a
 // build of the three artifacts a release publishes, the published base image on
 // every platform it ships for, the worked examples docs/container/SPEC.md hands
@@ -236,7 +239,7 @@ func New(
 // one `dagger call ci` and stays one, because a workflow step that reran any of
 // these stages would be a second definition of them.
 //
-// The fourteen parts run concurrently and all are reported, for the reason the
+// The fifteen parts run concurrently and all are reported, for the reason the
 // standard runs its own four that way: waiting on a Go stage to learn that the
 // schema is unlintable, or the reverse, is a second push to find out about the
 // second failure.
@@ -245,10 +248,10 @@ func New(
 // +cache="session"
 func (m *Cpybkc) Ci(ctx context.Context) error {
 	var goErr, irErr, protoErr, buildErr, artifactErr, layoutErr, imageErr, exampleErr, attestErr error
-	var tagErr, notesErr, companionErr, engineErr, surfaceErr error
+	var tagErr, notesErr, companionErr, engineErr, surfaceErr, pipelineErr error
 
 	var wg sync.WaitGroup
-	wg.Add(14)
+	wg.Add(15)
 
 	go func() {
 		defer wg.Done()
@@ -325,10 +328,15 @@ func (m *Cpybkc) Ci(ctx context.Context) error {
 		surfaceErr = m.CliSurface(ctx)
 	}()
 
+	go func() {
+		defer wg.Done()
+		pipelineErr = m.PipelineCi(ctx)
+	}()
+
 	wg.Wait()
 
 	return errors.Join(goErr, irErr, protoErr, buildErr, artifactErr, layoutErr, imageErr, exampleErr, attestErr,
-		tagErr, notesErr, companionErr, engineErr, surfaceErr)
+		tagErr, notesErr, companionErr, engineErr, surfaceErr, pipelineErr)
 }
 
 // IrCi runs the same standard pipeline over irpb/, the published IR module.
@@ -348,6 +356,40 @@ func (m *Cpybkc) Ci(ctx context.Context) error {
 func (m *Cpybkc) IrCi(ctx context.Context) error {
 	return dag.Z5Labs().
 		GoLib(m.Source.Directory("irpb"), dagger.Z5LabsGoLibOpts{LintConfig: m.LintConfig}).
+		Ci(ctx)
+}
+
+// pipelineModuleDir is this pipeline's own Go module — the one whose functions
+// you are reading. It is a module rather than a package of the repository, so
+// `go test ./...` from the root stops at its go.mod exactly as it stops at
+// irpb/'s and the companion's.
+const pipelineModuleDir = ".dagger"
+
+// PipelineCi runs the standard Go pipeline over the pipeline's own module.
+//
+// It is a fourth call for the reason IrCi is a second and CompanionCi a third: a
+// nested go.mod is where `go test ./...` stops. Until this existed, the pipeline
+// that checks everything else in the repository was the one Go module nothing
+// checked — and what made that worth fixing rather than noting is #62's
+// CliSurface, whose reading of the CLI's flag constants lives in
+// internal/surface precisely so that it can be tested, and whose tests would
+// otherwise have run on a contributor's machine and nowhere else. A drift guard
+// nothing exercises is a drift guard nobody finds out has stopped working.
+//
+// What it really runs is that package. The module's own package main imports the
+// generated Dagger client, whose init panics without a session, so a test beside
+// main cannot run under plain `go test` here any more than it can in the
+// companion; keeping the readable part in a package that imports no Dagger is
+// what turns these rules into something a test pins.
+//
+// It is handed the same .golangci.yml, so all four Go modules are linted against
+// one configuration rather than one each.
+//
+// +check
+// +cache="session"
+func (m *Cpybkc) PipelineCi(ctx context.Context) error {
+	return dag.Z5Labs().
+		GoLib(m.Source.Directory(pipelineModuleDir), dagger.Z5LabsGoLibOpts{LintConfig: m.LintConfig}).
 		Ci(ctx)
 }
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -647,28 +647,65 @@ not to express it. `dagger call cli-surface` is the difference, and it is in
 dagger call cli-surface
 ```
 
-It reads the CLI's flag constants out of [`cmd/cpybkc/`](cmd/cpybkc/) and fails
-when one of them is not recorded in `companionCoverage` in
+It reads the CLI's flag constants out of the [`cmd/cpybkc/`](cmd/cpybkc/) tree
+and fails when one of them is not recorded in `companionCoverage` in
 [`.dagger/companion.go`](.dagger/companion.go), when a recorded entry names a
 function `daggerverse/cpybkc` does not declare, or when an entry names a flag
 the CLI has stopped accepting. **So adding a flag to cpybkc fails CI until
 somebody says which side of the curation it falls on** — a curated argument on
 `Generate`, or `Run`.
 
-Two things about how it reads that are worth knowing before changing either
-side. It reads the parser's **constants**, not `cpybkc --help` and not the
-spec's table: the help text is deliberately written out by hand, because what a
-flag is called is a covered guarantee and what usage says about it is
-explicitly not one, so a check reading it would fail on a rewording and pass on
-a flag the document forgot. And it is a **flag**-level check because
+Be exact about what an entry in that table claims, because it is less than it
+looks. It is a person's assertion that they thought about the flag and decided
+where it belongs; nothing verifies that the named function can *reach* it, and
+since `Run` forwards an arbitrary vector, every flag is reachable through `Run`
+by construction. What the check buys is that the assertion has to be re-made
+whenever the CLI's surface moves, which is exactly when it stops being true by
+accident.
+
+Three things about how it reads are worth knowing before changing either side.
+It reads the parser's **constants**, not `cpybkc --help` and not the spec's
+table: the help text is deliberately written out by hand, because what a flag is
+called is a covered guarantee and what usage says about it is explicitly not
+one, so a check reading it would fail on a rewording and pass on a flag the
+document forgot. It reads them from the whole tree and in every shape a constant
+can be written — package scope or a function body, one hyphen or two, a literal
+or one flag's spelling built from another's — because each of those was a hole
+found in review, and each is now a row in
+[`.dagger/internal/surface/`](.dagger/internal/surface/)'s tests rather than a
+sentence in a comment. And it is a **flag**-level check because
 `docs/cli/SPEC.md` fixes cpybkc as one command with no subcommands — there is no
 verb list for a module function to correspond to, so the surface that can drift
 is the flag table.
+
+Two things stop it degrading quietly, which matters more here than for an
+ordinary check: a drift guard's failure mode is *staying green*. A read that
+finds no flags at all fails rather than passes, and a constant whose value it
+cannot evaluate is reported rather than dropped, because "I could not read this"
+and "this is not a flag" are different things to have learned.
 
 This is the shape of check [#65 was closed for not
 being](#65-is-closed-rather-than-left-open). It fails on something a person does
 — adding a flag in one module and not thinking about the other — rather than on
 a constant compared against the thing it was generated from.
+
+### The pipeline module is checked like any other Go module here
+
+`dagger call pipeline-ci` runs the standard pipeline over
+[`.dagger/`](.dagger/), and it is in `ci`. It is a fourth call for the reason
+[`IrCi`](.dagger/main.go) is a second and
+[`CompanionCi`](.dagger/companion.go) a third: a nested `go.mod` is where `go
+test ./...` stops. Until it existed, the module that checks everything else in
+this repository was the one Go module nothing checked.
+
+What made that worth fixing rather than noting is `cli-surface`. Its reading of
+the CLI's constants lives in [`.dagger/internal/surface/`](.dagger/internal/surface/)
+**precisely so that it can be tested** — the pipeline's own `package main`
+imports the generated Dagger client, whose `init` panics without a session, so a
+test beside it cannot run under plain `go test`, exactly as in the companion.
+Without this stage those tests would run on a contributor's machine and nowhere
+else, and a drift guard nothing exercises is a drift guard nobody finds out has
+stopped working.
 
 ### The default image tag is the moving major tag
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -615,6 +615,61 @@ Both modules' generated code is committed, so a change to either is a
 [*After changing the module*](#after-changing-the-module) applies to the
 companion exactly as it does to the root.
 
+### The curated surface, and the check that keeps it honest
+
+`Generate` takes a source directory and a manifest and hands back a
+`Directory`; `Run` takes an argument vector verbatim and hands back a
+`Container`. Those two are the whole surface, and the split between them is a
+decision rather than a stopping point (#62).
+
+The module **does not** grow an argument per entry in
+[`docs/cli/SPEC.md`](docs/cli/SPEC.md)'s flag table. A module argument is public
+API for as long as the published ref exists — the [directory name is the public
+ref](#the-directory-name-is-the-public-ref-so-it-is-chosen-once) — so a table
+mapped one-to-one would make every change to the CLI's surface a change to this
+module's, and it would have to express in Dagger arguments two things a command
+line says better: a flag that *replaces* the action rather than configuring it
+(`--emit-ir` is terminal — no generator runs, and nothing is merged or pruned),
+and a flag that is only legal beside another (`--emit-ir-format` without
+`--emit-ir` is a usage error). `Run` is what makes the small surface safe: an
+uncurated flag is reachable without the module having an opinion about it, and
+it returns the container rather than a directory because the uncurated
+invocations are exactly the ones whose answer is not a tree — `--emit-ir` may
+write to standard output, and `--version` and `--help` write nothing else at
+all.
+
+What a curated surface risks is the CLI quietly growing a flag the module can
+no longer express, which reads from out here exactly like a module that chose
+not to express it. `dagger call cli-surface` is the difference, and it is in
+`ci`:
+
+```sh
+dagger call cli-surface
+```
+
+It reads the CLI's flag constants out of [`cmd/cpybkc/`](cmd/cpybkc/) and fails
+when one of them is not recorded in `companionCoverage` in
+[`.dagger/companion.go`](.dagger/companion.go), when a recorded entry names a
+function `daggerverse/cpybkc` does not declare, or when an entry names a flag
+the CLI has stopped accepting. **So adding a flag to cpybkc fails CI until
+somebody says which side of the curation it falls on** — a curated argument on
+`Generate`, or `Run`.
+
+Two things about how it reads that are worth knowing before changing either
+side. It reads the parser's **constants**, not `cpybkc --help` and not the
+spec's table: the help text is deliberately written out by hand, because what a
+flag is called is a covered guarantee and what usage says about it is
+explicitly not one, so a check reading it would fail on a rewording and pass on
+a flag the document forgot. And it is a **flag**-level check because
+`docs/cli/SPEC.md` fixes cpybkc as one command with no subcommands — there is no
+verb list for a module function to correspond to, so the surface that can drift
+is the flag table.
+
+This is the shape of check [#65 was closed for not
+being](#65-is-closed-rather-than-left-open). It fails on something a person does
+— adding a flag in one module and not thinking about the other — rather than on
+a constant compared against the thing it was generated from.
+
 ### The default image tag is the moving major tag
 
 `New`'s `version` argument defaults to **`v0`**, the moving major tag, and not

--- a/daggerverse/cpybkc/dagger.gen.go
+++ b/daggerverse/cpybkc/dagger.gen.go
@@ -206,6 +206,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 	switch parentName {
 	case "Cpybkc":
 		switch fnName {
+		case "Generate":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var source *dagger.Directory
+			if inputArgs["source"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["source"]), &source)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg source", err))
+				}
+			}
+			var manifest string
+			if inputArgs["manifest"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["manifest"]), &manifest)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg manifest", err))
+				}
+			}
+			return (*Cpybkc).Generate(&parent, ctx, source, manifest)
 		case "Image":
 			var parent Cpybkc
 			err = json.Unmarshal(parentJSON, &parent)
@@ -213,6 +234,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return (*Cpybkc).Image(&parent), nil
+		case "Run":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var args []string
+			if inputArgs["args"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["args"]), &args)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg args", err))
+				}
+			}
+			var source *dagger.Directory
+			if inputArgs["source"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["source"]), &source)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg source", err))
+				}
+			}
+			return (*Cpybkc).Run(&parent, ctx, args, source)
 		case "":
 			var parent Cpybkc
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/cpybkc/internal/argv/argv.go
+++ b/daggerverse/cpybkc/internal/argv/argv.go
@@ -1,0 +1,59 @@
+// Package argv assembles the argument vectors this module hands the cpybkc
+// CLI.
+//
+// It is a package of its own for the reason internal/imageref is one: the
+// module's own package main imports the generated Dagger client, whose init
+// panics without a session, so a test beside main cannot run under plain
+// `go test` at all. Keeping the part that is only string handling in a package
+// that imports no Dagger is what turns the vector a curated function builds
+// into something a test pins rather than something a comment asserts.
+//
+// What is deliberately not here is a builder covering the whole of
+// docs/cli/SPEC.md's flag table. The module curates: it maps the run a caller
+// almost always wants, and hands everything else to Run, whose vector is the
+// caller's own words and is not this package's to assemble.
+package argv
+
+import "fmt"
+
+// manifestFlag names the project manifest a run reads. It is spelled here
+// exactly as docs/cli/SPEC.md fixes it, and the separated form is the one the
+// document's synopsis writes.
+const manifestFlag = "--manifest"
+
+// standardOutput is the dash cpybkc reads as "a stream" wherever it accepts
+// one. --manifest is the one flag that refuses it.
+const standardOutput = "-"
+
+// Generate is the vector for a generation run over a project mounted at the
+// container's working directory.
+//
+// An empty manifest is a vector of no arguments, which is the whole point of
+// the CLI having no subcommand: generating is what cpybkc does when nothing
+// else is asked of it, and the mounted project's own cpybkc.json is what it
+// reads. A manifest names one somewhere else, relative to the mounted project
+// root because that is the working directory the CLI resolves a path typed on
+// the command line against.
+//
+// The dash is refused here rather than passed through for the CLI to refuse,
+// because the two refusals do not cost the same. A vector that reaches the
+// container has already paid for a pull and an exec to say what is knowable
+// from the argument alone, and the reason — a manifest's paths are relative to
+// the directory holding it, and a manifest on a stream is in no directory — is
+// the same reason either way. Every other value is passed through unexamined:
+// what is a readable manifest is a question about a filesystem this package
+// cannot see, and guessing at it here would refuse runs cpybkc would have
+// performed.
+func Generate(manifest string) ([]string, error) {
+	if manifest == "" {
+		return nil, nil
+	}
+
+	if manifest == standardOutput {
+		return nil, fmt.Errorf(
+			"manifest cannot be %q: a manifest's paths are relative to the directory holding it, and a manifest "+
+				"on a stream is in no directory", standardOutput)
+	}
+
+	return []string{manifestFlag, manifest}, nil
+}

--- a/daggerverse/cpybkc/internal/argv/argv_test.go
+++ b/daggerverse/cpybkc/internal/argv/argv_test.go
@@ -1,0 +1,85 @@
+// These tests cover the vector Generate hands the CLI, which is public API in
+// the same way imageref's default reference is: a caller who passes no manifest
+// gets an invocation of no arguments, and what that means — the mounted
+// project's own cpybkc.json, read from the working directory — is a promise
+// docs/cli/SPEC.md makes and this module relies on rather than restates. Pinning
+// the vector here turns a later accidental flag into a red build.
+//
+// What is not tested here is anything needing an engine: whether the exec
+// succeeds, whether the project mounted at the working directory has a manifest
+// in it, or what the CLI does with one. Those are the CLI's own tests and, for
+// this module driven over a real image, #64's.
+
+package argv
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestGenerateWithNoManifest(t *testing.T) {
+	got, err := Generate("")
+	if err != nil {
+		t.Fatalf("Generate(\"\"): unexpected error: %v", err)
+	}
+	// No arguments at all, and not a --manifest naming the default. Spelling the
+	// default here would be this module's second statement of where cpybkc looks
+	// for a manifest, and the two would drift the moment that document changed.
+	if len(got) != 0 {
+		t.Errorf("Generate(\"\") = %q, want no arguments", got)
+	}
+}
+
+func TestGenerateWithAManifest(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		manifest string
+		want     []string
+	}{
+		{
+			// The ordinary case: a project keeping its manifest below its root.
+			name:     "a path below the project root",
+			manifest: "build/cpybkc.json",
+			want:     []string{"--manifest", "build/cpybkc.json"},
+		},
+		{
+			name:     "a manifest named something else",
+			manifest: "orders.json",
+			want:     []string{"--manifest", "orders.json"},
+		},
+		{
+			// Separated rather than joined, so a value carrying an equals sign
+			// needs no thought about which one cpybkc cuts on.
+			name:     "a path carrying an equals sign",
+			manifest: "odd=name/cpybkc.json",
+			want:     []string{"--manifest", "odd=name/cpybkc.json"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Generate(tc.manifest)
+			if err != nil {
+				t.Fatalf("Generate(%q): unexpected error: %v", tc.manifest, err)
+			}
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("Generate(%q) = %q, want %q", tc.manifest, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGenerateRefusesTheDash(t *testing.T) {
+	got, err := Generate("-")
+	if err == nil {
+		t.Fatalf("Generate(\"-\") = %q, want an error", got)
+	}
+	if got != nil {
+		t.Errorf("Generate(\"-\") returned %q beside its error, want no vector", got)
+	}
+	// Checked for saying why rather than merely for being non-nil: a caller who
+	// reached for the dash was thinking of a stream, and the reason they cannot
+	// have one is the whole of what the message has to teach.
+	if !strings.Contains(err.Error(), "in no directory") {
+		t.Errorf("Generate(\"-\") error = %q, want it to say why a manifest cannot arrive on a stream", err)
+	}
+}

--- a/daggerverse/cpybkc/main.go
+++ b/daggerverse/cpybkc/main.go
@@ -59,17 +59,61 @@
 // pipeline. `dagger call ci`, the image builds and the contract checks are the
 // root module's.
 //
-// Running the CLI over a project (#62) and composing a generator into the image
-// (#63) are the functions this module exists for, and neither is here yet. What
-// is here is the part they both start from: deciding which image runs, which is
-// the choice a caller makes once and the one that has to be right before
-// anything is built on it.
+// Composing a generator into the image (#63) is not here yet. What is here is
+// running the CLI over a project — Generate, and Run for everything Generate
+// does not curate — on top of the part they both start from: deciding which
+// image runs, which is the choice a caller makes once and the one that has to be
+// right before anything is built on it.
+//
+// # The curated surface, and why it is not the flag table
+//
+// Generate takes a source directory and a manifest, and that is the whole of
+// what this module maps by name. It deliberately does not grow an argument per
+// entry in docs/cli/SPEC.md's flag table: a module argument is public API for as
+// long as the directory this module is published under exists, so a table
+// mapped one-to-one would make every change to that table a change to this
+// module's surface, and would have to express in Dagger arguments things a
+// command line says better — a flag that replaces the action rather than
+// configuring it, and a flag that may not appear beside another.
+//
+// Run is the other half of that decision, and the reason the first half can stay
+// small. It takes the argument vector verbatim and hands back the container, so
+// an uncurated flag — --emit-ir, --emit-ir-format, --version, --help, and
+// whatever this document has not heard of — is reachable without this module
+// having an opinion about it. The root pipeline's CliSurface check is what keeps
+// the split honest: it fails when the CLI grows a flag that neither Generate nor
+// Run is recorded as covering, so the two cannot drift quietly.
 package main
 
 import (
+	"context"
+	"fmt"
+
+	"dagger/cpybkc/internal/argv"
 	"dagger/cpybkc/internal/dagger"
 	"dagger/cpybkc/internal/imageref"
 )
+
+// projectDir is where a caller's project is mounted, and the working directory
+// the CLI is run from.
+//
+// It is this module's choice rather than the base-image contract's: that
+// document pins the entrypoint, the plugin directory and the user, and sets no
+// WORKDIR at all, leaving `docker run -v "$PWD:/src" -w /src …` to say where a
+// project lives for the length of one command. The value matters to a caller
+// only through Run, whose container is handed back with the project still at
+// this path, so it is written into that function's documentation rather than
+// left to be discovered.
+const projectDir = "/src"
+
+// contractUser is the UID:GID docs/container/SPEC.md pins the image to, used to
+// own the mounted project when the container cannot say who it runs as.
+//
+// The container is asked first, and this is the fallback, because a caller may
+// have passed --image. Owning the mount as somebody the process is not is a run
+// that fails on the first file a generator writes, which is a long way from the
+// argument that caused it.
+const contractUser = "65532:65532"
 
 // Cpybkc is one cpybkc image, plus the coordinates for resolving images related
 // to it.
@@ -203,4 +247,151 @@ func New(
 // this project published and not to the bytes.
 func (m *Cpybkc) Image() *dagger.Container {
 	return m.Container
+}
+
+// Generate runs cpybkc over a project and hands back the project as it should
+// now be committed:
+//
+//	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+//	  generate --source . export --path .
+//
+// Nothing is written to the host. The Directory that comes back is a value like
+// any other, and exporting it is the caller's separate, explicit step — which is
+// also what disposes of the ownership problem a bind mount has, where generated
+// files land owned by whichever UID the container ran as and a host user who is
+// not that UID owns none of their own project. Dagger's export writes as the
+// person running it, so the image's pinned user never reaches the host.
+//
+// What comes back is the **whole project directory**, not only the files a
+// generator produced. A generator's output lands where the manifest says, which
+// is ordinarily inside the source tree, and a run also prunes what a previous
+// run generated and no longer would — so the generated files alone cannot
+// express half of what a run did. `generate --source . export --path .` is
+// therefore the ordinary use, and it is a full statement of the run rather than
+// an overlay that leaves deletions behind.
+func (m *Cpybkc) Generate(
+	ctx context.Context,
+	// The project to generate over: the directory holding the manifest, the
+	// layout it names and the copybooks that layout names.
+	//
+	// It is mounted whole rather than filtered down to what a run reads, because
+	// which copybooks a run reads is a property of the layout — the manifest
+	// carries no input list — and a module guessing at that set would be a second,
+	// weaker answer to a question docs/cli/SPEC.md answers exactly.
+	source *dagger.Directory,
+	// The project manifest to read, relative to the root of source.
+	//
+	// It defaults to nothing, which leaves cpybkc reading `cpybkc.json` at the
+	// root of the mounted project — the CLI's own default, applied by the CLI,
+	// against the working directory this module puts the project at. There is no
+	// upward search and no second manifest, so a project keeping its manifest
+	// somewhere else says so here.
+	//
+	// A relative path resolves against that project root, because that is the
+	// directory the CLI resolves a path typed on the command line against. It
+	// cannot be "-": a manifest's own paths are relative to the directory holding
+	// it, and a manifest arriving on a stream is in no directory.
+	// +optional
+	manifest string,
+) (*dagger.Directory, error) {
+	args, err := argv.Generate(manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	project, err := m.project(ctx, source)
+	if err != nil {
+		return nil, err
+	}
+
+	return project.
+		WithExec(args, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
+		Directory(projectDir), nil
+}
+
+// Run is the escape hatch: cpybkc invoked with an argument vector this module
+// has no opinion about, in a container handed back whole.
+//
+//	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+//	  run --source . --args=--emit-ir,- stdout
+//
+//	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+//	  run --args=--help stdout
+//
+// It exists so that Generate does not have to grow an argument every time
+// docs/cli/SPEC.md's flag table does. A flag that replaces the action rather
+// than configuring it (--emit-ir is terminal: no generator runs and nothing is
+// merged or pruned), one that may only appear beside another (--emit-ir-format
+// without --emit-ir is a usage error), and one that answers a question about the
+// program rather than about a project (--version, --help) are all things a
+// command line states plainly and a set of Dagger arguments states badly.
+//
+// A container rather than a directory, because the uncurated invocations are the
+// ones whose answer is not a tree. --emit-ir may write to standard output, and
+// --version and --help write nothing else at all; a Directory return would make
+// the escape hatch unable to reach exactly the flags it exists for. A caller who
+// does want the tree takes it from the container, where the project is still
+// mounted at /src:
+//
+//	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+//	  run --source . --args=--manifest,build/cpybkc.json \
+//	  directory --path=/src export --path .
+//
+// Nothing here is validated. A vector this module checked would be a second,
+// unversioned reading of a contract the CLI already implements, and its
+// diagnostics are better than anything guessed at from out here: what an
+// unrecognised flag is, whether a flag may repeat and what a usage error exits
+// with are all docs/cli/SPEC.md's, and the exec's failure carries them back
+// verbatim.
+func (m *Cpybkc) Run(
+	ctx context.Context,
+	// The argument vector, passed to the CLI exactly as written. The entrypoint
+	// is the CLI itself, so this is everything after the command name and it
+	// never names the command.
+	args []string,
+	// The project to run over, mounted at /src and made the working directory.
+	//
+	// It is optional because half the reason this function exists is the
+	// invocations that have no project — `--version` and `--help` read nothing and
+	// contact nothing. With no source the container is the image as it was
+	// resolved, and cpybkc runs in whatever directory the image left it in.
+	// +optional
+	source *dagger.Directory,
+) (*dagger.Container, error) {
+	container := m.Container
+	if source != nil {
+		mounted, err := m.project(ctx, source)
+		if err != nil {
+			return nil, err
+		}
+
+		container = mounted
+	}
+
+	return container.WithExec(args, dagger.ContainerWithExecOpts{UseEntrypoint: true}), nil
+}
+
+// project mounts a caller's project at [projectDir] and stands in it.
+//
+// The mount is owned by whoever the container runs as, asked of the container
+// rather than assumed, so that a caller who passed --image built on a derived
+// image with its own user still gets a project their process can write into. A
+// container that reports no user at all falls back to [contractUser], which is
+// what the base-image contract pins and what an image satisfying it runs as; the
+// alternative, leaving the mount root-owned, is a run that fails on the first
+// file a generator writes.
+func (m *Cpybkc) project(ctx context.Context, source *dagger.Directory) (*dagger.Container, error) {
+	user, err := m.Container.User(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("reading the user the cpybkc image runs as, which the mounted project has to be "+
+			"writable by: %w", err)
+	}
+
+	if user == "" {
+		user = contractUser
+	}
+
+	return m.Container.
+		WithDirectory(projectDir, source, dagger.ContainerWithDirectoryOpts{Owner: user}).
+		WithWorkdir(projectDir), nil
 }


### PR DESCRIPTION
Closes #62

The companion Dagger module (`daggerverse/cpybkc`) can now run the CLI over a project, and the pipeline gained a check that stops its curated surface drifting away from the CLI's.

## Acceptance criteria

- [x] **`Generate` accepts a source directory and returns `*dagger.Directory`.** It mounts `source` at `/src`, makes it the working directory, runs the image's entrypoint and returns `/src`. The whole project directory comes back, not only the generated files — a generator writes where the manifest says, which is ordinarily inside the source tree, and a run also prunes what a previous run generated, so generated files alone cannot express half of what a run did. `generate --source . export --path .` is the ordinary use.
- [x] **Never writes to the host; the caller exports.** Nothing in the module exports, publishes or writes anywhere. That is also what disposes of the ownership problem a bind mount has: Dagger's export writes as whoever runs it, so the image's pinned UID never reaches the host.
- [x] **A `Run(args []string)` escape hatch covers uncurated flags.** It takes the vector verbatim and returns the `*dagger.Container`, with an optional `source`. A container rather than a directory, because the uncurated invocations are exactly the ones whose answer is not a tree — `--emit-ir` may write to standard output, and `--version` and `--help` write nothing else at all. Nothing is validated: the CLI's own diagnostics are better than anything guessed at from out here.
- [x] **Subcommand mapping follows the house chaining pattern.** There are no subcommands to map — `docs/cli/SPEC.md`'s *One command, and no subcommands* forbids them, and reserves the operand position deliberately. What the criterion asks for structurally is met the way the module already worked: every function is a builder returning a `Cpybkc`, a terminal that runs something, or an accessor handing back what was resolved, so `dagger call --version=v0.3.1 generate --source . export --path .` reads as the image being assembled and then used, and nothing mutates.
- [x] **A CI check fails when a CLI command has no corresponding dagger function.** `dagger call cli-surface`, in `ci`.

## The curated surface, and the check

`Generate(source, manifest)` and `Run(args, source)` are the whole surface. The module deliberately does **not** grow an argument per entry in the CLI's flag table: a module argument is public API for as long as the published ref exists, so a one-to-one mapping would make every change to the CLI's surface a change to this module's — and it would have to express in Dagger arguments two things a command line says better, a flag that *replaces* the action (`--emit-ir` is terminal) and a flag that is only legal beside another (`--emit-ir-format` without `--emit-ir` is a usage error).

`CliSurface` is what makes that safe. Since the CLI is one command, the surface that can drift is the flag table, so the check is flag-level: it reads the parser's flag constants out of `cmd/cpybkc/` and fails when one is not recorded in `companionCoverage`, when a record names a function `daggerverse/cpybkc` does not declare, or when a record names a flag the CLI no longer accepts. Adding a flag to cpybkc now fails CI until somebody says which side of the curation it falls on.

It reads the **constants** rather than `cpybkc --help` or the spec's table on purpose: the help text is written out by hand because what a flag is called is a covered guarantee and what usage says about it explicitly is not, so a check reading it would fail on a rewording and pass on a flag the document forgot. A flag introduced without a constant would escape it; that limit is written into the function's comment, and an empty result is a failure rather than a pass, so the check cannot quietly degrade into one that compares nothing.

## Judgment calls

- **No `user` argument.** avroc's `Generate` takes one, because a Dagger caller exports as whoever runs the export. Returning a `Directory` is what solves that here, so the argument would be surface bought for nothing. The mount is instead owned by whoever the container reports it runs as — asked of the container, so a caller who passed `--image` built on a derived image still gets a project their process can write into — falling back to the contract's pinned `65532:65532` if it reports none.
- **`Run` returns a container, not a directory.** See above; a `Directory` return would make the escape hatch unable to reach the flags it exists for. The project is still at `/src` on it, and that path is documented on the function rather than left to be discovered.
- **`--manifest` is the one flag `Generate` maps.** It says *which project is being generated*, which is the question `--source` is already half of. The dash is refused in the module rather than left to the CLI, because that refusal is knowable from the argument alone and the container round trip is not free.

## Verification

- `dagger call ci` — green, now fourteen parts.
- `dagger call cli-surface` — green, and demonstrated failing in both directions before commit: adding a `--jobs` constant to `cmd/cpybkc/args.go` produced *"the cpybkc CLI accepts --jobs and daggerverse/cpybkc records nothing that covers it"*, and pointing a record at a function that does not exist produced *"…and that module declares no such function"*.
- Both new functions driven over the image this pipeline builds, with a temporary probe removed before commit: `Run --args=--version` returned `cpybkc 0.0.0-dev (IR version 1)`, and `Generate` over a project holding only a manifest failed with the CLI's own diagnostic — `error: there is no layout to read at "orders.sexpr" / looked for /src/orders.sexpr` — which is the mount, the working directory and the default manifest all confirmed from inside the container. A run that completes needs a generator in the image, which is #63, and driving the module in CI is #64.
- New `internal/argv` package with tests, following `internal/imageref`'s precedent: the module's own `package main` imports the generated client, whose `init` panics without a session, so the pure part lives where `go test` can reach it. `dagger call companion-ci` covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJtAWEJJX2nj8hKWm73xxC