### PR TITLE
story(layout): decide how a record-level redefine alternative is named and selected

### DIFF
--- a/cmd/cpybkc-gen-go/redefine_test.go
+++ b/cmd/cpybkc-gen-go/redefine_test.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+	"github.com/Zaba505/cpybkc/internal/manifest"
+	"github.com/Zaba505/cpybkc/internal/project"
+	"github.com/Zaba505/cpybkc/irpb"
+)
+
+// TestARecordLevelRedefineGeneratesOneTypePerAlternative is #164 driven the
+// whole way: a copybook whose `01`-level is redefined three ways, discriminated
+// on a code behind a shared account key, resolved and assembled into a
+// descriptor, and generated from here without a collision.
+//
+// It runs the real chain rather than a hand-built descriptor because the failure
+// it is about lived between the stages. `resolve` had always produced one record
+// type per alternative and this generator had always refused two of them called
+// one thing (#50); what was missing was any way for a layout to say which
+// alternative a record form meant and what to call it, so the shape resolved,
+// assembled, and then died here with a message pointing at a remedy that did not
+// exist. Asserting it from a descriptor written by hand would assert the half
+// that was never broken.
+//
+// The three types are named by the three `rename` forms on the records. Without
+// them the descriptor is still well formed — all three record nodes carry
+// `TXN-REC`, which is the honest original for every alternative of that level
+// (docs/ir/SPEC.md, "Names") — and this generator refuses it, which is the
+// second half of the test below.
+func TestARecordLevelRedefineGeneratesOneTypePerAlternative(t *testing.T) {
+	t.Parallel()
+
+	descriptor := transactions(t, renamedRecords)
+
+	out := t.TempDir()
+	if err := generate(descriptor, out, options{packageName: "txn"}); err != nil {
+		t.Fatalf("generating from three alternatives of one 01-level: %v", err)
+	}
+
+	source, err := os.ReadFile(filepath.Join(out, recordsFile))
+	if err != nil {
+		t.Fatalf("reading the generated records: %v", err)
+	}
+
+	for _, want := range []string{"type TxnPurchaseRec", "type TxnRefundRec", "type TxnAdjustRec"} {
+		if !strings.Contains(string(source), want) {
+			t.Errorf("the generated package has no %s:\n%s", want, source)
+		}
+	}
+
+	// Each type holds its own alternative's items and neither of the others',
+	// which is what says the layout's choice selected a record type rather than
+	// being carried along beside one.
+	bodies := declarations(string(source))
+
+	for typ, own := range map[string]string{
+		"TxnPurchaseRec": "PurAmt",
+		"TxnRefundRec":   "RefOrig",
+		"TxnAdjustRec":   "AdjReason",
+	} {
+		for _, field := range []string{"PurAmt", "RefOrig", "AdjReason"} {
+			held := strings.Contains(bodies[typ], field)
+			if held != (field == own) {
+				t.Errorf("%s holds %s: %v, want %v", typ, field, held, field == own)
+			}
+		}
+	}
+}
+
+// declarations is each generated type's source, by the name it was declared
+// under, so that a test can say what one type holds without saying anything
+// about the others.
+func declarations(source string) map[string]string {
+	bodies := make(map[string]string)
+
+	for _, decl := range strings.Split(source, "\ntype ")[1:] {
+		name, body, found := strings.Cut(decl, " ")
+		if !found {
+			continue
+		}
+
+		bodies[name] = body
+	}
+
+	return bodies
+}
+
+// TestThreeAlternativesUnrenamedStillCollide holds the other half of the
+// decision: the layout is what tells two record types over one `01`-level apart,
+// and a layout that does not is refused here exactly as it was before #164.
+//
+// The refusal is what makes the rename load-bearing rather than decorative. It
+// is also why nothing in the layout format *requires* one: whether two record
+// nodes carrying one name are a problem is a property of the target language,
+// and this generator is the thing that has the answer for Go.
+func TestThreeAlternativesUnrenamedStillCollide(t *testing.T) {
+	t.Parallel()
+
+	descriptor := transactions(t, plainRecords)
+
+	err := generate(descriptor, t.TempDir(), options{packageName: "txn"})
+	if err == nil {
+		t.Fatal("three record types called TXN-REC generate without a collision")
+	}
+
+	if !strings.Contains(err.Error(), "TXN-REC") {
+		t.Errorf("the collision does not name the record it is about: %v", err)
+	}
+}
+
+// The two layouts the tests above resolve: the same records and the same
+// discriminators, differing only in whether the record types are renamed.
+const (
+	renamedRecords = `(rename PURCHASE "TXN-PURCHASE-REC")
+(rename REFUND   "TXN-REFUND-REC")
+(rename ADJUST   "TXN-ADJUST-REC")
+`
+
+	plainRecords = ""
+)
+
+// transactions writes the redefined transaction record, resolves it, and hands
+// back the descriptor.
+func transactions(t *testing.T, renames string) *irpb.Descriptor {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	write(t, filepath.Join(dir, "txn.cpy"), fixedFormat(
+		"01  TXN-REC.",
+		"    05  TXN-ACCT        PIC X(4).",
+		"    05  TXN-PURCHASE.",
+		"        10  PUR-CODE    PIC X(2).",
+		"        10  PUR-AMT     PIC X(6).",
+		"    05  TXN-REFUND REDEFINES TXN-PURCHASE.",
+		"        10  REF-CODE    PIC X(2).",
+		"        10  REF-ORIG    PIC X(6).",
+		"    05  TXN-ADJUST REDEFINES TXN-PURCHASE.",
+		"        10  ADJ-CODE    PIC X(2).",
+		"        10  ADJ-REASON  PIC X(6).",
+	))
+
+	write(t, filepath.Join(dir, "txn.sexpr"), `(encoding
+  (charset ascii) (sign-convention ascii-zone-37)
+  (byte-order big-endian) (float-format ieee-754))
+(framing (recfm F) (lrecl 12))
+
+(record PURCHASE (copybook "txn.cpy" TXN-REC) (alternative (item PURCHASE TXN-PURCHASE)))
+(record REFUND   (copybook "txn.cpy" TXN-REC) (alternative (item REFUND   TXN-REFUND)))
+(record ADJUST   (copybook "txn.cpy" TXN-REC) (alternative (item ADJUST   TXN-ADJUST)))
+
+`+renames+`
+(discriminate PURCHASE (equals (item PURCHASE TXN-PURCHASE PUR-CODE) "PU"))
+(discriminate REFUND   (equals (item REFUND   TXN-REFUND   REF-CODE) "RF"))
+(discriminate ADJUST   (equals (item ADJUST   TXN-ADJUST   ADJ-CODE) "AJ"))
+
+(sequence (* (alt PURCHASE REFUND ADJUST)))
+`)
+
+	write(t, filepath.Join(dir, manifest.Name),
+		`{"layout": "txn.sexpr", "generators": [{"name": "go", "out": "gen"}]}`)
+
+	run, err := project.Load(filepath.Join(dir, manifest.Name))
+	if err != nil {
+		t.Fatalf("the project does not resolve:\n%s", diag.Render(err))
+	}
+
+	return run.Descriptor
+}
+
+// write puts a file where a test needs one.
+func write(t *testing.T, path, body string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+}
+
+// fixedFormat renders copybook lines the way a copybook is written: fixed-format
+// COBOL, with the six-column sequence area in front of every line.
+func fixedFormat(lines ...string) string {
+	var b strings.Builder
+
+	for _, line := range lines {
+		b.WriteString("      " + line + "\n")
+	}
+
+	return b.String()
+}

--- a/docs/ir/SPEC.md
+++ b/docs/ir/SPEC.md
@@ -1746,6 +1746,28 @@ The original **MUST** be present even where an override is. A rename substitutes
 a name, and the substitute is carried beside the original rather than in place
 of it, so that generated code can still point back at the copybook it came from.
 
