### PR TITLE
story(container): publish cpybkc-gen-go as a generator image

### DIFF
--- a/.dagger/companion.go
+++ b/.dagger/companion.go
@@ -381,16 +381,6 @@ const (
 	// for byte, and this repository already has that tree.
 	companionExampleDir = "example"
 
-	// generatorExecutable is what the CLI's PATH-based discovery looks for, and
-	// generatorPackage is what builds it.
-	//
-	// Both are assembled from worked_example.go's two constants rather than
-	// written out, so the executable this check installs is the one
-	// docs/plugin/SPEC.md's discovery rule names rather than a second spelling of
-	// it, and the command directory is not a third.
-	generatorExecutable = generatorPrefix + ownGenerator
-	generatorPackage    = "./cmd/" + generatorExecutable
-
 	// neverPulledRepository is the registry repository this check hands the
 	// module, and it is deliberately one that cannot exist: `.invalid` is
 	// reserved by RFC 2606 and resolves nowhere, ever.
@@ -402,6 +392,14 @@ const (
 	// generator, generate with it, and pass, quietly checking the last release
 	// instead of the change. Pointing the coordinates at a host with no registry
 	// behind it makes that call fail instead, naming this constant.
+	//
+	// #180 made that guard load bearing rather than precautionary, which is worth
+	// saying because the change looks like the opposite. Until a release published
+	// a generator image there was nothing at `<repository>-gen-go` for a forgotten
+	// --image to find, so the call would have failed at the registry anyway; from
+	// the first release onwards it resolves, and what it resolves to is the last
+	// release rather than the change. This constant is the whole of what stands
+	// between those two outcomes.
 	//
 	// The version is left at the module's own default. Nothing resolves it here
 	// for the same reason, and overriding it would only add a second unused
@@ -560,53 +558,8 @@ func (m *Cpybkc) companion(platform dagger.Platform) *dagger.Companion {
 	})
 }
 
-// generatorBinary builds cpybkc's own generator for one platform.
-//
-// It is image.go's binary with a different package and name, and it carries the
-// same CGO and -trimpath switches for the same reasons: what a generator image
-// ships has to start in a scratch image, which is the requirement
-// docs/container/SPEC.md states as `CGO_ENABLED=0` and leaves to whoever builds
-// the generator.
-func (m *Cpybkc) generatorBinary(platform dagger.Platform) *dagger.File {
-	return dag.Go().
-		Build(m.Source, dagger.GoBuildOpts{
-			Pkg:          generatorPackage,
-			ArtifactName: generatorExecutable,
-			Trimpath:     true,
-			DisableCgo:   true,
-			Platform:     string(platform),
-		}).
-		File(generatorExecutable)
-}
-
-// generatorImage is a generator image for cpybkc's own generator: the base image
-// this pipeline built, plus one executable in the plugin directory.
-//
-// That is the shape docs/container/SPEC.md fixes for a generator image — "an
-// image built FROM the base, adding one executable at the path this section
-// names and changing nothing else" — so with-generator is handed the thing an
-// adopter's generator image actually is rather than a container assembled to
-// suit this check. Deriving it from the same base also settles the platform:
-// with-generator refuses a generator image built for another one, and a
-// container that came from baseImage cannot be for another one.
-//
-// The COPY creates the plugin directory, because since #185 the base image does
-// not have one — nothing is in it, and the archetype refuses a contribution to
-// any directory the image's PATH resolves against. That is what an adopter's
-// Dockerfile does too, and what the worked example checks.
-//
-// It is not published and never will be. What #48 ships is a release's business;
-// this is one file in a container that exists for the length of one call.
-func (m *Cpybkc) generatorImage(platform dagger.Platform) *dagger.Container {
-	return m.baseImage(platform).WithFile(
-		pluginDir+"/"+generatorExecutable,
-		m.generatorBinary(platform),
-		dagger.ContainerWithFileOpts{Owner: imageUser, Permissions: derivedExecutableMode},
-	)
-}
-
-// checkComposedImage requires the composed image's plugin directory to hold the
-// generator, and nothing else.
+// checkComposedImage requires an image's plugin directory to hold the generator,
+// and nothing else.
 //
 // The directory is listed rather than the image run, because the image is a
 // scratch one: there is no shell and no `ls` in it, and the only thing that can

