### PR TITLE
story(cli): the scratch space and each invocation's descriptor go in the output tree, not under TMPDIR

### DIFF
--- a/.dagger/image.go
+++ b/.dagger/image.go
@@ -103,19 +103,6 @@ const (
 	// dirMode is the mode of every directory in the image.
 	dirMode = 0o755
 
-	// tmpDir is a writable temporary directory, and it is the one thing in the
-	// image that docs/container/SPEC.md deliberately does not cover — it lists
-	// the directory under implementation detail rather than as a guarantee.
-	//
-	// It is here because cpybkc writes each invocation's descriptor into a
-	// directory it creates under os.TempDir, and hands each generator an output
-	// directory it created the same way, so a scratch image without one fails
-	// every generation with an error naming /tmp. tmpDirMode is 1777 —
-	// root-owned, world-writable and sticky — which is the ordinary arrangement
-	// and the one that keeps working when a caller overrides the UID.
-	tmpDir     = "/tmp"
-	tmpDirMode = 0o1777
-
 	// irDir is where the IR schema ships, and the two paths under it are the
 	// ones docs/container/SPEC.md fixes for a consumer (#57).
 	//
@@ -167,8 +154,9 @@ func imagePlatforms() []dagger.Platform {
 // document makes is made here: the CLI in /usr/local/bin with that directory on
 // PATH, the CLI as the entrypoint with an empty Cmd, UID and GID 65532 owning
 // the plugin directory and running the process, the IR schema under
-// /usr/local/share/cpybkc in both published forms, a writable temporary
-// directory, and nothing else in the filesystem at all.
+// /usr/local/share/cpybkc in both published forms, and nothing else in the
+// filesystem at all — not even a writable temporary directory, which cpybkc
+// stopped needing in #184.
 //
 // No generator is in it, and that absence is a promise rather than an omission:
 // cpybkc-gen-go (#48-#53) reaches a user the way a stranger's generator does, as
@@ -362,10 +350,12 @@ func (m *Cpybkc) image(platform dagger.Platform) *dagger.Container {
 		// rewrite them is what makes "MUST NOT modify it in place" true of the
 		// filesystem rather than only of the document.
 		WithDirectory(irDir, m.irDirectory()).
-		// A temporary directory, because cpybkc writes each invocation's
-		// descriptor into one. Not owned by the image's user: 1777 is what makes
-		// it usable by whichever UID the container is actually running as.
-		WithDirectory("/", m.tmpDirectory()).
+		// And nothing else. In particular no writable temporary directory:
+		// cpybkc makes its scratch space and each invocation's descriptor
+		// directory inside the project it was pointed at (#184), so a run needs
+		// nothing writable outside the tree the caller mounted, and a scratch
+		// image with no /tmp in it generates exactly as well as one with.
+		//
 		// PATH is set outright rather than appended to, because a scratch image
 		// has no PATH to append to. Only the guarantee that it contains the
 		// plugin directory is covered; the rest of the value is not.
@@ -397,29 +387,6 @@ func (m *Cpybkc) binary(platform dagger.Platform) *dagger.File {
 			Platform:     string(platform),
 		}).
 		File(cliBinary)
-}
-
-// tmpDirectory is a directory holding nothing but `tmp`, with mode 1777, for
-// grafting onto the image's root.
-//
-// It is staged by a real mkdir in a container that has one rather than by
-// WithDirectory's permissions argument, because that argument sets the mode of
-// the files written *into* a directory and not the mode of the directory
-// itself — which would leave /tmp root-owned at 0755, and every generation
-// failing with `permission denied` the moment the process is not root. That is
-// a fault the filesystem listing catches and no configuration check would.
-//
-// The toolchain container is the one dag.Go() already builds from this
-// repository's go.mod, rather than an image of this file's choosing: it is
-// pulled by every other stage anyway, so staging one directory costs nothing
-// beyond the exec.
-func (m *Cpybkc) tmpDirectory() *dagger.Directory {
-	const staging = "/staging"
-
-	return dag.Go().
-		Container(m.Source).
-		WithExec([]string{"install", "-d", "-m", "1777", staging + tmpDir}).
-		Directory(staging)
 }
 
 // irDirectory is the contents of irDir: the FileDescriptorSet beside an include
@@ -768,17 +735,11 @@ func buildSettings(out string) map[string]string {
 // derived image may copy out and must not modify, and 0644 owned by root is
 // that sentence enforced rather than asserted.
 //
-// Listing /tmp here does not make it a covered guarantee, and the two are not
-// the same kind of statement. Covered is about what a *consumer* may depend on,
-// and docs/container/SPEC.md keeps the temporary directory out of that
-// deliberately: its path and its mode may change in a patch release. This map
-// is what *this repository* expects its own build to produce, and it has to be
-// exhaustive or the promise it exists to check — scratch plus the files that
-// document names, so no shell, no libc and no package manager — degrades into a
-// spot check that a busybox under another name would pass. A patch release that
-// moved the temporary directory would edit this line in the same commit, which
-// is the difference between changing an implementation detail and changing it
-// without noticing.
+// There is no writable temporary directory in it, and that is the point of the
+// listing being exhaustive: cpybkc makes its scratch space and each
+// invocation's descriptor directory inside the project it was pointed at
+// (#184), so nothing in the image needs one, and a stage that put one back
+// would fail here rather than ship.
 // protos is every schema source the image carries, relative to the include root
 // — shippedProtos' answer, read out of the tree rather than named here.
 func baseImageContents(protos []string) map[string]imageEntry {
@@ -789,7 +750,6 @@ func baseImageContents(protos []string) map[string]imageEntry {
 	}
 
 	contents[pluginDir] = imageEntry{kindDir, imageUID, imageGID, dirMode}
-	contents[tmpDir] = imageEntry{kindDir, 0, 0, tmpDirMode}
 	contents[irDescriptorSetPath] = imageEntry{kindFile, 0, 0, dataMode}
 
 	for _, name := range baseImageExecutables() {

--- a/.dagger/worked_example.go
+++ b/.dagger/worked_example.go
@@ -245,17 +245,30 @@ func (m *Cpybkc) workedExampleAt(ctx context.Context, check workedExampleCheck) 
 //     user, which is the invocation docs/container/SPEC.md recommends whenever
 //     output lands in a bind mount, and a shipped file readable only by 65532
 //     would fail here rather than in an adopter's pipeline.
-//   - The output directory works. It is created under the image's temporary
-//     directory, owned by the running user, which is the arrangement cpybkc
-//     itself makes for a generator.
+//   - The output directory works. It is created by this check, at a path the
+//     image does not carry, owned by the running user. That the *check* has to
+//     provide it is the point rather than a detail: the image has no writable
+//     directory of its own, because cpybkc needs none — its scratch space and
+//     each invocation's descriptor directory are made inside the project it was
+//     pointed at (#184), which here is nothing but a place to run a generator by
+//     hand. A generator invoked the ordinary way is handed a directory cpybkc
+//     already made, in a tree the caller already mounted.
 func (m *Cpybkc) checkReadsTheShippedIr(
 	ctx context.Context,
 	e *workedExample,
 	derived *dagger.Container,
 ) error {
+	// A directory this check adds to the container, and the only writable one
+	// in it. Not /tmp: the image has none since #184, and reintroducing one
+	// here — even only for the exec — would be this check quietly restoring the
+	// thing the story deleted, so an image that had lost it would still pass.
+	// Not the plugin directory either, which the document's own COPY owns, and
+	// not a mounted source directory, which would make the check depend on the
+	// host's filesystem instead of on the image.
 	const (
-		descriptor = tmpDir + "/descriptor.binpb"
-		out        = tmpDir + "/out"
+		workspace  = "/example"
+		descriptor = workspace + "/descriptor.binpb"
+		out        = workspace + "/out"
 	)
 
 	generator := e.copies[0].operands[1]

--- a/cmd/cpybkc/main.go
+++ b/cmd/cpybkc/main.go
@@ -217,9 +217,9 @@ func perform(ctx context.Context, inv invocation, stdout io.Writer, log *slog.Lo
 		return emit.Write(inv.emitIR, stdout, run.Descriptor, inv.format())
 	}
 
-	// docs/cli/SPEC.md: PATH is one of the two environment variables a run
-	// reads, and it is read here rather than inside the search so that the
-	// search stays a function of its arguments.
+	// docs/cli/SPEC.md: PATH is the one environment variable a run reads, and
+	// it is read here rather than inside the search so that the search stays a
+	// function of its arguments.
 	generators, err := run.Generators(os.Getenv("PATH"))
 	if err != nil {
 		return err
@@ -233,11 +233,25 @@ func perform(ctx context.Context, inv invocation, stdout io.Writer, log *slog.Lo
 		// the root is prunes nothing, and a wrong guess is a run that deletes
 		// something a person wrote.
 		Root: run.Dir,
-		Log:  log,
+
+		// And it is where the run's scratch space is made, which is the whole
+		// of a run's answer to that question (#184): PATH is now the only
+		// environment variable a run reads, and TMPDIR is not consulted by
+		// cpybkc or by anything it calls. A run needs nothing of its host but
+		// the project it was pointed at — which is what lets the published
+		// image be scratch plus the files it names, with no writable /tmp for a
+		// deployment to have to supply.
+		//
+		// The project's root rather than a directory beside it because the
+		// project is the one tree a run is already writing to and already had
+		// to be able to write to. The cost is a directory a person and their
+		// `git status` can see if a run is killed outright, where the removal
+		// never happens; it is named for what left it, and it is nothing the
+		// record or pruning will ever touch, since neither walks the tree.
+		Scratch: run.Dir,
+
+		Log: log,
 	}
 
-	// TMPDIR is the other variable a run reads, and it is left to the standard
-	// library to read: os.MkdirTemp already honours it, and naming it here
-	// would be a second answer to where a run's scratch space goes.
 	return cancelled(ctx, runner.Run(ctx, run.Descriptor, generators))
 }

--- a/cmd/cpybkc/relay_test.go
+++ b/cmd/cpybkc/relay_test.go
@@ -70,8 +70,7 @@ func runGenerator(t *testing.T, body string) (stderr, executable string, err err
 	var out bytes.Buffer
 
 	runner := &plugin.Runner{
-		Log:     logger(&out),
-		TempDir: t.TempDir(),
+		Log: logger(&out),
 		// PATH is stated rather than inherited because Env is either the whole
 		// environment or nothing, and a shell script needs the commands it
 		// calls.

--- a/docs/cli/SPEC.md
+++ b/docs/cli/SPEC.md
@@ -48,7 +48,7 @@ Out of scope, with reasons, in [Out of Scope](#out-of-scope).
   made.
   <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html>
 - **POSIX.1-2024 Base Definitions, chapter 8**, *Environment Variables* — the
-  normative definition of the two variables a run reads, `PATH` and `TMPDIR`.
+  normative definition of `PATH`, the one variable a run reads.
   [The environment](#the-environment) is a statement about that list being
   closed, and it is stated in the terms this chapter already defines.
   <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap08.html>
@@ -613,14 +613,19 @@ of status `1`.
 
 ## The environment
 
-cpybkc reads two environment variables and no others:
+cpybkc reads one environment variable and no others:
 
 - **`PATH`**, to resolve `cpybkc-gen-<name>` for each generator the manifest
   names (#41). Its rules are the plugin contract's, including that an empty
   element is not the working directory.
-- **`TMPDIR`**, as the system's temporary directory, where a run's scratch
-  space is created (#43). Where that space is has no effect on what a run
-  produces.
+
+`TMPDIR` is **not** read, and neither is any other name for a system temporary
+directory (#184). A run's scratch space — and the per-invocation directory the
+descriptor is written into — is created inside the project cpybkc was pointed
+at, so a run needs nothing writable outside the tree it is already writing.
+Both are removed as the work that made them finishes, whatever the exit status;
+a run killed outright leaves them, named so that what left them is plain. Where
+that space is has no effect on what a run produces.
 
 cpybkc **MUST NOT** define an environment variable of its own — there is no
 `CPYBKC_*` — and **MUST NOT** take any part of a run's configuration from the

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -389,9 +389,14 @@ descriptor](../plugin/SPEC.md#the-descriptors-location-and-lifetime) and [each
 generator's empty output directory](../plugin/SPEC.md#the-output-directory)
 inside the project it was pointed at, so everything a run writes is in the tree
 the caller already mounted and already made writable. There is no `TMPDIR` to
-set and no `/tmp` to mount: every `docker run` this document prints is the
-whole of the arrangement, and each of them keeps working with a read-only root
-filesystem and under whatever UID the caller chooses.
+set and no `/tmp` to mount, so the `docker run` invocations this document
+prints are the whole of the arrangement, whatever UID they run as.
+
+Its **absence** is not covered either, and neither is anything about it. A
+generator that wants a temporary directory of its own is a derived image's
+business exactly as it was before: `COPY` one in, or have the deployment mount
+one. What changed is only that the base no longer needs one in order to
+generate.
 
 Keeping the shell out is the same decision as having no plugin registry: the
 image's contents are exactly the executables somebody deliberately put there,

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -382,17 +382,16 @@ the hard way by somebody:
   arguments, or against an image built `FROM` this one with a busybox copied in
   for the purpose.
 
-One directory in the image holds no file and is worth naming anyway: there is a
-writable temporary directory, because cpybkc writes [each invocation's
-descriptor](../plugin/SPEC.md#the-descriptors-location-and-lifetime) into a
-directory it creates under one, and hands each generator [an empty output
-directory](../plugin/SPEC.md#the-output-directory) it created the same way. It
-is **not covered** — its path, its mode and its existence are implementation
-detail like everything else in the filesystem that is not named above, and a
-derived image writing into it by path would be depending on something that may
-change in a patch release. It is mentioned only so that "`scratch` plus the
-files named above" is not read as a promise that the image cannot write
-anywhere at all.
+One thing the image does not have is worth naming anyway: there is no writable
+temporary directory in it, and none is needed. cpybkc creates [each
+invocation's
+descriptor](../plugin/SPEC.md#the-descriptors-location-and-lifetime) and [each
+generator's empty output directory](../plugin/SPEC.md#the-output-directory)
+inside the project it was pointed at, so everything a run writes is in the tree
+the caller already mounted and already made writable. There is no `TMPDIR` to
+set and no `/tmp` to mount: every `docker run` this document prints is the
+whole of the arrangement, and each of them keeps working with a read-only root
+filesystem and under whatever UID the caller chooses.
 
 Keeping the shell out is the same decision as having no plugin registry: the
 image's contents are exactly the executables somebody deliberately put there,
@@ -1058,8 +1057,7 @@ change to any of them is a breaking change:
 depending on something that may change in a patch release, with no notice:
 
 - The base image, and everything in the filesystem other than what is named
-  above — its existence, its contents and its paths, including the writable
-  temporary directory.
+  above — its existence, its contents and its paths.
 - The path of the `cpybkc` executable itself, and the literal value of
   `Entrypoint`.
 - The value of `PATH` beyond its containing `/usr/local/bin`, and the value of

--- a/internal/conformance/gorunner/gorunner.go
+++ b/internal/conformance/gorunner/gorunner.go
@@ -179,6 +179,13 @@ func (r *Runner) scratch(entry *conformance.Entry) (string, error) {
 // performs — the vector, the absolute paths, the descriptor written for one
 // invocation and removed with it — instead of a second arrangement that happens
 // to work.
+//
+// That is also why nothing here has to say where the descriptor goes (#184).
+// The zero [github.com/Zaba505/cpybkc/internal/plugin.Runner] puts it beside
+// the directory the invocation writes into, which is [Runner.scratch]'s tree
+// under the required [Runner.Root] — so the corpus gets the same property
+// cpybkc's own runs get, with no special case for it, and this package's
+// os.MkdirTemp is a parent it was given rather than one the machine named.
 func (r *Runner) generate(ctx context.Context, entry *conformance.Entry, out string) error {
 	runner := &plugin.Runner{}
 

--- a/internal/generate/determinism_test.go
+++ b/internal/generate/determinism_test.go
@@ -77,11 +77,13 @@ const emitsItsHostname = `echo "$HOSTNAME" > "$4/host"`
 // invocation's descriptor directory goes. Those are the two absolute paths this
 // package chooses, so they are what the comparison has to see differ.
 //
-// TMPDIR is still varied, and it is varied at a directory that does not exist.
-// Nothing reads it any more — that is the claim — and a claim is worth a check:
-// were either path put back on it, the run would fail outright on a parent that
-// is not there, rather than quietly passing because two runs agreed about a
-// directory neither of them was looking at.
+// TMPDIR is still varied, and it is varied at a path that is not a directory at
+// all. Nothing reads it any more — that is the claim — and a claim is worth a
+// check: a generator that took a path from it would fail outright rather than
+// quietly passing because two runs agreed about a directory neither of them was
+// looking at. What cpybkc itself would do with TMPDIR is the other half, and it
+// is scratch_test.go's TestARunNeedsNoTemporaryDirectoryOfTheSystems, which
+// states the variable in this process rather than in a generator's environment.
 //
 // Environment-visible throughout, which is the limit of what a run in this
 // process can vary; see the note at the top of this file for what covers the
@@ -109,11 +111,11 @@ func machine(t *testing.T, n int) *Runner {
 				"LOGNAME=person-" + id,
 				"HOME=/home/person-" + id,
 				"PWD=" + t.TempDir(),
-				// A directory that is not there, on purpose: see the note
-				// above. Nothing in cpybkc reads TMPDIR since #184, and a run
-				// that started reading it again would fail here rather than
-				// pass.
-				"TMPDIR=" + filepath.Join(t.TempDir(), "no-temporary-directory-"+id),
+				// Not a directory, on purpose: see the note above. The
+				// generators below never look at it, and one that started to
+				// would fail rather than agree with its neighbour about a
+				// directory neither had.
+				"TMPDIR=" + notADirectory(t, id),
 				"TZ=" + []string{"UTC", "Australia/Eucla"}[n%2],
 				"LANG=" + []string{"C", "tr_TR.UTF-8"}[n%2],
 				"SOURCE_DATE_EPOCH=1700000000",
@@ -206,4 +208,20 @@ func TestTheComparisonWouldSeeARunThatVariedWithItsMachine(t *testing.T) {
 	if maps.Equal(generate(t, 0, emitsItsHostname), generate(t, 1, emitsItsHostname)) {
 		t.Error("two runs whose machines disagree produced one tree from a generator that embeds its hostname")
 	}
+}
+
+// notADirectory is a path with a regular file at it, for TMPDIR to name.
+//
+// A file rather than a missing path because os.MkdirAll creates what is missing
+// and would carry on; nothing creates a directory over a file, so every way of
+// asking for one under this fails with ENOTDIR.
+func notADirectory(t *testing.T, id string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "not-a-temporary-directory-"+id)
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+
+	return path
 }

--- a/internal/generate/determinism_test.go
+++ b/internal/generate/determinism_test.go
@@ -67,10 +67,21 @@ const emitsItsHostname = `echo "$HOSTNAME" > "$4/host"`
 
 // machine is a runner whose surroundings are stated rather than inherited, so
 // that two runs can genuinely disagree about all of them: the user, the host,
-// the home directory, the temporary directory, the time zone, the locale and
-// the working directory, each as a generator finds it in its environment, plus
-// the scratch space and the plugin's own path, which differ because every
-// directory here is the test's own.
+// the home directory, the time zone, the locale and the working directory, each
+// as a generator finds it in its environment, plus the plugin's own path, which
+// differs because every directory here is the test's own.
+//
+// The axis that used to be the temporary directory is now [Runner.Scratch], and
+// it varies with n through [generate]: since #184 that field is what decides
+// where a run's scratch space goes and where, one level inside it, each
+// invocation's descriptor directory goes. Those are the two absolute paths this
+// package chooses, so they are what the comparison has to see differ.
+//
+// TMPDIR is still varied, and it is varied at a directory that does not exist.
+// Nothing reads it any more — that is the claim — and a claim is worth a check:
+// were either path put back on it, the run would fail outright on a parent that
+// is not there, rather than quietly passing because two runs agreed about a
+// directory neither of them was looking at.
 //
 // Environment-visible throughout, which is the limit of what a run in this
 // process can vary; see the note at the top of this file for what covers the
@@ -87,8 +98,7 @@ func machine(t *testing.T, n int) *Runner {
 
 	return &Runner{
 		Plugins: &plugin.Runner{
-			Log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
-			TempDir: t.TempDir(),
+			Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
 			Env: []string{
 				// PATH so that a shell script can reach the commands it calls,
 				// and this process's because a stated one would be a claim
@@ -99,13 +109,16 @@ func machine(t *testing.T, n int) *Runner {
 				"LOGNAME=person-" + id,
 				"HOME=/home/person-" + id,
 				"PWD=" + t.TempDir(),
-				"TMPDIR=" + t.TempDir(),
+				// A directory that is not there, on purpose: see the note
+				// above. Nothing in cpybkc reads TMPDIR since #184, and a run
+				// that started reading it again would fail here rather than
+				// pass.
+				"TMPDIR=" + filepath.Join(t.TempDir(), "no-temporary-directory-"+id),
 				"TZ=" + []string{"UTC", "Australia/Eucla"}[n%2],
 				"LANG=" + []string{"C", "tr_TR.UTF-8"}[n%2],
 				"SOURCE_DATE_EPOCH=1700000000",
 			},
 		},
-		TempDir: t.TempDir(),
 	}
 }
 
@@ -118,6 +131,12 @@ func generate(t *testing.T, n int, bodies ...string) map[string]string {
 
 	r := machine(t, n)
 	r.Root = project
+
+	// The axis that used to be TMPDIR. The run's scratch space is made here,
+	// and each invocation's descriptor directory one level inside it, so this
+	// is the field the absolute paths cpybkc chooses now come from — and it is
+	// a different directory on every run.
+	r.Scratch = project
 
 	generators := make([]Generator, 0, len(bodies))
 

--- a/internal/generate/errors.go
+++ b/internal/generate/errors.go
@@ -30,7 +30,8 @@ import (
 // No generator ran, or one of them was about to and had nowhere to put its
 // output. It is separate from a generator that ran and failed because nothing
 // about it is the generator's doing: what failed is this process making a
-// directory, and the fix is a full disk or a TMPDIR that is not writable.
+// directory, and the fix is a full disk or a [Runner.Scratch] that is not
+// writable.
 type ScratchError struct {
 	// Name is the generator whose directory it was, or empty where what could
 	// not be made is the run's own scratch space.

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -7,6 +7,7 @@ package generate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -25,10 +26,17 @@ import (
 // It names cpybkc because the space is made under [Runner.Scratch] — for
 // cpybkc's own runs, the project's root — rather than in a temporary directory
 // the operating system would eventually sweep. A run killed outright, where the
-// deferred removal never happens, leaves this directory in somebody's tree and
-// in their `git status`, so the name has to say what left it and that it is
-// nobody's output.
-const scratchPattern = "cpybkc-scratch-"
+// deferred removal never happens, leaves this directory in somebody's tree, so
+// the name has to say what left it and that it is nobody's output.
+//
+// The leading dot is what keeps that survivor out of the way of everything
+// else. `go build ./...`, `go vet ./...` and the go tool generally skip a
+// directory whose name begins with a dot or an underscore, so a half-written
+// package left by a killed run is not a package the next build tries to
+// compile, and a build running in the tree while a run is in progress does not
+// see one either. It stays visible to `git status`, which is where a person
+// finds it.
+const scratchPattern = ".cpybkc-scratch-"
 
 // scratchMode is the mode a generator's own directory inside that space is
 // created with: this process's and nothing else's.
@@ -204,8 +212,14 @@ func (r *Runner) Run(ctx context.Context, d *irpb.Descriptor, generators []Gener
 	// with nowhere to make its scratch space is a caller that assembled a Runner
 	// it never finished, and there is no directory this package is entitled to
 	// pick on its behalf (#184).
+	//
+	// Worded for whoever reads it rather than for whoever wrote this file. It
+	// is not reachable from the command line — cmd/cpybkc passes the project's
+	// root, which is filepath.Dir of the manifest's path and so is never empty
+	// — so the only reader is a caller embedding this package, and what they
+	// need is what was not decided rather than which field spells it.
 	if r.Scratch == "" {
-		invalid.Fail(fmt.Errorf("this run has no directory to make its scratch space in; Scratch is required"))
+		invalid.Fail(errors.New("this run has nowhere to make its scratch space; it was given no project directory to make it in"))
 	}
 
 	for _, generator := range generators {

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -21,7 +21,14 @@ import (
 
 // scratchPattern is the prefix [os.MkdirTemp] builds the name of one run's
 // scratch space from.
-const scratchPattern = "cpybkc-out-"
+//
+// It names cpybkc because the space is made under [Runner.Scratch] — for
+// cpybkc's own runs, the project's root — rather than in a temporary directory
+// the operating system would eventually sweep. A run killed outright, where the
+// deferred removal never happens, leaves this directory in somebody's tree and
+// in their `git status`, so the name has to say what left it and that it is
+// nobody's output.
+const scratchPattern = "cpybkc-scratch-"
 
 // scratchMode is the mode a generator's own directory inside that space is
 // created with: this process's and nothing else's.
@@ -75,11 +82,11 @@ type Owner struct {
 
 // Runner runs the generators of one project.
 //
-// The zero value runs them: the generators are run by the zero
-// [github.com/Zaba505/cpybkc/internal/plugin.Runner], the scratch directories
-// are made wherever the system puts temporary files, everything merged is given
-// this process's umask applied to the usual creation modes, and ownership is
-// left as the merging process's.
+// [Runner.Scratch] is required and everything else has a zero value that runs:
+// the generators are run by the zero
+// [github.com/Zaba505/cpybkc/internal/plugin.Runner], everything merged is
+// given this process's umask applied to the usual creation modes, and ownership
+// is left as the merging process's.
 type Runner struct {
 	// Plugins runs the generator executables. Nil is the zero
 	// [github.com/Zaba505/cpybkc/internal/plugin.Runner], read at the moment of
@@ -87,13 +94,31 @@ type Runner struct {
 	// is still heard.
 	Plugins *plugin.Runner
 
-	// TempDir is where this run's scratch space is created. Empty is the
-	// default [os.MkdirTemp] uses.
+	// Scratch is the directory this run's scratch space is created in, and is
+	// required. A run has nowhere to put its generators' output without one, so
+	// an empty Scratch fails the run before a generator is started rather than
+	// falling back to somewhere ambient.
 	//
-	// It is worth setting to somewhere beside the project when the two are on
-	// different filesystems: the merge copies rather than renames, so nothing
-	// breaks when they differ, but the run then writes its whole output twice.
-	TempDir string
+	// That it is required is the whole of #184. What an empty field used to mean
+	// was [os.MkdirTemp]'s default — TMPDIR, or the system's temporary directory
+	// — and a field defaulting to that is what made an ambient directory
+	// reachable at all. cpybkc's image carries no /tmp to reach, so the fallback
+	// is deleted rather than repaired, and the type is what says so: no zero
+	// value of this Runner can run.
+	//
+	// It is a field of its own rather than [Runner.Root] because the two answer
+	// differently when unset. A run that has not been told where the project's
+	// root is keeps no record and prunes nothing, which is an honest degraded
+	// run; a run that has not been told where to put its scratch space has no
+	// degraded form at all, and guessing is exactly what this field exists to
+	// stop. cpybkc's own runs pass the project's root for both, which is what
+	// puts the scratch space in the tree the run is already writing.
+	//
+	// The merge copies rather than renames, so Scratch and the project need not
+	// share a filesystem — a caller whose tree is on a small or slow one may
+	// point this somewhere else, at the cost of the run writing its output
+	// twice. What it may not be is nothing.
+	Scratch string
 
 	// Umask is the file-creation mask taken out of the mode of everything the
 	// merge creates. Nil is this process's own, read once per run.
@@ -175,6 +200,14 @@ func (r *Runner) Run(ctx context.Context, d *irpb.Descriptor, generators []Gener
 	// finding it after a run would mean discovering it once the work was done.
 	var invalid diag.List
 
+	// Checked with them, and first, because it is the same kind of fault: a run
+	// with nowhere to make its scratch space is a caller that assembled a Runner
+	// it never finished, and there is no directory this package is entitled to
+	// pick on its behalf (#184).
+	if r.Scratch == "" {
+		invalid.Fail(fmt.Errorf("this run has no directory to make its scratch space in; Scratch is required"))
+	}
+
 	for _, generator := range generators {
 		if generator.Out == "" {
 			invalid.Fail(fmt.Errorf("the generator %s has no directory for its output to land in",
@@ -195,7 +228,7 @@ func (r *Runner) Run(ctx context.Context, d *irpb.Descriptor, generators []Gener
 		return err
 	}
 
-	root, err := os.MkdirTemp(r.TempDir, scratchPattern)
+	root, err := os.MkdirTemp(r.Scratch, scratchPattern)
 	if err != nil {
 		return &ScratchError{Err: err}
 	}
@@ -209,7 +242,7 @@ func (r *Runner) Run(ctx context.Context, d *irpb.Descriptor, generators []Gener
 	}()
 
 	// Made absolute so that the diagnostics and the argument vector name the
-	// same directory even when TempDir was written relative.
+	// same directory even when Scratch was written relative.
 	root, err = filepath.Abs(root)
 	if err != nil {
 		return &ScratchError{Err: err}
@@ -237,6 +270,13 @@ func (r *Runner) Run(ctx context.Context, d *irpb.Descriptor, generators []Gener
 // docs/plugin/SPEC.md says a scratch directory is not. Nothing reads the name:
 // a plugin is told where to write and is entitled to derive nothing from the
 // path it was told.
+//
+// Each generator's directory is one level down from root, and the merge walks
+// those and never root itself. That is what makes room for
+// [github.com/Zaba505/cpybkc/internal/plugin]'s per-invocation descriptor
+// directories, which land beside them here (#184): they are inside this run's
+// scratch space, outside every walk the merge makes, and removed with the space
+// they are in — without being hidden, and without a rule anybody has to keep.
 func (r *Runner) scratch(generators []Generator, root string) ([]plugin.Invocation, error) {
 	invocations := make([]plugin.Invocation, len(generators))
 

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -89,10 +89,9 @@ func runner(t *testing.T) *Runner {
 
 	return &Runner{
 		Plugins: &plugin.Runner{
-			Log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
-			TempDir: t.TempDir(),
+			Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
 		},
-		TempDir: t.TempDir(),
+		Scratch: t.TempDir(),
 	}
 }
 
@@ -355,8 +354,8 @@ func TestTheScratchSpaceDoesNotOutliveTheRun(t *testing.T) {
 
 			_ = run(t, r, generator(t, "go", test.body, out))
 
-			if !empty(t, r.TempDir) {
-				t.Errorf("%s left %v behind", test.about, tree(t, r.TempDir))
+			if !empty(t, r.Scratch) {
+				t.Errorf("%s left %v behind", test.about, tree(t, r.Scratch))
 			}
 		})
 	}
@@ -387,8 +386,8 @@ echo kept > "$4/orders.go"`, out)); err != nil {
 	// The one it wrote into the scratch space went with the scratch space, and
 	// the one it wrote where it liked stayed where it wrote it — outside the
 	// project's tree, which is the claim.
-	if !empty(t, r.TempDir) {
-		t.Errorf("the scratch space still holds %v", tree(t, r.TempDir))
+	if !empty(t, r.Scratch) {
+		t.Errorf("the scratch space still holds %v", tree(t, r.Scratch))
 	}
 
 	if !exists(t, escaped) {
@@ -421,7 +420,7 @@ func TestAGeneratorWithNowhereForItsOutputIsRefusedBeforeAnythingRuns(t *testing
 		t.Error("the generator ran, want the run refused before anything started")
 	}
 
-	if !empty(t, r.TempDir) {
-		t.Errorf("the refused run left %v behind", tree(t, r.TempDir))
+	if !empty(t, r.Scratch) {
+		t.Errorf("the refused run left %v behind", tree(t, r.Scratch))
 	}
 }

--- a/internal/generate/scratch_test.go
+++ b/internal/generate/scratch_test.go
@@ -1,0 +1,238 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package generate
+
+import (
+	"io"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/plugin"
+)
+
+// Where a run puts the two directories it makes is #184's subject, and this
+// file is what holds it: the run's scratch space, and the per-invocation
+// directory the descriptor is written into. Both are inside the project the run
+// was pointed at, neither is anywhere the operating system named, and neither
+// is anywhere the merge looks.
+
+// reports is a generator that writes down what it was handed and whether its
+// output directory was empty when it arrived, under names of its own so that
+// two of them can land in one directory.
+//
+// docs/plugin/SPEC.md forbids a plugin to derive anything from the descriptor's
+// path, and this one does not: it copies the path out so that a *test* can say
+// where cpybkc put it, which is a claim about cpybkc rather than a plugin
+// hanging meaning on its surroundings.
+//
+// `$2` is the descriptor and `$4` the output directory, because the vector is
+// `--descriptor <path> --out <dir>`.
+func reports(name string) string {
+	return `[ -z "$(ls -A "$4")" ] && echo empty > "$4/` + name + `.state" || echo dirty > "$4/` + name + `.state"
+echo "$2" > "$4/` + name + `.descriptor"
+echo "$4" > "$4/` + name + `.handed"
+echo "package pkg // ` + name + `" > "$4/` + name + `.go"`
+}
+
+// quiet is a runner that says nothing, pointed at one project for everything it
+// decides: where its record goes, and where its scratch space is made.
+func quiet(t *testing.T, project string) *Runner {
+	t.Helper()
+
+	return &Runner{
+		Plugins: &plugin.Runner{Log: slog.New(slog.NewTextHandler(io.Discard, nil))},
+		Root:    project,
+		Scratch: project,
+	}
+}
+
+func TestTheDescriptorDirectoryIsOutsideEveryWalkTheMergeMakes(t *testing.T) {
+	t.Parallel()
+
+	// One project, two generators landing in one directory of it, which is the
+	// arrangement a project generating a package from two of them has.
+	project := t.TempDir()
+	out := filepath.Join(project, "pkg")
+
+	names := []string{"one", "two"}
+
+	generators := make([]Generator, 0, len(names))
+	for _, name := range names {
+		generators = append(generators, generator(t, name, reports(name), out))
+	}
+
+	if err := run(t, quiet(t, project), generators...); err != nil {
+		t.Fatalf("running the generators: %v", err)
+	}
+
+	// What each generator reported, read back out of the project. The merge is
+	// what put these there, so this is what a generator saw rather than what
+	// the test assumed it would see.
+	descriptors := make([]string, 0, len(names))
+	handed := make([]string, 0, len(names))
+
+	for _, name := range names {
+		descriptors = append(descriptors, reported(t, out, name+".descriptor"))
+		handed = append(handed, reported(t, out, name+".handed"))
+
+		// docs/plugin/SPEC.md: a plugin MAY assume the directory it is handed
+		// is empty. Asserted here as well as where it has its own check,
+		// because a descriptor directory landing beside that directory is what
+		// this test is about and this is exactly what would break.
+		if got := reported(t, out, name+".state"); got != "empty" {
+			t.Errorf("the generator %s found its output directory %s, want it empty", name, got)
+		}
+	}
+
+	if handed[0] == handed[1] {
+		t.Errorf("both generators were handed %s, want a directory each", handed[0])
+	}
+
+	if descriptors[0] == descriptors[1] {
+		t.Errorf("both generators were handed the descriptor at %s; docs/plugin/SPEC.md gives each invocation "+
+			"a directory of its own", descriptors[0])
+	}
+
+	for i, descriptor := range descriptors {
+		dir := filepath.Dir(descriptor)
+
+		// The property the merge rests on. produced() walks the directory each
+		// generator was handed and everything beneath one is output, so a
+		// descriptor directory inside one would be merged into the project as
+		// though a generator had written it.
+		for _, handedTo := range handed {
+			if within(handedTo, descriptor) {
+				t.Errorf("the descriptor for %s is at %s, inside the output directory %s, which the merge walks",
+					names[i], descriptor, handedTo)
+			}
+		}
+
+		// And where it is instead: a sibling of the directory that generator
+		// was handed, so both are one level inside the run's scratch space, and
+		// nothing walks that level. The property above therefore holds by the
+		// layout rather than by the directory being hidden or named carefully.
+		if got, want := filepath.Dir(dir), filepath.Dir(handed[i]); got != want {
+			t.Errorf("the descriptor directory for %s is in %s and the directory it was handed is in %s; they "+
+				"are meant to be siblings inside the run's scratch space", names[i], got, want)
+		}
+
+		// Inside the project, which is the other half of #184: no part of a run
+		// reaches a directory the operating system named.
+		if !within(project, dir) {
+			t.Errorf("the descriptor directory for %s is at %s, outside the project at %s", names[i], dir, project)
+		}
+
+		// docs/plugin/SPEC.md, "The descriptor's location and lifetime": the
+		// file is removed with its directory once the generator has exited.
+		if exists(t, dir) {
+			t.Errorf("the descriptor directory for %s is still at %s after the run", names[i], dir)
+		}
+	}
+
+	// And the project afterwards holds what the two generators produced and the
+	// record of it, and nothing else — no scratch space, no descriptor
+	// directory, and nothing left a level above the output.
+	same(t, project, map[string]string{
+		"pkg": "<dir>",
+
+		filepath.Join("pkg", "one.state"):      "empty\n",
+		filepath.Join("pkg", "one.descriptor"): descriptors[0] + "\n",
+		filepath.Join("pkg", "one.handed"):     handed[0] + "\n",
+		filepath.Join("pkg", "one.go"):         "package pkg // one\n",
+
+		filepath.Join("pkg", "two.state"):      "empty\n",
+		filepath.Join("pkg", "two.descriptor"): descriptors[1] + "\n",
+		filepath.Join("pkg", "two.handed"):     handed[1] + "\n",
+		filepath.Join("pkg", "two.go"):         "package pkg // two\n",
+
+		RecordName: `{
+  "version": 1,
+  "files": [
+    "pkg/one.descriptor",
+    "pkg/one.go",
+    "pkg/one.handed",
+    "pkg/one.state",
+    "pkg/two.descriptor",
+    "pkg/two.go",
+    "pkg/two.handed",
+    "pkg/two.state"
+  ]
+}
+`,
+	})
+}
+
+func TestARunNeedsNoTemporaryDirectoryOfTheSystems(t *testing.T) {
+	// Not parallel, because it states TMPDIR in this process's own
+	// environment. That is the only way to check what *cpybkc* would do with
+	// it: the determinism check varies TMPDIR in the environment a generator is
+	// started with, which says nothing about os.MkdirTemp's default here.
+	//
+	// The project is taken before TMPDIR is moved, because testing makes its
+	// base directory on the first t.TempDir call and that call is the one that
+	// reads TMPDIR.
+	project := t.TempDir()
+
+	// A path with nothing at it. Every way of reaching an ambient temporary
+	// directory ends at os.MkdirTemp or os.CreateTemp with no parent, and both
+	// fail outright on a parent that is not there — so a read put back anywhere
+	// in a run fails this test rather than passing quietly because two runs
+	// agreed about a directory neither was looking at.
+	t.Setenv("TMPDIR", filepath.Join(project, "no-such-temporary-directory"))
+
+	out := filepath.Join(project, "pkg")
+
+	if err := run(t, quiet(t, project),
+		generator(t, "go", `echo "package pkg" > "$4/orders.go"`, out)); err != nil {
+		t.Fatalf("a run whose TMPDIR names nothing failed with %v; since #184 no part of a run reads it", err)
+	}
+
+	if got, want := contents(t, filepath.Join(out, "orders.go")), "package pkg\n"; got != want {
+		t.Errorf("the run produced %q, want %q", got, want)
+	}
+}
+
+func TestARunWithNowhereToMakeItsScratchSpaceIsRefusedBeforeAnythingRuns(t *testing.T) {
+	t.Parallel()
+
+	project := t.TempDir()
+	marker := filepath.Join(project, "ran")
+
+	// The zero value of the field #184 made required. A Runner that has not
+	// been told where to make its scratch space fails rather than falling back
+	// to somewhere ambient, and it fails before a generator has run.
+	r := &Runner{Plugins: &plugin.Runner{Log: slog.New(slog.NewTextHandler(io.Discard, nil))}}
+
+	err := run(t, r, generator(t, "go", `echo ran > `+marker, filepath.Join(project, "pkg")))
+	if err == nil {
+		t.Fatal("a run with no Scratch was accepted, want it refused")
+	}
+
+	if !strings.Contains(err.Error(), "Scratch") {
+		t.Errorf("the run failed with %v, which does not name the field that was not set", err)
+	}
+
+	if exists(t, marker) {
+		t.Error("the generator ran, want the run refused before anything started")
+	}
+}
+
+// within reports whether path is dir or anything beneath it.
+func within(dir, path string) bool {
+	rel, err := filepath.Rel(dir, path)
+
+	return err == nil && (rel == "." || filepath.IsLocal(rel))
+}
+
+// reported is the one line a generator wrote into name, with the newline taken
+// off: a path it was handed, or what it found where it was handed it.
+func reported(t *testing.T, out, name string) string {
+	t.Helper()
+
+	return strings.TrimSuffix(contents(t, filepath.Join(out, name)), "\n")
+}

--- a/internal/generate/scratch_test.go
+++ b/internal/generate/scratch_test.go
@@ -8,6 +8,7 @@ package generate
 import (
 	"io"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -178,12 +179,19 @@ func TestARunNeedsNoTemporaryDirectoryOfTheSystems(t *testing.T) {
 	// reads TMPDIR.
 	project := t.TempDir()
 
-	// A path with nothing at it. Every way of reaching an ambient temporary
-	// directory ends at os.MkdirTemp or os.CreateTemp with no parent, and both
-	// fail outright on a parent that is not there — so a read put back anywhere
-	// in a run fails this test rather than passing quietly because two runs
-	// agreed about a directory neither was looking at.
-	t.Setenv("TMPDIR", filepath.Join(project, "no-such-temporary-directory"))
+	// A regular file, not a directory and not a path with nothing at it. A
+	// missing path is enough to fail os.MkdirTemp and os.CreateTemp, which are
+	// where the fallback used to be, but not enough to fail os.MkdirAll — and
+	// `os.MkdirAll(filepath.Join(os.TempDir(), …))` is an ordinary enough way
+	// to reintroduce the thing this test exists to keep out that it would
+	// otherwise pass here quietly. A file underneath fails all three with
+	// ENOTDIR, so any of them put back anywhere in a run fails this test.
+	trap := filepath.Join(project, "not-a-temporary-directory")
+	if err := os.WriteFile(trap, nil, 0o644); err != nil {
+		t.Fatalf("writing %s: %v", trap, err)
+	}
+
+	t.Setenv("TMPDIR", trap)
 
 	out := filepath.Join(project, "pkg")
 
@@ -213,8 +221,11 @@ func TestARunWithNowhereToMakeItsScratchSpaceIsRefusedBeforeAnythingRuns(t *test
 		t.Fatal("a run with no Scratch was accepted, want it refused")
 	}
 
-	if !strings.Contains(err.Error(), "Scratch") {
-		t.Errorf("the run failed with %v, which does not name the field that was not set", err)
+	// On what the diagnostic says rather than on the field's name: the message
+	// is for whoever reads it, and a test that pinned "Scratch" would make the
+	// Go identifier part of what a caller is shown.
+	if !strings.Contains(err.Error(), "nowhere to make its scratch space") {
+		t.Errorf("the run failed with %v, which does not say what was not decided", err)
 	}
 
 	if exists(t, marker) {

--- a/internal/plugin/determinism_test.go
+++ b/internal/plugin/determinism_test.go
@@ -54,7 +54,7 @@ func TestSourceDateEpochReachesAGeneratorFromCpybkcsOwnEnvironment(t *testing.T)
 
 	// A nil Env: this process's environment, which is what a run made by
 	// anything but a test has.
-	r := &Runner{Log: log, TempDir: t.TempDir()}
+	r := &Runner{Log: log}
 
 	if err := r.Run(t.Context(), descriptor(), []Invocation{invocation}); err != nil {
 		t.Fatalf("running the generator: %v", err)

--- a/internal/plugin/invoke.go
+++ b/internal/plugin/invoke.go
@@ -54,8 +54,10 @@ const descriptorFile = "descriptor.bin"
 // It names cpybkc because the directory is made beside the invocation's output
 // directory rather than in a temporary directory the operating system would
 // eventually sweep, so a process killed outright leaves it where a person will
-// find it — and what a person finds has to say what left it.
-const descriptorDirPattern = "cpybkc-descriptor-"
+// find it — and what a person finds has to say what left it. The leading dot is
+// [github.com/Zaba505/cpybkc/internal/generate]'s scratch pattern's: a survivor
+// of a killed run is not something the go tool should try to compile.
+const descriptorDirPattern = ".cpybkc-descriptor-"
 
 // Option is one option a generator is invoked with, which reaches it as a
 // single `--opt k=v` argument.

--- a/internal/plugin/invoke.go
+++ b/internal/plugin/invoke.go
@@ -50,6 +50,11 @@ const descriptorFile = "descriptor.bin"
 
 // descriptorDirPattern is the prefix [os.MkdirTemp] builds the per-invocation
 // directory's name from.
+//
+// It names cpybkc because the directory is made beside the invocation's output
+// directory rather than in a temporary directory the operating system would
+// eventually sweep, so a process killed outright leaves it where a person will
+// find it — and what a person finds has to say what left it.
 const descriptorDirPattern = "cpybkc-descriptor-"
 
 // Option is one option a generator is invoked with, which reaches it as a
@@ -98,6 +103,15 @@ type Invocation struct {
 	// answer to where a generator's output goes. What happens here is only that
 	// the path is made absolute, because docs/plugin/SPEC.md requires the
 	// vector to carry one.
+	//
+	// It is also where this package puts the directory holding the invocation's
+	// descriptor: beside it, in its parent, for the whole of the invocation and
+	// no longer (#184). That makes the descriptor's location a function of the
+	// one directory an invocation cannot be run without, so a [Runner] has
+	// nothing to be told about where temporary files go and no zero value of
+	// one can reach an ambient directory. It costs the caller nothing it was
+	// not already deciding: whoever chose a scratch directory for a generator
+	// chose the tree the descriptor lands in at the same moment.
 	Out string
 
 	// Options are the options to pass, in the order they are to be passed —
@@ -110,8 +124,8 @@ type Invocation struct {
 // Runner runs generators.
 //
 // The zero value runs them: the process's own environment is passed through,
-// the per-invocation descriptor directories are made wherever the system puts
-// temporary files, and what the generators write is surfaced through
+// each invocation's descriptor directory is made beside the directory that
+// invocation writes into, and what the generators write is surfaced through
 // [slog.Default].
 type Runner struct {
 	// Log is where a generator's output is surfaced. A nil Log is
@@ -130,10 +144,6 @@ type Runner struct {
 	// environment instead of moving the one the test binary runs in; the same
 	// reasoning makes [Resolve] take a PATH.
 	Env []string
-
-	// TempDir is where the directory holding one invocation's descriptor is
-	// created. Empty is the default [os.MkdirTemp] uses.
-	TempDir string
 }
 
 // Run runs every invocation against d, concurrently, and reports every one that
@@ -237,7 +247,15 @@ func (r *Runner) invoke(ctx context.Context, invocation Invocation, descriptor [
 	// removed with its directory once the generator has exited — whether it
 	// exited zero or not. One directory per invocation is what makes the bytes
 	// attributable; the removal is the whole of the file's lifetime.
-	dir, err := os.MkdirTemp(r.TempDir, descriptorDirPattern)
+	//
+	// It is made beside the output directory rather than in whatever the system
+	// calls its temporary directory (#184). The parent of an absolute --out is
+	// a directory the caller already had to make, so cpybkc needs no writable
+	// /tmp, reads no TMPDIR, and a Runner nobody configured cannot reach an
+	// ambient directory. It is a *sibling* of the output directory and not a
+	// child of it, because the one thing docs/plugin/SPEC.md promises about
+	// --out is that the generator finds it empty.
+	dir, err := os.MkdirTemp(filepath.Dir(out), descriptorDirPattern)
 	if err != nil {
 		return &DescriptorError{Name: invocation.Name, Err: err}
 	}

--- a/internal/plugin/invoke_test.go
+++ b/internal/plugin/invoke_test.go
@@ -98,7 +98,7 @@ func runner(t *testing.T, kv ...string) *Runner {
 
 	log, _ := recorder()
 
-	return &Runner{Log: log, TempDir: t.TempDir(), Env: env(kv...)}
+	return &Runner{Log: log, Env: env(kv...)}
 }
 
 // run runs invocations against [descriptor] and hands back the run's verdict.
@@ -597,7 +597,7 @@ func TestAGeneratorThatLeavesAChildHoldingItsOutputStillFinishes(t *testing.T) {
 	invocation := generator(t, "go", `sleep 120 & echo "note: finished" >&2; exit 0`, t.TempDir())
 
 	log, kept := recorder()
-	r := &Runner{Log: log, TempDir: t.TempDir(), Env: env()}
+	r := &Runner{Log: log, Env: env()}
 
 	done := make(chan error, 1)
 

--- a/internal/plugin/stream_test.go
+++ b/internal/plugin/stream_test.go
@@ -233,7 +233,7 @@ func TestBothStreamsAreSurfacedAndAttributed(t *testing.T) {
 	invocation := generator(t, "go", body, t.TempDir())
 
 	log, kept := recorder()
-	r := &Runner{Log: log, TempDir: t.TempDir(), Env: env()}
+	r := &Runner{Log: log, Env: env()}
 
 	if err := r.Run(t.Context(), descriptor(), []Invocation{invocation}); err != nil {
 		t.Fatalf("running the generator: %v", err)
@@ -265,7 +265,7 @@ func TestEachGeneratorsOutputIsAttributedToIt(t *testing.T) {
 	second := generator(t, "docs", `echo "error: from docs" >&2`, t.TempDir())
 
 	log, kept := recorder()
-	r := &Runner{Log: log, TempDir: t.TempDir(), Env: env()}
+	r := &Runner{Log: log, Env: env()}
 
 	if err := r.Run(t.Context(), descriptor(), []Invocation{first, second}); err != nil {
 		t.Fatalf("running the generators: %v", err)
@@ -306,7 +306,7 @@ func TestALineIsSurfacedBeforeTheGeneratorExits(t *testing.T) {
 	`, out)
 
 	log, kept := recorder()
-	r := &Runner{Log: log, TempDir: t.TempDir(), Env: env("OUT=" + out)}
+	r := &Runner{Log: log, Env: env("OUT=" + out)}
 
 	done := make(chan error, 1)
 

--- a/tempdir_test.go
+++ b/tempdir_test.go
@@ -39,6 +39,30 @@ import (
 // would carry os.TempDir straight past a search for that text. Comments are not
 // parsed at all, which is why the prose above and the several comments in this
 // repository that name /tmp are not findings.
+//
+// # What holds the property, and what this only guards
+//
+// The types hold it. internal/plugin.Runner has no field for a temporary
+// directory at all and puts each descriptor directory beside the output
+// directory the invocation cannot be run without; internal/generate.Runner and
+// internal/conformance/gorunner.Runner each refuse a run whose directory field
+// is empty, before a generator starts. Those are the three os.MkdirTemp call
+// sites in this repository, and every one of them passes a variable.
+//
+// This scan cannot see any of them, and that is not a gap to be closed here:
+// deciding whether an arbitrary expression can be empty is a type-checker in a
+// test, and the three answers it would give are already given by the code. What
+// the scan guards is the next call site — source written naively, where the
+// ambient directory is asked for outright — and the ways of asking that a
+// search for `os.TempDir` would miss. It is a fence around a decision the types
+// have already made, not the decision itself.
+//
+// It does not resolve shadowing, does not follow a forbidden function used as a
+// value (`f := os.TempDir`), and does not read a variable passed to os.Getenv.
+// Generated files are scanned like any other, deliberately: a generated client
+// that reached a temporary directory would reach one at run time exactly as
+// hand-written source would, and an exemption written before anybody has seen
+// such a case is an exemption nobody would ever revisit.
 
 // searched is every tree held to the rule.
 //

--- a/tempdir_test.go
+++ b/tempdir_test.go
@@ -1,0 +1,490 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package cpybkc_test
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// cpybkc reads no ambient temporary directory (#184). A run's scratch space is
+// made in the project it was pointed at, and each invocation's descriptor
+// directory beside the output directory that invocation writes into, so nothing
+// about a run needs a writable /tmp, a TMPDIR, or any other directory the
+// machine happened to name.
+//
+// That is a property of the whole repository rather than of one package, so it
+// is checked as one: the fields that used to make an ambient directory
+// reachable are gone or required, and this is what says no new way of reaching
+// one has appeared beside them. docs/cli/SPEC.md's "The environment" is the
+// statement being kept true — PATH is the one variable a run reads — and
+// docs/container/SPEC.md's "Shell or no shell" is what rests on it, since the
+// published image is scratch plus the files that document names and there is no
+// /tmp in it to reach.
+//
+// A parse rather than a grep, for internal/plugin's determinism scan's reason:
+// the name a package is imported under is not the name in its path, so an alias
+// would carry os.TempDir straight past a search for that text. Comments are not
+// parsed at all, which is why the prose above and the several comments in this
+// repository that name /tmp are not findings.
+
+// searched is every tree held to the rule.
+//
+// The three the story names, and all of the source in each: internal/ is where
+// a run's directories are made, cmd/ is what points a run at a project, and
+// daggerverse/ is the module an adopter calls from their own pipeline, running
+// against the same image. .dagger/ is not here — it is this repository's own
+// build, it runs on a machine with a /tmp, and what it may put in the *image*
+// is checked exhaustively by ImageContract instead.
+var searched = []string{"cmd", "daggerverse", "internal"}
+
+// readsAnAmbientDirectory is a call that reaches a temporary directory nobody
+// named, by import path and the name reached through it.
+//
+// [os.TempDir] is the answer itself. io/ioutil's two are the pre-1.16 spelling
+// of the same thing and are listed whatever they are passed, because the
+// package is deprecated and neither belongs in new source at all.
+var readsAnAmbientDirectory = map[string][]string{
+	"os":        {"TempDir"},
+	"io/ioutil": {"TempDir", "TempFile"},
+}
+
+// defaultsToAnAmbientDirectory is a call whose first argument is the directory
+// to create in, and which falls back to [os.TempDir] when that argument is
+// empty.
+//
+// Only an empty *literal* is a finding. An argument that is anything else is a
+// directory the caller was given or chose, and whether it can be empty is a
+// question about a type rather than about a call — which is why #184 answers it
+// in the types: internal/plugin.Runner no longer has a field for one, and
+// internal/generate.Runner's is required and refused when it is empty.
+var defaultsToAnAmbientDirectory = map[string][]string{
+	"os": {"CreateTemp", "MkdirTemp"},
+}
+
+// namesAnAmbientDirectory is a call that reads one out of the environment, by
+// the name it would be asked for.
+var namesAnAmbientDirectory = map[string][]string{
+	"os": {"Getenv", "LookupEnv"},
+}
+
+// temporaryDirectoryVars is every environment variable that names one. TMPDIR
+// is POSIX's; the other two are what a program ported from Windows reaches for.
+var temporaryDirectoryVars = []string{"TEMP", "TMP", "TMPDIR"}
+
+// temporaryDirectoryPaths is every path a literal would spell one as. A string
+// equal to one of these, or beneath one, is a finding wherever it appears:
+// there is no legitimate reason for this repository's source to name the
+// machine's temporary directory at all.
+var temporaryDirectoryPaths = []string{"/tmp", "/var/tmp"}
+
+func TestNothingReadsAnAmbientTemporaryDirectory(t *testing.T) {
+	t.Parallel()
+
+	for _, tree := range searched {
+		t.Run(tree, func(t *testing.T) {
+			t.Parallel()
+
+			if _, err := os.Stat(tree); err != nil {
+				t.Fatalf("%s is held to the rule and is not there: %v", tree, err)
+			}
+
+			found, files := scan(t, tree)
+
+			// A scan that walked nothing reports nothing, which is the one way
+			// this check could pass without looking. The trees below hold
+			// dozens of files each; one is enough to say the walk works.
+			if files == 0 {
+				t.Fatalf("the scan read no Go source under %s, so it found nothing by not looking", tree)
+			}
+
+			for _, finding := range found {
+				t.Errorf("%s, and cpybkc reads no temporary directory it was not given (#184)", finding)
+			}
+		})
+	}
+}
+
+// reachesOne is source with every way of reaching an ambient temporary
+// directory in it, one per line, including two the text of `os.TempDir` would
+// not find: an alias, and a package whose import is dotted.
+const reachesOne = `package gen
+
+import (
+	"io/ioutil"
+	stdos "os"
+	"path/filepath"
+)
+
+func Scratch(parent string) (string, error) {
+	_ = stdos.TempDir()
+	_, _ = stdos.MkdirTemp("", "x-")
+	_, _ = stdos.CreateTemp("", "x-")
+	_ = stdos.Getenv("TMPDIR")
+	_, _ = stdos.LookupEnv("TMPDIR")
+	_, _ = ioutil.TempDir("", "x-")
+	_, _ = ioutil.TempFile("", "x-")
+	_ = filepath.Join("/tmp", "x")
+	_ = "/var/tmp/x"
+
+	return stdos.MkdirTemp(parent, "x-")
+}
+`
+
+// dotted is the other way a call hides from a text search: the package's names
+// are in the file's own scope, so nothing spells out which package TempDir came
+// from.
+const dotted = `package gen
+
+import . "os"
+
+func Scratch() string { return TempDir() }
+`
+
+// reachesNone is source the scan has to leave alone: a temporary directory made
+// under a parent the caller supplied, a method whose name matches one of the
+// forbidden ones on a receiver that is not a package, an environment variable
+// that is not one of these, and a path that only starts like one.
+const reachesNone = `package gen
+
+import "os"
+
+type fake struct{}
+
+func (fake) TempDir() string { return "" }
+
+const home = "/tmpl/templates"
+
+func Scratch(f fake, parent string) (string, error) {
+	_ = f.TempDir()
+	_ = os.Getenv("PATH")
+	_ = home
+
+	return os.MkdirTemp(parent, "x-")
+}
+`
+
+func TestTheScanSeesEveryWayOfReachingOne(t *testing.T) {
+	t.Parallel()
+
+	found, _ := scan(t, fixture(t, reachesOne))
+
+	want := []string{
+		`"/tmp"`,
+		`"/var/tmp/x"`,
+		"ioutil.TempDir",
+		"ioutil.TempFile",
+		"stdos.CreateTemp with no directory to create in",
+		"stdos.Getenv(\"TMPDIR\")",
+		"stdos.LookupEnv(\"TMPDIR\")",
+		"stdos.MkdirTemp with no directory to create in",
+		"stdos.TempDir",
+	}
+
+	// Compared by what each finding names rather than by where it was, so that
+	// editing the fixture is not a two-place change.
+	if got := slices.Sorted(slices.Values(named(found))); !slices.Equal(got, want) {
+		t.Errorf("the scan found %v, want %v", got, want)
+	}
+}
+
+func TestTheScanRefusesADotImportItCannotResolve(t *testing.T) {
+	t.Parallel()
+
+	found, _ := scan(t, fixture(t, dotted))
+
+	want := []string{"a dot import of os"}
+
+	if got := named(found); !slices.Equal(got, want) {
+		t.Errorf("the scan found %v, want %v", got, want)
+	}
+}
+
+func TestTheScanAcceptsSourceThatOnlyLooksLikeItReachesOne(t *testing.T) {
+	t.Parallel()
+
+	if found, _ := scan(t, fixture(t, reachesNone)); len(found) != 0 {
+		t.Errorf("the scan found %v in source that reaches no temporary directory", found)
+	}
+}
+
+// fixture is a directory holding src as one Go file, beside a test file the
+// scan has to skip: a test may name a temporary directory, and one that could
+// not would not be able to assert that nothing else does.
+func fixture(t *testing.T, src string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	for name, content := range map[string]string{
+		"gen.go":      src,
+		"gen_test.go": reachesOne,
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+	}
+
+	return dir
+}
+
+// scan reports everything under root's non-test Go files that reaches a
+// temporary directory nobody named, as `file:line:col: what`, and how many
+// files it read.
+//
+// The whole tree rather than one directory, because the rule is about three
+// trees and not about a package: a new package added under one of them is held
+// to it from the commit that adds it rather than from the commit where somebody
+// remembered to list it.
+func scan(t *testing.T, root string) ([]string, int) {
+	t.Helper()
+
+	fset := token.NewFileSet()
+
+	var (
+		found []string
+		files int
+	)
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		switch {
+		case err != nil:
+			return err
+		case d.IsDir():
+			// testdata is what a test reads, and go/build ignores it for the
+			// same reason: it is not source this repository compiles.
+			if d.Name() == "testdata" {
+				return fs.SkipDir
+			}
+
+			return nil
+		case !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go"):
+			return nil
+		}
+
+		file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if err != nil {
+			return fmt.Errorf("parsing %s: %w", path, err)
+		}
+
+		files++
+
+		imported, dotted := imports(t, fset, file)
+		found = append(found, dotted...)
+		found = append(found, reaches(fset, file, imported)...)
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("reading %s: %v", root, err)
+	}
+
+	slices.Sort(found)
+
+	return found, files
+}
+
+// reaches is everything in one parsed file that reaches a temporary directory
+// nobody named, given what each of its imports is called.
+func reaches(fset *token.FileSet, file *ast.File, imported map[string]string) []string {
+	var found []string
+
+	report := func(pos token.Pos, what string) {
+		found = append(found, fmt.Sprintf("%s: %s", fset.Position(pos), what))
+	}
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		// A literal naming the machine's temporary directory, wherever it is
+		// written: as an argument, as a constant, as half of a concatenation.
+		if lit, ok := n.(*ast.BasicLit); ok && lit.Kind == token.STRING {
+			if value, err := strconv.Unquote(lit.Value); err == nil && isTemporaryPath(value) {
+				report(lit.Pos(), lit.Value)
+			}
+
+			return true
+		}
+
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		pkg, name, ok := qualified(call.Fun, imported)
+		if !ok {
+			return true
+		}
+
+		switch {
+		case listed(readsAnAmbientDirectory, pkg, name):
+			report(call.Pos(), called(call.Fun, name))
+
+		case listed(defaultsToAnAmbientDirectory, pkg, name) && emptyString(call.Args):
+			report(call.Pos(), called(call.Fun, name)+" with no directory to create in")
+
+		case listed(namesAnAmbientDirectory, pkg, name):
+			if v, ok := literal(call.Args); ok && slices.Contains(temporaryDirectoryVars, v) {
+				report(call.Pos(), fmt.Sprintf("%s(%q)", called(call.Fun, name), v))
+			}
+		}
+
+		return true
+	})
+
+	return found
+}
+
+// qualified is the import path and the name of a call written as `pkg.Name`,
+// and whether it is one at all.
+//
+// A qualified identifier is a package name and nothing else, so a method call
+// on a value that happens to be named for a package — a receiver called `os` —
+// is not one. Shadowing is not resolved, for the reason internal/plugin's scan
+// gives: the cost of missing a call made through a variable that took a
+// package's name is a finding this scan does not report, and the cost of
+// resolving it is a type-checker in a test.
+func qualified(fun ast.Expr, imported map[string]string) (pkg, name string, ok bool) {
+	selector, ok := fun.(*ast.SelectorExpr)
+	if !ok {
+		return "", "", false
+	}
+
+	ident, ok := selector.X.(*ast.Ident)
+	if !ok {
+		return "", "", false
+	}
+
+	pkg, ok = imported[ident.Name]
+
+	return pkg, selector.Sel.Name, ok
+}
+
+// called is how the call reads in the source, which is what a finding names:
+// the identifier the package was imported under, and not its path.
+func called(fun ast.Expr, name string) string {
+	if selector, ok := fun.(*ast.SelectorExpr); ok {
+		if ident, ok := selector.X.(*ast.Ident); ok {
+			return ident.Name + "." + name
+		}
+	}
+
+	return name
+}
+
+// listed reports whether pkg's name is on one of the lists above.
+func listed(names map[string][]string, pkg, name string) bool {
+	return slices.Contains(names[pkg], name)
+}
+
+// literal is the value of a call's first argument where it is a string
+// literal.
+func literal(args []ast.Expr) (string, bool) {
+	if len(args) == 0 {
+		return "", false
+	}
+
+	lit, ok := args[0].(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+
+	value, err := strconv.Unquote(lit.Value)
+
+	return value, err == nil
+}
+
+// emptyString reports whether a call's first argument is the empty string
+// written out.
+func emptyString(args []ast.Expr) bool {
+	value, ok := literal(args)
+
+	return ok && value == ""
+}
+
+// isTemporaryPath reports whether a literal spells the machine's temporary
+// directory or something beneath it.
+func isTemporaryPath(value string) bool {
+	for _, dir := range temporaryDirectoryPaths {
+		if value == dir || strings.HasPrefix(value, dir+"/") {
+			return true
+		}
+	}
+
+	return false
+}
+
+// imports is what each of file's imports is called where it is used, against
+// the path it names, and the findings the import block is itself.
+//
+// A dot import of a watched package is a finding rather than an entry: it puts
+// that package's names in the file's own scope, where nothing distinguishes
+// `TempDir()` from a function of the file's, so it is refused instead of being
+// resolved.
+func imports(t *testing.T, fset *token.FileSet, file *ast.File) (map[string]string, []string) {
+	t.Helper()
+
+	var found []string
+
+	names := map[string]string{}
+
+	for _, spec := range file.Imports {
+		path, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			t.Fatalf("%s: an import path that is not a string: %v", fset.Position(spec.Pos()), err)
+		}
+
+		name := path[strings.LastIndex(path, "/")+1:]
+		if spec.Name != nil {
+			name = spec.Name.Name
+		}
+
+		switch name {
+		case "_":
+			// Imported for its side effects; nothing is called through it.
+		case ".":
+			if watched(path) {
+				found = append(found, fmt.Sprintf("%s: a dot import of %s", fset.Position(spec.Pos()), path))
+			}
+		default:
+			names[name] = path
+		}
+	}
+
+	return names, found
+}
+
+// watched reports whether any of the lists above names path.
+func watched(path string) bool {
+	for _, names := range []map[string][]string{
+		readsAnAmbientDirectory, defaultsToAnAmbientDirectory, namesAnAmbientDirectory,
+	} {
+		if _, ok := names[path]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// named is what each finding calls, with the position dropped.
+func named(found []string) []string {
+	names := make([]string, 0, len(found))
+
+	for _, finding := range found {
+		_, what, _ := strings.Cut(finding, ": ")
+		names = append(names, what)
+	}
+
+	return names
+}


### PR DESCRIPTION
Closes #184

Both directories a run makes move out of the ambient temporary directory and into the tree the run is already writing, and the two `TempDir` fields that made an ambient one reachable at all go with them.

## The two decisions

**`internal/plugin.Runner.TempDir` is deleted.** The per-invocation descriptor directory is created beside the invocation's `--out` — `os.MkdirTemp(filepath.Dir(out), …)`. `Invocation.Out` is already required and validated, so the descriptor's location is a function of the one directory an invocation cannot be run without: no zero value of that `Runner` can reach an ambient directory, and there is nothing left to configure. `internal/conformance/gorunner`'s bare `&plugin.Runner{}` gets the property for free, with no special case for the corpus.

**`internal/generate.Runner.TempDir` becomes `Scratch`, required and validated** the way `gorunner.Runner.Root` is. It is a field of its own rather than derived from `Root` because the two answer differently when unset: a run that has not been told where the project's root is keeps no record and prunes nothing, which is an honest degraded run, while a run that has not been told where to make its scratch space has no degraded form at all. An empty `Scratch` fails the run before a generator starts, beside the existing check for a generator with no `Out`.

**Where the scratch root goes: the project's root.** `cmd/cpybkc` passes `run.Dir` for both fields. The project is the one tree a run is already writing to and already had to be able to write to — which is exactly what makes a `scratch` image with no `/tmp` work. The per-invocation descriptor directories are siblings of `root/<i>` inside it, which is invisible to the merge by the layout rather than by hiding: `produced()` walks `root/<i>` and nothing walks `root`. The cost is a directory a person and `git status` can see after a `SIGKILL`, where the deferred removal never runs, so `scratchPattern` is now `cpybkc-scratch-` — the name has to say what left it. Neither `prune` nor `tidy` walks the project tree, so neither will ever touch it.

## Acceptance criteria

- [x] Nothing in `internal/`, `cmd/` or `daggerverse/` reads `os.TempDir`, `TMPDIR` or any other ambient temporary directory — `tempdir_test.go`, an AST scan of all three trees, with three sibling tests exercising its own failure path: every way of reaching one (`os.TempDir`, `MkdirTemp`/`CreateTemp` with no parent, `os.Getenv`/`LookupEnv` of `TMPDIR`/`TMP`/`TEMP`, `ioutil.TempDir`/`TempFile`, a `/tmp` or `/var/tmp` literal, under an alias), a dot import it refuses rather than resolves, and lookalikes it must leave alone. It fails outright if the walk reads no files.
- [x] **Decide** what becomes of the two `TempDir` fields — above. `cmd/cpybkc/relay_test.go` and `internal/generate/determinism_test.go` moved with them.
- [x] **Decide** where the run's scratch root goes, reasoning written down — above, and in `Runner.Scratch`'s and `perform`'s comments.
- [x] A check drives two generators over one project — `TestTheDescriptorDirectoryIsOutsideEveryWalkTheMergeMakes`: neither `--out` held anything, each descriptor is outside both output directories and a sibling of the directory its generator was handed, both are gone afterwards, and the project holds exactly what the two generators produced plus the record.
- [x] Each directory is still one per run / one per invocation and still removed whatever the exit status. `docs/plugin/SPEC.md` is **not modified**.
- [x] `cmd/cpybkc/main.go`'s `TMPDIR` comment is corrected.
- [x] `.dagger/worked_example.go`'s `checkReadsTheShippedIr` writes into `/example`, a directory the check itself adds, and its comment no longer calls that "the arrangement cpybkc itself makes for a generator". The image gains no writable path.
- [x] The determinism check's `TMPDIR` axis is re-pointed at `Runner.Scratch`, which varies per run, with a comment naming it; `TMPDIR` keeps being varied and now names a directory that does not exist. `TestARunNeedsNoTemporaryDirectoryOfTheSystems` states a nonexistent `TMPDIR` in *cpybkc's own* process and requires the run to succeed, which is the half the generator's environment cannot cover.
- [x] `docs/container/SPEC.md`'s *Shell or no shell* paragraph is replaced by one saying there is no writable temporary directory and none is needed; the *Not covered* mention is gone. No covered guarantee changes and no printed command changes.
- [x] `.dagger/image.go`'s `tmpDir`/`tmpDirMode`, `tmpDirectory()`, the `WithDirectory("/", …)` graft and the `/tmp` row of `baseImageContents` are gone, and `ImageContract`'s exhaustive listing gains nothing.
- [x] The conformance corpus still passes, driven through `internal/plugin` as before.
- [x] `dagger call ci` passes and `example/` comes back byte for byte.

## Also changed

`docs/cli/SPEC.md`'s *The environment* said cpybkc reads two variables, `PATH` and `TMPDIR`. That sentence is now false, so it says one; the governing-sources entry for POSIX chapter 8 moves with it. No command it prints changes.

## Verified

- `dagger call ci` — green.
- A real `docker run`, against the image this pipeline builds today with `cpybkc-gen-go` copied in as the worked example does, over a bind-mounted copy of `example/` with `--read-only` on the root filesystem, no `--tmpfs` and no volume supplying `/tmp`:
  - as the default 65532 — exit 0, `example/ledger` and `cpybkc.gen.json` byte-identical;
  - under `--user "$(id -u):$(id -g)"` — the same;
  - with no volume at all — `--version` works, and a run with no project fails on its own missing-manifest diagnostic rather than inside the standard library.
- The exported base image's layer holds no `/tmp` at all: `usr/local/bin/cpybkc` and `usr/local/share/cpybkc/…` and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)