+**A record node resolved from a `REDEFINES` carries the `01`-level's name**, and
+not the alternative's. [Members never overlap, and `REDEFINES` is resolved
+away](#members-never-overlap-and-redefines-is-resolved-away) turns one
+`01`-level into one record node per alternative, and every one of them describes
+that `01`-level: `TXN-REC` is what the copybook calls the record each of them
+is, and the alternative is which description of its bytes was taken. So several
+record nodes of one descriptor **MAY** carry one original, and a producer
+**MUST NOT** substitute an alternative's name for the `01`-level's to tell them
+apart (#164).
+
+Taking the alternative's name would read well for a copybook with one redefine
+in it and answer nothing for a copybook with two, where the record nodes are one
+per *combination* and no single alternative names any of them. A rule that
+changed what a record node was called when a second `REDEFINES` was added to a
+copybook would change it in a file no layout is stored beside.
+
+What tells them apart is the override, which the layout supplies — [`layout/SPEC.md`](../layout/SPEC.md#a-rename-may-name-a-record)
+spells it — and nothing here requires one. Two record nodes carrying one name
+are a descriptor this document admits; whether that is a problem is the
+consuming generator's, and `cpybkc-gen-go` refuses the pair it cannot munge into
+two identifiers (#50).
+
 A name is local. Qualification — COBOL's `OF`/`IN` form, whose grammar is
 cobol-go's root `SPEC.md`'s — is the chain of enclosing nodes, and the IR
 carries no materialized qualified path for the same reason it carries no
@@ -3622,7 +3644,7 @@ records offer them.
 | [Offsets and widths](#offsets-and-widths) | #32, #34, #35 `resolve`, #77, #82, #84, #87, #88, #89, #90 `ir` |
 | [Physical framing](#physical-framing) | #78, #88, #92, #94 `ir`, #26 `layout`, #52 `gen-go` |
 | [The encoding profile, applied](#the-encoding-profile-applied) | #33 `resolve` |
-| [Names](#names) | #30 `layout`, #38 `resolve` |
+| [Names](#names) | #30 `layout`, #38 `resolve`; what a record node resolved from a `REDEFINES` is called, settled by #164 |
 | [The sequencing automaton](#the-sequencing-automaton) | #36 `resolve`, #76, #77, #80, #84, #88 `ir` |
 | [Discriminator predicates](#discriminator-predicates) | #28 `layout`, #37 `resolve`, #80, #84, #88, #90, #94 `ir` |
 | [Writing a file](#writing-a-file) | #79, #80, #82, #88, #89, #90 `ir`, #51, #52 `gen-go` |

--- a/docs/layout/SPEC.md
+++ b/docs/layout/SPEC.md
@@ -632,13 +632,15 @@ and an adopter who guesses gives up a diagnostic without being told.
 
 ```
 (record <name>
-  (copybook "<path>" <top-level-name>))
+  (copybook "<path>" <top-level-name>)
+  (alternative <item-ref>) …)
 ```
 
 | Argument or child | Arity | Value |
 |---|---|---|
 | `<name>` | 1 | a symbol, unique among the layout's records |
 | `copybook` | 1 | a path, and the name of the item in it this record is |
+| `alternative` | 0..n | one alternative of a `REDEFINES` outside a repeating group; see [Which alternative a record is](#which-alternative-a-record-is) |
 
 A record name is the layout's own identifier for a record type. It **MAY** be
 the same symbol as the copybook item's name and does not have to be, and nothing
@@ -684,11 +686,61 @@ names the item as it is reached through `ORDER-DETAIL`, so two records over one
 neither reaches the other. [A
 rename](#a-rename-substitutes-a-name-and-keeps-the-original)'s at-most-one rule
 counts per record for that reason: the item it may name once is the item
-reached through the record it names, not the copybook item behind it.
+reached through the record it names, not the copybook item behind it. A rename
+is therefore **per record and not per item**, and an implementation keying one
+on the copybook item alone has one substitute where this section promises two
+(#164).
 
 Whether two paths name one copybook is a question about the files they resolve
 to rather than about how they are spelled, and the resolving is the CLI's. No
 rule here is stated over `copybook` children carrying equal strings.
+
+### Which alternative a record is
+
+A `REDEFINES` outside a repeating group is resolved away into one record type
+per alternative
+([`ir/SPEC.md`](../ir/SPEC.md#members-never-overlap-and-redefines-is-resolved-away)),
+and a `record` form names an `01`-level rather than an alternative of one. The
+`alternative` child is where the layout says which of them the form means:
+
+```
+(record PURCHASE
+  (copybook "txn.cpy" TXN-REC)
+  (alternative (item PURCHASE TXN-PURCHASE)))
+
+(record REFUND
+  (copybook "txn.cpy" TXN-REC)
+  (alternative (item REFUND TXN-REFUND)))
+```
+
+The reference names the alternative as an ordinary [item
+reference](#an-item-reference), rooted at the record whose choice it is stating.
+It is a reference rather than a bare name for the reason every other position
+takes one: duplicate data names are legal COBOL, so a name alone is not an
+identity, and a redefine may sit at any depth under the `01`-level.
+
+A `record` form **MUST** carry exactly one `alternative` child per `REDEFINES`
+the copybook writes into its `01`-level outside a repeating group, and **MUST
+NOT** carry one where the copybook writes none. Two independent redefines are
+two children, in either order — each names a distinct run of bytes, so nothing
+depends on which is written first — and together they select exactly one of the
+combinations [`ir/SPEC.md`](../ir/SPEC.md#members-never-overlap-and-redefines-is-resolved-away)
+enumerates. How many a copybook writes, and whether a reference names an
+alternative at all, are `resolve`'s: both need the copybook.
+
+**The pairing is stated and never inferred.** Matching a record form to the
+alternative containing its discriminator's target is a rule that works on the
+shape a discriminator reaches into and answers nothing for an alternative no
+`discriminate` form touches, and pairing by the order the forms are written in
+is a rule an adopter could not read anywhere. Either would be a program's
+convention deciding which bytes a record type describes, silently, and changing
+its answer when a copybook gains a redefine in a file no layout is stored beside.
+
+A redefine **inside** a repeating group is not this. The alternative there is
+chosen once per occurrence rather than once per record, so it is a
+[`discriminate-variant`](#a-discriminator-for-a-redefine-inside-a-table) and
+never an `alternative` child; a layout naming one here is naming an item that is
+not a record-level alternative, and is a diagnostic on those terms.
 
 ### Composition is the copybook's, and `COPY` is where it is written
 
@@ -779,11 +831,12 @@ span](#every-diagnostic-carries-a-span-and-some-carry-two) is protecting.
 
 ```
 (rename <item-ref> "<name>")
+(rename <record-name> "<name>")
 ```
 
-A rename gives the item an override name, carried in the IR beside the original
-rather than in place of it, so that generated code can still point back at the
-copybook it came from
+A rename gives its target an override name, carried in the IR beside the
+original rather than in place of it, so that generated code can still point back
+at the copybook it came from
 ([`ir/SPEC.md`](../ir/SPEC.md#names)). The substitute is a string and is carried
 verbatim: it is language-neutral, and no implementation **MAY** apply the casing
 or identifier conventions of any language to it — turning a name into an
@@ -795,6 +848,59 @@ repeats, in which case the substitute is the name of the item and reaches every
 occurrence of it. The substitute is a name and not an occurrence's, for the
 reason [an item reference](#an-item-reference) names an item and not an
 occurrence of one: a table of a hundred entries has one field there, named once.
+
+A rename is **per record**, not per copybook item. Its target is the item as it
+is reached through the record the reference is rooted at, so a rename written
+under one of two records over one `01`-level does not reach the other — which is
+[Many records may name one
+copybook](#many-records-may-name-one-copybook-and-two-may-name-one-item)'s
+independence, and is a requirement on an implementation rather than a
+consequence of how it happens to hold its copybook items (#164).
+
+### A rename may name a record
+
+The second spelling takes a **record name** where the first takes a reference,
+and it substitutes a name for the record type's own — the name the IR carries on
+a record node, which is the one the copybook's `01`-level gives it
+([`ir/SPEC.md`](../ir/SPEC.md#names)):
+
+```
+(record PURCHASE (copybook "txn.cpy" TXN-REC) (alternative (item PURCHASE TXN-PURCHASE)))
+(record REFUND   (copybook "txn.cpy" TXN-REC) (alternative (item REFUND   TXN-REFUND)))
+
+(rename PURCHASE "TXN-PURCHASE-REC")
+(rename REFUND   "TXN-REFUND-REC")
+```
+
+It is a record name rather than `(item PURCHASE)` because [an item
+reference](#an-item-reference) does not repeat the top-level item's own name —
+the `record` form has already stated it — so the one item whose name a record
+node carries is the one item a reference cannot reach. Admitting a reference
+naming a record and no item below it would put two meanings on a spelling every
+other position in this format refuses.
+
+It is the same form as the first spelling, and not a new one, because it says
+exactly what the first says: a substitute carried beside an original that
+survives. A record's own name is a name like any other, and the alternative was
+a second form differing from `rename` in nothing but what stands in its first
+position.
+
+The rules carry over unchanged in the shape they can. At most one rename **MAY**
+name a given record. Two renames **MUST NOT** substitute one name for two
+records, and a rename **MUST NOT** substitute a name another record's `copybook`
+child spells as its top-level item — both decidable from the layout alone, and
+both the same ambiguity [A substitute is a name nothing beside it already
+answers to](#a-substitute-is-a-name-nothing-beside-it-already-answers-to)
+removes between siblings. There is no parent for a record node to have siblings
+under, so no rule beyond those two is stated.
+
+**Nothing requires a record to be renamed**, including two records over one
+`01`-level, which carry one name between them until a rename says otherwise
+([`ir/SPEC.md`](../ir/SPEC.md#names)). Whether one name on two record types is a
+problem is a property of the target language: a generator munging both into one
+identifier refuses and says which two collided (#50), and a generator that
+qualifies its output has nothing to refuse. Requiring the rename here would put
+one language's collision rule in the layer every language's generator reads.
 
 ### A substitute is a name nothing beside it already answers to
 
@@ -1507,9 +1613,13 @@ arms of one variant naming one alternative, or naming one target and one
 literal; an arm whose target is rooted at another record, stands under another
 outermost group than the variant, or descends through the variant or one of its
 arms; a record name in the sequencing expression that no `record` form defines,
-and a `record` the expression never names; a second `rename` naming one item, a
-name substituted for two items under one parent, and a substitute equal to the
-name of an item the layout itself references under that parent; a `blksize`,
+and a `record` the expression never names; an `alternative` child whose
+reference is rooted at another record, and two of them naming one item; a second
+`rename` naming one item or one record, a
+name substituted for two items under one parent or for two records, a substitute
+equal to the
+name of an item the layout itself references under that parent, and a substitute
+equal to the top-level item another record's `copybook` child names; a `blksize`,
 `lrecl`, `max-segment` or `delimiter` under a spelling that does not admit it;
 and the framing spellings rejected by name — `U`, a carriage-control suffix,
 `(blocks in-stream)`.
@@ -1517,7 +1627,10 @@ and the framing spellings rejected by name — `U`, a carriage-control suffix,
 **`resolve`** (#32–#38) has the copybooks too, and reports everything that needs
 them: a `copybook` child naming a file it cannot read, and one naming a
 top-level item the copybook it read does not declare (#27); an item reference
-naming no item or more than one; a reference that
+naming no item or more than one; a `record` form whose `alternative` children do
+not name exactly one alternative per `REDEFINES` its `01`-level carries outside
+a repeating group, and one naming an item that is no such alternative; a
+reference that
 repeats or sits inside a repeating group where the position forbids it; a
 discriminator behind a variable item; a rename whose substitute is the name of
 an item beside its target that the layout itself never references; a literal
@@ -1772,7 +1885,7 @@ computed once by `resolve`.
 | [The surface syntax](#the-surface-syntax) | #22 `layout` |
 | [The encoding profile](#the-encoding-profile) | #25 `layout` |
 | [Physical framing](#physical-framing) | #26 `layout` |
-| [Record definitions](#record-definitions) | #27, #30 `layout`; `copybook-reading` by #35 `resolve` |
+| [Record definitions](#record-definitions) | #27, #30 `layout`; `copybook-reading` by #35 `resolve`; which alternative a `record` form is, a rename naming a record, and a rename being per record, settled by #164 |
 | [Discrimination](#discrimination) | #28 `layout`; the strategies lowered into IR predicates, the literals resolved to bytes, and the rules on a target that need a copybook, by #37 `resolve` |
 | [Sequencing](#sequencing) | #29 `layout`; the expression compiled to an automaton, and the rules on `times` and `when` that need a copybook, by #36 `resolve`; what a `when` does and does not require, and where a guard lands on a repetition, settled by #144 against the compiler #36 had already produced |
 | [The published schema](#the-published-schema) | #23 `layout` |

--- a/internal/assemble/assemble.go
+++ b/internal/assemble/assemble.go
@@ -165,7 +165,19 @@ func Assemble(opts Options) (*irpb.Descriptor, error) {
 	}
 
 	for _, rename := range opts.Renames {
+		// A rename with no record reaches nothing, and a descriptor assembled
+		// past one is well formed and missing every override the layout asked
+		// for. It is reported here rather than ignored for that reason: the
+		// output of ignoring it is indistinguishable from a layout that wrote no
+		// renames at all.
 		if rename.Record == "" {
+			named := ""
+			if rename.Item != nil {
+				named = itemName(rename.Item)
+			}
+
+			a.faults.Fail(&UnnamedRenameError{Substitute: rename.Substitute, Item: named})
+
 			continue
 		}
 

--- a/internal/assemble/assemble.go
+++ b/internal/assemble/assemble.go
@@ -57,20 +57,29 @@ type Options struct {
 	// [github.com/Zaba505/cpybkc/internal/resolve.Record] per combination of
 	// alternatives, each of which is its own record type with its own
 	// discriminator (docs/ir/SPEC.md, "Members never overlap, and `REDEFINES`
-	// is resolved away"), and which of them a given transition admits is a
-	// question about the layout rather than about the resolved records. So the
-	// pairing arrives made: a caller hands over one entry per name a
-	// transition may admit, and this package neither splits nor merges them.
+	// is resolved away").
+	//
+	// Which of them a `record` form means is the layout's own statement and not
+	// a rule anything infers: the form carries one `alternative` child per
+	// redefine, naming the alternative it is (docs/layout/SPEC.md, "Which
+	// alternative a record is", #164). So a caller hands over one entry per name
+	// a transition may admit, having made the pairing the layout wrote, and this
+	// package neither splits nor merges them.
 	Records []Record
 
-	// Renames are the renames the layout wrote, resolved to the copybook items
-	// they name.
+	// Renames are the renames the layout wrote, resolved to what they name.
 	//
 	// A rename substitutes a name and keeps the original, so what one
 	// contributes is the override beside the name the copybook gave the item
-	// (docs/ir/SPEC.md, "Names"). It reaches every node standing for that item,
-	// in every record type that holds it: a rename is a name, and a name is per
-	// item rather than per record.
+	// (docs/ir/SPEC.md, "Names").
+	//
+	// It is **per record**, not per copybook item. Two record types over one
+	// `01`-level are renamed independently and neither reaches the other
+	// (docs/layout/SPEC.md, "Many records may name one copybook, and two may
+	// name one item"), so a rename carries the record it was written under and
+	// reaches only that record's nodes. Keying on the copybook item alone would
+	// make the independence a property of whether a caller happened to build one
+	// item tree per record rather than a property of this package (#164).
 	Renames []Rename
 }
 
@@ -95,7 +104,20 @@ type Record struct {
 
 // Rename is one `rename` form, resolved.
 type Rename struct {
-	// Item is the copybook item renamed.
+	// Record is the name of the record type the rename was written under: the
+	// [Record.Name] of the entry whose nodes it reaches, and no other's.
+	//
+	// It is required. A rename with no record reaches nothing, which is the
+	// honest reading of a substitute nobody said where to apply.
+	Record string
+
+	// Item is the copybook item renamed, or nil where the rename names the
+	// record type itself.
+	//
+	// The nil case is docs/layout/SPEC.md's "A rename may name a record": a
+	// record node's name is its `01`-level's, which is the one item an item
+	// reference cannot reach, so the layout names the record and this carries
+	// no item.
 	Item *copybook.Field
 
 	// Substitute is the name carried beside the original, exactly as the
@@ -133,18 +155,27 @@ func Assemble(opts Options) (*irpb.Descriptor, error) {
 	}
 
 	a := &assembler{
-		opts:       opts,
-		byName:     make(map[string]*scope, len(opts.Records)),
-		renames:    make(map[*copybook.Field]string, len(opts.Renames)),
-		registers:  make(map[*resolve.Register]uint64),
-		states:     make(map[*resolve.State]uint64),
-		predicates: make(map[predicateKey]uint64),
+		opts:              opts,
+		byName:            make(map[string]*scope, len(opts.Records)),
+		renames:           make(map[renameKey]string, len(opts.Renames)),
+		recordSubstitutes: make(map[string]string),
+		registers:         make(map[*resolve.Register]uint64),
+		states:            make(map[*resolve.State]uint64),
+		predicates:        make(map[predicateKey]uint64),
 	}
 
 	for _, rename := range opts.Renames {
-		if rename.Item != nil {
-			a.renames[rename.Item] = rename.Substitute
+		if rename.Record == "" {
+			continue
 		}
+
+		if rename.Item == nil {
+			a.recordSubstitutes[rename.Record] = rename.Substitute
+
+			continue
+		}
+
+		a.renames[renameKey{record: rename.Record, item: rename.Item}] = rename.Substitute
 	}
 
 	descriptor := a.assemble()
@@ -172,7 +203,12 @@ type assembler struct {
 	// byName is the record types under the name a transition admits each by.
 	byName map[string]*scope
 
-	renames    map[*copybook.Field]string
+	// renames is the substitute for each renamed item, under the record it was
+	// written for. recordSubstitutes is the substitute for a record type's own
+	// name, by the name a transition admits it by.
+	renames           map[renameKey]string
+	recordSubstitutes map[string]string
+
 	registers  map[*resolve.Register]uint64
 	states     map[*resolve.State]uint64
 	predicates map[predicateKey]uint64
@@ -206,6 +242,21 @@ type scope struct {
 	// names an elementary one.
 	nodes  map[*resolve.Node]uint64
 	fields map[*copybook.Field]uint64
+}
+
+// renameKey is what a rename applies to: the record type it was written under,
+// and the copybook item it names.
+//
+// The record is half of the key rather than the item alone, because
+// docs/layout/SPEC.md has two record types over one `01`-level renamed
+// independently — "neither reaches the other". A caller that builds one item
+// tree per record makes the item pointer unique already, but that is the
+// caller's arrangement rather than this package's contract, and a rename that
+// leaked into a second record type would leak silently: both record nodes would
+// come out well-formed, carrying a name only one of them was given.
+type renameKey struct {
+	record string
+	item   *copybook.Field
 }
 
 // predicateKey is what makes two references to one predicate the same node: the
@@ -294,8 +345,32 @@ func (a *assembler) record(record Record) {
 
 	node.Kind = &irpb.Node_Record{Record: &irpb.Record{
 		RootId: s.nodes[record.Resolved.Root],
-		Names:  a.names(record.Resolved.Item),
+		Names:  a.recordName(record),
 	}}
+}
+
+// recordName is what a record node carries: the name its copybook `01`-level
+// has, and the substitute a rename on the record asked for beside it.
+//
+// The original is the `01`-level's whichever alternative of a record-level
+// REDEFINES this record type is. Every alternative describes that same
+// `01`-level, and a producer taking an alternative's name instead would have
+// nothing to take for a copybook with two redefines in it, where the record
+// types are one per combination (docs/ir/SPEC.md, "Names", #164). So several
+// record nodes of one descriptor may carry one original, and what tells them
+// apart is the override.
+func (a *assembler) recordName(record Record) *irpb.Names {
+	field := record.Resolved.Item
+	if field == nil || field.Filler || field.Name == "" {
+		return nil
+	}
+
+	names := &irpb.Names{Original: field.Name}
+	if substitute, renamed := a.recordSubstitutes[record.Name]; renamed {
+		names.OverrideName = proto.String(substitute)
+	}
+
+	return names
 }
 
 // allocate hands an identifier to every node of a record's tree, in containment
@@ -334,7 +409,7 @@ func (a *assembler) fill(s *scope, node *resolve.Node) {
 
 		at.Kind = &irpb.Node_Group{Group: &irpb.Group{
 			MemberIds:  members,
-			Names:      a.names(node.Field),
+			Names:      a.names(s, node.Field),
 			Repetition: a.repetition(s, node.Repetition),
 		}}
 	case resolve.KindField:
@@ -343,7 +418,7 @@ func (a *assembler) fill(s *scope, node *resolve.Node) {
 			Encoding:   encodingOf(node.Encoding),
 			Usage:      usageOf(node.Field),
 			Picture:    pictureOf(node.Field),
-			Names:      a.names(node.Field),
+			Names:      a.names(s, node.Field),
 			Repetition: a.repetition(s, node.Repetition),
 		}}
 	case resolve.KindVariant:
@@ -427,13 +502,16 @@ func (a *assembler) repetition(s *scope, repetition *resolve.Repetition) *irpb.R
 // standing for a FILLER: an item COBOL gives no data-name has no original for a
 // substitute to stand beside, and docs/ir/SPEC.md's "Names" makes the original
 // the member that **MUST** be present.
-func (a *assembler) names(field *copybook.Field) *irpb.Names {
+//
+// The lookup is per record type, which is what makes a rename written under one
+// of two records over one `01`-level reach that record and not the other.
+func (a *assembler) names(s *scope, field *copybook.Field) *irpb.Names {
 	if field == nil || field.Filler || field.Name == "" {
 		return nil
 	}
 
 	names := &irpb.Names{Original: field.Name}
-	if substitute, renamed := a.renames[field]; renamed {
+	if substitute, renamed := a.renames[renameKey{record: s.name, item: field}]; renamed {
 		names.OverrideName = proto.String(substitute)
 	}
 

--- a/internal/assemble/assemble_test.go
+++ b/internal/assemble/assemble_test.go
@@ -634,7 +634,7 @@ func TestAnOverrideStandsBesideTheOriginal(t *testing.T) {
 	opts := options(t, countedRun, countedRunCopybooks())
 
 	item := fieldNamed(t, opts.Records[0].Resolved.Item, "DTL-COUNT")
-	opts.Renames = []Rename{{Item: item, Substitute: "detail_count"}}
+	opts.Renames = []Rename{{Record: opts.Records[0].Name, Item: item, Substitute: "detail_count"}}
 
 	descriptor, err := Assemble(opts)
 	if err != nil {
@@ -652,11 +652,11 @@ func TestAnOverrideStandsBesideTheOriginal(t *testing.T) {
 }
 
 // TestARenameReachesOneItemAndNoOther holds a rename to being about the item it
-// names, which is what makes it safe for it to be keyed on the copybook item
-// rather than on a record.
+// names and no other, under the one record type it was written for.
 func TestARenameReachesOneItemAndNoOther(t *testing.T) {
 	opts := options(t, countedRun, countedRunCopybooks())
 	opts.Renames = []Rename{{
+		Record:     opts.Records[0].Name,
 		Item:       fieldNamed(t, opts.Records[0].Resolved.Item, "HDR-TYPE"),
 		Substitute: "kind",
 	}}
@@ -1045,4 +1045,129 @@ func fieldNodeNamed(t *testing.T, d *irpb.Descriptor, original string) *irpb.Fie
 	t.Fatalf("no field node is named %s", original)
 
 	return nil
+}
+
+// twoOverOne is a layout binding two record names to one copybook item, which is
+// the shape docs/layout/SPEC.md's "Many records may name one copybook, and two
+// may name one item" admits and the one every rename rule below turns on.
+const twoOverOne = `(framing (recfm FB) (lrecl 8))
+(encoding (charset cp037) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))
+(record ORDER-OPEN (copybook "ord.cpy" ORD-REC))
+(record ORDER-CLOSE (copybook "ord.cpy" ORD-REC))
+(discriminate ORDER-OPEN (equals (item ORDER-OPEN ORD-TYPE) "O"))
+(discriminate ORDER-CLOSE (equals (item ORDER-CLOSE ORD-TYPE) "C"))
+(sequence (seq ORDER-OPEN ORDER-CLOSE))`
+
+// order is the copybook both of them name.
+const order = `01 ORD-REC.
+   05 ORD-TYPE PIC X(1).
+   05 ORD-NO PIC X(7).
+`
+
+// twoOrders is that layout resolved: two record types over one copybook item,
+// each with an item tree of its own, exactly as the pipeline in front of this
+// package builds them.
+func twoOrders(t *testing.T) Options {
+	t.Helper()
+
+	opts := options(t, twoOverOne, map[string]string{"ORDER-OPEN": order, "ORDER-CLOSE": order})
+	if len(opts.Records) != 2 {
+		t.Fatalf("the layout resolved to %d record types, want 2", len(opts.Records))
+	}
+
+	return opts
+}
+
+// TestARenameIsPerRecordAndNotPerCopybookItem is #164's half of the rename rule:
+// a rename belongs to the record type it was written under, and reaches no node
+// of any other.
+//
+// The rename below names ORDER-OPEN's own ORD-NO item and is written under
+// ORDER-CLOSE, which is a rename an adopter cannot write and this package can
+// nevertheless be handed. It has to reach nothing. Keyed on the copybook item
+// alone it would reach ORDER-OPEN — the record it was not written for — and the
+// descriptor would come out well-formed, carrying a name only the other record
+// was given.
+func TestARenameIsPerRecordAndNotPerCopybookItem(t *testing.T) {
+	opts := twoOrders(t)
+
+	opts.Renames = []Rename{{
+		Record:     "ORDER-CLOSE",
+		Item:       fieldNamed(t, opts.Records[0].Resolved.Item, "ORD-NO"),
+		Substitute: "OpeningOrderNumber",
+	}}
+
+	descriptor, err := Assemble(opts)
+	if err != nil {
+		t.Fatalf("assembling the descriptor: %v", err)
+	}
+
+	for _, node := range descriptor.GetNodes() {
+		names := node.GetField().GetNames()
+		if names.GetOriginal() == "ORD-NO" && names.OverrideName != nil {
+			t.Errorf("an ORD-NO node carries %q, and the rename was written under the other record",
+				names.GetOverrideName())
+		}
+	}
+
+	// The same rename under the record it names does reach it, so the check
+	// above is about the record and not about the item having been missed.
+	opts.Renames[0].Record = "ORDER-OPEN"
+
+	descriptor, err = Assemble(opts)
+	if err != nil {
+		t.Fatalf("assembling the descriptor: %v", err)
+	}
+
+	substitutes := make([]string, 0, 2)
+
+	for _, node := range descriptor.GetNodes() {
+		names := node.GetField().GetNames()
+		if names.GetOriginal() == "ORD-NO" {
+			substitutes = append(substitutes, names.GetOverrideName())
+		}
+	}
+
+	if want := []string{"OpeningOrderNumber", ""}; !slices.Equal(substitutes, want) {
+		t.Errorf("the two ORD-NO nodes carry %q, want %q", substitutes, want)
+	}
+}
+
+// TestARenameOnARecordNamesTheRecordNode is the other half: a rename carrying no
+// item substitutes a name for the record type's own, which is the one name an
+// item reference cannot reach.
+//
+// The original stays the `01`-level's, and both record nodes carry it: every
+// alternative of a redefined level is a description of that level, and the
+// override is what tells two of them apart (docs/ir/SPEC.md, "Names").
+func TestARenameOnARecordNamesTheRecordNode(t *testing.T) {
+	opts := twoOrders(t)
+
+	opts.Renames = []Rename{{Record: "ORDER-CLOSE", Substitute: "ORD-CLOSE-REC"}}
+
+	descriptor, err := Assemble(opts)
+	if err != nil {
+		t.Fatalf("assembling the descriptor: %v", err)
+	}
+
+	originals := make([]string, 0, 2)
+	overrides := make([]string, 0, 2)
+
+	for _, node := range descriptor.GetNodes() {
+		record := node.GetRecord()
+		if record == nil {
+			continue
+		}
+
+		originals = append(originals, record.GetNames().GetOriginal())
+		overrides = append(overrides, record.GetNames().GetOverrideName())
+	}
+
+	if want := []string{"ORD-REC", "ORD-REC"}; !slices.Equal(originals, want) {
+		t.Errorf("the record nodes are named %q, want %q", originals, want)
+	}
+
+	if want := []string{"", "ORD-CLOSE-REC"}; !slices.Equal(overrides, want) {
+		t.Errorf("the record nodes carry the overrides %q, want %q", overrides, want)
+	}
 }

--- a/internal/assemble/assemble_test.go
+++ b/internal/assemble/assemble_test.go
@@ -1171,3 +1171,34 @@ func TestARenameOnARecordNamesTheRecordNode(t *testing.T) {
 		t.Errorf("the record nodes carry the overrides %q, want %q", overrides, want)
 	}
 }
+
+// TestARenameNamingNoRecordIsReported holds a rename with no record to being a
+// fault rather than a no-op.
+//
+// A rename is per record, so one naming none reaches nothing — and the
+// descriptor that comes out of ignoring it is well formed and carries no
+// override at all, which is indistinguishable from a layout that wrote no
+// renames. It is also the shape a caller written against the older [Rename]
+// produces, and that caller still compiles.
+func TestARenameNamingNoRecordIsReported(t *testing.T) {
+	opts := twoOrders(t)
+
+	opts.Renames = []Rename{{
+		Item:       fieldNamed(t, opts.Records[0].Resolved.Item, "ORD-NO"),
+		Substitute: "OpeningOrderNumber",
+	}}
+
+	_, err := Assemble(opts)
+	if err == nil {
+		t.Fatal("a rename naming no record assembles")
+	}
+
+	var unnamed *UnnamedRenameError
+	if !errors.As(err, &unnamed) {
+		t.Fatalf("a rename naming no record reads as %v, want an UnnamedRenameError", err)
+	}
+
+	if !strings.Contains(err.Error(), "ORD-NO") || !strings.Contains(err.Error(), "OpeningOrderNumber") {
+		t.Errorf("the diagnostic names neither the item nor the substitute: %v", err)
+	}
+}

--- a/internal/assemble/errors.go
+++ b/internal/assemble/errors.go
@@ -79,6 +79,47 @@ func (e *DuplicateRecordError) Diagnostic() diag.Diagnostic {
 	}
 }
 
+// UnnamedRenameError is a [Rename] handed over without the record type it was
+// written under.
+//
+// A rename is per record (docs/layout/SPEC.md, "Many records may name one
+// copybook, and two may name one item"), so a rename naming no record reaches
+// nothing. It is reported rather than ignored because the descriptor that comes
+// out of ignoring it is well formed: every node carries its copybook name and
+// none carries the override the caller asked for, which is a layout's `rename`
+// forms silently doing nothing at all.
+//
+// It is the shape a caller written against the older [Rename] produces — one
+// carrying an item and a substitute and no record — and that caller still
+// compiles, so a diagnostic is the only thing standing between it and output
+// nobody checks.
+type UnnamedRenameError struct {
+	// Substitute is the name the rename asked for, which is what a caller can
+	// find in the layout that wrote it.
+	Substitute string
+
+	// Item is the copybook item it named, and is empty where it named none.
+	Item string
+}
+
+// Error implements the error interface.
+func (e *UnnamedRenameError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic is what the error says, and where.
+func (e *UnnamedRenameError) Diagnostic() diag.Diagnostic {
+	target := "a record type"
+	if e.Item != "" {
+		target = e.Item
+	}
+
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"the rename substituting %s for %s names no record type, and a rename is per record",
+			e.Substitute, target),
+		Spans: []diag.Span{{Note: "every rename carries the record its layout form was written under"}},
+	}
+}
+
 // UnknownRecordError is a transition admitting a record type nothing defines.
 //
 // The automaton names the records its transitions admit, and every one of them

--- a/internal/layoutmodel/discriminate.go
+++ b/internal/layoutmodel/discriminate.go
@@ -313,14 +313,25 @@ func ReadDiscrimination(file *layout.File) (*Discrimination, error) {
 type recordDefinition struct {
 	name string
 	pos  layout.Pos
+
+	// item is the top-level item the `copybook` child binds the record to, and
+	// itemPos is where that name was written. Both are zero for a form this
+	// could not read a binding out of.
+	//
+	// It is read here because a record's own name in the IR is that item's
+	// (docs/ir/SPEC.md, "Names"), so a rename substituting a name for a record
+	// collides with it exactly as a rename on an item collides with a sibling —
+	// and both halves of that are in the layout, with no copybook needed.
+	item    string
+	itemPos layout.Pos
 }
 
 // recordNames gathers the records a layout defines, in source order.
 //
-// Only the name is read. What a record is bound to is the record-definitions
-// layer's (#27, #30), and a `record` form this cannot read a name out of is that
-// layer's fault to report: a second message about it here would name the same
-// line twice.
+// Only the name and the item it is bound to are read. Whether that binding is
+// well formed is the record-definitions layer's (#27, #30), and a `record` form
+// this cannot read a name out of is that layer's fault to report: a second
+// message about it here would name the same line twice.
 func recordNames(file *layout.File) []recordDefinition {
 	var records []recordDefinition
 
@@ -329,9 +340,22 @@ func recordNames(file *layout.File) []recordDefinition {
 			continue
 		}
 
-		if symbol, ok := form.Elements[0].(layout.Symbol); ok {
-			records = append(records, recordDefinition{name: symbol.Value, pos: form.Pos})
+		symbol, ok := form.Elements[0].(layout.Symbol)
+		if !ok {
+			continue
 		}
+
+		record := recordDefinition{name: symbol.Value, pos: form.Pos}
+
+		if len(form.Elements) > 1 {
+			if child, ok := form.Elements[1].(layout.Form); ok && child.Tag == childCopybook && len(child.Elements) == 2 {
+				if item, ok := child.Elements[1].(layout.Symbol); ok {
+					record.item, record.itemPos = item.Value, item.Pos
+				}
+			}
+		}
+
+		records = append(records, record)
 	}
 
 	return records

--- a/internal/layoutmodel/errors.go
+++ b/internal/layoutmodel/errors.go
@@ -973,16 +973,21 @@ func (e *ArmOverlapError) Error() string {
 	)
 }
 
-// RenameFormError is a `rename` that is not `(rename <item-ref> "<name>")`.
+// RenameFormError is a `rename` that is neither `(rename <item-ref> "<name>")`
+// nor `(rename <record-name> "<name>")`.
 //
 // It covers both shapes the fault takes — a form carrying something other than
-// an item and a name, and a name written as anything but text — because what is
+// a target and a name, and a name written as anything but text — because what is
 // wrong with each is the same thing: the form takes two things and holds
 // something else. A reference that is written and wrong is an
-// [ItemReferenceError] instead, which is also what a rename naming its target
-// with a bare name gets: a bare name is not a reference, and it is not one
-// because duplicate data names are legal COBOL and a name alone is not an
-// identity.
+// [ItemReferenceError] instead.
+//
+// A bare name in the target position is not one of these. It is a record name
+// (docs/layout/SPEC.md, "A rename may name a record"), and a bare name that is
+// not a record the layout defines is an [UnknownRecordError]. An *item* still
+// cannot be named by a bare name, because duplicate data names are legal COBOL
+// and a name alone is not an identity — but a record's is, since the `record`
+// form defines it.
 type RenameFormError struct {
 	// Pos is the form, or the part of it that is wrong.
 	Pos layout.Pos
@@ -993,7 +998,11 @@ type RenameFormError struct {
 
 // Error implements the error interface.
 func (e *RenameFormError) Error() string {
-	return fmt.Sprintf("%s: a rename is written (rename <item-ref> \"<name>\"), and this has %s", e.Pos, e.Found)
+	return fmt.Sprintf(
+		"%s: a rename is written (rename <item-ref> \"<name>\") or (rename <record-name> \"<name>\"), "+
+			"and this has %s",
+		e.Pos, e.Found,
+	)
 }
 
 // EmptyRenameError is a rename substituting a name of no characters.
@@ -1005,15 +1014,25 @@ type EmptyRenameError struct {
 	// Pos is the string.
 	Pos layout.Pos
 
-	// Item is the item it was written for.
+	// Item is the item it was written for, and is the zero reference where the
+	// rename names a record.
 	Item ItemRef
+
+	// Record is the record it was written for, and is empty where the rename
+	// names an item.
+	Record string
 }
 
 // Error implements the error interface.
 func (e *EmptyRenameError) Error() string {
+	target := e.Item.String()
+	if e.Record != "" {
+		target = "record " + quote(e.Record)
+	}
+
 	return fmt.Sprintf(
 		"%s: the rename on %s substitutes a name of no characters, and a name is at least one",
-		e.Pos, e.Item,
+		e.Pos, target,
 	)
 }
 
@@ -1039,6 +1058,94 @@ func (e *DuplicateRenameError) Error() string {
 	return fmt.Sprintf(
 		"%s: %s is renamed twice, and is renamed first at %s; a rename names an item at most once",
 		e.Pos, e.Item, e.First,
+	)
+}
+
+// DuplicateRecordRenameError is a second `rename` naming a record another one
+// already named.
+//
+// It is [DuplicateRenameError]'s case for the other spelling, and it is a
+// message of its own rather than that one carrying an empty reference: what an
+// adopter has renamed twice is a record, and a message quoting `(item …)` about
+// it would name a reference nobody wrote.
+type DuplicateRecordRenameError struct {
+	// Pos is the second rename.
+	Pos layout.Pos
+
+	// First is the one before it.
+	First layout.Pos
+
+	// Record is the record both name.
+	Record string
+}
+
+// Error implements the error interface.
+func (e *DuplicateRecordRenameError) Error() string {
+	return fmt.Sprintf(
+		"%s: record %s is renamed twice, and is renamed first at %s; a rename names a record at most once",
+		e.Pos, quote(e.Record), e.First,
+	)
+}
+
+// RecordRenameCollisionError is one name substituted for two records.
+//
+// A record node has no parent, so this is not [RenameCollisionError]'s
+// sibling rule: what two record types share is the descriptor, and two of them
+// answering to one name is the ambiguity a rename exists to remove wherever it
+// arises. Both spans are carried for [RenameCollisionError]'s reason — either
+// rename is a perfectly good one on its own.
+type RecordRenameCollisionError struct {
+	// Pos is the second substitute.
+	Pos layout.Pos
+
+	// First is the one before it.
+	First layout.Pos
+
+	// Records are the two records, in the order the layout renames them.
+	Records [2]string
+
+	// Name is what both are called.
+	Name string
+}
+
+// Error implements the error interface.
+func (e *RecordRenameCollisionError) Error() string {
+	return fmt.Sprintf(
+		"%s: name %s is substituted for records %s and %s, and is substituted first at %s",
+		e.Pos, quote(e.Name), quote(e.Records[0]), quote(e.Records[1]), e.First,
+	)
+}
+
+// RecordRenameShadowsError is a substitute equal to the top-level item another
+// record is bound to.
+//
+// That item's name is the name the other record answers to (docs/ir/SPEC.md,
+// "Names"), and it answers to it still where it has been renamed, because the
+// original is carried beside a substitute rather than in place of it. So this is
+// [RenameShadowsSiblingError]'s rule read over record types, and it is decidable
+// from the layout alone: a `copybook` child states the item name.
+type RecordRenameShadowsError struct {
+	// Pos is the substitute.
+	Pos layout.Pos
+
+	// First is the `copybook` child's item name it collides with.
+	First layout.Pos
+
+	// Record is the record being renamed.
+	Record string
+
+	// Other is the record already answering to the name.
+	Other string
+
+	// Name is the substitute.
+	Name string
+}
+
+// Error implements the error interface.
+func (e *RecordRenameShadowsError) Error() string {
+	return fmt.Sprintf(
+		"%s: name %s is substituted for record %s, and record %s is bound to the item of that name at %s",
+		e.Pos, quote(e.Name), quote(e.Record), quote(e.Other), e.First,
 	)
 }
 
@@ -1415,6 +1522,84 @@ func (e *EmptyCopybookPathError) Error() string {
 	return fmt.Sprintf(
 		"%s: record %s is bound to a copybook path of no characters, and a path names a file",
 		e.Pos, quote(e.Record),
+	)
+}
+
+// AlternativeFormError is an `alternative` child that is not `(alternative
+// <item-ref>)`.
+//
+// The child carries one reference and nothing else. What is wrong *inside* the
+// reference is an [ItemReferenceError], so this answers only for a child
+// carrying no reference or more than one.
+type AlternativeFormError struct {
+	// Pos is the child.
+	Pos layout.Pos
+
+	// Found names what was written.
+	Found string
+}
+
+// Error implements the error interface.
+func (e *AlternativeFormError) Error() string {
+	return fmt.Sprintf(
+		"%s: an alternative is written (alternative <item-ref>), and this has %s",
+		e.Pos, e.Found,
+	)
+}
+
+// AlternativeRootError is an `alternative` child whose reference is rooted at
+// some record other than the one carrying it.
+//
+// An item reference is rooted at a record name, and the alternative a `record`
+// form chooses is an item of the `01`-level *that* form is bound to
+// (docs/layout/SPEC.md, "Which alternative a record is"). A reference rooted
+// elsewhere would be looked up in another record's item tree, so the choice
+// would be read against a copybook this record is not bound to — and once it had
+// been, no later diagnostic could say that was what happened.
+type AlternativeRootError struct {
+	// Pos is the reference.
+	Pos layout.Pos
+
+	// Record is the record the child was written under.
+	Record string
+
+	// Ref is the reference as the layout wrote it.
+	Ref ItemRef
+}
+
+// Error implements the error interface.
+func (e *AlternativeRootError) Error() string {
+	return fmt.Sprintf(
+		"%s: record %s chooses alternative %s, which is rooted at record %s; an alternative is "+
+			"an item of the record choosing it",
+		e.Pos, quote(e.Record), e.Ref, quote(e.Ref.Record),
+	)
+}
+
+// DuplicateAlternativeError is a second `alternative` child naming an item
+// another one already named.
+//
+// A record carries one child per redefine its `01`-level writes outside a
+// repeating group, and two naming one item choose one redefine twice — which
+// leaves another one unchosen while looking, by the count alone, as though every
+// redefine had been answered.
+type DuplicateAlternativeError struct {
+	// Pos is the second child.
+	Pos layout.Pos
+
+	// First is the one before it.
+	First layout.Pos
+
+	// Ref is the reference both name.
+	Ref ItemRef
+}
+
+// Error implements the error interface.
+func (e *DuplicateAlternativeError) Error() string {
+	return fmt.Sprintf(
+		"%s: alternative %s is chosen twice, and is chosen first at %s; a record chooses each "+
+			"alternative once",
+		e.Pos, e.Ref, e.First,
 	)
 }
 

--- a/internal/layoutmodel/record.go
+++ b/internal/layoutmodel/record.go
@@ -10,9 +10,14 @@ import (
 	"github.com/Zaba505/cpybkc/internal/layout"
 )
 
-// The tag the binding half of the record definitions layer reads. `record` is
-// the form; `copybook` is its one child.
-const childCopybook = "copybook"
+// The tags the binding half of the record definitions layer reads. `record` is
+// the form; `copybook` is its one required child, and `alternative` the
+// repeatable one that says which alternative of a record-level `REDEFINES` the
+// form means.
+const (
+	childCopybook    = "copybook"
+	childAlternative = "alternative"
+)
 
 // Record is one `record` form: the name it defines, and the copybook item it
 // binds that name to.
@@ -57,6 +62,23 @@ type Record struct {
 
 	// ItemPos is the item name itself.
 	ItemPos layout.Pos
+
+	// Alternatives are the `alternative` children, in the order the form
+	// writes them: one item reference per `REDEFINES` the bound `01`-level
+	// carries outside a repeating group, naming the alternative this record
+	// type is (docs/layout/SPEC.md, "Which alternative a record is").
+	//
+	// Nothing at this layer knows how many there should be, or whether a
+	// reference names an alternative at all: both are facts about the copybook
+	// and are `resolve`'s. What is checked here is what the layout decides on
+	// its own — that each reference is rooted at the record carrying it, and
+	// that no two of them name one item.
+	//
+	// The order is the layout's and carries no meaning. Two redefines name two
+	// distinct runs of bytes, so which is written first decides nothing, and a
+	// consumer pairing them by position would be inventing the rule this child
+	// exists to state.
+	Alternatives []ItemRef
 }
 
 // ReadRecords reads the record definitions out of a parsed layout, in the order
@@ -68,11 +90,14 @@ type Record struct {
 //
 // What it enforces is what a declaration cannot state and a copybook is not
 // needed for: that a layout defines at least one record, that each `record` is
-// written as a name over one `copybook` child, that the path and the names are
-// written at all, and that no two forms define one name. Everything else about
-// a binding needs the file — whether the path names something that can be
-// opened, and whether what it opens declares the item — and is the CLI's, which
-// is the one place that knows where a copybook is looked for.
+// written as a name over one `copybook` child and any number of `alternative`
+// children, that the path and the names are written at all, that every
+// `alternative` names an item through the record carrying it and no two of them
+// name one item, and that no two forms define one name. Everything else about a
+// binding needs the file — whether the path names something that can be opened,
+// whether what it opens declares the item, and how many alternatives its
+// `01`-level has for the children to choose among — and is `resolve`'s or the
+// CLI's, which is the one place that knows where a copybook is looked for.
 //
 // Two records naming one copybook and one item is not a fault and is the
 // ordinary way a layout tells one `01`-level apart by where it sits
@@ -127,7 +152,7 @@ type recordReader struct {
 
 // record reads one `record` form.
 func (r *recordReader) record(form layout.Form) (Record, bool) {
-	if len(form.Elements) != 2 {
+	if len(form.Elements) < 2 {
 		r.Fail(&RecordFormError{Pos: form.Pos, Found: shortfall(form.Elements)})
 
 		return Record{}, false
@@ -154,13 +179,87 @@ func (r *recordReader) record(form layout.Form) (Record, bool) {
 
 	record := Record{Pos: form.Pos, Name: name.Value, NamePos: name.Pos, Copybook: child.Pos}
 
-	// The two halves are read whatever the other said, for the reason a rename
-	// is held to every rule past the first it breaks: a record whose name is
-	// already taken and whose copybook has no path is two things to fix rather
-	// than one to discover on the next run.
+	// Every half is read whatever the ones before it said, for the reason a
+	// rename is held to every rule past the first it breaks: a record whose
+	// name is already taken and whose copybook has no path is two things to fix
+	// rather than one to discover on the next run.
 	sound := r.binding(&record, child)
+	sound = r.alternatives(&record, form) && sound
 
 	return record, r.name(form, name) && sound
+}
+
+// alternatives reads the `alternative` children of a `record` form.
+//
+// They follow the `copybook` child, and every element past it is one: the form
+// admits no other child, so a tag that is not `alternative` there is answered by
+// the same message a wrong first child is.
+//
+// Two things are checked, and they are the two the layout decides on its own. A
+// reference is rooted at a record, and an `alternative` naming an alternative of
+// some *other* record's copybook is a statement about a copybook this record is
+// not bound to — it would be read against the wrong item tree, and no diagnostic
+// afterwards could say so. And two children naming one item choose one
+// alternative twice, which leaves the record's other redefine unchosen while
+// looking like it was answered.
+func (r *recordReader) alternatives(record *Record, form layout.Form) bool {
+	sound := true
+
+	named := make(map[string]layout.Pos, len(form.Elements))
+
+	for _, element := range form.Elements[2:] {
+		child, ok := element.(layout.Form)
+		if !ok || child.Tag != childAlternative {
+			r.Fail(&ChildError{
+				Pos:    element.Position(),
+				Form:   form.Tag,
+				Found:  describe(element),
+				Admits: []string{childAlternative},
+			})
+
+			sound = false
+
+			continue
+		}
+
+		if len(child.Elements) != 1 {
+			r.Fail(&AlternativeFormError{Pos: child.Pos, Found: count(len(child.Elements))})
+
+			sound = false
+
+			continue
+		}
+
+		ref, err := readItemRef(child.Elements[0])
+		if err != nil {
+			r.Fail(err)
+
+			sound = false
+
+			continue
+		}
+
+		if ref.Record != record.Name {
+			r.Fail(&AlternativeRootError{Pos: ref.Pos, Record: record.Name, Ref: ref})
+
+			sound = false
+
+			continue
+		}
+
+		if first, already := named[ref.identity()]; already {
+			r.Fail(&DuplicateAlternativeError{Pos: child.Pos, First: first, Ref: ref})
+
+			sound = false
+
+			continue
+		}
+
+		named[ref.identity()] = child.Pos
+		record.Alternatives = append(record.Alternatives, ref)
+	}
+
+	return sound
 }
 
 // binding reads the `copybook` child: the path, and the top-level item in it.

--- a/internal/layoutmodel/record_test.go
+++ b/internal/layoutmodel/record_test.go
@@ -221,3 +221,107 @@ func TestOtherLayersAreNotRead(t *testing.T) {
 		t.Fatalf("the layout defines %d records, want 1", len(records))
 	}
 }
+
+// TestARecordChoosesItsAlternativesByName is docs/layout/SPEC.md's "Which
+// alternative a record is", read: the children arrive in the order the form
+// writes them, each carrying the reference the layout wrote.
+func TestARecordChoosesItsAlternativesByName(t *testing.T) {
+	t.Parallel()
+
+	records, err := recordsOf(t, `(record TXN
+  (copybook "cpy/txn.cpy" TXN-REC)
+  (alternative (item TXN TXN-PURCHASE))
+  (alternative (item TXN TXN-BODY TXN-CARD)))
+`)
+	if err != nil {
+		t.Fatalf("records: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("the layout defines %d records, want 1", len(records))
+	}
+
+	chosen := make([]string, 0, 2)
+	for _, ref := range records[0].Alternatives {
+		chosen = append(chosen, ref.String())
+	}
+
+	want := []string{"(item TXN TXN-PURCHASE)", "(item TXN TXN-BODY TXN-CARD)"}
+	if strings.Join(chosen, " ") != strings.Join(want, " ") {
+		t.Errorf("the record chooses %v, want %v", chosen, want)
+	}
+}
+
+// TestARecordWithNoAlternativeChoosesNone is the ordinary case, stated so that
+// the reading above cannot start applying to every record.
+func TestARecordWithNoAlternativeChoosesNone(t *testing.T) {
+	t.Parallel()
+
+	records, err := recordsOf(t, "(record ORDER (copybook \"cpy/orders.cpy\" ORDER-REC))\n")
+	if err != nil {
+		t.Fatalf("records: %v", err)
+	}
+
+	if len(records[0].Alternatives) != 0 {
+		t.Errorf("a record with no alternative child chooses %v", records[0].Alternatives)
+	}
+}
+
+// TestReadRecordsRejectsAlternatives is the half of the choice the reader
+// decides without a copybook. How many alternatives there are to choose among is
+// `resolve`'s and is not here.
+func TestReadRecordsRejectsAlternatives(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name: "an alternative rooted at another record",
+			source: `(record TXN (copybook "cpy/txn.cpy" TXN-REC)
+  (alternative (item OTHER TXN-PURCHASE)))`,
+			want: "layout.sexpr:2:16: record \"TXN\" chooses alternative (item OTHER TXN-PURCHASE), which is " +
+				"rooted at record \"OTHER\"; an alternative is an item of the record choosing it",
+		},
+		{
+			name: "one alternative chosen twice",
+			source: `(record TXN (copybook "cpy/txn.cpy" TXN-REC)
+  (alternative (item TXN TXN-PURCHASE))
+  (alternative (item TXN TXN-PURCHASE)))`,
+			want: "layout.sexpr:3:3: alternative (item TXN TXN-PURCHASE) is chosen twice, and is chosen " +
+				"first at layout.sexpr:2:3; a record chooses each alternative once",
+		},
+		{
+			name: "an alternative carrying no reference",
+			source: `(record TXN (copybook "cpy/txn.cpy" TXN-REC)
+  (alternative))`,
+			want: "layout.sexpr:2:3: an alternative is written (alternative <item-ref>), and this has no value",
+		},
+		{
+			name: "a child the form does not admit",
+			source: `(record TXN (copybook "cpy/txn.cpy" TXN-REC)
+  (copybook "cpy/other.cpy" OTHER-REC))`,
+			want: "layout.sexpr:2:3: form \"record\" admits alternative, and this is form \"copybook\"",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			read, err := recordsOf(t, testCase.source)
+			if err == nil {
+				t.Fatalf("the reader accepts %s", testCase.source)
+			}
+
+			if read != nil {
+				t.Errorf("the reader hands back records beside the fault: %+v", read)
+			}
+
+			if got := err.Error(); got != testCase.want {
+				t.Errorf("the reader reports\n%s\nwant\n%s", got, testCase.want)
+			}
+		})
+	}
+}

--- a/internal/layoutmodel/rename.go
+++ b/internal/layoutmodel/rename.go
@@ -88,9 +88,12 @@ func (r Rename) Original() string {
 // target is what makes two renames name one thing: the reference's spelling for
 // an item, and the record name for a record.
 //
-// The two cannot collide. An item's identity opens with `(item ` and a record's
-// with a symbol, so one map holds both without a rename on a record ever reading
-// as a rename on an item called the same thing.
+// The `record ` prefix is what keeps the two apart, and it is load-bearing
+// rather than decorative — one map holds both, and without it a rename on a
+// record would read as a rename on an item spelled the same way. It is not
+// enough that an item's identity happens to open with `(item `: that is
+// [ItemRef.String]'s business, and a key relying on it would break here when
+// that rendering changed.
 func (r Rename) target() string {
 	if r.NamesRecord() {
 		return "record " + r.Record

--- a/internal/layoutmodel/rename.go
+++ b/internal/layoutmodel/rename.go
@@ -34,25 +34,70 @@ type Rename struct {
 	// Pos is the `rename` form.
 	Pos layout.Pos
 
-	// Item is what is renamed. It names its target in full: a reference is
-	// rooted at a record and carries one name per level down to the item, which
-	// is what makes it an identity where a bare name is not — duplicate data
-	// names are legal COBOL, and a rename that named one would not say which
-	// item it meant.
+	// Item is what is renamed, where the target is an item. It names its target
+	// in full: a reference is rooted at a record and carries one name per level
+	// down to the item, which is what makes it an identity where a bare name is
+	// not — duplicate data names are legal COBOL, and a rename that named one
+	// would not say which item it meant.
+	//
+	// It is the zero reference where the target is a record; [Rename.Record]
+	// says which of the two this is.
 	Item ItemRef
+
+	// Record is the record renamed, where the target is a record rather than an
+	// item, and is empty otherwise.
+	//
+	// A record's own name in the IR is the one its copybook `01`-level carries
+	// (docs/ir/SPEC.md, "Names"), and that is the one item an item reference
+	// cannot reach — the `record` form has already stated it, so a path never
+	// repeats it. So the target is written as a bare record name
+	// (docs/layout/SPEC.md, "A rename may name a record"), and this is where it
+	// lands.
+	Record string
+
+	// RecordPos is the record name itself, and is the zero position for an item
+	// rename.
+	RecordPos layout.Pos
 
 	// Substitute is the name to carry beside the original, exactly as the
 	// layout wrote it.
 	Substitute string
 
 	// SubstitutePos is the string itself, which is what a diagnostic about the
-	// name rather than about the item points at.
+	// name rather than about the target points at.
 	SubstitutePos layout.Pos
 }
 
+// NamesRecord reports whether the rename names a record rather than an item
+// inside one.
+func (r Rename) NamesRecord() bool { return r.Record != "" }
+
 // Original is the name the copybook gives the renamed item, which a substitute
 // stands beside and never replaces.
-func (r Rename) Original() string { return r.Item.Name() }
+//
+// A record rename has none here: the name it stands beside is the record's
+// `01`-level, which the `copybook` child names and this model does not carry.
+func (r Rename) Original() string {
+	if r.NamesRecord() {
+		return ""
+	}
+
+	return r.Item.Name()
+}
+
+// target is what makes two renames name one thing: the reference's spelling for
+// an item, and the record name for a record.
+//
+// The two cannot collide. An item's identity opens with `(item ` and a record's
+// with a symbol, so one map holds both without a rename on a record ever reading
+// as a rename on an item called the same thing.
+func (r Rename) target() string {
+	if r.NamesRecord() {
+		return "record " + r.Record
+	}
+
+	return r.Item.identity()
+}
 
 // ReadRenames reads the renames out of a parsed layout, in the order the layout
 // writes them.
@@ -63,14 +108,21 @@ func (r Rename) Original() string { return r.Item.Name() }
 // fault — the form's arity is zero or more.
 //
 // What it enforces is what a declaration cannot state and a copybook is not
-// needed for: that a rename names its target as a reference rather than as a
-// bare name, that the record it is rooted at is one the layout defines, that at
-// most one rename names a given item, and the collisions decidable from the
-// layout alone — two renames substituting one name for two items under one
-// parent, and a substitute equal to the name of an item the layout itself
-// references under that parent. The rest of the collision rule needs the
-// copybook's sibling list and is `resolve`'s, as is whether the path names an
-// item at all (#31, #32).
+// needed for: that a rename names an item as a reference rather than as a bare
+// name, that the record it names or is rooted at is one the layout defines, that
+// at most one rename names a given item or a given record, and the collisions
+// decidable from the layout alone — two renames substituting one name for two
+// items under one parent or for two records, a substitute equal to the name of
+// an item the layout itself references under that parent, and a substitute equal
+// to the top-level item another record is bound to. The rest of the collision
+// rule needs the copybook's sibling list and is `resolve`'s, as is whether the
+// path names an item at all (#31, #32).
+//
+// A rename **MAY** name a record instead of an item, and that spelling is a bare
+// record name rather than a reference (docs/layout/SPEC.md, "A rename may name a
+// record"). It is not an exception to the paragraph below: a record's own name
+// is stated by its `record` form, so there is nothing about it for a path to be
+// ambiguous over.
 //
 // Nothing here restricts what a rename may name below the record. The reference
 // **MAY** name a group, and **MAY** name an item that repeats or sit inside
@@ -79,9 +131,10 @@ func (r Rename) Original() string { return r.Item.Name() }
 // occurrence. Whether a given path is either of those needs the copybook, so a
 // rule keyed on it could not be enforced here even if the format had one.
 //
-// What a rename cannot name is the record's top-level item, and that is the
+// What a *reference* cannot name is the record's top-level item, and that is the
 // reference grammar's rather than this reader's: a path carries the names below
-// the top-level item and the `record` form has already stated that one.
+// the top-level item and the `record` form has already stated that one. Which is
+// why renaming that item is spelled by naming the record.
 //
 // Top-level forms belonging to other layers are not read here and are not
 // faults, but their item references are: an item the layout names anywhere is
@@ -138,11 +191,25 @@ func (r *renameReader) rename(read []Rename, form layout.Form) (Rename, bool) {
 		return Rename{}, false
 	}
 
-	item, err := readItemRef(form.Elements[0])
-	if err != nil {
-		r.Fail(err)
+	rename := Rename{Pos: form.Pos}
 
-		return Rename{}, false
+	// A record name is a symbol where an item reference is a form, so which of
+	// the two spellings was written is decided by the shape of the first
+	// element and never by looking a name up. A symbol that is not a record the
+	// layout defines is a rename on a record that is not there, which is the
+	// message an adopter needs; reading it as a malformed item reference would
+	// send them to the reference grammar instead.
+	if symbol, ok := form.Elements[0].(layout.Symbol); ok {
+		rename.Record, rename.RecordPos = symbol.Value, symbol.Pos
+	} else {
+		item, err := readItemRef(form.Elements[0])
+		if err != nil {
+			r.Fail(err)
+
+			return Rename{}, false
+		}
+
+		rename.Item = item
 	}
 
 	name, ok := form.Elements[1].(layout.Text)
@@ -152,16 +219,16 @@ func (r *renameReader) rename(read []Rename, form layout.Form) (Rename, bool) {
 		return Rename{}, false
 	}
 
-	rename := Rename{Pos: form.Pos, Item: item, Substitute: name.Value, SubstitutePos: name.Pos}
+	rename.Substitute, rename.SubstitutePos = name.Value, name.Pos
 
 	// Every check below is run whatever the ones before it said, for the reason
 	// a discriminator's strategy is read past a misspelled record name: a rename
 	// rooted at a record nobody defined and substituting a name a sibling
 	// carries is two things to fix rather than one to discover on the next run.
-	sound := r.target(form, item)
+	sound := r.target(form, rename)
 
 	if name.Value == "" {
-		r.Fail(&EmptyRenameError{Pos: name.Pos, Item: item})
+		r.Fail(&EmptyRenameError{Pos: name.Pos, Item: rename.Item, Record: rename.Record})
 
 		// A name of no characters collides with nothing, and every message the
 		// collision rules could produce about it would name the empty string.
@@ -171,19 +238,34 @@ func (r *renameReader) rename(read []Rename, form layout.Form) (Rename, bool) {
 	return rename, r.collisions(read, rename) && sound
 }
 
-// target holds the item a rename names to what can be checked without a
-// copybook: the record it is rooted at, and the renames already read.
-func (r *renameReader) target(form layout.Form, item ItemRef) bool {
+// target holds what a rename names to what can be checked without a copybook:
+// that the record it names, or is rooted at, is one the layout defines, and that
+// nothing has been renamed twice.
+func (r *renameReader) target(form layout.Form, rename Rename) bool {
 	sound := true
 
-	if !slices.ContainsFunc(r.records, func(record recordDefinition) bool { return record.name == item.Record }) {
-		r.Fail(&UnknownRecordError{Pos: item.Pos, Record: item.Record, Form: form.Tag})
+	named := rename.Record
+	if !rename.NamesRecord() {
+		named = rename.Item.Record
+	}
+
+	if !slices.ContainsFunc(r.records, func(record recordDefinition) bool { return record.name == named }) {
+		pos := rename.RecordPos
+		if !rename.NamesRecord() {
+			pos = rename.Item.Pos
+		}
+
+		r.Fail(&UnknownRecordError{Pos: pos, Record: named, Form: form.Tag})
 
 		sound = false
 	}
 
-	if first, already := r.renamed[item.identity()]; already {
-		r.Fail(&DuplicateRenameError{Pos: form.Pos, First: first, Item: item})
+	if first, already := r.renamed[rename.target()]; already {
+		if rename.NamesRecord() {
+			r.Fail(&DuplicateRecordRenameError{Pos: form.Pos, First: first, Record: rename.Record})
+		} else {
+			r.Fail(&DuplicateRenameError{Pos: form.Pos, First: first, Item: rename.Item})
+		}
 
 		return false
 	}
@@ -192,7 +274,7 @@ func (r *renameReader) target(form layout.Form, item ItemRef) bool {
 		r.renamed = make(map[string]layout.Pos)
 	}
 
-	r.renamed[item.identity()] = form.Pos
+	r.renamed[rename.target()] = form.Pos
 
 	return sound
 }
@@ -218,6 +300,10 @@ func (r *renameReader) target(form layout.Form, item ItemRef) bool {
 // leaves every name where it was — and a second rename on one item is reported
 // as the duplicate it is and not as a collision between an item and itself.
 func (r *renameReader) collisions(read []Rename, rename Rename) bool {
+	if rename.NamesRecord() {
+		return r.recordCollisions(read, rename)
+	}
+
 	sound := true
 
 	// An item is not its own sibling here either: two renames on one item are a
@@ -251,6 +337,59 @@ func (r *renameReader) collisions(read []Rename, rename Rename) bool {
 			Item:    rename.Item,
 			Sibling: r.named[sibling],
 			Name:    rename.Substitute,
+		})
+
+		sound = false
+	}
+
+	return sound
+}
+
+// recordCollisions reports a substitute for a record's name that another record
+// already answers to.
+//
+// A record node has no parent, so there are no siblings to be ambiguous among
+// and the sibling rules above do not carry over. What carries over is the
+// ambiguity they remove, between the names two record types answer to in one
+// descriptor, and two halves of it are decidable from the layout alone: a name
+// substituted for two records, and a name equal to the `01`-level another record
+// is bound to — which is the name that record answers to, because the original
+// is carried beside a substitute rather than in place of it (docs/ir/SPEC.md,
+// "Names").
+//
+// A record is not its own collision under either check. A rename substituting
+// the name of the `01`-level its own record is bound to says the same thing
+// twice and leaves every name where it was, and a second rename on one record is
+// reported as the duplicate it is.
+func (r *renameReader) recordCollisions(read []Rename, rename Rename) bool {
+	sound := true
+
+	earlier := slices.IndexFunc(read, func(other Rename) bool {
+		return other.NamesRecord() &&
+			other.Substitute == rename.Substitute &&
+			other.Record != rename.Record
+	})
+	if earlier >= 0 {
+		r.Fail(&RecordRenameCollisionError{
+			Pos:     rename.SubstitutePos,
+			First:   read[earlier].SubstitutePos,
+			Records: [2]string{read[earlier].Record, rename.Record},
+			Name:    rename.Substitute,
+		})
+
+		sound = false
+	}
+
+	bound := slices.IndexFunc(r.records, func(record recordDefinition) bool {
+		return record.name != rename.Record && record.item == rename.Substitute
+	})
+	if bound >= 0 {
+		r.Fail(&RecordRenameShadowsError{
+			Pos:    rename.SubstitutePos,
+			First:  r.records[bound].itemPos,
+			Record: rename.Record,
+			Other:  r.records[bound].name,
+			Name:   rename.Substitute,
 		})
 
 		sound = false
@@ -310,7 +449,7 @@ func itemsNamed(file *layout.File) []ItemRef {
 	return named
 }
 
-// renameShortfall names what a `rename` form carries where an item and a name
+// renameShortfall names what a `rename` form carries where a target and a name
 // belong.
 func renameShortfall(elements []layout.Node) string {
 	switch {
@@ -320,9 +459,9 @@ func renameShortfall(elements []layout.Node) string {
 		return "several"
 	default:
 		if _, ok := elements[0].(layout.Text); ok {
-			return "a name and no item"
+			return "a name and no target"
 		}
 
-		return "an item and no name"
+		return "a target and no name"
 	}
 }

--- a/internal/layoutmodel/rename_test.go
+++ b/internal/layoutmodel/rename_test.go
@@ -248,13 +248,16 @@ func TestReadRenamesRejects(t *testing.T) {
 		want   []string
 	}{
 		{
-			// Duplicate data names are legal COBOL, so a bare name is not an
-			// identity and the format has no spelling for one.
-			name:   "a target named by a bare name",
+			// A bare name in the target position is a record name, so a bare
+			// name that is not one is a rename on a record that is not there —
+			// and never an item named without a reference. Duplicate data names
+			// are legal COBOL, so a bare name is still not an identity for an
+			// *item*, and the format has no spelling for one.
+			name:   "a bare name that is not a record the layout defines",
 			source: renaming([]string{"DETAIL"}, `(rename D-CUST-NO "CustomerNumber")`),
 			want: []string{
-				"layout.sexpr:2:9: an item reference is written (item <record-name> <name> ...), and this is " +
-					"the symbol \"D-CUST-NO\"",
+				"layout.sexpr:2:9: form \"rename\" names record \"D-CUST-NO\", and the layout defines no " +
+					"record of that name",
 			},
 		},
 		{
@@ -277,23 +280,23 @@ func TestReadRenamesRejects(t *testing.T) {
 			name:   "a rename carrying no name",
 			source: renaming([]string{"DETAIL"}, `(rename (item DETAIL D-CUST-NO))`),
 			want: []string{
-				"layout.sexpr:2:1: a rename is written (rename <item-ref> \"<name>\"), and this has an item and " +
+				"layout.sexpr:2:1: a rename is written (rename <item-ref> \"<name>\") or (rename <record-name> \"<name>\"), and this has a target and " +
 					"no name",
 			},
 		},
 		{
-			name:   "a rename carrying no item",
+			name:   "a rename carrying no target",
 			source: renaming([]string{"DETAIL"}, `(rename "CustomerNumber")`),
 			want: []string{
-				"layout.sexpr:2:1: a rename is written (rename <item-ref> \"<name>\"), and this has a name and " +
-					"no item",
+				"layout.sexpr:2:1: a rename is written (rename <item-ref> \"<name>\") or (rename <record-name> \"<name>\"), and this has a name and " +
+					"no target",
 			},
 		},
 		{
 			name:   "a rename carrying two names",
 			source: renaming([]string{"DETAIL"}, `(rename (item DETAIL D-CUST-NO) "CustomerNumber" "CustNo")`),
 			want: []string{
-				"layout.sexpr:2:1: a rename is written (rename <item-ref> \"<name>\"), and this has several",
+				"layout.sexpr:2:1: a rename is written (rename <item-ref> \"<name>\") or (rename <record-name> \"<name>\"), and this has several",
 			},
 		},
 		{
@@ -303,7 +306,7 @@ func TestReadRenamesRejects(t *testing.T) {
 			name:   "a name written as a symbol",
 			source: renaming([]string{"DETAIL"}, `(rename (item DETAIL D-CUST-NO) CustomerNumber)`),
 			want: []string{
-				"layout.sexpr:2:33: a rename is written (rename <item-ref> \"<name>\"), and this has the symbol " +
+				"layout.sexpr:2:33: a rename is written (rename <item-ref> \"<name>\") or (rename <record-name> \"<name>\"), and this has the symbol " +
 					"\"CustomerNumber\"",
 			},
 		},
@@ -438,8 +441,18 @@ func TestRenameFaultsAreAssertable(t *testing.T) {
 		assert func(*testing.T, error)
 	}{
 		{
-			name:   "a bare name is a reference fault",
+			name:   "a bare name naming no record is a record fault",
 			source: renaming([]string{"DETAIL"}, `(rename D-CUST-NO "CustomerNumber")`),
+			assert: func(t *testing.T, err error) {
+				var fault *UnknownRecordError
+				if !errors.As(err, &fault) {
+					t.Fatalf("no UnknownRecordError in %v", err)
+				}
+			},
+		},
+		{
+			name:   "a reference that is not one is still a reference fault",
+			source: renaming([]string{"DETAIL"}, `(rename (item DETAIL) "CustomerNumber")`),
 			assert: func(t *testing.T, err error) {
 				var fault *ItemReferenceError
 				if !errors.As(err, &fault) {
@@ -571,5 +584,115 @@ func TestTheSpecsWorkedExampleRenames(t *testing.T) {
 
 	if read[0].Substitute != "CustomerNumber" || read[0].Original() != "OH-CUST-NO" {
 		t.Errorf("the example renames %q to %q, want \"OH-CUST-NO\" to \"CustomerNumber\"", read[0].Original(), read[0].Substitute)
+	}
+}
+
+// TestARenameMayNameARecord is docs/layout/SPEC.md's "A rename may name a
+// record": the target position takes a bare record name as well as a reference,
+// and which of the two was written is decided by its shape.
+func TestARenameMayNameARecord(t *testing.T) {
+	t.Parallel()
+
+	read, err := renamesOf(t, renaming([]string{"PURCHASE", "REFUND"},
+		`(rename PURCHASE "TXN-PURCHASE-REC")`,
+		`(rename (item REFUND R-KEY) "RefundKey")`,
+	))
+	if err != nil {
+		t.Fatalf("renames: %v", err)
+	}
+
+	if len(read) != 2 {
+		t.Fatalf("the layout carries %d renames, want 2", len(read))
+	}
+
+	if !read[0].NamesRecord() || read[0].Record != "PURCHASE" {
+		t.Errorf("the first rename names %+v, want record PURCHASE", read[0])
+	}
+
+	// A record rename has no original here. The name it stands beside is the
+	// record's `01`-level, which the `copybook` child names and this model does
+	// not carry.
+	if read[0].Original() != "" {
+		t.Errorf("a record rename carries the original %q", read[0].Original())
+	}
+
+	if read[1].NamesRecord() {
+		t.Errorf("the second rename reads as a record rename: %+v", read[1])
+	}
+}
+
+// TestReadRenamesRejectsRecordRenames is the collision rule read over record
+// types: a record node has no parent, so what is checked is the two halves that
+// are still decidable from the layout alone.
+func TestReadRenamesRejectsRecordRenames(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name: "one record renamed twice",
+			source: renaming([]string{"PURCHASE"},
+				`(rename PURCHASE "One")`,
+				`(rename PURCHASE "Two")`,
+			),
+			want: "layout.sexpr:3:1: record \"PURCHASE\" is renamed twice, and is renamed first at " +
+				"layout.sexpr:2:1; a rename names a record at most once",
+		},
+		{
+			name: "one name substituted for two records",
+			source: renaming([]string{"PURCHASE", "REFUND"},
+				`(rename PURCHASE "Txn")`,
+				`(rename REFUND   "Txn")`,
+			),
+			want: "layout.sexpr:4:18: name \"Txn\" is substituted for records \"PURCHASE\" and \"REFUND\", " +
+				"and is substituted first at layout.sexpr:3:18",
+		},
+		{
+			name: "a substitute another record is bound to",
+			source: renaming([]string{"PURCHASE", "REFUND"},
+				`(rename PURCHASE "REFUND-REC")`,
+			),
+			want: "layout.sexpr:3:18: name \"REFUND-REC\" is substituted for record \"PURCHASE\", and record " +
+				"\"REFUND\" is bound to the item of that name at layout.sexpr:2:38",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			read, err := renamesOf(t, testCase.source)
+			if err == nil {
+				t.Fatalf("the reader accepts %s", testCase.source)
+			}
+
+			if read != nil {
+				t.Errorf("the reader hands back renames beside the fault: %+v", read)
+			}
+
+			if got := err.Error(); got != testCase.want {
+				t.Errorf("the reader reports\n%s\nwant\n%s", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestARecordRenamedToItsOwnBindingIsAdmitted is the "not its own collision"
+// half, which the sibling rules have too: a rename substituting the name its own
+// record is already bound to says the same thing twice and leaves every name
+// where it was.
+func TestARecordRenamedToItsOwnBindingIsAdmitted(t *testing.T) {
+	t.Parallel()
+
+	read, err := renamesOf(t, renaming([]string{"PURCHASE"}, `(rename PURCHASE "PURCHASE-REC")`))
+	if err != nil {
+		t.Fatalf("the reader refuses a record renamed to its own binding: %v", err)
+	}
+
+	if len(read) != 1 {
+		t.Fatalf("the layout carries %d renames, want 1", len(read))
 	}
 }

--- a/internal/project/descriptor.go
+++ b/internal/project/descriptor.go
@@ -137,12 +137,18 @@ func (l *layers) assemble(bound *bindings) (*irpb.Descriptor, error) {
 	overrides, flat := l.overrides(bound)
 	redefines := l.redefines(bound)
 	renames := l.substitutes(bound)
+	chosen := l.alternatives(bound)
 
+	// Every item reference the layout writes is resolved before this line, and
+	// nothing below resolves another. A reference that names no item reports
+	// itself against `bound`, and `bound` is read exactly here — so a stage that
+	// resolved a reference of its own would record a fault nobody ever reads,
+	// and its record would be dropped from the run without a diagnostic.
 	if bound.Failed() {
 		return nil, bound.Err()
 	}
 
-	records, sequenced, err := l.resolve(bound, overrides, redefines)
+	records, sequenced, err := l.resolve(bound, overrides, redefines, chosen)
 	if err != nil {
 		return nil, err
 	}
@@ -177,6 +183,7 @@ func (l *layers) resolve(
 	bound *bindings,
 	overrides map[string][]resolve.EncodingOverride,
 	redefines map[string][]resolve.Redefine,
+	chosen map[string][]*copybook.Field,
 ) ([]assemble.Record, []resolve.SequencedRecord, error) {
 	var faults diag.List
 
@@ -199,15 +206,15 @@ func (l *layers) resolve(
 			continue
 		}
 
-		chosen := l.choose(bound, &faults, b, resolved)
-		if chosen == nil {
+		alternative := choose(&faults, b, chosen[b.Record.Name], resolved)
+		if alternative == nil {
 			continue
 		}
 
 		records = append(records, assemble.Record{
 			Name:     b.Record.Name,
 			Copybook: b.Record.Path,
-			Resolved: chosen,
+			Resolved: alternative,
 		})
 
 		sequenced = append(sequenced, resolve.SequencedRecord{
@@ -223,6 +230,32 @@ func (l *layers) resolve(
 	}
 
 	return records, sequenced, nil
+}
+
+// alternatives resolves each `record` form's `alternative` children to the
+// copybook items they name, keyed by the record they were written under.
+//
+// It sits beside [layers.overrides] and [layers.redefines] rather than inside
+// the resolving loop because every one of the three resolves item references,
+// and a reference that names no item reports itself against `bound` — which
+// [layers.assemble] reads at one point, before any of them has been resolved
+// twice and before the loop begins. Resolving one later would record a fault
+// nobody reads and drop a record type from the run in silence.
+func (l *layers) alternatives(bound *bindings) map[string][]*copybook.Field {
+	chosen := make(map[string][]*copybook.Field)
+
+	for _, b := range bound.bound {
+		for _, ref := range b.Record.Alternatives {
+			item := bound.field(ref)
+			if item == nil {
+				continue
+			}
+
+			chosen[b.Record.Name] = append(chosen[b.Record.Name], item)
+		}
+	}
+
+	return chosen
 }
 
 // choose picks the one record type a `record` form means out of what its
@@ -245,26 +278,12 @@ func (l *layers) resolve(
 // by the same message a wrong choice is. Nothing here guesses: a record whose
 // children match no combination is refused, with every combination named, rather
 // than resolved to whichever one this program met first.
-func (l *layers) choose(
-	bound *bindings,
+func choose(
 	faults *diag.List,
 	b binding,
+	chosen []*copybook.Field,
 	resolved []*resolve.Record,
 ) *resolve.Record {
-	chosen := make([]*copybook.Field, 0, len(b.Record.Alternatives))
-
-	for _, ref := range b.Record.Alternatives {
-		item := bound.field(ref)
-		if item == nil {
-			// The reference names no item, and `bind` has already said so
-			// against the copybook it looked in. A second message here would
-			// name the same line twice.
-			return nil
-		}
-
-		chosen = append(chosen, item)
-	}
-
 	for _, candidate := range resolved {
 		if sameAlternatives(candidate.Alternatives, chosen) {
 			return candidate
@@ -285,6 +304,14 @@ func (l *layers) choose(
 
 // sameAlternatives reports whether two choices are the same set of items.
 //
+// Containment is required in both directions rather than in one beside a length
+// check, so that the answer is set equality whatever the layout wrote. One
+// direction plus a length is equality only where neither side repeats an item,
+// and the reader's duplicate guard counts an alternative as chosen twice by the
+// *spelling* of the reference — which is an identity for a reference and not for
+// the item behind one. A rule holding only because two spellings cannot reach
+// one item is a rule that reads the reference grammar from another package.
+//
 // Pointer identity is the test because both sides come out of one item tree:
 // `bind` builds a fresh tree per record and resolves that record's references
 // against it, so two references to one item are one pointer and two items with
@@ -297,6 +324,12 @@ func sameAlternatives(resolved, chosen []*copybook.Field) bool {
 
 	for _, item := range chosen {
 		if !slices.Contains(resolved, item) {
+			return false
+		}
+	}
+
+	for _, item := range resolved {
+		if !slices.Contains(chosen, item) {
 			return false
 		}
 	}

--- a/internal/project/descriptor.go
+++ b/internal/project/descriptor.go
@@ -9,6 +9,9 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"slices"
+
+	"github.com/Zaba505/cobol-go/copybook"
 
 	"github.com/Zaba505/cpybkc/internal/assemble"
 	"github.com/Zaba505/cpybkc/internal/diag"
@@ -196,31 +199,15 @@ func (l *layers) resolve(
 			continue
 		}
 
-		// A copybook holding a REDEFINES outside a repeating group resolves to
-		// one record type per combination of alternatives, and nothing in the
-		// layout format names them apart: a `record` form binds a name to an
-		// `01`-level, and every alternative of that level is the same level. So
-		// there is no rule for pairing the forms to the alternatives and no
-		// spelling that would give two of them two names, and #164 is the story
-		// that decides both. Refusing the layout is the honest answer until it
-		// does — pairing them by position would be a rule this program invented
-		// and an adopter could not read anywhere.
-		if len(resolved) != 1 {
-			faults.Fail(&AlternativesError{
-				Pos:          span(b.Record.Pos),
-				Record:       b.Record.Name,
-				Path:         b.Record.Path,
-				Item:         b.Record.Item,
-				Alternatives: len(resolved),
-			})
-
+		chosen := l.choose(bound, &faults, b, resolved)
+		if chosen == nil {
 			continue
 		}
 
 		records = append(records, assemble.Record{
 			Name:     b.Record.Name,
 			Copybook: b.Record.Path,
-			Resolved: resolved[0],
+			Resolved: chosen,
 		})
 
 		sequenced = append(sequenced, resolve.SequencedRecord{
@@ -236,6 +223,118 @@ func (l *layers) resolve(
 	}
 
 	return records, sequenced, nil
+}
+
+// choose picks the one record type a `record` form means out of what its
+// copybook resolved to.
+//
+// A copybook holding a REDEFINES outside a repeating group resolves to one
+// record type per combination of alternatives (docs/ir/SPEC.md, "Members never
+// overlap, and `REDEFINES` is resolved away"), and the `alternative` children
+// are where the layout says which of them the form is (docs/layout/SPEC.md,
+// "Which alternative a record is", #164).
+//
+// The match is on the *set* of items chosen and not on their order. Two
+// redefines describe two distinct runs of bytes, so the order the children are
+// written in decides nothing, and matching by position would make a layout mean
+// something different when its two lines were swapped.
+//
+// A copybook with no redefine at all resolves to one record type choosing
+// nothing, and the empty set matches it — so an ordinary record needs no
+// `alternative` child and a form carrying one over such a copybook is reported
+// by the same message a wrong choice is. Nothing here guesses: a record whose
+// children match no combination is refused, with every combination named, rather
+// than resolved to whichever one this program met first.
+func (l *layers) choose(
+	bound *bindings,
+	faults *diag.List,
+	b binding,
+	resolved []*resolve.Record,
+) *resolve.Record {
+	chosen := make([]*copybook.Field, 0, len(b.Record.Alternatives))
+
+	for _, ref := range b.Record.Alternatives {
+		item := bound.field(ref)
+		if item == nil {
+			// The reference names no item, and `bind` has already said so
+			// against the copybook it looked in. A second message here would
+			// name the same line twice.
+			return nil
+		}
+
+		chosen = append(chosen, item)
+	}
+
+	for _, candidate := range resolved {
+		if sameAlternatives(candidate.Alternatives, chosen) {
+			return candidate
+		}
+	}
+
+	faults.Fail(&AlternativesError{
+		Pos:      span(b.Record.Pos),
+		Record:   b.Record.Name,
+		Path:     b.Record.Path,
+		Item:     b.Record.Item,
+		Chosen:   alternativeNames(chosen),
+		Resolved: combinations(resolved),
+	})
+
+	return nil
+}
+
+// sameAlternatives reports whether two choices are the same set of items.
+//
+// Pointer identity is the test because both sides come out of one item tree:
+// `bind` builds a fresh tree per record and resolves that record's references
+// against it, so two references to one item are one pointer and two items with
+// one COBOL name are two. Comparing names would make a copybook's duplicate data
+// names — legal COBOL — into one alternative.
+func sameAlternatives(resolved, chosen []*copybook.Field) bool {
+	if len(resolved) != len(chosen) {
+		return false
+	}
+
+	for _, item := range chosen {
+		if !slices.Contains(resolved, item) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// alternativeNames is what a diagnostic calls a set of chosen items.
+func alternativeNames(items []*copybook.Field) []string {
+	names := make([]string, 0, len(items))
+
+	for _, item := range items {
+		names = append(names, itemName(item))
+	}
+
+	return names
+}
+
+// combinations is every set of alternatives a copybook resolved to, in the order
+// `resolve` enumerated them, which is what a record choosing none of them is
+// offered instead.
+func combinations(resolved []*resolve.Record) [][]string {
+	found := make([][]string, 0, len(resolved))
+
+	for _, record := range resolved {
+		found = append(found, alternativeNames(record.Alternatives))
+	}
+
+	return found
+}
+
+// itemName is what a diagnostic calls one copybook item.
+func itemName(item *copybook.Field) string {
+	if item == nil || item.Filler || item.Name == "" {
+		return "a FILLER item"
+	}
+
+	return item.Name
 }
 
 // discriminator is the strategy the layout's `discriminate` form chose for a
@@ -320,21 +419,43 @@ func (l *layers) redefines(bound *bindings) map[string][]resolve.Redefine {
 	return redefines
 }
 
-// substitutes resolves each `rename` to the copybook item it names.
+// substitutes resolves each `rename` to what it names: a copybook item, or the
+// record type itself.
 //
-// They are one list rather than keyed by record because `assemble` takes one:
-// a rename reaches every node standing for that item, and an item belongs to
-// one record's tree, so the list is already partitioned by the fields in it.
+// Every one carries the record it was written under, because a rename is per
+// record (docs/layout/SPEC.md, "Many records may name one copybook, and two may
+// name one item"). Two records over one `01`-level hold two item trees here, so
+// the fields alone would in fact partition — but that is this package's
+// arrangement rather than `assemble`'s contract, and a rename saying which
+// record it belongs to is the difference between independence that holds and
+// independence that happens to (#164).
+//
+// A rename naming a record contributes no item: the name it stands beside is the
+// record node's, which is the `01`-level's, and that is the one item an item
+// reference cannot reach.
 func (l *layers) substitutes(bound *bindings) []assemble.Rename {
 	renames := make([]assemble.Rename, 0, len(l.renames))
 
 	for _, rename := range l.renames {
+		if rename.NamesRecord() {
+			renames = append(renames, assemble.Rename{
+				Record:     rename.Record,
+				Substitute: rename.Substitute,
+			})
+
+			continue
+		}
+
 		item := bound.field(rename.Item)
 		if item == nil {
 			continue
 		}
 
-		renames = append(renames, assemble.Rename{Item: item, Substitute: rename.Substitute})
+		renames = append(renames, assemble.Rename{
+			Record:     rename.Item.Record,
+			Item:       item,
+			Substitute: rename.Substitute,
+		})
 	}
 
 	return renames

--- a/internal/project/errors.go
+++ b/internal/project/errors.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/Zaba505/cobol-go/copybook"
 
@@ -236,20 +237,24 @@ func (e *AmbiguousItemError) Diagnostic() diag.Diagnostic {
 	}
 }
 
-// AlternativesError is a `record` bound to an `01`-level that resolves to more
-// than one record type.
+// AlternativesError is a `record` form whose `alternative` children choose no
+// combination of alternatives its copybook actually has.
 //
 // A copybook holding a REDEFINES outside a repeating group describes one run of
 // bytes several ways, and `resolve` reads it the way docs/ir/SPEC.md says: one
-// record type per combination of alternatives. Nothing in the layout format
-// carries that across. A `record` form binds a name to an `01`-level and every
-// alternative of that level is the same level, so there is no spelling that
-// gives two of them two names and no rule saying which alternative a form meant.
+// record type per combination of alternatives. Which of them a `record` form
+// means is the layout's own statement — one `alternative` child per redefine,
+// naming the alternative chosen (docs/layout/SPEC.md, "Which alternative a
+// record is") — and this is the choice not landing on one.
 //
-// #164 is the story that decides both, and until it does this is refused rather
-// than answered by a rule this program invented — pairing the forms to the
-// alternatives by position is a rule an adopter could not read anywhere, and one
-// they would only find out about from generated code naming the wrong fields.
+// It covers every way that happens, because they are one fault from an
+// adopter's side and one message answers all of them: a record over a redefined
+// `01`-level carrying no children at all, one carrying too few or too many, one
+// naming an item that is an alternative of a redefine *inside* a repeating group
+// or no alternative at all, and one carrying a child over a copybook with no
+// redefine in it. What the message does in each case is name what was chosen and
+// list every combination there was to choose from, so that the fix is readable
+// off the diagnostic rather than out of the copybook.
 type AlternativesError struct {
 	// Pos is the `record` form.
 	Pos diag.Span
@@ -263,8 +268,13 @@ type AlternativesError struct {
 	// Item is the top-level item it is bound to.
 	Item string
 
-	// Alternatives is how many record types the item resolved to.
-	Alternatives int
+	// Chosen is what the `alternative` children named, in the order the form
+	// writes them.
+	Chosen []string
+
+	// Resolved is every combination the copybook resolved to, in the order
+	// `resolve` enumerated them.
+	Resolved [][]string
 }
 
 // Error implements the error interface.
@@ -274,15 +284,62 @@ func (e *AlternativesError) Error() string { return e.Diagnostic().String() }
 func (e *AlternativesError) Diagnostic() diag.Diagnostic {
 	return diag.Diagnostic{
 		Message: fmt.Sprintf(
-			"record %s is bound to %s in %s, which REDEFINES describes %d ways, "+
-				"and nothing in this layout says which of them the record is",
-			strconv.Quote(e.Record), strconv.Quote(e.Item), strconv.Quote(e.Path), e.Alternatives),
+			"record %s is bound to %s in %s, and chooses %s, which is none of the %d it describes",
+			strconv.Quote(e.Record), strconv.Quote(e.Item), strconv.Quote(e.Path),
+			chosenAs(e.Chosen), len(e.Resolved)),
 		Spans: []diag.Span{
 			e.Pos,
-			{Note: "a record form names an 01-level, and every alternative of it is that same level; " +
-				"naming and selecting one is #164"},
+			{Note: "it describes " + offered(e.Resolved) +
+				"; a record form carries one (alternative <item-ref>) child per REDEFINES outside a " +
+				"repeating group, naming the alternative it is"},
 		},
 	}
+}
+
+// chosenAs is how a diagnostic reads back what a record chose.
+func chosenAs(chosen []string) string {
+	if len(chosen) == 0 {
+		return "no alternative"
+	}
+
+	return strings.Join(quoteAll(chosen), " with ")
+}
+
+// offered is how a diagnostic lists the combinations there were to choose from.
+//
+// Each combination is one choice however many items it took, so they are
+// rendered as one entry apiece rather than flattened — a copybook with two
+// redefines offers four choices of two items and not eight of one.
+func offered(resolved [][]string) string {
+	if len(resolved) == 0 {
+		return "nothing to choose"
+	}
+
+	entries := make([]string, 0, len(resolved))
+
+	for _, combination := range resolved {
+		if len(combination) == 0 {
+			entries = append(entries, "no alternative")
+
+			continue
+		}
+
+		entries = append(entries, strings.Join(quoteAll(combination), " with "))
+	}
+
+	return strings.Join(entries, ", ")
+}
+
+// quoteAll quotes every name of a combination, so that an item called `with`
+// cannot read as the word joining two of them.
+func quoteAll(names []string) []string {
+	quoted := make([]string, 0, len(names))
+
+	for _, name := range names {
+		quoted = append(quoted, strconv.Quote(name))
+	}
+
+	return quoted
 }
 
 // GeneratorError is a generator the manifest names that could not be resolved to

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -824,3 +824,192 @@ func TestOneMissingCopybookIsReportedAgainstEveryRecordThatNamesIt(t *testing.T)
 		t.Errorf("both faults point at %s, want one per record", found[0].Spans[0])
 	}
 }
+
+// TestTwoRedefinesAreChosenAsASetAndNotInOrder is the case the whole naming
+// decision rests on, and the only one that exercises the choice as a set.
+//
+// Two independent redefines in one `01`-level resolve to one record type per
+// *combination*, which is why a record node cannot take an alternative's name —
+// there are two of them and neither names the record. So the two `alternative`
+// children are a set: written in either order they choose the same record type,
+// and a layout that swapped its two lines would otherwise mean something else.
+func TestTwoRedefinesAreChosenAsASetAndNotInOrder(t *testing.T) {
+	t.Parallel()
+
+	// A-or-B beside C-or-D: four record types, each carrying the whole record.
+	copybook := fixed(
+		"01  PAIR-REC.",
+		"    05  PAIR-A      PIC X(4).",
+		"    05  PAIR-B REDEFINES PAIR-A PIC X(4).",
+		"    05  PAIR-C      PIC X(6).",
+		"    05  PAIR-D REDEFINES PAIR-C PIC X(6).",
+	)
+
+	layoutFor := func(first, second string) string {
+		return `(encoding
+  (charset ascii) (sign-convention ascii-zone-37)
+  (byte-order big-endian) (float-format ieee-754))
+(framing (recfm F) (lrecl 10))
+(record PAIR (copybook "pair.cpy" PAIR-REC)
+  (alternative (item PAIR ` + first + `))
+  (alternative (item PAIR ` + second + `)))
+(discriminate PAIR single-record-type)
+(sequence (* PAIR))
+`
+	}
+
+	// Both orders name one record type, and it is the one holding B and D.
+	for _, order := range [][2]string{{"PAIR-B", "PAIR-D"}, {"PAIR-D", "PAIR-B"}} {
+		dir := t.TempDir()
+
+		write(t, filepath.Join(dir, "pair.cpy"), copybook)
+		write(t, filepath.Join(dir, "pair.sexpr"), layoutFor(order[0], order[1]))
+		write(t, filepath.Join(dir, manifest.Name),
+			`{"layout": "pair.sexpr", "generators": [{"name": "go", "out": "gen"}]}`)
+
+		run, err := project.Load(filepath.Join(dir, manifest.Name))
+		if err != nil {
+			t.Fatalf("(alternative %s) then (alternative %s) does not resolve:\n%s",
+				order[0], order[1], diag.Render(err))
+		}
+
+		if got := records(run.Descriptor); got != 1 {
+			t.Fatalf("choosing %v resolves to %d record types, want 1", order, got)
+		}
+
+		fields := fieldNames(run.Descriptor)
+		for name, want := range map[string]int{"PAIR-A": 0, "PAIR-B": 1, "PAIR-C": 0, "PAIR-D": 1} {
+			if fields[name] != want {
+				t.Errorf("choosing %v, %s stands %d times, want %d", order, name, fields[name], want)
+			}
+		}
+	}
+}
+
+// TestAChoiceThatIsNoCombinationNamesEveryCombination is the diagnostic over the
+// same copybook: a record choosing one alternative where two redefines want two
+// is refused, and every combination there was to choose from is in the message.
+//
+// One redefine chosen twice is refused by the reader before this, so the shapes
+// that reach here are a choice that is short, long, or names something that is
+// no alternative at all — and one message answers all of them.
+func TestAChoiceThatIsNoCombinationNamesEveryCombination(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	write(t, filepath.Join(dir, "pair.cpy"), fixed(
+		"01  PAIR-REC.",
+		"    05  PAIR-A      PIC X(4).",
+		"    05  PAIR-B REDEFINES PAIR-A PIC X(4).",
+		"    05  PAIR-C      PIC X(6).",
+		"    05  PAIR-D REDEFINES PAIR-C PIC X(6).",
+	))
+
+	write(t, filepath.Join(dir, "pair.sexpr"), `(encoding
+  (charset ascii) (sign-convention ascii-zone-37)
+  (byte-order big-endian) (float-format ieee-754))
+(framing (recfm F) (lrecl 10))
+(record PAIR (copybook "pair.cpy" PAIR-REC)
+  (alternative (item PAIR PAIR-B)))
+(discriminate PAIR single-record-type)
+(sequence (* PAIR))
+`)
+	write(t, filepath.Join(dir, manifest.Name),
+		`{"layout": "pair.sexpr", "generators": [{"name": "go", "out": "gen"}]}`)
+
+	_, err := project.Load(filepath.Join(dir, manifest.Name))
+
+	var alternatives *project.AlternativesError
+	if !errors.As(err, &alternatives) {
+		t.Fatalf("a short choice reads as %v, want an AlternativesError", err)
+	}
+
+	rendered := diag.Render(err)
+
+	// Four combinations of two, rendered one entry apiece rather than flattened
+	// into eight names — a copybook with two redefines offers four choices.
+	for _, want := range []string{
+		`"PAIR-A" with "PAIR-C"`,
+		`"PAIR-A" with "PAIR-D"`,
+		`"PAIR-B" with "PAIR-C"`,
+		`"PAIR-B" with "PAIR-D"`,
+		"which is none of the 4 it describes",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("the diagnostic does not carry %s:\n%s", want, rendered)
+		}
+	}
+}
+
+// TestAnAlternativeOverACopybookWithNoRedefineIsRefused is the other end of the
+// same rule: a copybook with nothing to choose among resolves to one record type
+// choosing nothing, and a form choosing something has named an item that is no
+// alternative.
+func TestAnAlternativeOverACopybookWithNoRedefineIsRefused(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	write(t, filepath.Join(dir, "flat.cpy"), fixed(
+		"01  FLAT-REC.",
+		"    05  FLAT-KEY   PIC X(4).",
+	))
+
+	write(t, filepath.Join(dir, "flat.sexpr"), `(encoding
+  (charset ascii) (sign-convention ascii-zone-37)
+  (byte-order big-endian) (float-format ieee-754))
+(framing (recfm F) (lrecl 4))
+(record FLAT (copybook "flat.cpy" FLAT-REC)
+  (alternative (item FLAT FLAT-KEY)))
+(discriminate FLAT single-record-type)
+(sequence (* FLAT))
+`)
+	write(t, filepath.Join(dir, manifest.Name),
+		`{"layout": "flat.sexpr", "generators": [{"name": "go", "out": "gen"}]}`)
+
+	_, err := project.Load(filepath.Join(dir, manifest.Name))
+
+	var alternatives *project.AlternativesError
+	if !errors.As(err, &alternatives) {
+		t.Fatalf("an alternative over a copybook with no redefine reads as %v, want an AlternativesError", err)
+	}
+
+	if !strings.Contains(diag.Render(err), "no alternative") {
+		t.Errorf("the diagnostic does not say there was nothing to choose:\n%s", diag.Render(err))
+	}
+}
+
+// TestAnAlternativeNamingNoItemIsReported is the fault the resolving order
+// exists for: an `alternative` naming an item the copybook does not declare is
+// reported against the layout, rather than dropping its record type out of the
+// run in silence.
+func TestAnAlternativeNamingNoItemIsReported(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	write(t, filepath.Join(dir, "txn.cpy"), fixed(
+		"01  TXN-REC.",
+		"    05  TXN-PURCHASE  PIC X(4).",
+		"    05  TXN-REFUND REDEFINES TXN-PURCHASE PIC X(4).",
+	))
+
+	write(t, filepath.Join(dir, "txn.sexpr"), `(encoding
+  (charset ascii) (sign-convention ascii-zone-37)
+  (byte-order big-endian) (float-format ieee-754))
+(framing (recfm F) (lrecl 4))
+(record PURCHASE (copybook "txn.cpy" TXN-REC) (alternative (item PURCHASE TXN-CHARGE)))
+(discriminate PURCHASE single-record-type)
+(sequence (* PURCHASE))
+`)
+	write(t, filepath.Join(dir, manifest.Name),
+		`{"layout": "txn.sexpr", "generators": [{"name": "go", "out": "gen"}]}`)
+
+	_, err := project.Load(filepath.Join(dir, manifest.Name))
+
+	var unknown *project.UnknownItemError
+	if !errors.As(err, &unknown) {
+		t.Fatalf("an alternative naming no item reads as %v, want an UnknownItemError", err)
+	}
+}

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -422,10 +423,11 @@ func TestEveryFaultInOnePassIsReported(t *testing.T) {
 // composition found and did not paper over.
 //
 // `resolve` reads one `01`-level holding a REDEFINES outside a repeating group
-// as one record type per alternative, and nothing in the layout format names
-// them apart or says which alternative a `record` form meant. Pairing them by
-// position would be a rule an adopter could not read anywhere, so the layout is
-// refused with a diagnostic naming #164 — the story that decides it.
+// as one record type per alternative, and the `alternative` children are where a
+// layout says which of them a `record` form is. A form carrying none over such a
+// copybook has chosen nothing, and pairing it to an alternative by position
+// would be a rule an adopter could not read anywhere — so it is refused, with
+// every alternative there was to choose from named in the message.
 func TestARecordLevelRedefineIsRefusedRatherThanGuessedAt(t *testing.T) {
 	t.Parallel()
 
@@ -457,9 +459,175 @@ func TestARecordLevelRedefineIsRefusedRatherThanGuessedAt(t *testing.T) {
 		t.Fatalf("a record-level redefine reads as %v, want an AlternativesError", err)
 	}
 
-	if !strings.Contains(diag.Render(err), "#164") {
-		t.Errorf("the diagnostic does not name the story that decides it:\n%s", diag.Render(err))
+	// The message names what there was to choose from, because the fix is
+	// writing one of them down and an adopter should not have to open the
+	// copybook to find out what the choices were.
+	rendered := diag.Render(err)
+
+	for _, want := range []string{"TXN-PURCHASE", "TXN-REFUND", "alternative"} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("the diagnostic does not name %s:\n%s", want, rendered)
+		}
 	}
+}
+
+// TestARecordFormChoosesItsAlternativeByName is #164 end to end on the layout
+// side: one `01`-level redefined three ways, discriminated behind a shared key,
+// resolves to three record types, each of them the alternative its `record` form
+// named and each carrying the name its `rename` gave it.
+//
+// Every half of the decision is asserted rather than described. The pairing is
+// the layout's statement — swap the two lines and the two record types swap with
+// them — and the naming is a rename on the record, because the `01`-level's name
+// is what all three of them carry as an original (docs/ir/SPEC.md, "Names").
+func TestARecordFormChoosesItsAlternativeByName(t *testing.T) {
+	t.Parallel()
+
+	run, err := project.Load(filepath.Join(redefinedTransactions(t), manifest.Name))
+	if err != nil {
+		t.Fatalf("the project does not resolve:\n%s", diag.Render(err))
+	}
+
+	if got := records(run.Descriptor); got != 3 {
+		t.Fatalf("the descriptor carries %d record types, want one per alternative", got)
+	}
+
+	// The original is the `01`-level's on all three: every alternative is a
+	// description of that level, and taking an alternative's name would leave a
+	// copybook with two redefines with nothing to take.
+	overrides := make([]string, 0, 3)
+
+	for _, node := range run.Descriptor.GetNodes() {
+		record := node.GetRecord()
+		if record == nil {
+			continue
+		}
+
+		if got := record.GetNames().GetOriginal(); got != "TXN-REC" {
+			t.Errorf("a record node is named %q, want the 01-level's TXN-REC", got)
+		}
+
+		overrides = append(overrides, record.GetNames().GetOverrideName())
+	}
+
+	want := []string{"TXN-PURCHASE-REC", "TXN-REFUND-REC", "TXN-ADJUST-REC"}
+	if !slices.Equal(overrides, want) {
+		t.Errorf("the record nodes carry %v, want %v", overrides, want)
+	}
+
+	// The pairing reached the fields: PURCHASE holds the purchase alternative's
+	// items and neither of the others', which is what says the choice selected a
+	// record type rather than being carried along beside one.
+	fields := fieldNames(run.Descriptor)
+
+	for _, name := range []string{"PUR-AMT", "REF-ORIG", "ADJ-REASON"} {
+		if got := fields[name]; got != 1 {
+			t.Errorf("%s stands in %d record types, want exactly the one that chose it", name, got)
+		}
+	}
+}
+
+// TestAnAlternativeIsRootedAtTheRecordChoosingIt is the half of the choice the
+// layout reader decides on its own: a reference is rooted at a record, and an
+// `alternative` rooted at another record would be looked up in another record's
+// item tree.
+func TestAnAlternativeIsRootedAtTheRecordChoosingIt(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	write(t, filepath.Join(dir, "txn.cpy"), fixed(
+		"01  TXN-REC.",
+		"    05  TXN-PURCHASE  PIC X(4).",
+		"    05  TXN-REFUND REDEFINES TXN-PURCHASE PIC X(4).",
+	))
+
+	write(t, filepath.Join(dir, "txn.sexpr"), `(encoding
+  (charset ascii) (sign-convention ascii-zone-37)
+  (byte-order big-endian) (float-format ieee-754))
+(framing (recfm F) (lrecl 4))
+(record PURCHASE (copybook "txn.cpy" TXN-REC) (alternative (item REFUND TXN-PURCHASE)))
+(record REFUND   (copybook "txn.cpy" TXN-REC) (alternative (item REFUND TXN-REFUND)))
+(discriminate PURCHASE single-record-type)
+(discriminate REFUND   single-record-type)
+(sequence (seq PURCHASE REFUND))
+`)
+	write(t, filepath.Join(dir, manifest.Name), `{"layout": "txn.sexpr", "generators": [{"name": "go", "out": "gen"}]}`)
+
+	_, err := project.Load(filepath.Join(dir, manifest.Name))
+	if err == nil {
+		t.Fatal("the reader accepts an alternative rooted at another record")
+	}
+
+	if !strings.Contains(err.Error(), "rooted at record") {
+		t.Errorf("the diagnostic does not say what is wrong with it:\n%s", diag.Render(err))
+	}
+}
+
+// redefinedTransactions writes the worked shape #164 decides — one `01`-level
+// redefined three ways, discriminated on a code behind a shared account key —
+// and hands back the directory holding it.
+//
+// The same shape is written again in `cpybkc-gen-go`'s tests, which assert that
+// the descriptor generates without a collision — the other half of #164, and the
+// half that cannot be asserted from here, because a generator is a program this
+// package runs rather than a package it imports.
+func redefinedTransactions(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	write(t, filepath.Join(dir, "txn.cpy"), fixed(
+		"01  TXN-REC.",
+		"    05  TXN-ACCT        PIC X(4).",
+		"    05  TXN-PURCHASE.",
+		"        10  PUR-CODE    PIC X(2).",
+		"        10  PUR-AMT     PIC X(6).",
+		"    05  TXN-REFUND REDEFINES TXN-PURCHASE.",
+		"        10  REF-CODE    PIC X(2).",
+		"        10  REF-ORIG    PIC X(6).",
+		"    05  TXN-ADJUST REDEFINES TXN-PURCHASE.",
+		"        10  ADJ-CODE    PIC X(2).",
+		"        10  ADJ-REASON  PIC X(6).",
+	))
+
+	write(t, filepath.Join(dir, "txn.sexpr"), `(encoding
+  (charset ascii) (sign-convention ascii-zone-37)
+  (byte-order big-endian) (float-format ieee-754))
+(framing (recfm F) (lrecl 12))
+
+(record PURCHASE (copybook "txn.cpy" TXN-REC) (alternative (item PURCHASE TXN-PURCHASE)))
+(record REFUND   (copybook "txn.cpy" TXN-REC) (alternative (item REFUND   TXN-REFUND)))
+(record ADJUST   (copybook "txn.cpy" TXN-REC) (alternative (item ADJUST   TXN-ADJUST)))
+
+(rename PURCHASE "TXN-PURCHASE-REC")
+(rename REFUND   "TXN-REFUND-REC")
+(rename ADJUST   "TXN-ADJUST-REC")
+
+(discriminate PURCHASE (equals (item PURCHASE TXN-PURCHASE PUR-CODE) "PU"))
+(discriminate REFUND   (equals (item REFUND   TXN-REFUND   REF-CODE) "RF"))
+(discriminate ADJUST   (equals (item ADJUST   TXN-ADJUST   ADJ-CODE) "AJ"))
+
+(sequence (* (alt PURCHASE REFUND ADJUST)))
+`)
+
+	write(t, filepath.Join(dir, manifest.Name),
+		`{"layout": "txn.sexpr", "generators": [{"name": "go", "out": "gen"}]}`)
+
+	return dir
+}
+
+// fieldNames is how many field nodes of a descriptor carry each copybook name.
+func fieldNames(d *irpb.Descriptor) map[string]int {
+	found := make(map[string]int)
+
+	for _, node := range d.GetNodes() {
+		if field := node.GetField(); field != nil {
+			found[field.GetNames().GetOriginal()]++
+		}
+	}
+
+	return found
 }
 
 // records is how many record nodes a descriptor carries, which is one per
@@ -556,10 +724,12 @@ func TestAnItemReferenceThatNamesNothingCarriesTwoSpans(t *testing.T) {
 // is assembled into one item tree per `record` form.
 //
 // docs/layout/SPEC.md requires two records over one `01`-level to be renamed,
-// discriminated and encoding-overridden independently, and `assemble` keys its
-// renames on the copybook field. So a shared tree would make a rename written
-// for one record reach the other, and the two record nodes would come out with
-// the same substituted names.
+// discriminated and encoding-overridden independently. `assemble` keys a rename
+// on the record it was written under as well as on the copybook item (#164), so
+// a shared tree would no longer make a rename reach the wrong record — but every
+// item reference here would still resolve into one tree, and an
+// encoding-override or a discriminator written for one record would be looked up
+// against the other's items.
 func TestTwoRecordsOverOneCopybookAreRenamedIndependently(t *testing.T) {
 	t.Parallel()
 

--- a/schema/layout.sexpr
+++ b/schema/layout.sexpr
@@ -78,6 +78,12 @@
 ;; One alternative of a variant, and what selects it.
 (sort variant-arm (form arm))
 
+;; What a rename may name: an item inside a record, or a record itself. A record
+;; is admitted here and nowhere else, because a record's top-level item is the
+;; one item an item reference cannot reach — the `record` form has already
+;; stated it, so a path never repeats it.
+(sort rename-target item-ref record-name)
+
 ;; A sequencing expression: a record name, or one of the seven operators. The
 ;; set is closed for the same reason the strategies are.
 (sort expression
@@ -181,16 +187,24 @@
 
 (form record (in top-level) (arity one-or-more) (layer record-definitions)
   (argument name symbol exactly-one)
-  (child copybook exactly-one))
+  (child copybook exactly-one)
+  (child alternative zero-or-more))
 
 (form copybook
   (argument path text exactly-one)
   (argument top-level-name symbol exactly-one))
 
+;; One alternative of a REDEFINES outside a repeating group, chosen by naming
+;; it. How many a record needs — one per redefine the copybook writes outside a
+;; repeating group, and none where it writes none — is `resolve`'s, because
+;; counting them needs the copybook.
+(form alternative
+  (argument item item-ref exactly-one))
+
 ;; The substitute name is text and is carried verbatim: it is language-neutral,
 ;; and turning a name into an identifier is a generator's work.
 (form rename (in top-level) (arity zero-or-more) (layer record-definitions)
-  (argument item item-ref exactly-one)
+  (argument target rename-target exactly-one)
   (argument name text exactly-one))
 
 (form copybook-reading (in top-level) (arity at-most-one) (layer record-definitions)


### PR DESCRIPTION
Closes #164.

A base `01`-level redefined several ways resolves to one record type per alternative, and nothing in the layout format said **which** of them a `record` form meant, or gave two of them **two names**. `internal/project` refused the shape outright rather than guess (`AlternativesError`, citing this issue). This settles both halves, and the rename question the same section raised.

## The decision

**Selection — a new `alternative` child on `record`.**

```
(record PURCHASE (copybook "txn.cpy" TXN-REC) (alternative (item PURCHASE TXN-PURCHASE)))
(record REFUND   (copybook "txn.cpy" TXN-REC) (alternative (item REFUND   TXN-REFUND)))
```

One child per `REDEFINES` outside a repeating group, naming the alternative as an ordinary item reference — a reference rather than a bare name because duplicate data names are legal COBOL and a redefine may sit at any depth. The children are matched as a **set**, so two independent redefines are two children in either order and swapping the lines changes nothing.

Of the three options the issue weighed, this is the second. The schema version it costs is free: `docs/layout/SPEC.md` already says version 1 "stands at 1 while that version is being assembled", and a change made before the first release is the settling that section asks for.

**Naming — `rename` may name a record.**

```
(rename PURCHASE "TXN-PURCHASE-REC")
```

A record name where the form otherwise takes a reference. It is the same form and not a new one, because it says exactly what the first spelling says: a substitute carried beside an original that survives. It is a bare record name rather than `(item PURCHASE)` because an item reference deliberately does not repeat the top-level item's name — the one item whose name a record node carries is the one item a reference cannot reach, which is the closed escape the issue described.

**What a record node is called — the `01`-level's name, unchanged.**

`docs/ir/SPEC.md`'s Names now says so outright. Taking the alternative's name reads well for a copybook with one redefine and answers nothing for a copybook with two, where the record types are one per *combination* and no single alternative names any of them; a rule that changed a record node's name when a second `REDEFINES` was added would change it in a file no layout is stored beside. Several record nodes **may** carry one original, and the override is what tells them apart. Nothing requires one — whether two record types answering to one name is a problem is the target language's question, and `cpybkc-gen-go` still refuses the pair it cannot munge (#50).

**A rename is per record.** The spec already claimed it ("neither reaches the other") and `internal/assemble` keyed on `*copybook.Field` alone. Per record stands, and the assembler is what changed: the key is now the record *and* the item. The pipeline builds one item tree per record, so this was true by accident already; it is now true by contract, which is the difference between independence that holds and independence that happens to.

## Acceptance criteria

- [x] **What name a record node resolved from a record-level redefine alternative carries** — the `01`-level's, stated in `docs/ir/SPEC.md`'s [Names] with the reasoning, and cross-referenced from `docs/layout/SPEC.md`.
- [x] **Two record types from one `01`-level can be given two names** without copying the level in the copybook — `(rename <record-name> "<name>")`, spelled in `docs/layout/SPEC.md`'s new "A rename may name a record".
- [x] **Which alternative a `record` form means** — the `alternative` child, in `docs/layout/SPEC.md`'s new "Which alternative a record is". `assemble.Options.Records` no longer says the pairing merely arrives made; it says the layout states it and the caller carries it over.
- [x] **Per item or per record** — per record. `assemble.Rename` gained `Record`, the assembler keys on both, and `internal/project` supplies the record every rename was written under.
- [x] **A test drives the shape end to end** — `TestARecordLevelRedefineGeneratesOneTypePerAlternative` in `cmd/cpybkc-gen-go` writes a copybook whose `01`-level is redefined three ways behind a shared account key, resolves and assembles it through `internal/project`, and generates `TxnPurchaseRec`/`TxnRefundRec`/`TxnAdjustRec` with no collision — each holding its own alternative's items and neither of the others'. `TestThreeAlternativesUnrenamedStillCollide` is the other side: without the renames the descriptor is still well formed and the generator still refuses it, which is what makes the rename load-bearing.
- [x] **#145 and #148 updated** — see the comments on each.

## Judgment calls

- **`alternative` is a child of `record`, not a top-level form.** A top-level `(select-alternative PURCHASE (item …))` would have been a second form saying what the `record` form is already about, and the arity rule "one per redefine" would have become a rule counting two forms against each other rather than one the schema can state at a position.
- **The choice is matched as a set, and a record choosing no combination is refused with every combination named.** Rejecting rather than falling back to "the only one" keeps a copybook that gains a redefine from silently re-pointing an existing layout.
- **The layout reader owns the halves that need no copybook** — an `alternative` rooted at another record, and two of them naming one item. How many there should be is `resolve`'s, because counting redefines needs the file.
- **The collision rules for record renames are the two decidable from the layout alone**: one name for two records, and a substitute equal to the `01`-level another record's `copybook` child names. A record node has no parent, so the sibling rules have no third half to carry over.

## Verified

`dagger call ci` — green. New coverage in `internal/layoutmodel` (the `alternative` child and its four faults; record renames, their duplicate and their two collisions), `internal/assemble` (a rename under the wrong record reaches nothing; a record rename lands on the record node while both nodes keep `ORD-REC`), `internal/project` (three alternatives resolve to three named record types, each holding only its own items) and `cmd/cpybkc-gen-go` (the end-to-end generation above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
