### PR TITLE
story(dagger): test the module against the image built in the same PR

### DIFF
--- a/.dagger/companion.go
+++ b/.dagger/companion.go
@@ -494,21 +494,40 @@ func (m *Cpybkc) CompanionModule(ctx context.Context) error {
 
 	var errs []error
 
+	// The wrapper names the calls the tree came through rather than asserting
+	// which of them broke, because it cannot know: a composition that failed
+	// before generate ran arrives here too, and the one this check is built to
+	// produce — a with-generator that forgot its image, reaching for
+	// [neverPulledRepository] — is exactly that shape. The wrapped error is what
+	// says which, and it names the registry host when that is the answer.
 	if err := m.diffTrees(ctx, committed, fromImage.Generate(committed), "/companion-module/image"); err != nil {
 		errs = append(errs, fmt.Errorf(
-			"with-generator composed the generator out of an image and generate did not reproduce the committed %s/: %w",
+			"with-generator taking the generator out of an image, then generate, did not hand back the committed "+
+				"%s/ (or did not get that far — the wrapped error says which): %w",
 			companionExampleDir, err))
 	}
 
 	if err := m.diffTrees(ctx, committed, fromExecutable.Generate(committed), "/companion-module/executable"); err != nil {
 		errs = append(errs, fmt.Errorf(
-			"with-generator-executable composed the generator out of a file and generate did not reproduce the "+
-				"committed %s/: %w",
+			"with-generator-executable taking the generator out of a file, then generate, did not hand back the "+
+				"committed %s/ (or did not get that far — the wrapped error says which): %w",
 			companionExampleDir, err))
 	}
 
+	// Both compositions, not just the first. Generate succeeding says only that
+	// *a* working generator was resolvable on PATH; it does not say the plugin
+	// directory holds what it should, so a with-generator-executable that
+	// installed a second copy under another name would pass every assertion
+	// above.
 	if err := m.checkComposedImage(ctx, fromImage.Image()); err != nil {
-		errs = append(errs, fmt.Errorf("image handed back a container the CLI could not find the generator in: %w", err))
+		errs = append(errs, fmt.Errorf(
+			"with-generator, then image, handed back a container the CLI could not resolve the generator in: %w", err))
+	}
+
+	if err := m.checkComposedImage(ctx, fromExecutable.Image()); err != nil {
+		errs = append(errs, fmt.Errorf(
+			"with-generator-executable, then image, handed back a container the CLI could not resolve the "+
+				"generator in: %w", err))
 	}
 
 	// --version through the escape hatch, with no project: it is the one
@@ -593,9 +612,11 @@ func (m *Cpybkc) generatorImage(platform dagger.Platform) *dagger.Container {
 // resolves a generator on — PATH in this image is the plugin directory and
 // nothing more.
 //
-// Exhaustive rather than a containment check. A composition that installed the
-// generator twice under two names, or left something else behind, is a
-// with-generator this pipeline should report rather than a detail it tolerates.
+// Exhaustive rather than a containment check, and run over both compositions
+// rather than one. A composition that installed the generator twice under two
+// names, or left something else behind, is a composition this pipeline should
+// report rather than a detail it tolerates — and generate succeeding says
+// nothing about it, because a run only needs *a* generator resolvable on PATH.
 func (m *Cpybkc) checkComposedImage(ctx context.Context, composed *dagger.Container) error {
 	entries, err := composed.Directory(pluginDir).Entries(ctx)
 	if err != nil {
@@ -607,8 +628,8 @@ func (m *Cpybkc) checkComposedImage(ctx context.Context, composed *dagger.Contai
 	slices.Sort(entries)
 
 	if !slices.Equal(entries, want) {
-		return fmt.Errorf("%s holds %v and the composition put %v there: the CLI resolves a generator on PATH, "+
-			"and PATH in this image is that directory alone", pluginDir, entries, want)
+		return fmt.Errorf("%s holds %v where the composition should have left %v: the CLI resolves a generator on "+
+			"PATH, and PATH in this image is that directory alone", pluginDir, entries, want)
 	}
 
 	return nil

--- a/.dagger/companion.go
+++ b/.dagger/companion.go
@@ -2,7 +2,7 @@
 // daggerverse/cpybkc that runs the published image for somebody else's pipeline
 // (#61). It is not that module; it is this pipeline's opinion about it.
 //
-// Three things are checked here, and they are separate because they fail for
+// Four things are checked here, and they are separate because they fail for
 // unrelated reasons and a run should say which.
 //
 // CompanionCi runs the standard Go pipeline over the module, exactly as IrCi
@@ -20,6 +20,12 @@
 // The module curates deliberately rather than mapping the flag table one-to-one
 // (#62), and a curated surface is only safe if adding a flag to the CLI forces
 // somebody to say which side of the curation it falls on.
+//
+// CompanionModule runs the module's functions — over the image this pull request
+// built rather than over the last release (#64). The three above read the
+// module's source, its dagger.json and its function names; this one is the only
+// place the calls are made, so it is the only place a composition that no longer
+// composes can fail.
 package main
 
 import (
@@ -363,4 +369,273 @@ func goFiles(ctx context.Context, source *dagger.Directory, dir string) (map[str
 	}
 
 	return files, nil
+}
+
+const (
+	// companionExampleDir is the committed worked example (#177): the inputs a
+	// caller writes, and the tree cpybkc writes for them, checked in whole.
+	//
+	// It is the golden tree example/regenerate_test.go already holds the CLI to,
+	// and reusing it rather than generating something smaller here is the whole
+	// assertion. A smoke test saying that the module's calls *ran* would pass on
+	// a module that composed an image which generated the wrong thing; what is
+	// worth asserting is that the module reproduced the committed example byte
+	// for byte, and this repository already has that tree.
+	companionExampleDir = "example"
+
+	// generatorExecutable is what the CLI's PATH-based discovery looks for, and
+	// generatorPackage is what builds it.
+	//
+	// Both are assembled from worked_example.go's two constants rather than
+	// written out, so the executable this check installs is the one
+	// docs/plugin/SPEC.md's discovery rule names rather than a second spelling of
+	// it, and the command directory is not a third.
+	generatorExecutable = generatorPrefix + ownGenerator
+	generatorPackage    = "./cmd/" + generatorExecutable
+
+	// neverPulledRepository is the registry repository this check hands the
+	// module, and it is deliberately one that cannot exist: `.invalid` is
+	// reserved by RFC 2606 and resolves nowhere, ever.
+	//
+	// It is what turns *this pull request's image, never a published one* from a
+	// convention into a failure. The module pulls `<repository>-gen-<name>` only
+	// when with-generator is called without an image, and every call below passes
+	// one — but a call added later that forgot would pull the *released*
+	// generator, generate with it, and pass, quietly checking the last release
+	// instead of the change. Pointing the coordinates at a host with no registry
+	// behind it makes that call fail instead, naming this constant.
+	//
+	// The version is left at the module's own default. Nothing resolves it here
+	// for the same reason, and overriding it would only add a second unused
+	// value to read.
+	neverPulledRepository = "cpybkc.invalid/never-pulled"
+)
+
+// CompanionModule drives the companion module's functions over the image this
+// pipeline just built, and requires what comes out to be the committed worked
+// example byte for byte (#64).
+//
+// # Why the module's own functions need a check at all
+//
+// CompanionCi, EngineLock and CliSurface read the module — its Go source, its
+// dagger.json and its function names. None of them makes a call, so a module
+// whose calls no longer compose into a working image would fail none of them.
+// This is the only place `dagger call -m daggerverse/cpybkc …` actually happens,
+// and the module is a convenience over docs/container/SPEC.md rather than a
+// contract of its own, which is exactly why a broken one is worse than none: a
+// caller reaches for it because they did not want to learn the contract
+// underneath, so the failure lands on somebody with no reason to know where to
+// look.
+//
+// # Why it drives the image built here
+//
+// The module's defaults pull `ghcr.io/zaba505/cpybkc:v0`, which is a *released*
+// image. A check that used them would be checking the last release, and would
+// keep passing through a pull request that broke both the module and the image
+// it drives. So the base image this pipeline just built is passed through the
+// same --image argument a caller uses to try an unreleased cpybkc, the generator
+// is the one built from this tree, and the coordinates that would resolve
+// anything else point at [neverPulledRepository]. Nothing here reaches a
+// registry.
+//
+// That is also the only reason the module takes --image at all, which is worth
+// knowing before anybody removes it as unused: it is used here, on every pull
+// request.
+//
+// # What is checked
+//
+// Both ways of adding a generator (#63), against the same expected tree:
+//
+//   - with-generator, taking the executable out of a generator image — this is
+//     `COPY --from`, and it is the documented adopter path.
+//   - with-generator-executable, taking the same executable as a file straight
+//     from the build. This is the generator author's path, before anything of
+//     theirs is published, and it is the one nobody would notice breaking.
+//
+// Requiring both to produce the committed example is what makes them
+// interchangeable rather than merely both present.
+//
+// Then the two functions that are not part of that pair, because a check that
+// exercised only what it needed would leave the rest of the module's surface
+// covered by nothing: image, whose plugin directory has to hold the generator
+// the CLI resolves on PATH, and run, the escape hatch, asked the one question
+// docs/cli/SPEC.md requires to succeed against nothing at all.
+//
+// Both compositions start from the base image this pipeline built, which carries
+// the CLI and no generator — so a generation that succeeded did so with the
+// generator these calls installed and not with something that was lying around
+// in the image.
+//
+// Every call is checked and every failure reported rather than stopping at the
+// first, because *it works from the image and not from the file* is the finding
+// rather than a detail, and each message names the module function that broke.
+//
+// # One platform
+//
+// The engine's own, rather than every published one. What varies per platform is
+// the executable, and ImageContract already builds and checks the image on each
+// of them; what this adds is that the module's calls compose into a working
+// image, which is not a property a second architecture can disagree about.
+//
+// +check
+// +cache="session"
+func (m *Cpybkc) CompanionModule(ctx context.Context) error {
+	platform, err := dag.DefaultPlatform(ctx)
+	if err != nil {
+		return fmt.Errorf("resolving the engine's platform, which is the one this check runs on: %w", err)
+	}
+
+	committed := m.Source.Directory(companionExampleDir)
+
+	fromImage := m.companion(platform).WithGenerator(ownGenerator, dagger.CompanionWithGeneratorOpts{
+		Image: m.generatorImage(platform),
+	})
+	fromExecutable := m.companion(platform).WithGeneratorExecutable(ownGenerator, m.generatorBinary(platform))
+
+	var errs []error
+
+	if err := m.diffTrees(ctx, committed, fromImage.Generate(committed), "/companion-module/image"); err != nil {
+		errs = append(errs, fmt.Errorf(
+			"with-generator composed the generator out of an image and generate did not reproduce the committed %s/: %w",
+			companionExampleDir, err))
+	}
+
+	if err := m.diffTrees(ctx, committed, fromExecutable.Generate(committed), "/companion-module/executable"); err != nil {
+		errs = append(errs, fmt.Errorf(
+			"with-generator-executable composed the generator out of a file and generate did not reproduce the "+
+				"committed %s/: %w",
+			companionExampleDir, err))
+	}
+
+	if err := m.checkComposedImage(ctx, fromImage.Image()); err != nil {
+		errs = append(errs, fmt.Errorf("image handed back a container the CLI could not find the generator in: %w", err))
+	}
+
+	// --version through the escape hatch, with no project: it is the one
+	// invocation docs/cli/SPEC.md requires to succeed touching nothing, so a
+	// failure here is run failing to reach the CLI rather than anything about a
+	// manifest. The line's shape is checked by the same function Build and the
+	// image contract use, because what "this is cpybkc answering" means is a
+	// property of the line and not of which container it came out of.
+	line, err := fromImage.Run([]string{"--version"}).Stdout(ctx)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("run did not reach the CLI in the composed image: %w", err))
+	} else if err := checkVersionLine(line); err != nil {
+		errs = append(errs, fmt.Errorf("run reached the CLI in the composed image and %w", err))
+	}
+
+	return errors.Join(errs...)
+}
+
+// companion is the module bound to the image this pipeline built, and it is the
+// one construction of it: both compositions come through here, so there is no
+// arrangement in which one of them is driving a released image and the other the
+// change.
+//
+// The container is passed rather than the coordinates because that is what pins
+// bytes — --version and --repository name a tag, and a tag is not a build. See
+// [neverPulledRepository] for what the coordinates are set to instead and why
+// they are set at all.
+func (m *Cpybkc) companion(platform dagger.Platform) *dagger.Companion {
+	return dag.Companion(dagger.CompanionOpts{
+		Image:      m.image(platform),
+		Repository: neverPulledRepository,
+	})
+}
+
+// generatorBinary builds cpybkc's own generator for one platform.
+//
+// It is image.go's binary with a different package and name, and it carries the
+// same CGO and -trimpath switches for the same reasons: what a generator image
+// ships has to start in a scratch image, which is the requirement
+// docs/container/SPEC.md states as `CGO_ENABLED=0` and leaves to whoever builds
+// the generator.
+func (m *Cpybkc) generatorBinary(platform dagger.Platform) *dagger.File {
+	return dag.Go().
+		Build(m.Source, dagger.GoBuildOpts{
+			Pkg:          generatorPackage,
+			ArtifactName: generatorExecutable,
+			Trimpath:     true,
+			DisableCgo:   true,
+			Platform:     string(platform),
+		}).
+		File(generatorExecutable)
+}
+
+// generatorImage is a generator image for cpybkc's own generator: the base image
+// this pipeline built, plus one executable in the plugin directory.
+//
+// That is the shape docs/container/SPEC.md fixes for a generator image — "an
+// image built FROM the base, adding one executable at the path this section
+// names and changing nothing else" — so with-generator is handed the thing an
+// adopter's generator image actually is rather than a container assembled to
+// suit this check. Deriving it from the same base also settles the platform:
+// with-generator refuses a generator image built for another one, and a
+// container that came from image() cannot be for another one.
+//
+// It is not published and never will be. What #48 ships is a release's business;
+// this is one file in a container that exists for the length of one call.
+func (m *Cpybkc) generatorImage(platform dagger.Platform) *dagger.Container {
+	return m.image(platform).WithFile(
+		pluginDir+"/"+generatorExecutable,
+		m.generatorBinary(platform),
+		dagger.ContainerWithFileOpts{Owner: imageUser, Permissions: executableMode},
+	)
+}
+
+// checkComposedImage requires the composed image's plugin directory to hold the
+// CLI and the generator, and nothing else.
+//
+// The directory is listed rather than the image run, because the image is a
+// scratch one: there is no shell and no `ls` in it, and the only thing that can
+// be executed is cpybkc itself. Reading the directory out of the container
+// answers the question anyway, and it answers it about the exact path the CLI
+// resolves a generator on — PATH in this image is the plugin directory and
+// nothing more.
+//
+// Exhaustive rather than a containment check. A composition that installed the
+// generator twice under two names, or left something else behind, is a
+// with-generator this pipeline should report rather than a detail it tolerates.
+func (m *Cpybkc) checkComposedImage(ctx context.Context, composed *dagger.Container) error {
+	entries, err := composed.Directory(pluginDir).Entries(ctx)
+	if err != nil {
+		return fmt.Errorf("listing %s in the composed image: %w", pluginDir, err)
+	}
+
+	want := []string{cliBinary, generatorExecutable}
+	slices.Sort(want)
+	slices.Sort(entries)
+
+	if !slices.Equal(entries, want) {
+		return fmt.Errorf("%s holds %v and the composition put %v there: the CLI resolves a generator on PATH, "+
+			"and PATH in this image is that directory alone", pluginDir, entries, want)
+	}
+
+	return nil
+}
+
+// diffTrees requires two directory trees to be identical and reports how they
+// differ when they are not.
+//
+// A real diff rather than a walk comparing file contents, because the failure
+// this reports is one somebody has to act on: which file, which line, and what
+// changed is the whole of the diagnostic, and a boolean would send them to
+// regenerate the example locally to find out. --text because every file cpybkc
+// writes is text, and a diff that said only "binary files differ" would report
+// the failure without reporting what it was.
+//
+// The trees are mounted under one directory named by the caller, so a run with
+// more than one comparison in it says which comparison the paths in the output
+// belong to.
+func (m *Cpybkc) diffTrees(ctx context.Context, want, got *dagger.Directory, at string) error {
+	wantAt, gotAt := at+"/want", at+"/got"
+
+	_, err := dag.Go().
+		Container(m.Source).
+		WithMountedDirectory(wantAt, want).
+		WithMountedDirectory(gotAt, got).
+		WithExec([]string{"diff", "--recursive", "--unified", "--text", wantAt, gotAt}).
+		Sync(ctx)
+
+	return err
 }

--- a/.dagger/dagger.gen.go
+++ b/.dagger/dagger.gen.go
@@ -321,6 +321,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Cpybkc).CompanionCi(&parent, ctx)
+		case "CompanionModule":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Cpybkc).CompanionModule(&parent, ctx)
 		case "EngineLock":
 			var parent Cpybkc
 			err = json.Unmarshal(parentJSON, &parent)

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -234,12 +234,13 @@ func New(
 // build of the three artifacts a release publishes, the published base image on
 // every platform it ships for, the worked examples docs/container/SPEC.md hands
 // an adopter, the attestations a release attaches to what it publishes, the tag
-// scheme and release notes a release is published under, and the companion
-// module's coverage of the CLI's flags. This is the single entrypoint — CI is
+// scheme and release notes a release is published under, the companion
+// module's coverage of the CLI's flags, and that module's own functions driven
+// over the image this run just built. This is the single entrypoint — CI is
 // one `dagger call ci` and stays one, because a workflow step that reran any of
 // these stages would be a second definition of them.
 //
-// The fifteen parts run concurrently and all are reported, for the reason the
+// The sixteen parts run concurrently and all are reported, for the reason the
 // standard runs its own four that way: waiting on a Go stage to learn that the
 // schema is unlintable, or the reverse, is a second push to find out about the
 // second failure.
@@ -248,10 +249,10 @@ func New(
 // +cache="session"
 func (m *Cpybkc) Ci(ctx context.Context) error {
 	var goErr, irErr, protoErr, buildErr, artifactErr, layoutErr, imageErr, exampleErr, attestErr error
-	var tagErr, notesErr, companionErr, engineErr, surfaceErr, pipelineErr error
+	var tagErr, notesErr, companionErr, engineErr, surfaceErr, moduleErr, pipelineErr error
 
 	var wg sync.WaitGroup
-	wg.Add(15)
+	wg.Add(16)
 
 	go func() {
 		defer wg.Done()
@@ -330,13 +331,18 @@ func (m *Cpybkc) Ci(ctx context.Context) error {
 
 	go func() {
 		defer wg.Done()
+		moduleErr = m.CompanionModule(ctx)
+	}()
+
+	go func() {
+		defer wg.Done()
 		pipelineErr = m.PipelineCi(ctx)
 	}()
 
 	wg.Wait()
 
 	return errors.Join(goErr, irErr, protoErr, buildErr, artifactErr, layoutErr, imageErr, exampleErr, attestErr,
-		tagErr, notesErr, companionErr, engineErr, surfaceErr, pipelineErr)
+		tagErr, notesErr, companionErr, engineErr, surfaceErr, moduleErr, pipelineErr)
 }
 
 // IrCi runs the same standard pipeline over irpb/, the published IR module.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -605,10 +605,10 @@ imports no Dagger is what turns the published default
 `ghcr.io/zaba505/cpybkc:v0` into a string a test pins rather than a string a
 comment asserts.
 
-This is not #64. That story drives the module's *functions* over the image
-built in the same pull request, which needs an engine and a built image; this
-is the ordinary Go pipeline over the module's source, and the two catch
-different things.
+This is not [`companion-module`](#the-modules-own-calls-are-checked-against-the-image-this-pull-request-built).
+That one drives the module's *functions* over the image built in the same pull
+request, which needs an engine and a built image; this is the ordinary Go
+pipeline over the module's source, and the two catch different things.
 
 Both modules' generated code is committed, so a change to either is a
 `dagger develop` in that module and the generated files in the same commit —
@@ -777,6 +777,72 @@ published as variants of one index, and the loop belongs to the caller because
 the index does: which platforms a derived image serves is a property of who will
 run it, and a module that decided it would be publishing this project's platform
 table as somebody else's. The module comment carries the loop.
+
+### The module's own calls are checked against the image this pull request built
+
+Everything above reads the module. `companion-ci` runs `go test` over its
+source, `engine-lock` reads its `dagger.json` and `cli-surface` reads its
+function *names* — and none of the three makes a call, so a module whose calls
+no longer compose into a working image would fail none of them. `dagger call
+companion-module` is the one place `dagger call -m daggerverse/cpybkc …`
+actually happens, and it is in `ci` (#64):
+
+```sh
+dagger call companion-module
+```
+
+That matters more than it would for a contract, because the module is a
+*convenience* over the [base-image contract](docs/container/SPEC.md) rather than
+an interface of its own. A caller reaches for it precisely because they did not
+want to learn the contract underneath, so a convenience that has quietly stopped
+working lands the failure on somebody with no reason to know where to look.
+
+**It drives the image this run built, never a published one.** The module's
+defaults pull `ghcr.io/zaba505/cpybkc:v0`, which is a *released* image: a check
+that used them would be checking the last release and would keep passing through
+a pull request that broke both the module and the image it drives. So the base
+image [`image.go`](.dagger/image.go) just built is passed through the same
+`--image` argument a caller uses to try an unreleased cpybkc, and the generator
+is `cmd/cpybkc-gen-go` built from the tree under test. That is also the only
+reason the module takes `--image` at all, which is worth knowing before anybody
+removes it as unused — it is used here, on every pull request, and the [local
+dependency edge](#one-engineversion-held-by-a-dependency-edge-and-one-check) is
+what makes it reachable.
+
+*Never* is enforced rather than intended. The module is constructed with
+`--repository` pointing at `cpybkc.invalid/never-pulled` — `.invalid` is
+reserved by RFC 2606 and resolves nowhere — so a `with-generator` call added
+later that forgot to pass an image fails naming that host, instead of pulling
+the *released* generator, generating with it and passing. That is the failure
+worth designing against: it would look exactly like a green run while checking
+the last release instead of the change.
+
+**The assertion is the committed example, byte for byte.** The module composes a
+generator, runs `generate` over [`example/`](example/) and has to reproduce that
+tree exactly — the same golden tree
+[`example/regenerate_test.go`](example/regenerate_test.go) holds the CLI to. A
+smoke test saying the calls *ran* would pass on a module that composed an image
+which generated the wrong thing.
+
+**Both compositions, against that same tree.** `with-generator` from a generator
+image and `with-generator-executable` from a file are required to produce it,
+which is what makes the two
+[interchangeable](#composing-a-generator-is-copy---from-split-across-two-methods)
+rather than merely both present (#63). Both start from the base image, which
+carries the CLI and **no** generator — so a generation that succeeded did so with
+the generator these calls installed and not with something lying around in the
+image. `image` and `run` are checked too, since a check that exercised only what
+it needed would leave the rest of the module's surface covered by nothing.
+
+Every call is checked and every failure reported rather than stopping at the
+first, and each message names the module function that broke: *it works from the
+image and not from the file* is the finding, not a detail.
+
+It runs on the **engine's own platform only**. What varies per platform is the
+executable, and `image-contract` already builds and checks the image on each
+platform this project publishes for; what this adds is that the module's calls
+compose into a working image, which is not a property a second architecture can
+disagree about.
 
 ### The pipeline module is checked like any other Go module here
 


### PR DESCRIPTION
Closes #64

`CompanionModule` is the pipeline's fourth opinion about `daggerverse/cpybkc`, and the only one that makes a call. `CompanionCi` reads the module's source, `EngineLock` reads its `dagger.json` and `CliSurface` reads its function *names* — so a module whose calls no longer compose into a working image would fail none of them.

It composes `cpybkc-gen-go` into the base image this run just built, runs `generate` over `example/` both ways, and requires the committed tree byte for byte.

## Acceptance criteria

- [x] **A submodule exercises the module's functions, following the daggerverse layout** — landed as a check in the root pipeline (`.dagger/companion.go`) rather than as a `daggerverse/cpybkc/tests/` module. See *Judgment calls* below; every one of the module's six functions — `New`, `WithGenerator`, `WithGeneratorExecutable`, `Generate`, `Image`, `Run` — is now called.
- [x] **Root CI builds the image and injects it via `from`** — `dag.Companion(dagger.CompanionOpts{Image: m.image(platform)})`. The constructor argument landed in #171 as `--image` rather than `--from`; it is the same argument this story predicted, and the module's own documentation already says it exists for this.
- [x] **PR CI never pulls the published image** — and it is *enforced*, not intended. The module is constructed with `--repository` pointing at `cpybkc.invalid/never-pulled` (`.invalid` is RFC 2606 reserved and resolves nowhere), so a `with-generator` call added later that forgot to pass an image fails naming that host instead of silently pulling the released generator and passing.
- [x] **Test failures name the function under test** — every call is checked and every failure reported rather than stopping at the first, and each message names the module function: `with-generator …`, `with-generator-executable …`, `image handed back a container the CLI could not find the generator in`, `run did not reach the CLI in the composed image`.

## What is checked

The four choices the story called out from [avroc#170](https://github.com/z5labs/avroc/pull/170), taken whole:

- **The assertion is the committed example, byte for byte** — `diffTrees` against `example/`, the same golden tree `example/regenerate_test.go` holds the CLI to. A smoke test saying the calls *ran* would pass on a module that composed an image which generated the wrong thing.
- **Both compositions, against that same tree** — `with-generator` from a generator image and `with-generator-executable` from a file. Requiring both to produce it is what makes them interchangeable rather than merely both present (#63).
- **Both start from the base image this pipeline built**, which carries the CLI and no generator — so a generation that succeeded did so with the generator these calls installed, not with something lying around in the image.
- **Every composition reported, not the first failure** — `errors.Join`, because *it works from the image and not from the file* is the finding.

Beyond those, `image` and `run` are checked too, since a check that exercised only what it needed would leave the rest of the module's surface covered by nothing. `image`'s plugin directory is listed exhaustively (the image is scratch — there is no `ls` in it to run), and `run` is asked `--version`, the one invocation `docs/cli/SPEC.md` requires to succeed touching nothing, validated by the same `checkVersionLine` `Build` and the image contract use.

One platform, the engine's own: what varies per platform is the executable, and `ImageContract` already covers each published platform. What this adds is that the module's calls compose, which is not a property a second architecture can disagree about.

## Judgment calls

**The check is a root-module function, not a `daggerverse/cpybkc/tests/` module.** The criterion says "a `tests` submodule … following the daggerverse layout", and this does not create one. Three things decided it, and it is the one deviation in this PR worth a reviewer's attention:

- The issue's own *Related Issues* section names the mechanism as the root module — "the root module declares the companion as a **local** dependency in `dagger.json` … then constructs it with `dagger.CompanionOpts{Image: m.image(platform)}`" — and its Description says "the root module can build and inject it".
- `CONTRIBUTING.md` already wrote this down before the story was worked: *"The same edge is how the pipeline gets to drive the module over the image built in the pull request rather than the last published release (#64)"*, and, of `CompanionCi`, *"This is not #64. That story drives the module's functions over the image built in the same pull request"*. Both sentences are updated by this PR to point at the new check.
- A directory under `daggerverse/` is a permanent published module ref by this repository's own rule (*The directory name is the public ref, so it is chosen once*). A `tests` module there would be public API forever, for a check nobody outside would call, and it would need a third `engineVersion` kept in lockstep and a third `GoLib` invocation. The root module costs none of that and the criterion's substance — the module's functions exercised against the image built here — is met either way.

**The generator image is the base image plus one executable.** `WithGenerator` needs a container to copy out of, and this project publishes no `cpybkc-gen-go` image yet. Building one FROM the base is exactly the shape `docs/container/SPEC.md` fixes for a generator image, so `with-generator` is handed what an adopter's generator image actually is rather than a container assembled to suit the check — and, since it came from `image()`, its platform cannot disagree with the base being composed into.

**`checkComposedImage` is exhaustive rather than a containment check.** A composition that installed the generator twice under two names, or left something else in the plugin directory, is a `with-generator` this pipeline should report. PATH in the image is that directory alone.

No public API changed: `.dagger/` is published for nobody, and `daggerverse/cpybkc/` is untouched.

## Verified

- `dagger call ci` — green (16 parts, `companion-module` among them).
- Proved the check can fail: perturbing a generated file in `example/ledger/` made **both** compositions fail with a real unified diff naming the file and line, each under its own mount path (`/companion-module/image`, `/companion-module/executable`). Reverted.
- `dagger develop` run and `.dagger/dagger.gen.go` committed alongside, per *After changing the module*.

One note for the record: `dagger call ci` first failed with `resolve result …: missing shared result`, a stale engine session rather than anything in the tree. Restarting the local engine cleared it; nothing was edited to get past it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)