### PR TITLE
story(dagger): add WithPlugin for custom generator composition

### DIFF
--- a/.dagger/internal/dagger/companion.gen.go
+++ b/.dagger/internal/dagger/companion.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Companion
-func (r *Binding) AsCompanion() *Companion { // companion (../../../daggerverse/cpybkc/main.go:220:6)
+func (r *Binding) AsCompanion() *Companion { // companion (../../../daggerverse/cpybkc/main.go:221:6)
 	q := r.query.Select("asCompanion")
 
 	return &Companion{
@@ -24,7 +24,7 @@ func (r *Binding) AsCompanion() *Companion { // companion (../../../daggerverse/
 // A function on it is a builder returning a new Cpybkc, a terminal that runs
 // something, or an accessor handing back what was resolved, so a call chain
 // reads as the image being assembled and then used; nothing here mutates.
-type Companion struct { // companion (../../../daggerverse/cpybkc/main.go:220:6)
+type Companion struct { // companion (../../../daggerverse/cpybkc/main.go:221:6)
 	query *querybuilder.Selection
 
 	id *ID
@@ -60,7 +60,7 @@ type CompanionGenerateOpts struct {
 	// cannot be "-": a manifest's own paths are relative to the directory holding
 	// it, and a manifest arriving on a stream is in no directory.
 	//
-	Manifest string // companion (../../../daggerverse/cpybkc/main.go:568:2)
+	Manifest string // companion (../../../daggerverse/cpybkc/main.go:584:2)
 }
 
 // Generate runs cpybkc over a project and hands back the project as it should
@@ -83,7 +83,7 @@ type CompanionGenerateOpts struct {
 // express half of what a run did. `generate --source . export --path .` is
 // therefore the ordinary use, and it is a full statement of the run rather than
 // an overlay that leaves deletions behind.
-func (r *Companion) Generate(source *Directory, opts ...CompanionGenerateOpts) *Directory { // companion (../../../daggerverse/cpybkc/main.go:545:1)
+func (r *Companion) Generate(source *Directory, opts ...CompanionGenerateOpts) *Directory { // companion (../../../daggerverse/cpybkc/main.go:561:1)
 	assertNotNil("source", source)
 	q := r.query.Select("generate")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -166,7 +166,7 @@ func (r *Companion) UnmarshalJSON(bs []byte) error {
 // none of the signatures or attestations one does (docs/container/SPEC.md, "What
 // a tag carries besides the image"), because those are attached to the digest
 // this project published and not to the bytes.
-func (r *Companion) Image() *Container { // companion (../../../daggerverse/cpybkc/main.go:521:1)
+func (r *Companion) Image() *Container { // companion (../../../daggerverse/cpybkc/main.go:537:1)
 	q := r.query.Select("image")
 
 	return &Container{
@@ -184,7 +184,7 @@ type CompanionRunOpts struct {
 	// contact nothing. With no source the container is the image as it was
 	// resolved, and cpybkc runs in whatever directory the image left it in.
 	//
-	Source *Directory // companion (../../../daggerverse/cpybkc/main.go:632:2)
+	Source *Directory // companion (../../../daggerverse/cpybkc/main.go:648:2)
 }
 
 // Run is the escape hatch: cpybkc invoked with an argument vector this module
@@ -221,7 +221,7 @@ type CompanionRunOpts struct {
 // unrecognised flag is, whether a flag may repeat and what a usage error exits
 // with are all docs/cli/SPEC.md's, and the exec's failure carries them back
 // verbatim.
-func (r *Companion) Run(args []string, opts ...CompanionRunOpts) *Container { // companion (../../../daggerverse/cpybkc/main.go:619:1)
+func (r *Companion) Run(args []string, opts ...CompanionRunOpts) *Container { // companion (../../../daggerverse/cpybkc/main.go:635:1)
 	q := r.query.Select("run")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `source` optional argument
@@ -247,7 +247,7 @@ type CompanionWithGeneratorOpts struct {
 	// image being composed into, which is checked, because a mismatch here is
 	// checkable and its exec-time failure is not legible.
 	//
-	Image *Container // companion (../../../daggerverse/cpybkc/main.go:406:2)
+	Image *Container // companion (../../../daggerverse/cpybkc/main.go:419:2)
 }
 
 // WithGenerator adds one generator to the image by copying its executable out of
@@ -275,7 +275,7 @@ type CompanionWithGeneratorOpts struct {
 // about multi-platform: composing an amd64 generator into an arm64 image produces
 // an image that builds and pushes and then fails at exec with the kernel's
 // message rather than cpybkc's, which is a long way from the call that caused it.
-func (r *Companion) WithGenerator(name string, opts ...CompanionWithGeneratorOpts) *Companion { // companion (../../../daggerverse/cpybkc/main.go:393:1)
+func (r *Companion) WithGenerator(name string, opts ...CompanionWithGeneratorOpts) *Companion { // companion (../../../daggerverse/cpybkc/main.go:406:1)
 	q := r.query.Select("withGenerator")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `image` optional argument
@@ -312,7 +312,7 @@ func (r *Companion) WithGenerator(name string, opts ...CompanionWithGeneratorOpt
 // or foreign-architecture generator fails at exec time with the kernel's message
 // rather than cpybkc's. WithGenerator can check the platform half of that because
 // a container states one; here there is nothing to read.
-func (r *Companion) WithGeneratorExecutable(name string, executable *File) *Companion { // companion (../../../daggerverse/cpybkc/main.go:477:1)
+func (r *Companion) WithGeneratorExecutable(name string, executable *File) *Companion { // companion (../../../daggerverse/cpybkc/main.go:491:1)
 	assertNotNil("executable", executable)
 	q := r.query.Select("withGeneratorExecutable")
 	q = q.Arg("name", name)
@@ -332,7 +332,7 @@ func (r *Companion) AsNode() Node {
 }
 
 // Create or update a binding of type Companion in the environment
-func (r *Env) WithCompanionInput(name string, value *Companion, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:220:6)
+func (r *Env) WithCompanionInput(name string, value *Companion, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:221:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withCompanionInput")
 	q = q.Arg("name", name)
@@ -345,7 +345,7 @@ func (r *Env) WithCompanionInput(name string, value *Companion, description stri
 }
 
 // Declare a desired Companion output to be assigned in the environment
-func (r *Env) WithCompanionOutput(name string, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:220:6)
+func (r *Env) WithCompanionOutput(name string, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:221:6)
 	q := r.query.Select("withCompanionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -369,7 +369,7 @@ type CompanionOpts struct {
 	//
 	//
 	// Default: "v0"
-	Version string // companion (../../../daggerverse/cpybkc/main.go:284:2)
+	Version string // companion (../../../daggerverse/cpybkc/main.go:292:2)
 	//
 	// The registry repository the image is pulled from, as `<host>/<path>` with no
 	// tag.
@@ -384,7 +384,7 @@ type CompanionOpts struct {
 	//
 	//
 	// Default: "ghcr.io/zaba505/cpybkc"
-	Repository string // companion (../../../daggerverse/cpybkc/main.go:297:2)
+	Repository string // companion (../../../daggerverse/cpybkc/main.go:305:2)
 	//
 	// Run in this container instead of pulling one, replacing it entirely.
 	//
@@ -399,7 +399,12 @@ type CompanionOpts struct {
 	// change to cpybkc before it ships, and how a build pins the image by digest —
 	// a reference no tag argument can express, and the only one that pins bytes.
 	//
-	Image *Container // companion (../../../daggerverse/cpybkc/main.go:311:2)
+	// It pins this image and nothing else. A generator pulled afterwards by
+	// with-generator follows --version, which defaults to the moving "v0" tag and
+	// does not track whatever was pinned here, so a build that pins the CLI by
+	// digest and wants the pairing to hold still passes --version beside it.
+	//
+	Image *Container // companion (../../../daggerverse/cpybkc/main.go:324:2)
 	//
 	// Pull the image for this platform, as `GOOS/GOARCH`, instead of for the
 	// engine's own.
@@ -418,7 +423,7 @@ type CompanionOpts struct {
 	// Empty is the engine's own platform, which is what makes an ordinary
 	// `dagger call` from a checkout do the obvious thing.
 	//
-	Platform string // companion (../../../daggerverse/cpybkc/main.go:329:2)
+	Platform string // companion (../../../daggerverse/cpybkc/main.go:342:2)
 }
 
 // New selects the cpybkc release to run:
@@ -439,7 +444,7 @@ type CompanionOpts struct {
 // resolves companion images against, which is why an air-gapped caller passing a
 // container from their own registry should pass --repository beside it rather
 // than instead of it.
-func (r *Query) Companion(opts ...CompanionOpts) *Companion { // companion (../../../daggerverse/cpybkc/main.go:273:1)
+func (r *Query) Companion(opts ...CompanionOpts) *Companion { // companion (../../../daggerverse/cpybkc/main.go:281:1)
 	q := r.query.Select("companion")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `version` optional argument

--- a/.dagger/internal/dagger/companion.gen.go
+++ b/.dagger/internal/dagger/companion.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Companion
-func (r *Binding) AsCompanion() *Companion { // companion (../../../daggerverse/cpybkc/main.go:124:6)
+func (r *Binding) AsCompanion() *Companion { // companion (../../../daggerverse/cpybkc/main.go:220:6)
 	q := r.query.Select("asCompanion")
 
 	return &Companion{
@@ -24,10 +24,18 @@ func (r *Binding) AsCompanion() *Companion { // companion (../../../daggerverse/
 // A function on it is a builder returning a new Cpybkc, a terminal that runs
 // something, or an accessor handing back what was resolved, so a call chain
 // reads as the image being assembled and then used; nothing here mutates.
-type Companion struct { // companion (../../../daggerverse/cpybkc/main.go:124:6)
+type Companion struct { // companion (../../../daggerverse/cpybkc/main.go:220:6)
 	query *querybuilder.Selection
 
 	id *ID
+}
+type WithCompanionFunc func(r *Companion) *Companion
+
+// With calls the provided function with current Companion.
+//
+// This is useful for reusability and readability by not breaking the calling chain.
+func (r *Companion) With(f WithCompanionFunc) *Companion {
+	return f(r)
 }
 
 func (r *Companion) WithGraphQLQuery(q *querybuilder.Selection) *Companion {
@@ -52,7 +60,7 @@ type CompanionGenerateOpts struct {
 	// cannot be "-": a manifest's own paths are relative to the directory holding
 	// it, and a manifest arriving on a stream is in no directory.
 	//
-	Manifest string // companion (../../../daggerverse/cpybkc/main.go:295:2)
+	Manifest string // companion (../../../daggerverse/cpybkc/main.go:568:2)
 }
 
 // Generate runs cpybkc over a project and hands back the project as it should
@@ -75,7 +83,7 @@ type CompanionGenerateOpts struct {
 // express half of what a run did. `generate --source . export --path .` is
 // therefore the ordinary use, and it is a full statement of the run rather than
 // an overlay that leaves deletions behind.
-func (r *Companion) Generate(source *Directory, opts ...CompanionGenerateOpts) *Directory { // companion (../../../daggerverse/cpybkc/main.go:272:1)
+func (r *Companion) Generate(source *Directory, opts ...CompanionGenerateOpts) *Directory { // companion (../../../daggerverse/cpybkc/main.go:545:1)
 	assertNotNil("source", source)
 	q := r.query.Select("generate")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -140,9 +148,10 @@ func (r *Companion) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-// Image is the image this module resolved, for a caller who wants to do
-// something with it other than what this module offers — run a cpybkc
-// subcommand by hand, look at what is in it, or push it somewhere of their own:
+// Image is the image this module resolved and composed, for a caller who wants
+// to do something with it other than what this module offers — run a cpybkc
+// subcommand by hand, look at what is in it, publish a derived image holding
+// their generators, or make it one variant of a multi-platform index:
 //
 //	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
 //	  image with-exec --use-entrypoint --args=--version stdout
@@ -157,7 +166,7 @@ func (r *Companion) UnmarshalJSON(bs []byte) error {
 // none of the signatures or attestations one does (docs/container/SPEC.md, "What
 // a tag carries besides the image"), because those are attached to the digest
 // this project published and not to the bytes.
-func (r *Companion) Image() *Container { // companion (../../../daggerverse/cpybkc/main.go:248:1)
+func (r *Companion) Image() *Container { // companion (../../../daggerverse/cpybkc/main.go:521:1)
 	q := r.query.Select("image")
 
 	return &Container{
@@ -175,7 +184,7 @@ type CompanionRunOpts struct {
 	// contact nothing. With no source the container is the image as it was
 	// resolved, and cpybkc runs in whatever directory the image left it in.
 	//
-	Source *Directory // companion (../../../daggerverse/cpybkc/main.go:359:2)
+	Source *Directory // companion (../../../daggerverse/cpybkc/main.go:632:2)
 }
 
 // Run is the escape hatch: cpybkc invoked with an argument vector this module
@@ -212,7 +221,7 @@ type CompanionRunOpts struct {
 // unrecognised flag is, whether a flag may repeat and what a usage error exits
 // with are all docs/cli/SPEC.md's, and the exec's failure carries them back
 // verbatim.
-func (r *Companion) Run(args []string, opts ...CompanionRunOpts) *Container { // companion (../../../daggerverse/cpybkc/main.go:346:1)
+func (r *Companion) Run(args []string, opts ...CompanionRunOpts) *Container { // companion (../../../daggerverse/cpybkc/main.go:619:1)
 	q := r.query.Select("run")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `source` optional argument
@@ -227,6 +236,93 @@ func (r *Companion) Run(args []string, opts ...CompanionRunOpts) *Container { //
 	}
 }
 
+// CompanionWithGeneratorOpts contains options for Companion.WithGenerator
+type CompanionWithGeneratorOpts struct {
+	//
+	// Take the executable from this image instead of pulling the published
+	// generator image for name.
+	//
+	// Any image carrying the generator in the plugin directory will do, including
+	// one that was never published. It has to be for the same platform as the
+	// image being composed into, which is checked, because a mismatch here is
+	// checkable and its exec-time failure is not legible.
+	//
+	Image *Container // companion (../../../daggerverse/cpybkc/main.go:406:2)
+}
+
+// WithGenerator adds one generator to the image by copying its executable out of
+// a generator image:
+//
+//	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+//	  with-generator --name hello --image ghcr.io/example/cpybkc-gen-hello:v1 \
+//	  generate --source . export --path .
+//
+// This is the whole of adding a generator without writing a Dockerfile. The file
+// is taken out of the image at the path the base-image contract promises, which
+// is what `COPY --from` does, and it works just as well for a generator image
+// this project has never heard of — that is what image is for. Repeated calls
+// compose, so a project whose manifest names three generators is three calls and
+// one image.
+//
+// With no image, the generator this project publishes for name is pulled:
+// `<repository>-gen-<name>:<version>`, against the same coordinates the CLI image
+// came from. A generator from one release beside a CLI from another is a pairing
+// nobody tested, and defaulting to it is how somebody would end up in one without
+// having said so.
+//
+// The generator is pulled for the platform the container being composed into was
+// resolved for, not for the engine's. That is the whole of what this module does
+// about multi-platform: composing an amd64 generator into an arm64 image produces
+// an image that builds and pushes and then fails at exec with the kernel's
+// message rather than cpybkc's, which is a long way from the call that caused it.
+func (r *Companion) WithGenerator(name string, opts ...CompanionWithGeneratorOpts) *Companion { // companion (../../../daggerverse/cpybkc/main.go:393:1)
+	q := r.query.Select("withGenerator")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `image` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Image) {
+			q = q.Arg("image", opts[i].Image)
+		}
+	}
+	q = q.Arg("name", name)
+
+	return &Companion{
+		query: q,
+	}
+}
+
+// WithGeneratorExecutable adds one generator to the image from an executable
+// file, for a generator that ships no image — most often one the caller has just
+// built in the same pipeline:
+//
+//	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+//	  with-generator-executable --name hello --executable ./cpybkc-gen-hello \
+//	  generate --source . export --path .
+//
+// It is the generator author's path, before there is anything of theirs to pull.
+// Checking a plugin against a real cpybkc run is the first thing they need and
+// the last thing a published image can give them.
+//
+// The file lands as cpybkc-gen-<name> whatever it was called before, because
+// discovery is by filename and nothing inside the executable is consulted.
+//
+// It has to be a statically linked native executable for the image's platform,
+// and that is the caller's to meet rather than this module's to check: it is the
+// same requirement docs/container/SPEC.md's worked example states as
+// `CGO_ENABLED=0`, a File says nothing about what it is, and a dynamically linked
+// or foreign-architecture generator fails at exec time with the kernel's message
+// rather than cpybkc's. WithGenerator can check the platform half of that because
+// a container states one; here there is nothing to read.
+func (r *Companion) WithGeneratorExecutable(name string, executable *File) *Companion { // companion (../../../daggerverse/cpybkc/main.go:477:1)
+	assertNotNil("executable", executable)
+	q := r.query.Select("withGeneratorExecutable")
+	q = q.Arg("name", name)
+	q = q.Arg("executable", executable)
+
+	return &Companion{
+		query: q,
+	}
+}
+
 // AsNode returns this Companion as a Node.
 // This is a local type conversion — no GraphQL call.
 func (r *Companion) AsNode() Node {
@@ -236,7 +332,7 @@ func (r *Companion) AsNode() Node {
 }
 
 // Create or update a binding of type Companion in the environment
-func (r *Env) WithCompanionInput(name string, value *Companion, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:124:6)
+func (r *Env) WithCompanionInput(name string, value *Companion, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:220:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withCompanionInput")
 	q = q.Arg("name", name)
@@ -249,7 +345,7 @@ func (r *Env) WithCompanionInput(name string, value *Companion, description stri
 }
 
 // Declare a desired Companion output to be assigned in the environment
-func (r *Env) WithCompanionOutput(name string, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:124:6)
+func (r *Env) WithCompanionOutput(name string, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:220:6)
 	q := r.query.Select("withCompanionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -273,7 +369,7 @@ type CompanionOpts struct {
 	//
 	//
 	// Default: "v0"
-	Version string // companion (../../../daggerverse/cpybkc/main.go:187:2)
+	Version string // companion (../../../daggerverse/cpybkc/main.go:284:2)
 	//
 	// The registry repository the image is pulled from, as `<host>/<path>` with no
 	// tag.
@@ -288,7 +384,7 @@ type CompanionOpts struct {
 	//
 	//
 	// Default: "ghcr.io/zaba505/cpybkc"
-	Repository string // companion (../../../daggerverse/cpybkc/main.go:200:2)
+	Repository string // companion (../../../daggerverse/cpybkc/main.go:297:2)
 	//
 	// Run in this container instead of pulling one, replacing it entirely.
 	//
@@ -303,7 +399,26 @@ type CompanionOpts struct {
 	// change to cpybkc before it ships, and how a build pins the image by digest —
 	// a reference no tag argument can express, and the only one that pins bytes.
 	//
-	Image *Container // companion (../../../daggerverse/cpybkc/main.go:214:2)
+	Image *Container // companion (../../../daggerverse/cpybkc/main.go:311:2)
+	//
+	// Pull the image for this platform, as `GOOS/GOARCH`, instead of for the
+	// engine's own.
+	//
+	// It is what makes a derived image for another architecture reachable at all:
+	// a composition is one platform, and without this an amd64 engine could only
+	// ever compose an amd64 image. Every generator composed in afterwards follows
+	// it, so the platform is stated once, here, rather than on each call that
+	// could contradict the last.
+	//
+	// A multi-platform derived image is therefore one composition per platform,
+	// published as variants of one index — see this module's comment. That loop
+	// belongs to the caller because the index does: which platforms a derived
+	// image serves is a property of who will run it.
+	//
+	// Empty is the engine's own platform, which is what makes an ordinary
+	// `dagger call` from a checkout do the obvious thing.
+	//
+	Platform string // companion (../../../daggerverse/cpybkc/main.go:329:2)
 }
 
 // New selects the cpybkc release to run:
@@ -320,11 +435,11 @@ type CompanionOpts struct {
 //
 // image replaces the container that would otherwise be pulled, so passing it
 // means version and repository name nothing that gets fetched here. They are not
-// thereby inert: they stay on the module as the coordinates later compositions
-// resolve companion images against (#63), which is why an air-gapped caller
-// passing a container from their own registry should pass --repository beside it
-// rather than instead of it.
-func (r *Query) Companion(opts ...CompanionOpts) *Companion { // companion (../../../daggerverse/cpybkc/main.go:176:1)
+// thereby inert: they stay on the module as the coordinates WithGenerator
+// resolves companion images against, which is why an air-gapped caller passing a
+// container from their own registry should pass --repository beside it rather
+// than instead of it.
+func (r *Query) Companion(opts ...CompanionOpts) *Companion { // companion (../../../daggerverse/cpybkc/main.go:273:1)
 	q := r.query.Select("companion")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `version` optional argument
@@ -338,6 +453,10 @@ func (r *Query) Companion(opts ...CompanionOpts) *Companion { // companion (../.
 		// `image` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Image) {
 			q = q.Arg("image", opts[i].Image)
+		}
+		// `platform` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Platform) {
+			q = q.Arg("platform", opts[i].Platform)
 		}
 	}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -689,6 +689,93 @@ being](#65-is-closed-rather-than-left-open). It fails on something a person does
 — adding a flag in one module and not thinking about the other — rather than on
 a constant compared against the thing it was generated from.
 
+### Composing a generator is `COPY --from`, split across two methods
+
+The base image carries the CLI and no generator, so an image that generates
+anything is a composition. `WithGenerator` performs it, and the thing to keep in
+view is that it is not a second extension mechanism (#63):
+
+```sh
+dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+  with-generator --name hello --image ghcr.io/example/cpybkc-gen-hello:v1 \
+  generate --source . export --path .
+```
+
+```dockerfile
+FROM ghcr.io/zaba505/cpybkc:v0
+COPY --from=ghcr.io/example/cpybkc-gen-hello:v1 --chmod=0755 \
+     /usr/local/bin/cpybkc-gen-hello /usr/local/bin/cpybkc-gen-hello
+```
+
+Those are the same two instructions — the second is the final stage of
+[the container contract's worked
+example](docs/container/SPEC.md#worked-example-adding-a-generator), which is what
+an adopter writes by hand and what the module is measured against. What the
+module saves is the build context, the registry to push a derived image to and a
+Dockerfile to keep in step with a cpybkc release; a caller who prefers the
+Dockerfile is not on a lesser path, and the [module gets no
+`SPEC.md`](#the-companion-dagger-module) precisely so that nothing here reads as
+the contract having moved.
+
+**Two methods rather than one.** `WithGenerator` takes a generator *image* and is
+the adopter's path: it works for a generator image this project has never heard
+of, and with `--image` omitted it pulls `<repository>-gen-<name>:<version>` —
+resolved against the coordinates the CLI image itself came from, so a generator
+from one release never lands beside a CLI from another without somebody having
+said so. `WithGeneratorExecutable` takes a *File* and is the generator author's
+path, for the plugin that has been built and not yet published, which is exactly
+when checking it against a real cpybkc run matters most. The split follows
+[`z5labs/avroc`'s module](https://github.com/z5labs/avroc/blob/v0.2.0/daggerverse/avroc/main.go),
+where one method for both was tried first and the author's case turned out to be
+the one nobody would notice breaking.
+
+**Permissions and no owner.** The file lands `0755` and its ownership is left
+alone, which is the one place the module deliberately does less than the
+Dockerfile's `--chown=65532:65532`. The mode is what makes the file runnable, by
+the image's own UID and by any UID a caller overrides it with; the owner is a
+property of the image the module was handed, and a caller who passed `--image`
+may be composing onto a base with a user of their own that this module has no
+business overwriting with the contract's.
+
+**Static linking stays the caller's obligation.** Nothing in the module can check
+it, and a dynamically linked generator fails at exec time with the kernel's
+message rather than cpybkc's. That is the same requirement the worked example
+states as `CGO_ENABLED=0`, and it is said in both methods' documentation rather
+than enforced in either.
+
+### Multi-platform is one composition per platform
+
+A composed image is one platform, because a `dagger.Container` is. The module's
+guarantee is that it is *one* platform: `WithGenerator` reads the platform off
+the container it is composing into and pulls the generator image for that
+platform, and refuses an explicitly supplied generator image built for another
+one. An arm64 base quietly acquiring an amd64 generator is a build that succeeds,
+pushes, and then fails at the first generation with a kernel message naming
+neither cpybkc nor the call that caused it.
+
+That refusal has an escape hatch, named in its own error text: a platform string
+is a comparison the module can be wrong about — a variant spelling that runs
+perfectly well is still not the same string — so a caller who knows better takes
+the file out of the image themselves and passes it to
+`WithGeneratorExecutable`, which states the match as their obligation anyway.
+
+`New`'s `--platform` is what makes the other architecture reachable at all;
+without it an amd64 engine could only ever compose an amd64 image. It is refused
+beside `--image`, because a container arrives already built for a platform and
+the argument would then describe a pull that is not happening — ignoring it
+silently is the worse half of that choice, since the caller would believe they
+had asked for an architecture and find out at exec time that they had not. The
+check is a comparison of arguments rather than of the container's actual
+platform, so that a constructor still performs no network round trip, for the
+same reason [`internal/imageref`](daggerverse/cpybkc/internal/imageref/)
+validates the shape of a reference and not its existence.
+
+A derived **multi-platform index** is therefore one composition per platform,
+published as variants of one index, and the loop belongs to the caller because
+the index does: which platforms a derived image serves is a property of who will
+run it, and a module that decided it would be publishing this project's platform
+table as somebody else's. The module comment carries the loop.
+
 ### The pipeline module is checked like any other Go module here
 
 `dagger call pipeline-ci` runs the standard pipeline over

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -703,7 +703,7 @@ dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
 
 ```dockerfile
 FROM ghcr.io/zaba505/cpybkc:v0
-COPY --from=ghcr.io/example/cpybkc-gen-hello:v1 --chmod=0755 \
+COPY --from=ghcr.io/example/cpybkc-gen-hello:v1 --chown=65532:65532 --chmod=0755 \
      /usr/local/bin/cpybkc-gen-hello /usr/local/bin/cpybkc-gen-hello
 ```
 
@@ -731,11 +731,13 @@ the one nobody would notice breaking.
 
 **Permissions and no owner.** The file lands `0755` and its ownership is left
 alone, which is the one place the module deliberately does less than the
-Dockerfile's `--chown=65532:65532`. The mode is what makes the file runnable, by
-the image's own UID and by any UID a caller overrides it with; the owner is a
-property of the image the module was handed, and a caller who passed `--image`
-may be composing onto a base with a user of their own that this module has no
-business overwriting with the contract's.
+`COPY` line above it. The mode is what makes the file runnable, by the image's
+own UID and by any UID a caller overrides it with; the owner is a property of the
+image the module was handed, and a caller who passed `--image` may be composing
+onto a base with a user of their own that this module has no business overwriting
+with the contract's. The Dockerfile is entitled to write `--chown=65532:65532`
+because its `FROM` line names the image it derives from; a module handed a
+container knows no such thing.
 
 **Static linking stays the caller's obligation.** Nothing in the module can check
 it, and a dynamically linked generator fails at exec time with the kernel's

--- a/README.md
+++ b/README.md
@@ -120,21 +120,29 @@ Dockerfile:
 
 ```sh
 dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
-  image with-exec --use-entrypoint --args=--version stdout
+  with-generator --name hello --image ghcr.io/example/cpybkc-gen-hello:v1 \
+  generate --source . export --path .
 ```
 
 It is a convenience over [the container base-image
 contract](docs/container/SPEC.md) and not an interface of its own, so it has no
 `SPEC.md`: what it needs to say it says in `dagger call --help`. Everything it
-does can be written by hand as a `docker run` instead, and a caller reaching for
-one is not on a lesser path.
+does can be written by hand as a `docker run` or a `COPY --from` instead, and a
+caller reaching for one is not on a lesser path — `with-generator` stands for
+exactly the two lines [the worked
+example](docs/container/SPEC.md#worked-example-adding-a-generator) gives somebody
+writing a Dockerfile, and `with-generator-executable` does the same for a
+generator that has not been published yet.
 
 Its module ref is that directory path, which makes the path itself public API —
 the directory is never renamed. `--version` selects the release, defaulting to
 the moving major tag `v0`; `--repository` points it at a mirror or an internal
-registry; `--image` replaces the container outright, which is how a build pins a
-digest. [CONTRIBUTING.md](CONTRIBUTING.md#the-companion-dagger-module) is the
-argument behind those defaults.
+registry, and the generator images derive from it; `--platform` composes for an
+architecture other than the engine's, which is how a derived multi-platform
+image is built one variant at a time; `--image` replaces the container outright,
+which is how a build pins a digest.
+[CONTRIBUTING.md](CONTRIBUTING.md#the-companion-dagger-module) is the argument
+behind those defaults.
 
 The `.dagger/` module at the repository root is a different thing: it runs this
 repository's own pipeline and is published for nobody.

--- a/daggerverse/cpybkc/dagger.gen.go
+++ b/daggerverse/cpybkc/dagger.gen.go
@@ -255,6 +255,48 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Cpybkc).Run(&parent, ctx, args, source)
+		case "WithGenerator":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var name string
+			if inputArgs["name"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["name"]), &name)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg name", err))
+				}
+			}
+			var image *dagger.Container
+			if inputArgs["image"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["image"]), &image)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg image", err))
+				}
+			}
+			return (*Cpybkc).WithGenerator(&parent, ctx, name, image)
+		case "WithGeneratorExecutable":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var name string
+			if inputArgs["name"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["name"]), &name)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg name", err))
+				}
+			}
+			var executable *dagger.File
+			if inputArgs["executable"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["executable"]), &executable)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg executable", err))
+				}
+			}
+			return (*Cpybkc).WithGeneratorExecutable(&parent, name, executable)
 		case "":
 			var parent Cpybkc
 			err = json.Unmarshal(parentJSON, &parent)
@@ -282,7 +324,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg image", err))
 				}
 			}
-			return New(version, repository, image)
+			var platform string
+			if inputArgs["platform"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["platform"]), &platform)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg platform", err))
+				}
+			}
+			return New(version, repository, image, platform)
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}

--- a/daggerverse/cpybkc/internal/generator/generator.go
+++ b/daggerverse/cpybkc/internal/generator/generator.go
@@ -8,13 +8,14 @@
 // here would be asserted by a comment instead of pinned by a test. Nothing here
 // imports Dagger, so `go test ./internal/...` runs anywhere.
 //
-// Two strings are composed, and they are the module's whole knowledge of how a
-// generator is named: the filename inside the image, which docs/plugin/SPEC.md
-// fixes, and the repository a published generator image is pulled from, which is
-// this project's publishing rule rather than anybody's contract. Everything else
-// about a generator — the argument vector, the descriptor, the exit codes,
-// determinism — is docs/plugin/SPEC.md's, holds with no container anywhere in the
-// picture, and is not this module's business.
+// Three strings are composed, and they are the module's whole knowledge of how a
+// generator is named and where it goes: the filename inside the image and the
+// path it lands at, both of which the specs fix, and the repository a published
+// generator image is pulled from, which is this project's publishing rule rather
+// than anybody's contract. Everything else about a generator — the argument
+// vector, the descriptor, the exit codes, determinism — is docs/plugin/SPEC.md's,
+// holds with no container anywhere in the picture, and is not this module's
+// business.
 package generator
 
 import (
@@ -22,6 +23,20 @@ import (
 	"fmt"
 	"strings"
 )
+
+// pluginDir is the directory on the image's PATH that cpybkc discovers
+// generators in — docs/container/SPEC.md's plugin directory, and the one path
+// inside the image this module needs to know.
+//
+// It is a promise the base-image contract makes rather than a choice made here:
+// the path is what a `COPY` line writes to and the PATH membership is what makes
+// the copied file reachable by the name a manifest asks for, and either half
+// alone installs nothing. The contract covers it by its compatibility
+// guarantees, so it does not move within a major version.
+//
+// The CLI's own path in the image is neither knowable nor needed. Everything the
+// module runs, it runs through the entrypoint.
+const pluginDir = "/usr/local/bin"
 
 // executablePrefix and repositorySuffix are the two spellings of "the generator
 // called <name>", and they are deliberately not one constant: the first is a
@@ -44,6 +59,21 @@ const (
 // it — so renaming on the way in is not a liberty, it is the mechanism.
 func Executable(name string) string {
 	return executablePrefix + name
+}
+
+// Path is where the generator called name is installed in the image, and where
+// a generator image is read from when one is copied out of it.
+//
+// It is one function rather than a join spelled out at each end of the copy
+// because the two ends have to agree: the file is read from this path in the
+// generator image and written to it in the composed one, and a separator or a
+// directory that disagreed between them would produce an image that builds and
+// pushes and then reports that a generator the manifest plainly names cannot be
+// found. It is the whole of what makes an installed generator discoverable —
+// the directory is on PATH and the filename is what cpybkc searches for — so it
+// is also the string most worth pinning with a test.
+func Path(name string) string {
+	return pluginDir + "/" + Executable(name)
 }
 
 // Repository is where this project publishes the generator image for name,

--- a/daggerverse/cpybkc/internal/generator/generator.go
+++ b/daggerverse/cpybkc/internal/generator/generator.go
@@ -1,0 +1,90 @@
+// Package generator names a generator the way cpybkc finds one, and refuses the
+// names that would assemble into something cpybkc never searches for.
+//
+// It is a package of its own, rather than three functions in package main, for
+// the reason internal/imageref is one: the module's own package main imports the
+// generated Dagger client, whose init panics when no Dagger session is present,
+// so a test beside main cannot run under plain `go test` and the strings composed
+// here would be asserted by a comment instead of pinned by a test. Nothing here
+// imports Dagger, so `go test ./internal/...` runs anywhere.
+//
+// Two strings are composed, and they are the module's whole knowledge of how a
+// generator is named: the filename inside the image, which docs/plugin/SPEC.md
+// fixes, and the repository a published generator image is pulled from, which is
+// this project's publishing rule rather than anybody's contract. Everything else
+// about a generator — the argument vector, the descriptor, the exit codes,
+// determinism — is docs/plugin/SPEC.md's, holds with no container anywhere in the
+// picture, and is not this module's business.
+package generator
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// executablePrefix and repositorySuffix are the two spellings of "the generator
+// called <name>", and they are deliberately not one constant: the first is a
+// filename cpybkc resolves on PATH (docs/plugin/SPEC.md, Discovery) and the
+// second is a registry repository this project happens to publish under. They
+// look alike today and answer to different owners, so a change to either is not
+// a change to the other.
+const (
+	executablePrefix = "cpybkc-gen-"
+	repositorySuffix = "-gen-"
+)
+
+// Executable is the filename cpybkc searches PATH for when a manifest asks for
+// name.
+//
+// This is docs/plugin/SPEC.md's discovery rule and the only part of the plugin
+// contract this module implements. An installed executable takes this name
+// whatever it was called before it arrived, because the suffix of the filename
+// *is* the generator's name and nothing inside the file is consulted to discover
+// it — so renaming on the way in is not a liberty, it is the mechanism.
+func Executable(name string) string {
+	return executablePrefix + name
+}
+
+// Repository is where this project publishes the generator image for name,
+// derived from the repository the CLI image itself was pulled from.
+//
+// The derivation is a fact about how cpybkc publishes rather than a promise the
+// base-image contract makes, which is why it lives here and not in
+// docs/container/SPEC.md. Deriving it from the caller's --repository rather than
+// from a constant is what makes a mirror, an internal registry or an air-gapped
+// copy redirect the whole family at once: a caller who moved the CLI image and
+// not its generators would otherwise reach back to ghcr.io from inside a network
+// that cannot see it, on the second call rather than the first.
+func Repository(repository, name string) string {
+	return repository + repositorySuffix + name
+}
+
+// CheckName enforces docs/plugin/SPEC.md's two **MUST**s on a generator name:
+// non-empty, and no `/`.
+//
+// It is checked here because name is interpolated into a path inside the image
+// and into a registry repository, and neither failure says what went wrong. A
+// name carrying a separator writes the executable to a directory that is not on
+// PATH, and the run then fails much later complaining that a generator the caller
+// plainly asked for cannot be found; an empty one produces `cpybkc-gen-`, which
+// is a filename cpybkc will never search for. A name of `..` needs no rule of its
+// own — without a separator it cannot leave the plugin directory.
+//
+// Those two and no more. The same section's preference for lowercase ASCII,
+// digits and hyphens is a **SHOULD** — a convention about names that are easy to
+// type, not a constraint on what cpybkc will run — and a module refusing a name
+// cpybkc would have resolved would be making the contract smaller from the
+// outside, which is the one thing a convenience over a contract must not do.
+func CheckName(name string) error {
+	switch {
+	case name == "":
+		return errors.New(
+			"a generator name is required: it is the <name> in cpybkc-gen-<name>, which is the filename cpybkc resolves on PATH")
+	case strings.Contains(name, "/"):
+		return fmt.Errorf(
+			"generator name %q contains a /: a name is a single filename component (docs/plugin/SPEC.md, Discovery), and one carrying a path separator would put the executable somewhere cpybkc never searches",
+			name)
+	}
+	return nil
+}

--- a/daggerverse/cpybkc/internal/generator/generator_test.go
+++ b/daggerverse/cpybkc/internal/generator/generator_test.go
@@ -1,0 +1,142 @@
+// These tests cover the pure half of composing a generator: the two strings a
+// name is turned into, and the two names that are refused before either string
+// is built. That is the half worth a test, because both strings are public
+// behaviour from the first release — the filename is what cpybkc resolves on
+// PATH, so getting it wrong produces an image that builds, pushes and then
+// reports that a generator the manifest plainly names cannot be found.
+//
+// What is not tested here is anything that needs an engine: that /usr/local/bin
+// is on the image's PATH, that the file lands executable, that a composed image
+// actually runs the generator. Those are properties of the image rather than of
+// this module — the root pipeline's ImageContract checks the first two against
+// docs/container/SPEC.md, and #64 is the story that drives these compositions
+// over an image the pipeline just built and proves the last one end to end.
+
+package generator
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExecutable(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		want string
+	}{
+		// Spelled out rather than assembled from executablePrefix. A test that
+		// rebuilt the name the way Executable does would agree with it however
+		// wrong both were.
+		{name: "go", want: "cpybkc-gen-go"},
+		{name: "hello", want: "cpybkc-gen-hello"},
+		// docs/plugin/SPEC.md's SHOULD is lowercase ASCII, digits and hyphens; a
+		// name using all three has to survive unchanged, prefix and nothing else.
+		{name: "acme-cobol2", want: "cpybkc-gen-acme-cobol2"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Executable(tc.name); got != tc.want {
+				t.Errorf("Executable(%q) = %q, want %q", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRepository(t *testing.T) {
+	for _, tc := range []struct {
+		testName   string
+		repository string
+		name       string
+		want       string
+	}{
+		{
+			// The published family, spelled out: this is the reference a caller who
+			// passed neither --repository nor --image reaches on their first
+			// WithGenerator call.
+			testName:   "the published default",
+			repository: "ghcr.io/zaba505/cpybkc",
+			name:       "go",
+			want:       "ghcr.io/zaba505/cpybkc-gen-go",
+		},
+		{
+			// The air-gap case, and the whole reason the derivation reads the
+			// caller's repository rather than a constant: redirecting the CLI image
+			// has to redirect its generators too.
+			testName:   "an internal mirror redirects the family",
+			repository: "registry.internal/mirrors/cpybkc",
+			name:       "go",
+			want:       "registry.internal/mirrors/cpybkc-gen-go",
+		},
+		{
+			testName:   "a registry reached by host and port",
+			repository: "localhost:5000/cpybkc",
+			name:       "hello",
+			want:       "localhost:5000/cpybkc-gen-hello",
+		},
+	} {
+		t.Run(tc.testName, func(t *testing.T) {
+			if got := Repository(tc.repository, tc.name); got != tc.want {
+				t.Errorf("Repository(%q, %q) = %q, want %q", tc.repository, tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCheckNameAccepts(t *testing.T) {
+	for _, name := range []string{
+		"go",
+		"acme-cobol2",
+		// Refused by docs/plugin/SPEC.md's SHOULD and not by either MUST. cpybkc
+		// resolves it, so this module composes it: a convenience over a contract
+		// does not get to make the contract smaller.
+		"Weird_Name.v2",
+		// Without a separator it cannot leave the plugin directory, so it needs no
+		// rule of its own and must not acquire one by accident.
+		"..",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := CheckName(name); err != nil {
+				t.Errorf("CheckName(%q): unexpected error: %v", name, err)
+			}
+		})
+	}
+}
+
+func TestCheckNameRefuses(t *testing.T) {
+	for _, tc := range []struct {
+		testName string
+		name     string
+		// mentions is a substring the error has to carry, so a refusal is checked
+		// for saying what was wrong rather than merely for being non-nil.
+		mentions string
+	}{
+		{
+			// A +default fires on omission and name has none, so this arrives from
+			// the command line as an empty string rather than being unreachable.
+			testName: "an empty name",
+			name:     "",
+			mentions: "name is required",
+		},
+		{
+			testName: "a name carrying a path separator",
+			name:     "acme/go",
+			mentions: "contains a /",
+		},
+		{
+			// The shape that would otherwise write outside the plugin directory
+			// entirely, which is the failure the separator rule is really for.
+			testName: "a name escaping the plugin directory",
+			name:     "../../etc/go",
+			mentions: "contains a /",
+		},
+	} {
+		t.Run(tc.testName, func(t *testing.T) {
+			err := CheckName(tc.name)
+			if err == nil {
+				t.Fatalf("CheckName(%q) = nil, want an error", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.mentions) {
+				t.Errorf("CheckName(%q) error = %q, want it to mention %q", tc.name, err, tc.mentions)
+			}
+		})
+	}
+}

--- a/daggerverse/cpybkc/internal/generator/generator_test.go
+++ b/daggerverse/cpybkc/internal/generator/generator_test.go
@@ -41,6 +41,28 @@ func TestExecutable(t *testing.T) {
 	}
 }
 
+func TestPath(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		want string
+	}{
+		// Spelled out whole, directory and all. This is the string both
+		// acceptance criteria turn on — that a generator is installed into the
+		// documented plugin directory, and that the CLI's PATH-based resolution
+		// then finds it — and it is the one string in this module that nothing
+		// downstream would notice being wrong until a run reported a generator
+		// missing.
+		{name: "go", want: "/usr/local/bin/cpybkc-gen-go"},
+		{name: "hello", want: "/usr/local/bin/cpybkc-gen-hello"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Path(tc.name); got != tc.want {
+				t.Errorf("Path(%q) = %q, want %q", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestRepository(t *testing.T) {
 	for _, tc := range []struct {
 		testName   string

--- a/daggerverse/cpybkc/main.go
+++ b/daggerverse/cpybkc/main.go
@@ -3,10 +3,11 @@
 // write a Dockerfile.
 //
 //	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
-//	  image with-exec --use-entrypoint --args=--version stdout
+//	  with-generator --name hello --image ghcr.io/example/cpybkc-gen-hello:v1 \
+//	  generate --source . export --path .
 //
-// Nothing is installed on the host and no image is built: the published image is
-// pulled and used.
+// Nothing is installed on the host and no Dockerfile is written: the published
+// images are pulled, composed, and run.
 //
 // # This is a convenience, not a contract
 //
@@ -53,17 +54,85 @@
 // declares on this directory — an engine bump is then one commit touching both
 // files, rather than two files nothing requires to agree.
 //
+// # Composing a generator, and the Dockerfile it replaces
+//
+// The base image carries the CLI and no generator at all, so an image that
+// generates anything is a composition. WithGenerator is that composition:
+//
+//	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+//	  with-generator --name hello --image ghcr.io/example/cpybkc-gen-hello:v1 \
+//	  generate --source . export --path .
+//
+// and the two lines it stands for are the final stage of
+// docs/container/SPEC.md's worked example, written by hand:
+//
+//	FROM ghcr.io/zaba505/cpybkc:v0
+//	COPY --from=ghcr.io/example/cpybkc-gen-hello:v1 --chmod=0755 \
+//	     /usr/local/bin/cpybkc-gen-hello /usr/local/bin/cpybkc-gen-hello
+//
+// They are the same two instructions and the comparison is the point: the
+// mechanism is `COPY --from`, this is not a second way of extending cpybkc, and
+// a caller who prefers the Dockerfile is not on a lesser path. What the module
+// saves is the build context, the registry to push the derived image to, and a
+// Dockerfile to keep in step with a cpybkc release — a project whose manifest
+// names three generators is three calls and one image that is never pushed
+// anywhere.
+//
+// Two differences from the Dockerfile are deliberate rather than incidental.
+// There is no --chown: the mode is what makes the file runnable, by the image's
+// own UID and by any UID a caller overrides it with, while the owner the
+// Dockerfile hands it to is a property of the image this module was given rather
+// than one it may assume. And --image may be omitted, in which case the
+// generator image is the one this project publishes beside the CLI —
+// `<repository>-gen-<name>:<version>`, resolved against the same --repository and
+// --version the CLI image came from, so a generator from one release never lands
+// beside a CLI from another.
+//
+// WithGeneratorExecutable is the other half, and it takes a File rather than an
+// image: a generator that has not been published yet, most often one the caller
+// has just built in the same pipeline. A generator author needs it to check
+// their plugin against a real cpybkc run before there is anything of theirs to
+// pull.
+//
+// # Multi-platform derived builds
+//
+// A composed image is one platform, because a dagger.Container is. What this
+// module guarantees is that it is *one* platform: WithGenerator reads the
+// platform off the container it is composing into and pulls the generator image
+// for that platform, so an arm64 base never quietly acquires an amd64 generator
+// that fails at exec with the kernel's message rather than cpybkc's.
+//
+// --platform on the constructor is what makes the other platform reachable at
+// all. Without it the base image is pulled for the engine's own platform, and an
+// amd64 engine could only ever compose an amd64 image. With it, a derived
+// multi-platform index is one composition per platform, published as variants:
+//
+//	variants := make([]*dagger.Container, 0, len(platforms))
+//	for _, p := range platforms {
+//		variants = append(variants, dag.
+//			Cpybkc(dagger.CpybkcOpts{Platform: string(p)}).
+//			WithGenerator("hello").
+//			Image())
+//	}
+//	ref, err := dag.Container().Publish(ctx, address,
+//		dagger.ContainerPublishOpts{PlatformVariants: variants})
+//
+// The loop is the caller's rather than this module's because the index is: which
+// platforms a derived image serves is a property of who will run it, and a module
+// that decided it would be publishing this project's platform table as somebody
+// else's.
+//
 // # What this does not do
 //
 // It does not build cpybkc from source, and it is not this repository's
 // pipeline. `dagger call ci`, the image builds and the contract checks are the
 // root module's.
 //
-// Composing a generator into the image (#63) is not here yet. What is here is
-// running the CLI over a project — Generate, and Run for everything Generate
-// does not curate — on top of the part they both start from: deciding which
-// image runs, which is the choice a caller makes once and the one that has to be
-// right before anything is built on it.
+// It does not build a generator either. WithGenerator copies one out of an image
+// and WithGeneratorExecutable takes one already built; how a generator is
+// compiled, and that it must come out statically linked for the image's platform,
+// are the caller's (docs/container/SPEC.md's `CGO_ENABLED=0`). Nothing here can
+// check that, which is why it is said rather than enforced.
 //
 // # The curated surface, and why it is not the flag table
 //
@@ -91,8 +160,35 @@ import (
 
 	"dagger/cpybkc/internal/argv"
 	"dagger/cpybkc/internal/dagger"
+	"dagger/cpybkc/internal/generator"
 	"dagger/cpybkc/internal/imageref"
 )
+
+// pluginDir is the directory on the image's PATH that cpybkc discovers
+// generators in — docs/container/SPEC.md's plugin directory, and the one path
+// inside the image this module needs to know.
+//
+// It is a promise the base-image contract makes rather than a choice made here:
+// the path is what a `COPY` line writes to and the PATH membership is what makes
+// the copied file reachable by the name a manifest asks for, and either half
+// alone installs nothing. The contract covers it by its compatibility
+// guarantees, so it does not move within a major version.
+//
+// The CLI's own path in the image is not knowable and is not needed. Everything
+// this module runs, it runs through the entrypoint.
+const pluginDir = "/usr/local/bin"
+
+// executableMode is the mode an installed generator lands with, and it is the
+// derived Dockerfile's `--chmod=0755`.
+//
+// Readable and executable by the image's own UID and by any UID a caller
+// overrides it with, which is what keeps running the composed image as the host
+// user an ordinary configuration rather than a workaround. The base-image
+// contract requires an executable copied into the plugin directory to be
+// executable by the image's user; this is that requirement met, and it is met
+// with permissions rather than with an owner for the reason
+// WithGeneratorExecutable gives.
+const executableMode = 0o755
 
 // projectDir is where a caller's project is mounted, and the working directory
 // the CLI is run from.
@@ -122,16 +218,17 @@ const contractUser = "65532:65532"
 // something, or an accessor handing back what was resolved, so a call chain
 // reads as the image being assembled and then used; nothing here mutates.
 type Cpybkc struct {
-	// Container is the image cpybkc runs in.
+	// Container is the image cpybkc runs in, with whatever generators have been
+	// composed into it so far.
 	// +private
 	Container *dagger.Container
 
-	// Repository and Version are the coordinates a later composition resolves
-	// *other* images against — the companion generator images of #63, which are
-	// published as `<repository>-gen-<name>:<version>`. They are kept rather than
-	// consumed at construction because an override that reached only the first
-	// pull would leave every later one reaching for ghcr.io from inside a network
-	// that cannot see it, which is the air-gap requirement failing later and less
+	// Repository and Version are the coordinates WithGenerator resolves *other*
+	// images against — the companion generator images, published as
+	// `<repository>-gen-<name>:<version>`. They are kept rather than consumed at
+	// construction because an override that reached only the first pull would
+	// leave every later one reaching for ghcr.io from inside a network that
+	// cannot see it, which is the air-gap requirement failing later and less
 	// legibly than if the argument had never existed.
 	//
 	// They are deliberately *not* a description of what is in Container. When a
@@ -144,11 +241,11 @@ type Cpybkc struct {
 	//
 	// What this deliberately does not do is *infer* a release from a supplied
 	// container. Nothing here can read a version off an arbitrary container, and
-	// guessing one would produce exactly the untested pairing — a generator from
-	// one release beside a CLI from another — that #63 exists to refuse. Whether
-	// that mismatch is refused, warned about or required to be stated explicitly
-	// is #63's to settle, and it needs these two fields to say anything about it
-	// at all.
+	// guessing one would produce exactly the untested pairing WithGenerator's
+	// default exists to avoid — a generator from one release beside a CLI from
+	// another. So a caller who passed --image and then lets WithGenerator pull a
+	// published generator gets the release they named in --version, which is a
+	// pairing they stated rather than one that was guessed for them.
 	// +private
 	Repository string
 	// +private
@@ -169,10 +266,10 @@ type Cpybkc struct {
 //
 // image replaces the container that would otherwise be pulled, so passing it
 // means version and repository name nothing that gets fetched here. They are not
-// thereby inert: they stay on the module as the coordinates later compositions
-// resolve companion images against (#63), which is why an air-gapped caller
-// passing a container from their own registry should pass --repository beside it
-// rather than instead of it.
+// thereby inert: they stay on the module as the coordinates WithGenerator
+// resolves companion images against, which is why an air-gapped caller passing a
+// container from their own registry should pass --repository beside it rather
+// than instead of it.
 func New(
 	// The tag of the published cpybkc image to run.
 	//
@@ -212,25 +309,201 @@ func New(
 	// a reference no tag argument can express, and the only one that pins bytes.
 	// +optional
 	image *dagger.Container,
+	// Pull the image for this platform, as `GOOS/GOARCH`, instead of for the
+	// engine's own.
+	//
+	// It is what makes a derived image for another architecture reachable at all:
+	// a composition is one platform, and without this an amd64 engine could only
+	// ever compose an amd64 image. Every generator composed in afterwards follows
+	// it, so the platform is stated once, here, rather than on each call that
+	// could contradict the last.
+	//
+	// A multi-platform derived image is therefore one composition per platform,
+	// published as variants of one index — see this module's comment. That loop
+	// belongs to the caller because the index does: which platforms a derived
+	// image serves is a property of who will run it.
+	//
+	// Empty is the engine's own platform, which is what makes an ordinary
+	// `dagger call` from a checkout do the obvious thing.
+	// +optional
+	platform string,
 ) (*Cpybkc, error) {
 	// Checked even when image is supplied and nothing is pulled from them, because
-	// they are not decoration in that case either: #63 resolves companion images
-	// against them, and a repository that is wrong is as wrong then as now. A
-	// constructor that accepted them quietly would move the complaint to a call
+	// they are not decoration in that case either: WithGenerator resolves companion
+	// images against them, and a repository that is wrong is as wrong then as now.
+	// A constructor that accepted them quietly would move the complaint to a call
 	// the caller has not written yet.
 	ref, err := imageref.Assemble(repository, version)
 	if err != nil {
 		return nil, err
 	}
-	if image == nil {
-		image = dag.Container().From(ref)
+
+	// Refused rather than reconciled, because there is nothing to reconcile: a
+	// container arrives already built for a platform, and this argument only ever
+	// described a pull that is no longer happening. Silently ignoring it would be
+	// the worse half of the choice — the caller would believe they had asked for
+	// an architecture, and find out at exec time that they had not.
+	//
+	// It is a pure check rather than a comparison against the container's actual
+	// platform on purpose: reading that would mean a network round trip in a
+	// constructor, which is the same reason imageref validates the shape of a
+	// reference and not its existence.
+	if image != nil && platform != "" {
+		return nil, fmt.Errorf(
+			"--platform=%s was given beside --image: --platform says which platform to pull the cpybkc image for, "+
+				"and --image replaces that pull entirely, so the two together state a platform for something that "+
+				"is not being pulled — build the container for the platform you want and pass it to --image alone",
+			platform)
 	}
+
+	if image == nil {
+		// A zero Platform is omitted from the query, so this is exactly
+		// dag.Container().From(ref) when the caller named no platform.
+		image = dag.Container(dagger.ContainerOpts{Platform: dagger.Platform(platform)}).From(ref)
+	}
+
 	return &Cpybkc{Container: image, Repository: repository, Version: version}, nil
 }
 
-// Image is the image this module resolved, for a caller who wants to do
-// something with it other than what this module offers — run a cpybkc
-// subcommand by hand, look at what is in it, or push it somewhere of their own:
+// WithGenerator adds one generator to the image by copying its executable out of
+// a generator image:
+//
+//	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+//	  with-generator --name hello --image ghcr.io/example/cpybkc-gen-hello:v1 \
+//	  generate --source . export --path .
+//
+// This is the whole of adding a generator without writing a Dockerfile. The file
+// is taken out of the image at the path the base-image contract promises, which
+// is what `COPY --from` does, and it works just as well for a generator image
+// this project has never heard of — that is what image is for. Repeated calls
+// compose, so a project whose manifest names three generators is three calls and
+// one image.
+//
+// With no image, the generator this project publishes for name is pulled:
+// `<repository>-gen-<name>:<version>`, against the same coordinates the CLI image
+// came from. A generator from one release beside a CLI from another is a pairing
+// nobody tested, and defaulting to it is how somebody would end up in one without
+// having said so.
+//
+// The generator is pulled for the platform the container being composed into was
+// resolved for, not for the engine's. That is the whole of what this module does
+// about multi-platform: composing an amd64 generator into an arm64 image produces
+// an image that builds and pushes and then fails at exec with the kernel's
+// message rather than cpybkc's, which is a long way from the call that caused it.
+func (m *Cpybkc) WithGenerator(
+	ctx context.Context,
+	// The generator to add, by the `<name>` cpybkc.json asks for it by. Discovery
+	// is by filename, so this is the name in cpybkc-gen-<name> and nothing else.
+	name string,
+	// Take the executable from this image instead of pulling the published
+	// generator image for name.
+	//
+	// Any image carrying the generator in the plugin directory will do, including
+	// one that was never published. It has to be for the same platform as the
+	// image being composed into, which is checked, because a mismatch here is
+	// checkable and its exec-time failure is not legible.
+	// +optional
+	image *dagger.Container,
+) (*Cpybkc, error) {
+	if err := generator.CheckName(name); err != nil {
+		return nil, err
+	}
+
+	platform, err := m.Container.Platform(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("reading the platform the cpybkc image was resolved for, which the %s generator "+
+			"has to match: %w", name, err)
+	}
+
+	if image == nil {
+		ref, err := imageref.Assemble(generator.Repository(m.Repository, name), m.Version)
+		if err != nil {
+			return nil, fmt.Errorf("resolving the published image for the %s generator: %w", name, err)
+		}
+
+		image = dag.Container(dagger.ContainerOpts{Platform: platform}).From(ref)
+	} else {
+		supplied, err := image.Platform(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("reading the platform of the image the %s generator is taken from: %w", name, err)
+		}
+
+		// Refused rather than copied anyway. An executable for the wrong
+		// architecture is exactly what the base-image contract's "statically linked
+		// native executable for the image's platform" rules out, and unlike a bare
+		// File a container states its platform, so this is one of the few places
+		// that requirement can be checked at all rather than left to fail later.
+		//
+		// The escape hatch is named because a platform string is a comparison this
+		// module could be wrong about — a variant spelling that runs perfectly well
+		// is still not the same string — and a refusal with no way past it would be
+		// this module deciding something the contract left to the caller.
+		if supplied != platform {
+			return nil, fmt.Errorf(
+				"the image given for the %s generator is %s and the cpybkc image being composed into is %s: an "+
+					"executable for another platform fails at exec time with the kernel's message rather than "+
+					"cpybkc's, so it is refused here — compose from an image built for %s, or, if the two really "+
+					"are compatible, take the file out yourself and pass it to with-generator-executable, which "+
+					"states the match as your obligation",
+				name, supplied, platform, platform)
+		}
+	}
+
+	return m.WithGeneratorExecutable(name, image.File(pluginDir+"/"+generator.Executable(name)))
+}
+
+// WithGeneratorExecutable adds one generator to the image from an executable
+// file, for a generator that ships no image — most often one the caller has just
+// built in the same pipeline:
+//
+//	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+//	  with-generator-executable --name hello --executable ./cpybkc-gen-hello \
+//	  generate --source . export --path .
+//
+// It is the generator author's path, before there is anything of theirs to pull.
+// Checking a plugin against a real cpybkc run is the first thing they need and
+// the last thing a published image can give them.
+//
+// The file lands as cpybkc-gen-<name> whatever it was called before, because
+// discovery is by filename and nothing inside the executable is consulted.
+//
+// It has to be a statically linked native executable for the image's platform,
+// and that is the caller's to meet rather than this module's to check: it is the
+// same requirement docs/container/SPEC.md's worked example states as
+// `CGO_ENABLED=0`, a File says nothing about what it is, and a dynamically linked
+// or foreign-architecture generator fails at exec time with the kernel's message
+// rather than cpybkc's. WithGenerator can check the platform half of that because
+// a container states one; here there is nothing to read.
+func (m *Cpybkc) WithGeneratorExecutable(
+	// The generator's `<name>`, as cpybkc.json asks for it.
+	name string,
+	// The generator executable.
+	executable *dagger.File,
+) (*Cpybkc, error) {
+	if err := generator.CheckName(name); err != nil {
+		return nil, err
+	}
+
+	// Permissions and no owner. The mode is what makes the file runnable — by the
+	// image's own UID and by any UID a caller overrides it with — while the owner
+	// the derived Dockerfile's `--chown` hands it to is a property of the image
+	// this module was given rather than one it is entitled to assume: a caller who
+	// passed --image may be composing onto a base with a user of their own, and
+	// this module would be overwriting their answer with the contract's.
+	next := *m
+	next.Container = m.Container.WithFile(
+		pluginDir+"/"+generator.Executable(name),
+		executable,
+		dagger.ContainerWithFileOpts{Permissions: executableMode},
+	)
+
+	return &next, nil
+}
+
+// Image is the image this module resolved and composed, for a caller who wants
+// to do something with it other than what this module offers — run a cpybkc
+// subcommand by hand, look at what is in it, publish a derived image holding
+// their generators, or make it one variant of a multi-platform index:
 //
 //	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
 //	  image with-exec --use-entrypoint --args=--version stdout

--- a/daggerverse/cpybkc/main.go
+++ b/daggerverse/cpybkc/main.go
@@ -67,7 +67,7 @@
 // docs/container/SPEC.md's worked example, written by hand:
 //
 //	FROM ghcr.io/zaba505/cpybkc:v0
-//	COPY --from=ghcr.io/example/cpybkc-gen-hello:v1 --chmod=0755 \
+//	COPY --from=ghcr.io/example/cpybkc-gen-hello:v1 --chown=65532:65532 --chmod=0755 \
 //	     /usr/local/bin/cpybkc-gen-hello /usr/local/bin/cpybkc-gen-hello
 //
 // They are the same two instructions and the comparison is the point: the
@@ -78,15 +78,17 @@
 // names three generators is three calls and one image that is never pushed
 // anywhere.
 //
-// Two differences from the Dockerfile are deliberate rather than incidental.
-// There is no --chown: the mode is what makes the file runnable, by the image's
-// own UID and by any UID a caller overrides it with, while the owner the
-// Dockerfile hands it to is a property of the image this module was given rather
-// than one it may assume. And --image may be omitted, in which case the
-// generator image is the one this project publishes beside the CLI —
-// `<repository>-gen-<name>:<version>`, resolved against the same --repository and
-// --version the CLI image came from, so a generator from one release never lands
-// beside a CLI from another.
+// Two differences from that COPY line are deliberate rather than incidental.
+// The module sets no owner where the Dockerfile writes `--chown=65532:65532`:
+// the mode is what makes the file runnable, by the image's own UID and by any
+// UID a caller overrides it with, while the owner is a property of the image
+// this module was given rather than one it may assume. The Dockerfile can name
+// 65532 because it also names the base image it is deriving from; a module
+// handed a container through --image knows no such thing. And --image may be
+// omitted, in which case the generator image is the one this project publishes
+// beside the CLI — `<repository>-gen-<name>:<version>`, resolved against the same
+// --repository and --version the CLI image came from, so a generator from one
+// release never lands beside a CLI from another.
 //
 // WithGeneratorExecutable is the other half, and it takes a File rather than an
 // image: a generator that has not been published yet, most often one the caller
@@ -111,11 +113,19 @@
 //	for _, p := range platforms {
 //		variants = append(variants, dag.
 //			Cpybkc(dagger.CpybkcOpts{Platform: string(p)}).
-//			WithGenerator("hello").
+//			WithGenerator("hello", dagger.CpybkcWithGeneratorOpts{
+//				Image: dag.Container(dagger.ContainerOpts{Platform: p}).
+//					From("ghcr.io/example/cpybkc-gen-hello:v1"),
+//			}).
 //			Image())
 //	}
 //	ref, err := dag.Container().Publish(ctx, address,
 //		dagger.ContainerPublishOpts{PlatformVariants: variants})
+//
+// The generator image is built for p as well, which is the loop's one obligation
+// and the thing WithGenerator refuses rather than lets past. Omitting the image
+// and letting the published generator be pulled needs no such care, because the
+// pull already follows the container's platform.
 //
 // The loop is the caller's rather than this module's because the index is: which
 // platforms a derived image serves is a property of who will run it, and a module
@@ -164,20 +174,6 @@ import (
 	"dagger/cpybkc/internal/imageref"
 )
 
-// pluginDir is the directory on the image's PATH that cpybkc discovers
-// generators in — docs/container/SPEC.md's plugin directory, and the one path
-// inside the image this module needs to know.
-//
-// It is a promise the base-image contract makes rather than a choice made here:
-// the path is what a `COPY` line writes to and the PATH membership is what makes
-// the copied file reachable by the name a manifest asks for, and either half
-// alone installs nothing. The contract covers it by its compatibility
-// guarantees, so it does not move within a major version.
-//
-// The CLI's own path in the image is not knowable and is not needed. Everything
-// this module runs, it runs through the entrypoint.
-const pluginDir = "/usr/local/bin"
-
 // executableMode is the mode an installed generator lands with, and it is the
 // derived Dockerfile's `--chmod=0755`.
 //
@@ -188,6 +184,11 @@ const pluginDir = "/usr/local/bin"
 // executable by the image's user; this is that requirement met, and it is met
 // with permissions rather than with an owner for the reason
 // WithGeneratorExecutable gives.
+//
+// It stays here rather than moving into internal/generator with the path,
+// because a mode is not a name: that package answers what a generator is called
+// and where it goes, which is what the two specs fix, and how permissively it is
+// installed is this module's decision about a container.
 const executableMode = 0o755
 
 // projectDir is where a caller's project is mounted, and the working directory
@@ -243,9 +244,16 @@ type Cpybkc struct {
 	// container. Nothing here can read a version off an arbitrary container, and
 	// guessing one would produce exactly the untested pairing WithGenerator's
 	// default exists to avoid — a generator from one release beside a CLI from
-	// another. So a caller who passed --image and then lets WithGenerator pull a
-	// published generator gets the release they named in --version, which is a
-	// pairing they stated rather than one that was guessed for them.
+	// another.
+	//
+	// Be exact about what that leaves, because it is less than it sounds. A caller
+	// who passed --image and then lets WithGenerator pull a published generator
+	// gets whatever --version holds, and --version has a default: pin the CLI by
+	// digest and say nothing else, and the generator that arrives beside it is the
+	// moving "v0" tag. That combination is not refused, because refusing it would
+	// mean distinguishing an omitted --version from an explicit "v0", which a
+	// Dagger default cannot express. It is said instead — here, and in --image's
+	// own documentation, where the caller who pins a digest will meet it.
 	// +private
 	Repository string
 	// +private
@@ -307,6 +315,11 @@ func New(
 	// just built rather than against the last release (#64), how a caller tries a
 	// change to cpybkc before it ships, and how a build pins the image by digest —
 	// a reference no tag argument can express, and the only one that pins bytes.
+	//
+	// It pins this image and nothing else. A generator pulled afterwards by
+	// with-generator follows --version, which defaults to the moving "v0" tag and
+	// does not track whatever was pinned here, so a build that pins the CLI by
+	// digest and wants the pairing to hold still passes --version beside it.
 	// +optional
 	image *dagger.Container,
 	// Pull the image for this platform, as `GOOS/GOARCH`, instead of for the
@@ -443,13 +456,14 @@ func (m *Cpybkc) WithGenerator(
 				"the image given for the %s generator is %s and the cpybkc image being composed into is %s: an "+
 					"executable for another platform fails at exec time with the kernel's message rather than "+
 					"cpybkc's, so it is refused here — compose from an image built for %s, or, if the two really "+
-					"are compatible, take the file out yourself and pass it to with-generator-executable, which "+
-					"states the match as your obligation",
-				name, supplied, platform, platform)
+					"are compatible, take the file out of it yourself and pass it to with-generator-executable, "+
+					"which states the match as your obligation (from a Dagger module that is one expression; from "+
+					"the command line it is `file --path %s export` and a second call naming the exported path)",
+				name, supplied, platform, platform, generator.Path(name))
 		}
 	}
 
-	return m.WithGeneratorExecutable(name, image.File(pluginDir+"/"+generator.Executable(name)))
+	return m.WithGeneratorExecutable(name, image.File(generator.Path(name)))
 }
 
 // WithGeneratorExecutable adds one generator to the image from an executable
@@ -484,15 +498,17 @@ func (m *Cpybkc) WithGeneratorExecutable(
 		return nil, err
 	}
 
-	// Permissions and no owner. The mode is what makes the file runnable — by the
-	// image's own UID and by any UID a caller overrides it with — while the owner
-	// the derived Dockerfile's `--chown` hands it to is a property of the image
-	// this module was given rather than one it is entitled to assume: a caller who
-	// passed --image may be composing onto a base with a user of their own, and
-	// this module would be overwriting their answer with the contract's.
+	// Permissions and no owner, where the derived Dockerfile writes
+	// `--chown=65532:65532` beside its `--chmod=0755`. The mode is what makes the
+	// file runnable — by the image's own UID and by any UID a caller overrides it
+	// with — while the owner is a property of the image this module was given
+	// rather than one it is entitled to assume: a caller who passed --image may be
+	// composing onto a base with a user of their own, and this module would be
+	// overwriting their answer with the contract's. The Dockerfile is entitled to
+	// the number because its FROM line names the image it is deriving from.
 	next := *m
 	next.Container = m.Container.WithFile(
-		pluginDir+"/"+generator.Executable(name),
+		generator.Path(name),
 		executable,
 		dagger.ContainerWithFileOpts{Permissions: executableMode},
 	)


### PR DESCRIPTION
Closes #63

Composing a generator into the cpybkc image, as two methods on the companion Dagger module rather than the one `WithPlugin(name, bin)` the story planned. The split follows [`z5labs/avroc` v0.2.0](https://github.com/z5labs/avroc/blob/v0.2.0/daggerverse/avroc/main.go), which the issue records as the prior art worth adopting.

## What landed

- `WithGenerator(name, image)` — copies the executable out of a generator image at the path the base-image contract promises. This is `COPY --from`, it works for a generator image this project has never heard of, and with `--image` omitted it pulls `<repository>-gen-<name>:<version>` against the coordinates the CLI image itself came from. The adopter path.
- `WithGeneratorExecutable(name, executable)` — takes the executable straight from a `File`, for a generator that ships no image. The generator author's path, before anything of theirs is published.
- `New` gains `--platform`, refused beside `--image`.
- `daggerverse/cpybkc/internal/generator` — the pure half (the filename, the derived repository, the two name rules), in its own package so `go test` can reach it, exactly as `internal/imageref` is.

## Acceptance criteria

- [x] **`WithPlugin(name, bin)` installs a plugin into the documented plugin directory** — as the two methods above. The file lands at `/usr/local/bin/cpybkc-gen-<name>` with mode `0755` and no owner change, which is docs/container/SPEC.md's plugin directory and its `--chmod=0755`. Verified against a real engine: `ls -l` in the composed image reports `-rwxr-xr-x … /usr/local/bin/cpybkc-gen-hello`.
- [x] **Multiple plugins compose** — every builder returns a new `Cpybkc` and nothing mutates. Verified: two `with-generator-executable` calls in one chain produce an image holding `cpybkc-gen-go` and `cpybkc-gen-hello`.
- [x] **Multi-platform derived builds handled** — see below.
- [x] **Documented example alongside the equivalent hand-written Dockerfile, for comparison** — the module comment's *Composing a generator, and the Dockerfile it replaces* puts the `dagger call` and the `FROM`/`COPY --from` pair side by side, and CONTRIBUTING.md carries the longer argument. README's companion-module section leads with the composition.
- [x] **The installed plugin is discovered by the CLI's PATH-based resolution** — by construction: the filename is `cpybkc-gen-<name>` (docs/plugin/SPEC.md, Discovery), the directory is on `PATH` and the mode carries an execute bit (docs/container/SPEC.md). The first is unit-tested; the second and third are the contract's, checked by the root pipeline's `ImageContract`. #64 is the story that proves the three together against an image the pipeline just built.

## Multi-platform, the criterion with no prior art

avroc is single-platform per composition and leaves the platform match to the caller. Two things here:

1. **`WithGenerator` follows the container.** It reads the platform off the container it is composing into and pulls the generator image for *that* platform, and refuses an explicitly supplied generator image built for another one. An arm64 base quietly acquiring an amd64 generator is a build that succeeds, pushes, and then fails at the first generation with a kernel message naming neither cpybkc nor the call that caused it. The refusal names an escape hatch — a platform string is a comparison this module can be wrong about, so a caller who knows better takes the file out and passes it to `WithGeneratorExecutable`, which states the match as their obligation anyway.
2. **`New --platform`** makes the other architecture reachable at all; without it an amd64 engine could only ever compose an amd64 image. A derived multi-platform index is then one composition per platform, published as variants — the loop is the caller's because the index is, and a module that decided it would be publishing this project's platform table as somebody else's.

## Judgment calls on the public API

- **Two methods, not one.** `WithPlugin(name, bin)` as literally specced is only the author's path; an adopter with a published generator image would have to extract the file themselves, which is the `COPY --from` the module exists to save them.
- **`--platform` refused beside `--image`.** A container arrives already built for a platform, so the argument would describe a pull that is not happening. Ignoring it silently is worse: the caller would believe they had asked for an architecture and find out at exec time that they had not. It is a comparison of arguments rather than of the container's real platform, so the constructor still performs no network round trip.
- **Permissions, no owner.** The mode is what makes the file runnable by the image's UID and by any UID a caller overrides it with; the owner is a property of the image the module was handed, and a caller who passed `--image` may have a user of their own.
- **Static linking stays the caller's.** Nothing here can check it, and a dynamically linked generator fails at exec time with the kernel's message rather than cpybkc's. Said in both methods' docs rather than enforced in either.

## Verification

`dagger call ci` green from the worktree — including `companion-ci` (fmt, vet, lint, `go test -race` over the companion module, now covering `internal/generator`), `engine-lock` and `cli-surface`. Both modules' generated code regenerated with `dagger develop` and committed alongside.

Behaviour also exercised against a live engine, since the module's `package main` cannot be unit-tested: the file landing with its mode, two generators composing, the derived reference (`…/alpine-gen-hello:3` resolved at `linux/arm64` when the base was pulled for arm64), the platform-mismatch refusal, and the `--platform` beside `--image` refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJtAWEJJX2nj8hKWm73xxC