--- a/.dagger/image.go
+++ b/.dagger/image.go
@@ -201,6 +201,28 @@ const (
 	// adopter's compliance scan has to guess at.
 	contributionLicense = "MIT"
 
+	// generatorExecutable is what the CLI's PATH-based discovery looks for, and
+	// generatorPackage is what builds it.
+	//
+	// Both are assembled from worked_example.go's two constants rather than
+	// written out, so the executable a generator image installs is the one
+	// docs/plugin/SPEC.md's discovery rule names rather than a second spelling of
+	// it, and the command directory is not a third.
+	//
+	// They live here rather than beside the companion checks because the image
+	// this name goes into is published now (#180): it is a release's business
+	// alongside the base image, and the check that drives it is one caller among
+	// three.
+	generatorExecutable = generatorPrefix + ownGenerator
+	generatorPackage    = "./cmd/" + generatorExecutable
+
+	// generatorRepositorySuffix is what turns the CLI image's repository into the
+	// repository the generator image for one name is published to.
+	//
+	// It is a covered promise of docs/container/SPEC.md since #180 — see
+	// [generatorRepository] for what that costs and what it buys.
+	generatorRepositorySuffix = "-gen-"
+
 	// devVersion is the version every build that is not a release publishes
 	// under, and therefore the version every check builds.
 	//
@@ -316,6 +338,134 @@ func (m *Cpybkc) baseImage(platform dagger.Platform) *dagger.Container {
 	return m.baseApp(devVersion).Container(platform)
 }
 
+// generatorApp is the published generator image as the archetype's application:
+// the base image, wearing cpybkc's own generator in the plugin directory.
+//
+// This is the one construction of it, for baseApp's reason. CompanionModule
+// drives it, ImageContract checks it and Release publishes it, so the image a
+// check passed is the image somebody publishes and the extension mechanism the
+// pull request exercises is the one a release ships.
+//
+// # Composition rather than a second image recipe
+//
+// It is [dagger.Z5LabsApp.WithApp] onto the base App, which since #185 is the
+// only route an executable takes to the plugin directory: the archetype refuses
+// a contributed file there outright, on the grounds that content found on PATH
+// by name is how an arm64 image ends up running an amd64 executable. What that
+// buys here beyond the hand-rolled WithFile it replaces (#180) is three things
+// the old shape had to be trusted about — the variant sets are paired platform
+// by platform, so an arm64 base cannot acquire an amd64 generator; a collision
+// in the plugin directory is refused rather than layered over; and every
+// composed entry is exec'd in the finished image before the first byte is
+// pushed.
+//
+// The result is an ordinary App. It publishes, signs and attests exactly as the
+// base does, under the base's version, which is the whole of how #180's "the
+// same signature and attestations the base image carries" is satisfied: by being
+// published the same way rather than by a second arrangement here.
+func (m *Cpybkc) generatorApp(version string) *dagger.Z5LabsApp {
+	return m.baseApp(version).WithApp(m.ownGeneratorApp(version))
+}
+
+// ownGeneratorApp is cpybkc's own generator as an application of its own, before
+// it is composed onto anything.
+//
+// # Why the generic constructor and not the Go chain
+//
+// [dagger.Z5LabsGoChain.App] does not name the binary after the package it is
+// given. It reads go.mod's module directive and takes the basename, so for
+// module github.com/Zaba505/cpybkc the answer is `cpybkc` for *every* package in
+// the module — and this repository has two commands in one module. Building the
+// generator that way composes an executable named `cpybkc`, which nothing fails
+// on at build time: what fails is discovery, because docs/plugin/SPEC.md has
+// cpybkc find a generator on PATH by the exact name a layout asked for. The
+// image would ship the right bytes under a name nothing looks for, and — layered
+// onto a base whose own entry is also `cpybkc` — under a name something else
+// already answers to.
+//
+// So the name is stated rather than inferred, through the generic constructor's
+// WithVariant, which is the seam the chain does not have. The binary is still
+// built by the shared go module, one per platform, so this is the same build
+// with the name said out loud and not a second compiler invocation with flags of
+// its own. avroc#223 hit this first and wrote it down; the base image stays on
+// the Go chain because there the inferred name is the right one.
+//
+// # The document
+//
+// Each variant carries an SPDX document, because the archetype requires one for
+// every byte that enters an image and assembles the per-platform SBOM a release
+// attaches out of them. It is dag.Go().Spdx rather than Z5labs.FileDocument
+// because a Go binary's document is *derived* from the compiled artifact rather
+// than asserted about it — the publish checks that the document names the
+// SHA-256 of the executable it accompanies, and a derived document cannot
+// disagree with what it describes.
+func (m *Cpybkc) ownGeneratorApp(version string) *dagger.Z5LabsApp {
+	app := dag.Z5Labs().App(version)
+
+	for _, platform := range imagePlatforms() {
+		binary := m.generatorBinary(platform)
+
+		app = app.WithVariant(platform, binary, dag.Go().Spdx(binary, m.appSource()),
+			dagger.Z5LabsAppBuilderWithVariantOpts{Name: generatorExecutable})
+	}
+
+	return app.Build()
+}
+
+// generatorBinary builds cpybkc's own generator for one platform.
+//
+// It is [Cpybkc.binary] with a different package and name, and it carries the
+// same CGO and -trimpath switches for the same reasons: what a generator image
+// ships has to start in a scratch image, which is the requirement
+// docs/container/SPEC.md states as `CGO_ENABLED=0` and leaves to whoever builds
+// the generator.
+//
+// The source is appSource rather than m.Source, so the executable the published
+// generator image carries is compiled from the same tree — git metadata included
+// — as the CLI it is composed onto.
+func (m *Cpybkc) generatorBinary(platform dagger.Platform) *dagger.File {
+	return dag.Go().
+		Build(m.appSource(), dagger.GoBuildOpts{
+			Pkg:          generatorPackage,
+			ArtifactName: generatorExecutable,
+			Trimpath:     true,
+			DisableCgo:   true,
+			Platform:     string(platform),
+		}).
+		File(generatorExecutable)
+}
+
+// generatorImage is one platform's generator image, for the checks and for the
+// stages that drive it rather than publish it.
+//
+// It is an accessor onto the App, exactly as baseImage is, so a check reads the
+// container a publish would push.
+func (m *Cpybkc) generatorImage(platform dagger.Platform) *dagger.Container {
+	return m.generatorApp(devVersion).Container(platform)
+}
+
+// generatorRepository is where the generator image for name is published:
+// the CLI image's own repository with `-gen-<name>` appended.
+//
+// Derived from the caller's repository rather than from a constant, which is
+// what makes a mirror, an internal registry or an air-gapped copy redirect the
+// whole family at once. A caller who moved the CLI image and not its generators
+// would otherwise reach back to ghcr.io from inside a network that cannot see
+// it, on the second pull rather than the first.
+//
+// # This is the second spelling of one rule, and that is deliberate
+//
+// daggerverse/cpybkc/internal/generator.Repository is the first. The two are in
+// different Go modules and neither can import the other, so the rule is written
+// twice and pinned at both ends by a literal — that package's TestRepository,
+// and TagScheme here. #180 is what made the drift between them expensive: the
+// companion module's default with no --image resolves against its spelling, and
+// a release publishing under this one would leave that default pulling a
+// repository nothing pushes to.
+func generatorRepository(repository, name string) string {
+	return repository + generatorRepositorySuffix + name
+}
+
 // appChain is the Go chain an App is built from — the source with its git
 // metadata folded in, and nothing configured about the check stages.
 //
@@ -375,6 +525,11 @@ func (m *Cpybkc) irProtoTree() *dagger.Directory {
 //   - The entrypoint being the CLI, by running it — twice, as the image's own
 //     user and as an arbitrary other one.
 //
+// The generator image a release publishes beside the base is checked here too
+// (#180), on the same platforms and by the same reading of the same document:
+// it is the base's exhaustive listing plus exactly one file, at the name the
+// plugin contract resolves. See checkGeneratorImage.
+//
 // platform restricts the check to one of the published platforms; empty runs
 // every one of them, and every failure is reported rather than the first,
 // because "it holds on amd64 and not on arm64" is the finding.
@@ -401,6 +556,10 @@ func (m *Cpybkc) ImageContract(
 	for _, p := range platforms {
 		if err := errors.Join(m.checkBaseImage(ctx, m.baseImage(p), p)...); err != nil {
 			errs = append(errs, fmt.Errorf("%s: %w", p, err))
+		}
+
+		if err := errors.Join(m.checkGeneratorImage(ctx, m.generatorImage(p))...); err != nil {
+			errs = append(errs, fmt.Errorf("%s: the generator image: %w", p, err))
 		}
 	}
 
@@ -436,6 +595,79 @@ func (m *Cpybkc) checkBaseImage(
 	errs = append(errs, m.checkImageIsTheCLI(ctx, image)...)
 
 	return errs
+}
+
+// checkGeneratorImage holds one platform's generator image to what a generator
+// image is allowed to be (#180).
+//
+// It is a function rather than a sequence inside ImageContract for
+// checkBaseImage's reason: Release runs it too, over the very containers it is
+// about to push, so a check added here is a check the release gate acquires.
+//
+// Three groups, and each rules out a way the composition could go wrong while
+// building, pushing and passing everything else:
+//
+//   - The OCI configuration, unchanged from the base's. A composed image keeps
+//     the base's entrypoint, user and environment, so an image whose Entrypoint
+//     had become the generator it carries is a different program wearing
+//     cpybkc's filesystem — the edit docs/container/SPEC.md forbids a derived
+//     image, applied here by this project's own pipeline.
+//   - The filesystem, as the base's exhaustive listing plus exactly one file. A
+//     second file, or one landing anywhere but the plugin directory, fails here
+//     rather than in a stranger's COPY --from.
+//   - The plugin directory holding that file under the name cpybkc searches PATH
+//     for, listed rather than inferred from the row above. This is the failure
+//     the generic App constructor exists to rule out — an image correct in every
+//     respect except the one the plugin contract reads — so it is asserted in
+//     the terms the contract reads it in, and not only as an entry in a map.
+func (m *Cpybkc) checkGeneratorImage(ctx context.Context, image *dagger.Container) []error {
+	protos, err := m.shippedProtos(ctx)
+	if err != nil {
+		return []error{err}
+	}
+
+	errs := m.checkImageConfig(ctx, image)
+	errs = append(errs, m.checkImageContents(ctx, image, generatorImageContents(baseImageContents(protos)))...)
+
+	if err := m.checkComposedImage(ctx, image); err != nil {
+		errs = append(errs, err)
+	}
+
+	return errs
+}
+
+// generatorImageContents is the base image's listing plus the one executable a
+// generator image adds, which is the whole of what a generator image is.
+//
+// It is separate from derivedImageContents, which describes what a *stranger's*
+// Dockerfile produces, and the difference between the two is the point rather
+// than duplication. That one takes the copied path and the entry as arguments,
+// because the document states the owner and the mode of the COPY it hands an
+// adopter and the check reads both out of the committed text. This one states
+// them, because they are not anybody's choice: the archetype places a composed
+// application's entry itself.
+//
+// The mode and the owner are literals and not constants of this file's, and that
+// is deliberate. The nearest constant, derivedExecutableMode, is 0755 and
+// describes what an adopter's COPY --chown=65532:65532 --chmod=0755 writes —
+// which is what this image was built by before #180 and is not what the
+// archetype produces. Writing 0555 out here is what makes a check that would
+// otherwise have kept passing across that change say so.
+//
+// The plugin directory comes with it, because the base image does not have one:
+// since #185 nothing in the base creates it, so the composition is what does. It
+// arrives root-owned and 0755 — a directory the archetype made on the way to
+// somewhere else, exactly like the chain above the IR schema — and nothing may
+// depend on that. docs/container/SPEC.md holds the ownership and mode of this
+// directory out of the contract in as many words; the row is here because the
+// listing is exhaustive or it is nothing.
+func generatorImageContents(base map[string]imageEntry) map[string]imageEntry {
+	contents := maps.Clone(base)
+
+	contents[pluginDir] = imageEntry{kindDir, 0, 0, dirMode}
+	contents[pluginDir+"/"+generatorExecutable] = imageEntry{kindFile, imageUID, imageGID, 0o555}
+
+	return contents
 }
 
 // shippedProtos is every .proto the image carries, as a path relative to the

--- a/.dagger/image.go
+++ b/.dagger/image.go
@@ -554,11 +554,15 @@ func (m *Cpybkc) ImageContract(
 
 	var errs []error
 	for _, p := range platforms {
+		// Both branches name which image they are about. The base's used to be
+		// the only one and went unqualified; with two images in the loop, a
+		// reader would have had to know that a bare platform prefix meant the
+		// base — which stops being obvious the moment a third image arrives.
 		if err := errors.Join(m.checkBaseImage(ctx, m.baseImage(p), p)...); err != nil {
-			errs = append(errs, fmt.Errorf("%s: %w", p, err))
+			errs = append(errs, fmt.Errorf("%s: the base image: %w", p, err))
 		}
 
-		if err := errors.Join(m.checkGeneratorImage(ctx, m.generatorImage(p))...); err != nil {
+		if err := errors.Join(m.checkGeneratorImage(ctx, m.generatorImage(p), p)...); err != nil {
 			errs = append(errs, fmt.Errorf("%s: the generator image: %w", p, err))
 		}
 	}
@@ -590,7 +594,7 @@ func (m *Cpybkc) checkBaseImage(
 
 	errs := m.checkImageConfig(ctx, image)
 	errs = append(errs, m.checkImageContents(ctx, image, baseImageContents(protos))...)
-	errs = append(errs, m.checkImageBuild(ctx, image, platform)...)
+	errs = append(errs, m.checkImageBuild(ctx, image, platform, cliPath())...)
 	errs = append(errs, m.checkShippedIr(ctx, image)...)
 	errs = append(errs, m.checkImageIsTheCLI(ctx, image)...)
 
@@ -620,7 +624,24 @@ func (m *Cpybkc) checkBaseImage(
 //     the generic App constructor exists to rule out — an image correct in every
 //     respect except the one the plugin contract reads — so it is asserted in
 //     the terms the contract reads it in, and not only as an entry in a map.
-func (m *Cpybkc) checkGeneratorImage(ctx context.Context, image *dagger.Container) []error {
+//   - How **the generator** was built, read out of that file: CGO off, -trimpath
+//     on, and the GOOS and GOARCH of the platform whose image it landed in.
+//
+// That last group is why this takes a platform. generatorApp's comment names
+// "the variant sets are paired platform by platform, so an arm64 base cannot
+// acquire an amd64 generator" as one of the things composition buys, and that is
+// a property of somebody else's module — asserted in a comment is not the same
+// as checked. The three groups above would all pass on an arm64 image carrying
+// an amd64 generator, because none of them reads the file's architecture; this
+// one does, over the *contributed* executable rather than the CLI, which is the
+// only one of the two whose route into the image #180 changed. The failure it
+// rules out is an exec format error in a stranger's image and nothing at all
+// here.
+func (m *Cpybkc) checkGeneratorImage(
+	ctx context.Context,
+	image *dagger.Container,
+	platform dagger.Platform,
+) []error {
 	protos, err := m.shippedProtos(ctx)
 	if err != nil {
 		return []error{err}
@@ -628,6 +649,7 @@ func (m *Cpybkc) checkGeneratorImage(ctx context.Context, image *dagger.Containe
 
 	errs := m.checkImageConfig(ctx, image)
 	errs = append(errs, m.checkImageContents(ctx, image, generatorImageContents(baseImageContents(protos)))...)
+	errs = append(errs, m.checkImageBuild(ctx, image, platform, pluginDir+"/"+generatorExecutable)...)
 
 	if err := m.checkComposedImage(ctx, image); err != nil {
 		errs = append(errs, err)
@@ -647,12 +669,23 @@ func (m *Cpybkc) checkGeneratorImage(ctx context.Context, image *dagger.Containe
 // them, because they are not anybody's choice: the archetype places a composed
 // application's entry itself.
 //
-// The mode and the owner are literals and not constants of this file's, and that
-// is deliberate. The nearest constant, derivedExecutableMode, is 0755 and
-// describes what an adopter's COPY --chown=65532:65532 --chmod=0755 writes —
-// which is what this image was built by before #180 and is not what the
-// archetype produces. Writing 0555 out here is what makes a check that would
-// otherwise have kept passing across that change say so.
+// The mode and the owner of that file are **both** literals and not constants of
+// this file's, and that is deliberate on two counts. The nearest mode constant,
+// derivedExecutableMode, is 0755 and describes what an adopter's
+// COPY --chown=65532:65532 --chmod=0755 writes — which is how this image was
+// built before #180 and is not what the archetype produces, so writing 0555 out
+// here is what makes a check that would otherwise have kept passing across that
+// change say so. And imageUID/imageGID describe the identity *this repository*
+// asks its own image to run as; what is being asserted here is that the
+// archetype's placement of a composed entry agrees with it. Expressing the
+// expectation in terms of this repository's constants would make the two move
+// together, so the day they diverged the check would follow the base image
+// instead of reporting the divergence — which is the whole thing being checked.
+//
+// The directory's row keeps dirMode, and that is not an inconsistency: that
+// constant means "the mode of a directory the archetype creates implicitly, on
+// the way to somewhere else", which is exactly what this directory is, and
+// nothing may depend on it either way.
 //
 // The plugin directory comes with it, because the base image does not have one:
 // since #185 nothing in the base creates it, so the composition is what does. It
@@ -665,7 +698,7 @@ func generatorImageContents(base map[string]imageEntry) map[string]imageEntry {
 	contents := maps.Clone(base)
 
 	contents[pluginDir] = imageEntry{kindDir, 0, 0, dirMode}
-	contents[pluginDir+"/"+generatorExecutable] = imageEntry{kindFile, imageUID, imageGID, 0o555}
+	contents[pluginDir+"/"+generatorExecutable] = imageEntry{kindFile, 65532, 65532, 0o555}
 
 	return contents
 }
@@ -867,10 +900,18 @@ func (m *Cpybkc) checkImageIsTheCLI(ctx context.Context, image *dagger.Container
 //     would produce an index whose arm64 manifest holds an amd64 executable,
 //     which fails for the first person to pull it on the platform they asked
 //     for and for nobody here.
+//
+// executable is the path inside the image to read, because the image whose
+// architecture is worth asserting is not always the base's: a generator image
+// carries a second executable, contributed by a different route, and it is the
+// one an arm64 image would be running if the composition had paired the variant
+// sets wrongly (#180). The caller names it rather than this function assuming
+// the CLI.
 func (m *Cpybkc) checkImageBuild(
 	ctx context.Context,
 	image *dagger.Container,
 	platform dagger.Platform,
+	executable string,
 ) []error {
 	const mountedAt = "/image"
 
@@ -887,10 +928,10 @@ func (m *Cpybkc) checkImageBuild(
 	out, err := dag.Go().
 		Container(m.Source).
 		WithMountedDirectory(mountedAt, image.Rootfs()).
-		WithExec([]string{"go", "version", "-m", mountedAt + cliPath()}).
+		WithExec([]string{"go", "version", "-m", mountedAt + executable}).
 		Stdout(ctx)
 	if err != nil {
-		return []error{fmt.Errorf("reading the build settings of the executable in the image: %w", err)}
+		return []error{fmt.Errorf("reading the build settings of %s in the image: %w", executable, err)}
 	}
 
 	settings := buildSettings(out)
@@ -912,11 +953,11 @@ func (m *Cpybkc) checkImageBuild(
 		got, ok := settings[w.setting]
 		switch {
 		case !ok:
-			errs = append(errs, fmt.Errorf("the executable in the image states no %s; it has to be %s, because %s",
-				w.setting, w.value, w.why))
+			errs = append(errs, fmt.Errorf("%s in the image states no %s; it has to be %s, because %s",
+				executable, w.setting, w.value, w.why))
 		case got != w.value:
-			errs = append(errs, fmt.Errorf("the executable in the image was built with %s=%s, want %s: %s",
-				w.setting, got, w.value, w.why))
+			errs = append(errs, fmt.Errorf("%s in the image was built with %s=%s, want %s: %s",
+				executable, w.setting, got, w.value, w.why))
 		}
 	}
 

--- a/.dagger/release.go
+++ b/.dagger/release.go
@@ -240,22 +240,33 @@ func (m *Cpybkc) Release(
 	// generatorRepository gives: a mirror redirects the whole family by moving
 	// the CLI image, and a caller who could name the two independently could
 	// publish a generator the companion module's default would never look for.
+	//
+	// # The generator is first, and the order is the mitigation
+	//
+	// This slice is iterated for the gate and again for the push, so its order is
+	// the push order. The generator leads because its repository is the one that
+	// might not be writable: the first release under #180 *creates*
+	// `<repository>-gen-<name>`, and a registry that will accept a push to an
+	// existing package does not necessarily accept the creation of a new one. So
+	// the question that has never been answered is asked first, while the answer
+	// still costs nothing.
+	//
+	// Ordering is a mitigation and not a fix, because there is no fix available
+	// here — see the push loop below.
 	images := []struct {
 		app        *dagger.Z5LabsApp
 		repository string
 		check      func(context.Context, *dagger.Container, dagger.Platform) []error
 	}{
 		{
+			app:        m.generatorApp(version),
+			repository: generatorRepository(repository, ownGenerator),
+			check:      m.checkGeneratorImage,
+		},
+		{
 			app:        m.baseApp(version),
 			repository: repository,
 			check:      m.checkBaseImage,
-		},
-		{
-			app:        m.generatorApp(version),
-			repository: generatorRepository(repository, ownGenerator),
-			check: func(ctx context.Context, image *dagger.Container, _ dagger.Platform) []error {
-				return m.checkGeneratorImage(ctx, image)
-			},
 		},
 	}
 
@@ -269,10 +280,16 @@ func (m *Cpybkc) Release(
 	// so that a check added to ImageContract is a check this gate acquires.
 	//
 	// Both are gated before either is pushed, rather than each image being checked
-	// and then published in turn. A publish is not atomic across repositories, and
-	// a release that pushed the base and then found its generator unpublishable
-	// would leave a version tag out that this project's contract says is never
-	// repointed.
+	// and then published in turn, so that an image failing its contract cannot be
+	// discovered after the other one is already out.
+	//
+	// That rules out one cause of a half-published release and **not** the
+	// general case, which is worth saying plainly because the arrangement looks
+	// stronger than it is. The pushes below are sequential across two
+	// repositories and a registry has no transaction spanning them, so anything
+	// that fails at push time — a credential, a rate limit, a repository that
+	// cannot be created — still leaves the earlier image published under tags
+	// this project's contract says are never repointed.
 	var errs []error
 	for _, image := range images {
 		for _, platform := range imagePlatforms() {
@@ -290,6 +307,18 @@ func (m *Cpybkc) Release(
 
 	fmt.Fprintf(&report, "%s\n  version:    %s\n", registry, version)
 
+	// Two publishes, in the order the slice above fixes, and the failure of the
+	// second leaves the first published. What makes that survivable is that this
+	// whole function is safe to run again: each image is a function of the source,
+	// so a re-run pushes the same bytes and every tag lands back on the digest it
+	// already named. So the recovery from a half-published release is to fix
+	// whatever refused the push and re-run the job — not to hand-push the missing
+	// image, and never to repoint a tag.
+	//
+	// The report is written as it goes rather than at the end, and it is returned
+	// beside the error rather than discarded, precisely so a half-published
+	// release says which half. An error alone would leave whoever is holding it
+	// unable to tell a release that pushed nothing from one that pushed one image.
 	for _, image := range images {
 		published, err := image.app.
 			WithRegistry(registry, username, password).

--- a/.dagger/release.go
+++ b/.dagger/release.go
@@ -123,7 +123,15 @@ const (
 	notesClose = "<!-- /cpybkc:image -->"
 )
 
-// Release publishes the base image for the release at HEAD (#59, #185).
+// Release publishes the images for the release at HEAD (#59, #185, #180).
+//
+// Two of them, over the same platforms and under the same release's tags: the
+// base image, and the generator image carrying cpybkc's own generator. The
+// second is not an extra artifact bolted on beside the first — it is the base
+// App with one more application composed into it, so it is signed, attested and
+// tagged by having been published the same way rather than by a second
+// arrangement here. Where it goes is derived from where the base went; see
+// generatorRepository.
 //
 // Whether there is a release at all is decided here, from the release's own tag
 // and the refs at HEAD: a canonical version tag pointing at HEAD is a release,
@@ -177,8 +185,9 @@ func (m *Cpybkc) Release(
 	tag string,
 	// The registry to publish to, without a repository path — `ghcr.io`.
 	registry string,
-	// The image's repository within that registry, without a tag —
-	// `zaba505/cpybkc`.
+	// The base image's repository within that registry, without a tag —
+	// `zaba505/cpybkc`. The generator image's is derived from it, so moving this
+	// one moves the whole family.
 	repository string,
 	// The registry username to authenticate as.
 	username string,
@@ -226,20 +235,50 @@ func (m *Cpybkc) Release(
 			releaseName(tag), strings.Join(refs, ", ")), nil
 	}
 
-	app := m.baseApp(version)
+	// The two images this release publishes, and the repository each goes to. The
+	// generator's is derived rather than an argument for the reason
+	// generatorRepository gives: a mirror redirects the whole family by moving
+	// the CLI image, and a caller who could name the two independently could
+	// publish a generator the companion module's default would never look for.
+	images := []struct {
+		app        *dagger.Z5LabsApp
+		repository string
+		check      func(context.Context, *dagger.Container, dagger.Platform) []error
+	}{
+		{
+			app:        m.baseApp(version),
+			repository: repository,
+			check:      m.checkBaseImage,
+		},
+		{
+			app:        m.generatorApp(version),
+			repository: generatorRepository(repository, ownGenerator),
+			check: func(ctx context.Context, image *dagger.Container, _ dagger.Platform) []error {
+				return m.checkGeneratorImage(ctx, image)
+			},
+		},
+	}
 
-	// The gate. Nothing is pushed until the image has been checked against
-	// docs/container/SPEC.md on every platform it is published for, and it is
-	// checked on the containers this very App carries — see this file's comment
-	// for why that is not the same as having run `dagger call image-contract` a
-	// moment earlier.
+	// The gate. Nothing is pushed until **both** images have been checked against
+	// docs/container/SPEC.md on every platform they are published for, and each is
+	// checked on the containers its own App carries — see this file's comment for
+	// why that is not the same as having run `dagger call image-contract` a moment
+	// earlier.
 	//
-	// checkBaseImage rather than a sequence assembled here, so that a check added
-	// to ImageContract is a check this gate acquires.
+	// checkBaseImage and checkGeneratorImage rather than sequences assembled here,
+	// so that a check added to ImageContract is a check this gate acquires.
+	//
+	// Both are gated before either is pushed, rather than each image being checked
+	// and then published in turn. A publish is not atomic across repositories, and
+	// a release that pushed the base and then found its generator unpublishable
+	// would leave a version tag out that this project's contract says is never
+	// repointed.
 	var errs []error
-	for _, platform := range imagePlatforms() {
-		for _, err := range m.checkBaseImage(ctx, app.Container(platform), platform) {
-			errs = append(errs, fmt.Errorf("%s: %w", platform, err))
+	for _, image := range images {
+		for _, platform := range imagePlatforms() {
+			for _, err := range image.check(ctx, image.app.Container(platform), platform) {
+				errs = append(errs, fmt.Errorf("%s %s: %w", image.repository, platform, err))
+			}
 		}
 	}
 
@@ -247,22 +286,32 @@ func (m *Cpybkc) Release(
 		return "", fmt.Errorf("refusing to publish %s: %w", version, err)
 	}
 
-	published, err := app.
-		WithRegistry(registry, username, password).
-		WithOidc(idTokenRequestUrl, idTokenRequestToken).
-		Publish(ctx, []string{repository})
-	if err != nil {
-		return "", fmt.Errorf("publishing %s/%s: %w", registry, repository, err)
-	}
-
 	var report strings.Builder
-	fmt.Fprintf(&report, "%s/%s\n  version:    %s\n", registry, repository, version)
-	for _, ref := range published {
-		fmt.Fprintf(&report, "  %s\n", ref)
-	}
 
-	if err := checkPublished(version, published); err != nil {
-		return report.String(), err
+	fmt.Fprintf(&report, "%s\n  version:    %s\n", registry, version)
+
+	for _, image := range images {
+		published, err := image.app.
+			WithRegistry(registry, username, password).
+			WithOidc(idTokenRequestUrl, idTokenRequestToken).
+			Publish(ctx, []string{image.repository})
+		if err != nil {
+			return report.String(), fmt.Errorf("publishing %s/%s: %w", registry, image.repository, err)
+		}
+
+		fmt.Fprintf(&report, "  %s\n", image.repository)
+		for _, ref := range published {
+			fmt.Fprintf(&report, "    %s\n", ref)
+		}
+
+		// Read back per image rather than over the union. The three properties are
+		// each about *one* release of *one* repository — every tag naming one
+		// digest most of all — and checking a merged list would let a generator
+		// that published nothing but its version tag hide behind the base's
+		// moving ones.
+		if err := checkPublished(version, published); err != nil {
+			return report.String(), fmt.Errorf("%s: %w", image.repository, err)
+		}
 	}
 
 	return report.String(), nil
@@ -429,11 +478,15 @@ func (m *Cpybkc) ReleaseNotes(
 // TagScheme is the half of the release decision this repository still makes,
 // executed rather than read.
 //
-// What it covers is what planRelease answers: whether a release is a release of
-// the image at all, and which version it is. The tag *family* that version
-// implies is the archetype's since #185, and is checked by its own table over
-// its own literals — restating it here would be a second copy of somebody else's
-// rule, which is exactly what this file exists to avoid having.
+// What it covers is what planRelease answers — whether a release is a release of
+// the image at all, and which version it is — and, since #180, where the
+// generator image that release publishes beside the base goes. Both are
+// decisions this repository makes and the archetype does not.
+//
+// The tag *family* that version implies is the archetype's since #185, and is
+// checked by its own table over its own literals — restating it here would be a
+// second copy of somebody else's rule, which is exactly what this file exists to
+// avoid having.
 // docs/container/SPEC.md's tag table says where each half is checked, so that a
 // reader concludes neither that the table is unenforced nor that this repository
 // enforces it.
@@ -549,6 +602,29 @@ func (m *Cpybkc) TagScheme() error {
 		}
 	}
 
+	// Where the generator image goes, which is the other half of the release
+	// decision since #180: a release states a version *and* the repositories that
+	// version is published to, and only one of the two is an argument.
+	//
+	// The literals matter more here than anywhere else in this function, because
+	// this rule is written down twice — daggerverse/cpybkc/internal/generator's
+	// Repository is the other spelling, in a Go module this one cannot import.
+	// Its TestRepository pins the same two answers. So the pair below is not a
+	// tautology over one line of code: it is one end of a drift guard whose other
+	// end is a test in another module, and the failure it rules out is a release
+	// publishing where the companion module's default never looks.
+	for _, c := range []struct{ repository, name, want string }{
+		{"zaba505/cpybkc", "go", "zaba505/cpybkc-gen-go"},
+		// A mirror redirects the whole family by moving the CLI image alone,
+		// which is the property that makes the rule derived rather than constant.
+		{"mirrors/cpybkc", "go", "mirrors/cpybkc-gen-go"},
+	} {
+		if got := generatorRepository(c.repository, c.name); got != c.want {
+			errs = append(errs, fmt.Errorf("the generator image for %q beside %q publishes to %q, want %q",
+				c.name, c.repository, got, c.want))
+		}
+	}
+
 	return errors.Join(errs...)
 }
 
@@ -587,6 +663,11 @@ func (m *Cpybkc) ReleaseNotesContract() error {
 		"IR version 7",
 		"`v0.2.0`",
 		"ghcr.io/zaba505/cpybkc:v0.2.0",
+		// The generator image, named beside the base it is published with (#180).
+		// A literal rather than generatorRepository's answer, like every other
+		// expectation here: a check that derived it the way the block does would
+		// go green on a block that had stopped naming the generator at all.
+		"ghcr.io/zaba505/cpybkc-gen-go:v0.2.0",
 		notesOpen, notesClose,
 	} {
 		if !strings.Contains(block, want) {
@@ -900,6 +981,13 @@ func (m *Cpybkc) irVersion(ctx context.Context) (int, error) {
 // published, so ReleaseNotesContract can read it back without a registry, a git
 // checkout or a release.
 //
+// It names **both** images a release publishes (#180), and the generator's
+// reference is derived from the base's rather than passed in — one argument for
+// two images, so a mirror's release notes cannot name the mirror for one and
+// ghcr.io for the other. That the generator exists at all is the fact this half
+// of the block is for: `v0.0.0` published the base alone, and the one documented
+// way to get the generator was a reference that answered NAME_UNKNOWN.
+//
 // It names the version and no other tag. Which tags a version implies is the
 // shared pipeline's rule since #185, and a block enumerating them would be this
 // repository restating somebody else's table in the one artifact a reader cannot
@@ -920,11 +1008,17 @@ func releaseNotesBlock(version string, irVersion int, reference string) string {
 	var b strings.Builder
 
 	b.WriteString(notesOpen)
-	b.WriteString("\n## The image this release publishes\n\n")
+	b.WriteString("\n## The images this release publishes\n\n")
 
 	if reference != "" {
-		fmt.Fprintf(&b, "```console\n$ docker pull %s:%s\n```\n\n", reference, version)
+		fmt.Fprintf(&b, "```console\n$ docker pull %s:%s\n$ docker pull %s:%s\n```\n\n",
+			reference, version, generatorRepository(reference, ownGenerator), version)
 	}
+
+	fmt.Fprintf(&b, "Two images: the cpybkc CLI, and `cpybkc-gen-%s`, this project's own generator. The generator\n"+
+		"reaches you the way a stranger's does — an image to `COPY --from`, never something the base image\n"+
+		"carries — and it is published from this same release, over the same platforms and under the same\n"+
+		"tags.\n\n", ownGenerator)
 
 	fmt.Fprintf(&b, "**This image speaks IR version %d.** Every descriptor the `cpybkc` in it writes carries that\n"+
 		"version, and a generator that implements a lower one refuses the descriptor rather than guessing — so a\n"+

--- a/daggerverse/cpybkc/internal/generator/generator.go
+++ b/daggerverse/cpybkc/internal/generator/generator.go
@@ -11,8 +11,8 @@
 // Three strings are composed, and they are the module's whole knowledge of how a
 // generator is named and where it goes: the filename inside the image and the
 // path it lands at, both of which the specs fix, and the repository a published
-// generator image is pulled from, which is this project's publishing rule rather
-// than anybody's contract. Everything else about a generator — the argument
+// generator image is pulled from, which docs/container/SPEC.md covers as of #180.
+// Everything else about a generator — the argument
 // vector, the descriptor, the exit codes, determinism — is docs/plugin/SPEC.md's,
 // holds with no container anywhere in the picture, and is not this module's
 // business.
@@ -79,9 +79,18 @@ func Path(name string) string {
 // Repository is where this project publishes the generator image for name,
 // derived from the repository the CLI image itself was pulled from.
 //
-// The derivation is a fact about how cpybkc publishes rather than a promise the
-// base-image contract makes, which is why it lives here and not in
-// docs/container/SPEC.md. Deriving it from the caller's --repository rather than
+// The derivation is a promise the base-image contract makes — "Where this
+// project's own generators are published", covered by its compatibility
+// guarantees. It was described here as an internal publishing rule binding
+// nobody until #180, which was true for exactly as long as nothing was published
+// under it: this module's default with no --image resolves precisely this
+// reference, so the first release to push a generator image made the rule
+// something a published module's public API rests on. It is written down at both
+// ends now, and the literals in TestRepository are one end of the drift guard —
+// .dagger's TagScheme is the other, because the two spellings are in Go modules
+// that cannot import each other.
+//
+// Deriving it from the caller's --repository rather than
 // from a constant is what makes a mirror, an internal registry or an air-gapped
 // copy redirect the whole family at once: a caller who moved the CLI image and
 // not its generators would otherwise reach back to ghcr.io from inside a network

--- a/daggerverse/cpybkc/internal/generator/generator.go
+++ b/daggerverse/cpybkc/internal/generator/generator.go
@@ -82,10 +82,11 @@ func Path(name string) string {
 // The derivation is a promise the base-image contract makes — "Where this
 // project's own generators are published", covered by its compatibility
 // guarantees. It was described here as an internal publishing rule binding
-// nobody until #180, which was true for exactly as long as nothing was published
+// nobody until #180, which held for exactly as long as nothing was published
 // under it: this module's default with no --image resolves precisely this
-// reference, so the first release to push a generator image made the rule
-// something a published module's public API rests on. It is written down at both
+// reference, so the first release to push a generator image is what makes the
+// rule something a published module's public API rests on, and #180 is the
+// change that arranges for that release to happen. It is written down at both
 // ends now, and the literals in TestRepository are one end of the drift guard —
 // .dagger's TagScheme is the other, because the two spellings are in Go modules
 // that cannot import each other.

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -125,6 +125,16 @@ The base image holds **no** executable in the plugin directory (#55, #185).
 way a stranger's does: as an image built `FROM` the base, adding one executable at
 the path this section names and changing nothing else.
 
+It is **published**, and where is [named below](#where-this-projects-own-generators-are-published)
+(#180). That sentence used to describe an intention rather than a release: the
+first release published the base image alone, and the generator reference this
+document sent a reader to — the one the [companion Dagger
+module](#also-out-of-scope) resolves by default — answered `NAME_UNKNOWN`. So the
+one documented way to get `cpybkc-gen-go` was unavailable to everybody outside
+this repository, while three places in the tree said it existed. What closed the
+gap is the generator image being cut from the same release as the base, over the
+same platforms, under the same tags, signed and attested the same way.
+
 The CLI is not in there either. It used to be, and its path was never part of
 this contract — see [The CLI's own path is not part of the
 contract](#the-clis-own-path-is-not-part-of-the-contract), which is why the base
@@ -140,6 +150,59 @@ against a mechanism that had never been used.
 
 So the mechanism has a user before it has any, and the cost is one extra image
 reference in a consumer's Dockerfile.
+
+### Where this project's own generators are published
+
+A generator this project publishes for `<name>` is at the **base image's own
+repository with `-gen-<name>` appended**, in the same registry, under the same
+release's tags (#180). Today that is one image:
+
+| Image | Repository | Tags |
+| --- | --- | --- |
+| The cpybkc CLI | `<repository>` | [the family a release publishes](#tags-and-what-pinning-one-buys) |
+| The `go` generator | `<repository>-gen-go` | the same family, from the same release |
+
+So against the published release, and with `ghcr.io/zaba505/cpybkc` as the
+repository:
+
+```console
+$ docker pull ghcr.io/zaba505/cpybkc:v0
+$ docker pull ghcr.io/zaba505/cpybkc-gen-go:v0
+```
+
+The rule is **derived from the CLI image's repository and not from a constant**,
+which is what makes a mirror, an internal registry or an air-gapped copy redirect
+the whole family at once. Copy `<repository>` and `<repository>-gen-go` into
+`registry.internal/mirrors/`, point a build at
+`registry.internal/mirrors/cpybkc`, and the generator is where that rule says it
+is. A rule anchored to `ghcr.io` would instead send a build inside a network that
+cannot see it reaching back out on the second pull rather than the first.
+
+**This is a covered guarantee**, and that is a decision rather than an
+observation. Until #180 the derivation was described in the companion module's
+own source as "this project's publishing rule rather than anybody's contract" —
+which was true while nothing was published under it, and stopped being true the
+moment a release was. Two things now depend on it from outside this repository: a
+derived `Dockerfile` writing `COPY --from=<repository>-gen-go`, in a repository
+this project cannot see and cannot warn; and the [companion Dagger
+module](#also-out-of-scope)'s `with-generator`, whose default with no `--image`
+resolves exactly this reference and whose published module ref is public API for
+as long as it resolves. A rule two public things already rest on, documented as
+binding nobody, is the "private arrangement that resembles one" the section above
+exists to refuse — so it is written down here, where the [compatibility
+guarantees](#compatibility-guarantees) cover it and [How a covered thing would
+change](#how-a-covered-thing-would-change) applies to it.
+
+What is **not** covered is which registry any of it is in, exactly as for the
+base image: a mirror serving the same digests satisfies this identically. Nor is
+the *set* of generators this project publishes — `go` is the only one today, and
+another arriving beside it is not a breaking change, while moving or withdrawing
+one is.
+
+None of this makes a published generator a privileged kind of plugin. It is
+built, named and discovered by the same rules as a stranger's, which is the whole
+argument of the section above; what this section fixes is only the address, so
+that the address can be depended on.
 
 ### The CLI's own path is not part of the contract
 
@@ -1152,6 +1215,7 @@ change to any of them is a breaking change:
 | [Shell or no shell](#shell-or-no-shell) | Absent; extension is `COPY`-only |
 | [Platforms](#why-the-platform-set-is-the-two-it-is) | `linux/amd64` and `linux/arm64` |
 | [Tags](#tags-and-what-pinning-one-buys) | A published full-version tag never moves |
+| [This project's own generator images](#where-this-projects-own-generators-are-published) | `<repository>-gen-<name>`, in the same registry and under the same release's tags as the CLI image |
 | [Signatures](#what-a-tag-carries-besides-the-image) | The published index and each manifest beneath it are signed; the index digest carries provenance and an SBOM per platform, as referrers |
 
 **Not covered**, and explicitly implementation detail. Depending on any of it is
@@ -1191,6 +1255,11 @@ depending on something that may change in a patch release, with no notice:
 - Anything else appearing under `/usr/local/share/cpybkc/`. The two paths named
   above are the contract; a third file arriving beside them is not one to depend
   on until this document names it.
+- **Which** generators this project publishes, beyond `go`. The [naming
+  rule](#where-this-projects-own-generators-are-published) is covered and the set
+  it is applied to is not: another generator appearing beside `cpybkc-gen-go` is
+  not a breaking change, and neither is one never appearing. Nothing here
+  promises a generator for any particular language will exist.
 
 ### Why the platform set is the two it is
 
@@ -1288,7 +1357,8 @@ Go install with no document that applies to them.
 | Section | Implemented by |
 |---|---|
 | [The plugin directory](#the-plugin-directory) | #54, #55 `container`; #185 `container` withdraws the promise that the directory exists in the base image |
-| [Why cpybkc's own generator is not in the base image](#why-cpybkcs-own-generator-is-not-in-the-base-image) | #55 `container` for the base holding none, #48–#53 `gen-go` for the generator that goes through the front door |
+| [Why cpybkc's own generator is not in the base image](#why-cpybkcs-own-generator-is-not-in-the-base-image) | #55 `container` for the base holding none, #48–#53 `gen-go` for the generator that goes through the front door, #180 `container` for the release that publishes it |
+| [Where this project's own generators are published](#where-this-projects-own-generators-are-published) | #180 `container` decides the rule is covered rather than internal, and publishes the first image under it |
 | [The CLI's own path is not part of the contract](#the-clis-own-path-is-not-part-of-the-contract) | #55 `container`; #185 `container` is where it was spent |
 | [The entrypoint](#the-entrypoint) | #55 `container` |
 | [The user](#the-user) | #55 `container` |

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -125,15 +125,23 @@ The base image holds **no** executable in the plugin directory (#55, #185).
 way a stranger's does: as an image built `FROM` the base, adding one executable at
 the path this section names and changing nothing else.
 
-It is **published**, and where is [named below](#where-this-projects-own-generators-are-published)
-(#180). That sentence used to describe an intention rather than a release: the
-first release published the base image alone, and the generator reference this
-document sent a reader to — the one the [companion Dagger
-module](#also-out-of-scope) resolves by default — answered `NAME_UNKNOWN`. So the
-one documented way to get `cpybkc-gen-go` was unavailable to everybody outside
-this repository, while three places in the tree said it existed. What closed the
-gap is the generator image being cut from the same release as the base, over the
-same platforms, under the same tags, signed and attested the same way.
+**Every release from the next one on publishes it**, at the repository
+[named below](#where-this-projects-own-generators-are-published) (#180).
+
+That is a change of state and not just of wording. The sentence above described
+an intention for as long as it stood alone: `v0.0.0` published the base image
+alone, and the generator reference this document sent a reader to — the one the
+[companion Dagger module](#also-out-of-scope) resolves by default — answered
+`NAME_UNKNOWN`. So the one documented way to get `cpybkc-gen-go` was unavailable
+to everybody outside this repository, while three places in the tree said it
+existed. What closes the gap is the generator image being cut from the same
+release as the base, over the same platforms, under the same tags, signed and
+attested the same way.
+
+Until that release is cut, the references below resolve to nothing. They are
+written here ahead of it deliberately — the rule they follow is what the release
+is built against — but a reader arriving between this document and that release
+should expect the same `NAME_UNKNOWN` this paragraph is about.
 
 The CLI is not in there either. It used to be, and its path was never part of
 this contract — see [The CLI's own path is not part of the
@@ -155,15 +163,16 @@ reference in a consumer's Dockerfile.
 
 A generator this project publishes for `<name>` is at the **base image's own
 repository with `-gen-<name>` appended**, in the same registry, under the same
-release's tags (#180). Today that is one image:
+release's tags (#180). One generator is published under that rule, from the first
+release to carry it onwards:
 
 | Image | Repository | Tags |
 | --- | --- | --- |
 | The cpybkc CLI | `<repository>` | [the family a release publishes](#tags-and-what-pinning-one-buys) |
 | The `go` generator | `<repository>-gen-go` | the same family, from the same release |
 
-So against the published release, and with `ghcr.io/zaba505/cpybkc` as the
-repository:
+So with `ghcr.io/zaba505/cpybkc` as the repository, a release published under
+this rule is pulled as:
 
 ```console
 $ docker pull ghcr.io/zaba505/cpybkc:v0
@@ -181,8 +190,8 @@ cannot see it reaching back out on the second pull rather than the first.
 **This is a covered guarantee**, and that is a decision rather than an
 observation. Until #180 the derivation was described in the companion module's
 own source as "this project's publishing rule rather than anybody's contract" —
-which was true while nothing was published under it, and stopped being true the
-moment a release was. Two things now depend on it from outside this repository: a
+which is true only for as long as nothing is published under it, and the release
+that publishes the first generator image is what ends that. Two things now depend on it from outside this repository: a
 derived `Dockerfile` writing `COPY --from=<repository>-gen-go`, in a repository
 this project cannot see and cannot warn; and the [companion Dagger
 module](#also-out-of-scope)'s `with-generator`, whose default with no `--image`


### PR DESCRIPTION
Closes #180

`v0.0.0` published the base image and nothing else, so `cpybkc-gen-go` shipped in no image at all and the one documented way to get it answered `NAME_UNKNOWN`. Three places in the tree said it existed. This publishes it.

## Acceptance criteria

- [x] **`App.WithApp` composition onto the base `App`, not a second image recipe.** `generatorApp` is `baseApp(version).WithApp(ownGeneratorApp(version))`, and it is the one construction of it: `CompanionModule` drives it, `ImageContract` checks it and `Release` publishes it, so what a check composes against is what a release pushes.
- [x] **Built through the generic `Z5Labs.App` constructor with an explicit `Name`.** `Go.App` names every binary after `go.mod`'s module directive, and this repository's two commands share one module — so the chain would have composed an executable called `cpybkc`: the right bytes under a name nothing looks for, layered onto a base whose own entry already answers to it. `WithVariant`'s `Name` states it instead. The check asserts the **name** in the plugin directory (`checkComposedImage`), not only that exactly one file was added.
- [x] **The "It is not published and never will be" comment is corrected.** `generatorImage` moved to `image.go` beside `baseApp`, since it is a release's business now rather than a check fixture; the comment went with it and now says what it is. `neverPulledRepository`'s comment gained the note that #180 makes that guard load bearing rather than precautionary — from the first release onwards a forgotten `--image` *resolves*, to the last release instead of the change.
- [x] **A contract check on every published platform: the base's exhaustive listing plus exactly one file.** `checkGeneratorImage` runs the OCI configuration checks (so an edited entrypoint fails here), the exhaustive filesystem listing via `generatorImageContents`, and the plugin-directory listing. Expected mode and owner are literals — `0555`, `65532` — and deliberately not `derivedExecutableMode`, which is `0755` and describes the hand-rolled build this replaces.
- [x] **`Release` publishes it over the same platforms and under the same release's tags, through `App.Publish`.** Both images are gated on every platform *before* either is pushed, because a publish is not atomic across repositories and a half-done release leaves out a version tag this project never repoints. `checkPublished` runs per image rather than over the union, so a generator that published only its version tag cannot hide behind the base's moving tags.
- [x] **Same signature and attestations as the base**, by being published the same way — `App.Publish` on an ordinary App — rather than by a second arrangement here.
- [x] **Decided: the naming rule becomes a covered promise.** See below.
- [x] **`docs/container/SPEC.md` names where the generator is published**, so "reaches a user the way a stranger's does" describes a release rather than an intention.
- [x] **The release notes block names the generator image** beside the base, with the generator's reference derived from the base's — one argument for two images, so a mirror's notes cannot name the mirror for one and ghcr.io for the other.

## The decision the story left open

The repository naming rule `<cli-repository>-gen-<name>` and the shared tag scheme are now **covered promises** in `docs/container/SPEC.md`, in a new section *Where this project's own generators are published*, with a row in the compatibility guarantees table.

The argument: it was honest to call it "this project's publishing rule rather than anybody's contract" for exactly as long as nothing was published under it. Two things outside this repository already rest on it — a derived `Dockerfile` writing `COPY --from=<repository>-gen-go`, which this project cannot see and cannot warn, and the companion module's `with-generator` default with no `--image`, whose published module ref is public API for as long as it resolves. A rule two public things depend on, documented as binding nobody, is the "private arrangement that resembles one" that section already exists to refuse.

What is **not** covered: the registry (a mirror serving the same digests satisfies it identically, and the rule is derived from the caller's repository so a mirror redirects the whole family by moving the CLI image alone), and the *set* of generators — another arriving beside `go` is not a breaking change.

The rule is now written twice, in Go modules that cannot import each other. Both ends are pinned to the same literals: `internal/generator`'s `TestRepository` and `TagScheme` here.

## Judgment calls

- **`generatorBinary` now builds from `appSource()` rather than `Source`**, so the executable the published image carries is compiled from the same tree — git metadata included — as the CLI it is composed onto.
- **`/usr/local/bin` in the composed image is `d 0:0 0755`.** Read off the failing check rather than assumed: it is a directory the archetype creates on the way to somewhere else. `docs/container/SPEC.md` holds this directory's ownership and mode out of the contract in as many words; the row is in the listing because the listing is exhaustive or it is nothing.
- **`WorkedExample` is untouched.** `derivedImageContents` and `derivedExecutableMode` still describe what a *stranger's* `COPY --chmod=0755` produces, which is theirs to choose and not what the archetype writes.

## Verified

`dagger call ci` green on the full tree, from an ordinary clone — the pipeline cannot run from a git worktree since #185.

One local snag worth recording: the first `ci` run failed with `missing shared result` on a `File!`, then replayed that identical cached error on every re-run while `image-contract` and `companion-module` both passed standalone and `ci` passed on the same code with one comment added. It was a poisoned local cache entry, cleared by `dagger core engine local-cache prune`; the final run is a full cold 1m36s green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
