### PR TITLE
story(cli): the version a release publishes is the version it was cut from

### DIFF
--- a/.dagger/companion.go
+++ b/.dagger/companion.go
@@ -486,7 +486,7 @@ func (m *Cpybkc) CompanionModule(ctx context.Context) error {
 	fromImage := m.companion(platform).WithGenerator(ownGenerator, dagger.CompanionWithGeneratorOpts{
 		Image: m.generatorImage(platform),
 	})
-	fromExecutable := m.companion(platform).WithGeneratorExecutable(ownGenerator, m.generatorBinary(platform))
+	fromExecutable := m.companion(platform).WithGeneratorExecutable(ownGenerator, m.generatorBinary(devVersion, platform))
 
 	var errs []error
 
@@ -535,7 +535,7 @@ func (m *Cpybkc) CompanionModule(ctx context.Context) error {
 	line, err := fromImage.Run([]string{"--version"}).Stdout(ctx)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("run did not reach the CLI in the composed image: %w", err))
-	} else if err := checkVersionLine(line); err != nil {
+	} else if err := checkVersionLine(line, devVersion); err != nil {
 		errs = append(errs, fmt.Errorf("run reached the CLI in the composed image and %w", err))
 	}
 

--- a/.dagger/image.go
+++ b/.dagger/image.go
@@ -234,6 +234,17 @@ const (
 	// covers an annotation, so this value is invisible to a consumer; it exists
 	// so that "which release is this" has an answer that is never wrong.
 	devVersion = "v0.0.0-dev"
+
+	// generatorVersionProbePackage is the Go package name checkGeneratorVersion
+	// hands the generator, and it names nothing that is ever written.
+	//
+	// docs/plugin/SPEC.md has this generator require a package name before it
+	// will accept a vector at all, and the vector has to parse before the
+	// version check it is being run for is reached. Nothing is generated — the
+	// descriptor is refused first — so this identifier appears in no file and in
+	// no diagnostic; it is here rather than inline so that a reader meeting it in
+	// the argument vector is not left looking for where its output went.
+	generatorVersionProbePackage = "unused"
 )
 
 // imagePlatforms is the set of platforms the image is published for, and the
@@ -403,7 +414,7 @@ func (m *Cpybkc) ownGeneratorApp(version string) *dagger.Z5LabsApp {
 	app := dag.Z5Labs().App(version)
 
 	for _, platform := range imagePlatforms() {
-		binary := m.generatorBinary(platform)
+		binary := m.generatorBinary(version, platform)
 
 		app = app.WithVariant(platform, binary, dag.Go().Spdx(binary, m.appSource()),
 			dagger.Z5LabsAppBuilderWithVariantOpts{Name: generatorExecutable})
@@ -423,7 +434,26 @@ func (m *Cpybkc) ownGeneratorApp(version string) *dagger.Z5LabsApp {
 // The source is appSource rather than m.Source, so the executable the published
 // generator image carries is compiled from the same tree — git metadata included
 // — as the CLI it is composed onto.
-func (m *Cpybkc) generatorBinary(platform dagger.Platform) *dagger.File {
+//
+// # The version stamp is written out here, because nothing else would write it
+//
+// The CLI beside it is stamped by the archetype, which fixes both the flag and
+// the variable's name: every z5labs Go application answers "which build am I
+// running" the same way. This build is the generic constructor's, so nothing
+// upstream is stamping anything, and a generator reporting 0.0.0-dev out of a
+// released image gives its refusal a version number nobody can map to a release
+// (#181). So the same stamp is passed by hand, under the same name, and
+// checkGeneratorVersion holds the result to the version the image was built for
+// exactly as the CLI's is held.
+//
+// One `-X` and not two. The archetype's pair carries a commit as well, and
+// nothing in either of this repository's commands reads one: docs/cli/SPEC.md
+// keeps the rest of a build's provenance off the version line, and
+// docs/plugin/SPEC.md gives a refusal three facts, none of them a commit. A
+// stamp naming a variable that does not exist is silently dropped, so passing
+// one would be a line in this recipe that does nothing and reads as though it
+// did.
+func (m *Cpybkc) generatorBinary(version string, platform dagger.Platform) *dagger.File {
 	return dag.Go().
 		Build(m.appSource(), dagger.GoBuildOpts{
 			Pkg:          generatorPackage,
@@ -431,6 +461,7 @@ func (m *Cpybkc) generatorBinary(platform dagger.Platform) *dagger.File {
 			Trimpath:     true,
 			DisableCgo:   true,
 			Platform:     string(platform),
+			Stamps:       []string{"main.version=" + version},
 		}).
 		File(generatorExecutable)
 }
@@ -558,11 +589,17 @@ func (m *Cpybkc) ImageContract(
 		// the only one and went unqualified; with two images in the loop, a
 		// reader would have had to know that a bare platform prefix meant the
 		// base — which stops being obvious the moment a third image arrives.
-		if err := errors.Join(m.checkBaseImage(ctx, m.baseImage(p), p)...); err != nil {
+		// devVersion twice over, because that is what baseImage and
+		// generatorImage build under and the check is "what the image reports is
+		// what it was built for". A release asks the same two functions the same
+		// question with its own version — see release.go's gate — so the version
+		// a published image carries is checked by the same code that has already
+		// passed on every pull request.
+		if err := errors.Join(m.checkBaseImage(ctx, m.baseImage(p), p, devVersion)...); err != nil {
 			errs = append(errs, fmt.Errorf("%s: the base image: %w", p, err))
 		}
 
-		if err := errors.Join(m.checkGeneratorImage(ctx, m.generatorImage(p), p)...); err != nil {
+		if err := errors.Join(m.checkGeneratorImage(ctx, m.generatorImage(p), p, devVersion)...); err != nil {
 			errs = append(errs, fmt.Errorf("%s: the generator image: %w", p, err))
 		}
 	}
@@ -582,10 +619,16 @@ func (m *Cpybkc) ImageContract(
 // Every group is run and every failure collected rather than stopping at the
 // first: a change that broke the entrypoint most likely broke the user and the
 // plugin directory too, and one run should say so.
+// version is what the image was built for, and what the CLI in it has to report:
+// the release's own where a release is being gated, devVersion everywhere else.
+// It is a parameter for the reason baseApp's is — the container a check reads is
+// built exactly as the container a release pushes is, so the fact being checked
+// has to travel the same way the fact being built from does.
 func (m *Cpybkc) checkBaseImage(
 	ctx context.Context,
 	image *dagger.Container,
 	platform dagger.Platform,
+	version string,
 ) []error {
 	protos, err := m.shippedProtos(ctx)
 	if err != nil {
@@ -596,7 +639,7 @@ func (m *Cpybkc) checkBaseImage(
 	errs = append(errs, m.checkImageContents(ctx, image, baseImageContents(protos))...)
 	errs = append(errs, m.checkImageBuild(ctx, image, platform, cliPath())...)
 	errs = append(errs, m.checkShippedIr(ctx, image)...)
-	errs = append(errs, m.checkImageIsTheCLI(ctx, image)...)
+	errs = append(errs, m.checkImageIsTheCLI(ctx, image, version)...)
 
 	return errs
 }
@@ -637,10 +680,15 @@ func (m *Cpybkc) checkBaseImage(
 // only one of the two whose route into the image #180 changed. The failure it
 // rules out is an exec format error in a stranger's image and nothing at all
 // here.
+// The fifth group is the generator's own version, and it is the only one of the
+// five that reads the executable by running it. See checkGeneratorVersion.
+//
+// version is what the image was built for, for checkBaseImage's reason.
 func (m *Cpybkc) checkGeneratorImage(
 	ctx context.Context,
 	image *dagger.Container,
 	platform dagger.Platform,
+	version string,
 ) []error {
 	protos, err := m.shippedProtos(ctx)
 	if err != nil {
@@ -650,9 +698,92 @@ func (m *Cpybkc) checkGeneratorImage(
 	errs := m.checkImageConfig(ctx, image)
 	errs = append(errs, m.checkImageContents(ctx, image, generatorImageContents(baseImageContents(protos)))...)
 	errs = append(errs, m.checkImageBuild(ctx, image, platform, pluginDir+"/"+generatorExecutable)...)
+	errs = append(errs, m.checkGeneratorVersion(ctx, image, version)...)
 
 	if err := m.checkComposedImage(ctx, image); err != nil {
 		errs = append(errs, err)
+	}
+
+	return errs
+}
+
+// checkGeneratorVersion runs the generator in the image on a descriptor it must
+// refuse, and requires the version in that refusal to be the version the image
+// was built for.
+//
+// It is the generator's half of what checkImageIsTheCLI does for the CLI, and it
+// exists for the same reason (#181): the version is stamped at link time, the
+// linker silently ignores a stamp naming a constant, and a stamp that stopped
+// landing is invisible in everything else this file checks — the executable is
+// the right architecture, built the right way, in the right place, under the
+// right name, and reports a version belonging to no release.
+//
+// # Why a refusal is how the version is read
+//
+// The generator has no --version. docs/plugin/SPEC.md fixes a plugin's argument
+// vector at `--descriptor <path> --out <dir> [--opt k=v ...]` and gives it no
+// flag of its own, so the one surface this generator's version reaches anybody
+// through is the refusal — which is also the only place it is *used*, by a
+// reader deciding whether to upgrade the generator or pin the CLI. Reading it
+// where it is used is what makes this a check on the fact rather than on a
+// proxy for it. Adding a flag to ask more conveniently would be this
+// repository's own generator carrying a surface no other plugin has, which is
+// the arrangement its package comment exists to refuse.
+//
+// The descriptor is empty, so it states no IR version — the case
+// cmd/cpybkc-gen-go's own tests pin — and an empty file is the one descriptor
+// whose bytes need no encoding: it goes in as the empty string rather than as a
+// protobuf message this module would have to hand-assemble to make a version
+// number out of. --out names a directory that does not exist and never will,
+// which is safe because the refusal precedes generation: the version is read off
+// the wire before the message is decoded and nothing is written beneath --out at
+// all. Both are properties of that program rather than accidents, and the
+// assertion below fails loudly if either stops holding, because what it requires
+// is *this* refusal and not merely a non-zero exit.
+func (m *Cpybkc) checkGeneratorVersion(ctx context.Context, image *dagger.Container, version string) []error {
+	const (
+		descriptor = "/no-version.binpb"
+		out        = "/nowhere"
+	)
+
+	// Expect a failure, because a refusal is one: the generator exits non-zero
+	// and writes the diagnostic to standard error. A run that *succeeded* is the
+	// finding — a generator that accepted a descriptor stating no IR version has
+	// stopped implementing the version check docs/plugin/SPEC.md requires — and
+	// it arrives here as an error from Stderr rather than as a passing check.
+	refusal, err := image.
+		WithNewFile(descriptor, "").
+		WithExec([]string{
+			pluginDir + "/" + generatorExecutable,
+			"--descriptor", descriptor,
+			"--out", out,
+			"--opt", "package_name=" + generatorVersionProbePackage,
+		}, dagger.ContainerWithExecOpts{Expect: dagger.ReturnTypeFailure}).
+		Stderr(ctx)
+	if err != nil {
+		return []error{fmt.Errorf("running %s in the image on a descriptor stating no IR version: %w",
+			generatorExecutable, err)}
+	}
+
+	var errs []error
+
+	// The refusal, and not merely a failure. Every other way this invocation can
+	// fail — a vector the generator rejects, a descriptor it cannot read — also
+	// exits non-zero and writes to standard error, and each of them would leave
+	// the version assertion below looking at a message that never names one.
+	if !strings.Contains(refusal, "implements IR version") {
+		errs = append(errs, fmt.Errorf("%s in the image answered a descriptor stating no IR version with %q, "+
+			"and docs/plugin/SPEC.md has it refuse one naming the descriptor's version, the highest it "+
+			"implements and its own", generatorExecutable, strings.TrimSpace(refusal)))
+
+		return errs
+	}
+
+	if want := generatorExecutable + " " + reportedVersion(version) + " "; !strings.Contains(refusal, want) {
+		errs = append(errs, fmt.Errorf("%s in the image refused with %q, and an image built under %s carries a "+
+			"generator naming itself %q: a released generator reporting the development version gives its "+
+			"refusal a number nobody can map to a release", generatorExecutable, strings.TrimSpace(refusal),
+			version, strings.TrimSpace(want)))
 	}
 
 	return errs
@@ -852,7 +983,12 @@ func (m *Cpybkc) checkImageEnv(ctx context.Context, image *dagger.Container) []e
 // invocation whenever output lands in a bind mount, and an executable readable
 // only by 65532 would break it — which is a failure a caller sees and this
 // repository never would.
-func (m *Cpybkc) checkImageIsTheCLI(ctx context.Context, image *dagger.Container) []error {
+// The line's *version* is checked as well as its shape, against the version the
+// image was built for (#181). This is the only reading of that fact anywhere:
+// the version is stamped at link time, and a stamp the linker dropped leaves an
+// image that passes every other group in this file while telling a consumer it
+// is a build of something that was never released.
+func (m *Cpybkc) checkImageIsTheCLI(ctx context.Context, image *dagger.Container, version string) []error {
 	var errs []error
 
 	for _, user := range []string{imageUser, overrideUser} {
@@ -867,7 +1003,7 @@ func (m *Cpybkc) checkImageIsTheCLI(ctx context.Context, image *dagger.Container
 			continue
 		}
 
-		if err := checkVersionLine(line); err != nil {
+		if err := checkVersionLine(line, version); err != nil {
 			errs = append(errs, fmt.Errorf("as user %s, %w", user, err))
 		}
 	}

--- a/.dagger/image.go
+++ b/.dagger/image.go
@@ -235,6 +235,25 @@ const (
 	// so that "which release is this" has an answer that is never wrong.
 	devVersion = "v0.0.0-dev"
 
+	// contractVersion is a version nothing publishes, built under once per run so
+	// that the version stamp is exercised rather than merely agreed with.
+	//
+	// It exists because devVersion cannot do this job. That value is deliberately
+	// the same string both commands carry in their tree — a build nobody stamped
+	// has to be indistinguishable from an unreleased one that was — and the
+	// consequence is that every check run under it passes whether the stamp
+	// landed or was silently dropped. Turning either `version` back into a const,
+	// or an upstream rename of the symbol the archetype stamps, would sail
+	// through a pull request and fail at a release, after a version tag is
+	// already pushed at HEAD and this project's contract forbids repointing it.
+	//
+	// A third value is the whole fix: built under it, a binary that was stamped
+	// says so and a binary that was not still says `0.0.0-dev`. It is not a
+	// release number and never becomes one — a tag it could be confused with is
+	// the one thing it must not be — and nothing is published from the images it
+	// builds. See checkVersionIsStamped.
+	contractVersion = "v0.0.0-contract"
+
 	// generatorVersionProbePackage is the Go package name checkGeneratorVersion
 	// hands the generator, and it names nothing that is ever written.
 	//
@@ -604,7 +623,65 @@ func (m *Cpybkc) ImageContract(
 		}
 	}
 
+	if err := errors.Join(m.checkVersionIsStamped(ctx)...); err != nil {
+		errs = append(errs, fmt.Errorf("the version stamp: %w", err))
+	}
+
 	return errors.Join(errs...)
+}
+
+// checkVersionIsStamped builds both images under a version nothing publishes and
+// requires the two executables to report it.
+//
+// # What the loop above cannot see
+//
+// Everything in this file that reads a version reads it out of an image built
+// under devVersion, and devVersion is the same string both commands carry in
+// their tree. So a binary the linker stamped and a binary whose stamp the linker
+// silently dropped produce the identical line, and every one of those
+// assertions passes either way. They are not worthless — a reportedVersion that
+// stopped dropping the tag's `v` fails them — but the fact this story exists for
+// is the one they cannot see, and a check that cannot fail on the defect it
+// names is worse than no check, because it is read as cover.
+//
+// The failures it leaves open are both live. `-X` writes only to a package-level
+// string var, and a var quietly returned to a const is exactly what #181 was:
+// the pipeline appears to stamp while the program reports the tree. The stamp
+// naming a symbol that is not there is the same outcome by a different route —
+// a typo in generatorBinary's `main.version`, or the archetype renaming what it
+// stamps upstream — and the linker reports neither.
+//
+// Building under contractVersion is what makes both observable, and it is the
+// only arrangement that does: no value the pipeline already uses can, because
+// the one it builds everything unreleased under is required to collide with the
+// tree's. A pull request stays green — the version being asserted is one this
+// check chose, not a release it has to agree with — which is the point.
+//
+// # One platform, and both routes into an image
+//
+// The engine's own, because this is the only group here that has to *execute*
+// both executables and a foreign platform would buy emulation for an answer that
+// does not vary by architecture. checkImageBuild is where per-platform claims
+// about these binaries are made.
+//
+// Both apps rather than one, because the two are stamped by different parties.
+// The CLI's comes from the shared archetype, with the flag and the symbol fixed
+// upstream; the generator's is passed by hand in generatorBinary, since it is
+// built through the generic constructor and has nobody upstream to stamp it. A
+// check of one says nothing about the other.
+func (m *Cpybkc) checkVersionIsStamped(ctx context.Context) []error {
+	platform, err := dag.DefaultPlatform(ctx)
+	if err != nil {
+		return []error{fmt.Errorf("resolving the engine's platform, which is the one this check runs on: %w", err)}
+	}
+
+	base := m.baseApp(contractVersion).Container(platform)
+
+	errs := m.checkImageIsTheCLI(ctx, base, contractVersion)
+
+	generator := m.generatorApp(contractVersion).Container(platform)
+
+	return append(errs, m.checkGeneratorVersion(ctx, generator, contractVersion)...)
 }
 
 // checkBaseImage holds one platform's base image to docs/container/SPEC.md.

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -863,10 +863,16 @@ func (m *Cpybkc) versionLine(ctx context.Context) (string, error) {
 // stamping a version while --version kept printing whatever the tree said, and
 // v0.0.0 shipped identifying itself as an unreleased development build. Nothing
 // compared the two, because the only two readings of the line in this module
-// wanted its shape and its IR version. It runs on an ordinary pull request as
-// well as at a release — there devVersion is what the image was built for and
-// what it has to say — so the stamp is checked by every run rather than by the
-// one run that cannot be repeated.
+// wanted its shape and its IR version.
+//
+// What this catches under devVersion is narrower than it looks, and worth
+// stating exactly. devVersion is the same string the commands carry in their
+// tree, so a stamp that landed and a stamp the linker dropped write the same
+// line and both pass here. What fails is a reportedVersion that stopped
+// dropping the tag's leading `v`, and a release whose binaries disagree with its
+// tag. That the stamp lands *at all* is checked by building under a version
+// nothing publishes — see checkVersionIsStamped, which is where the collision is
+// escaped.
 func checkVersionLine(line, version string) error {
 	if !strings.HasPrefix(line, cliBinary+" ") || !strings.Contains(line, "IR version") {
 		return fmt.Errorf("cpybkc --version wrote %q, and the line names the program, its version and the IR "+

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -807,7 +807,14 @@ func (m *Cpybkc) Build(ctx context.Context) error {
 		return err
 	}
 
-	return checkVersionLine(line)
+	// devVersion, because this is the loose executable rather than the one the
+	// archetype stamps: dag.Go().Build passes no -X at all, so what comes back is
+	// the value cmd/cpybkc/version.go carries in the tree. Holding it to the
+	// version the pipeline builds everything that is not a release under is what
+	// keeps those two statements of "0.0.0-dev" from drifting apart — the source
+	// default and this module's constant are the same string, and a build nobody
+	// stamped has to be indistinguishable from an unreleased one that was.
+	return checkVersionLine(line, devVersion)
 }
 
 // versionLine runs `cpybkc --version` in an image holding nothing but the
@@ -832,22 +839,69 @@ func (m *Cpybkc) versionLine(ctx context.Context) (string, error) {
 	return line, nil
 }
 
-// checkVersionLine reports whether line is what `cpybkc --version` writes.
-//
-// Only the line's shape. What it says is cmd/cpybkc's own test's business, and
-// asserting the version here would pin a release number in the pipeline.
+// checkVersionLine reports whether line is what `cpybkc --version` writes for a
+// build made under version.
 //
 // It is shared with the image contract, which runs the same invocation through
 // the published image's entrypoint (#55): what "this is cpybkc answering" means
 // is a property of the line rather than of which container it came out of, and a
 // second spelling would be a second, weaker answer.
-func checkVersionLine(line string) error {
+//
+// # The version on the line, and why asserting it is not pinning a number
+//
+// This used to check the shape alone, on the argument that "asserting the
+// version here would pin a release number in the pipeline". It would have, as a
+// literal. What it takes instead is the version the build was *made for* — the
+// caller's, devVersion for everything that is not a release and the release's
+// own tag for the two containers Release is about to push — so nothing here
+// names a release and the assertion still holds every build to the one number
+// it was supposed to carry.
+//
+// That is the check #181 found missing. Since #185 the shared archetype
+// cross-compiles the published CLI with `-X main.version=<version>`, and the
+// linker silently ignores a stamp naming a constant: the pipeline appeared to be
+// stamping a version while --version kept printing whatever the tree said, and
+// v0.0.0 shipped identifying itself as an unreleased development build. Nothing
+// compared the two, because the only two readings of the line in this module
+// wanted its shape and its IR version. It runs on an ordinary pull request as
+// well as at a release — there devVersion is what the image was built for and
+// what it has to say — so the stamp is checked by every run rather than by the
+// one run that cannot be repeated.
+func checkVersionLine(line, version string) error {
 	if !strings.HasPrefix(line, cliBinary+" ") || !strings.Contains(line, "IR version") {
 		return fmt.Errorf("cpybkc --version wrote %q, and the line names the program, its version and the IR "+
 			"version this build produces", line)
 	}
 
+	want := reportedVersion(version)
+
+	if fields := strings.Fields(line); len(fields) < 2 || fields[1] != want {
+		return fmt.Errorf("cpybkc --version wrote %q, and a build made under %s reports %q: the version a "+
+			"release publishes is the version it was cut from, and a stamp the linker dropped looks exactly "+
+			"like this", line, version, want)
+	}
+
 	return nil
+}
+
+// reportedVersion is the version a binary built under version reports.
+//
+// This module states a version as an OCI image tag — `v0.2.0`, because that is
+// what docs/container/SPEC.md's tag table publishes, what planRelease reads off
+// HEAD and what the archetype is handed — and both of this repository's
+// commands report it as the SemVer 2.0.0 string their own contracts require,
+// `0.2.0`. One leading `v` is the whole of the difference.
+//
+// This is the third spelling of that rule and the other two are in
+// cmd/cpybkc/version.go and cmd/cpybkc-gen-go/version.go. They cannot be one:
+// this module is a Go module of its own and cannot import either command, and
+// the two commands cannot share it with each other because cmd/cpybkc-gen-go
+// imports nothing of this repository beyond irpb by design. What pins the three
+// together is the check above rather than an import — a spelling that drifted
+// would fail the image contract on the next pull request, which is the same
+// arrangement generatorRepository already lives under.
+func reportedVersion(version string) string {
+	return strings.TrimPrefix(version, "v")
 }
 
 // LayoutSchema builds the published layout schema — the released

--- a/.dagger/release.go
+++ b/.dagger/release.go
@@ -256,7 +256,7 @@ func (m *Cpybkc) Release(
 	images := []struct {
 		app        *dagger.Z5LabsApp
 		repository string
-		check      func(context.Context, *dagger.Container, dagger.Platform) []error
+		check      func(context.Context, *dagger.Container, dagger.Platform, string) []error
 	}{
 		{
 			app:        m.generatorApp(version),
@@ -290,10 +290,27 @@ func (m *Cpybkc) Release(
 	// that fails at push time — a credential, a rate limit, a repository that
 	// cannot be created — still leaves the earlier image published under tags
 	// this project's contract says are never repointed.
+	//
+	// # This is also where a version that disagrees with the tag is refused
+	//
+	// Each check is handed the version, and each holds the binaries in its image
+	// to it: the CLI's --version line and the version the generator's refusal
+	// names, both against the tag this release was cut from (#181). Here rather
+	// than in a check of its own, because there is exactly one moment at which
+	// the version a binary reports and the version a release is being cut under
+	// are both in hand, and it is this one — before anything is pushed, over the
+	// very containers that would be. A check of its own would have to rebuild
+	// both images to ask, and would be a second place a release can be refused
+	// from.
+	//
+	// It costs nothing at a release to say so, and it is worth saying: the same
+	// two functions run on every pull request under devVersion, so what this gate
+	// adds is the *comparison against the tag* rather than a check that has never
+	// been exercised until now.
 	var errs []error
 	for _, image := range images {
 		for _, platform := range imagePlatforms() {
-			for _, err := range image.check(ctx, image.app.Container(platform), platform) {
+			for _, err := range image.check(ctx, image.app.Container(platform), platform, version) {
 				errs = append(errs, fmt.Errorf("%s %s: %w", image.repository, platform, err))
 			}
 		}
@@ -508,9 +525,10 @@ func (m *Cpybkc) ReleaseNotes(
 // executed rather than read.
 //
 // What it covers is what planRelease answers — whether a release is a release of
-// the image at all, and which version it is — and, since #180, where the
-// generator image that release publishes beside the base goes. Both are
-// decisions this repository makes and the archetype does not.
+// the image at all, and which version it is — since #180 where the generator
+// image that release publishes beside the base goes, and since #181 what the
+// binaries in those images report their version as. All three are decisions this
+// repository makes and the archetype does not.
 //
 // The tag *family* that version implies is the archetype's since #185, and is
 // checked by its own table over its own literals — restating it here would be a
@@ -651,6 +669,34 @@ func (m *Cpybkc) TagScheme() error {
 		if got := generatorRepository(c.repository, c.name); got != c.want {
 			errs = append(errs, fmt.Errorf("the generator image for %q beside %q publishes to %q, want %q",
 				c.name, c.repository, got, c.want))
+		}
+	}
+
+	// What the binaries a release publishes say their version is, which is the
+	// third thing a version decides (#181). A release states one version and it
+	// reaches three places: the tags the image family is published under, the
+	// repositories those tags live in, and the line each executable answers with.
+	//
+	// The literals matter here for the reason they matter above. This rule is
+	// written down three times — cmd/cpybkc/version.go and
+	// cmd/cpybkc-gen-go/version.go carry the other two spellings, in packages
+	// this module cannot import and which deliberately do not import each other —
+	// and each of those has its own test pinning the same answers. The image
+	// contract is what compares them on a real binary; this is what says, in the
+	// place the version is derived, what the answer was supposed to be.
+	for _, c := range []struct{ version, want string }{
+		{"v0.2.0", "0.2.0"},
+		// A prerelease, because that is the shape a release candidate's tag takes
+		// and the one where a naive "everything after the first dot" would differ.
+		{"v0.3.0-rc.1", "0.3.0-rc.1"},
+		// The version everything that is not a release is built under. It has to
+		// come out as the `0.0.0-dev` docs/cli/SPEC.md requires of a build made
+		// outside a release, which is what lets this check run on a pull request.
+		{devVersion, "0.0.0-dev"},
+	} {
+		if got := reportedVersion(c.version); got != c.want {
+			errs = append(errs, fmt.Errorf("a build made under %q reports version %q, want %q",
+				c.version, got, c.want))
 		}
 	}
 

--- a/.dagger/worked_example.go
+++ b/.dagger/worked_example.go
@@ -736,7 +736,7 @@ func (m *Cpybkc) checkExtendsTheImage(
 	want := derivedImageContents(baseImageContents(protos), destination, imageEntry{kindFile, uid, gid, mode})
 
 	errs := m.checkImageContents(ctx, derived, want)
-	errs = append(errs, m.checkImageIsTheCLI(ctx, derived)...)
+	errs = append(errs, m.checkImageIsTheCLI(ctx, derived, devVersion)...)
 
 	if err := errors.Join(errs...); err != nil {
 		return derived, fmt.Errorf("%s: the worked example's final stage, built onto the image this pipeline "+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -508,9 +508,18 @@ entrypoint, and runs the generator out of the image on a descriptor stating no
 IR version so that the refusal names the generator's own, and holds both to the
 version the image was built for. `release` runs that same check as its gate,
 over the very containers it is about to push and under the release's tag, so
-nothing is published under a version its binaries disagree with. On a pull
-request the version being checked against is `devVersion` — so the stamp is
-checked by every run, rather than only by the one run that cannot be repeated.
+nothing is published under a version its binaries disagree with.
+
+On a pull request the version being checked against is `devVersion`, and that is
+the same string both commands carry in their tree — so a stamp that landed and a
+stamp the linker silently dropped write the same line, and neither of those
+assertions can tell them apart. What they do catch there is a version that
+stopped dropping the tag's leading `v`. Proving the stamp lands at all takes a
+version nothing publishes, which is why the contract builds one image under
+`v0.0.0-contract` and requires the two executables to report it: under a value
+that cannot collide with the tree's default, a `const` that `-X` cannot reach
+fails on an ordinary pull request instead of at a release, where the tag it
+disagrees with has already been pushed.
 
 `internal/assemble.Version` is a different number and is not stamped by
 anything: it is the IR version, and `--version` reports it beside the build's

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,8 +137,10 @@ on and `image-contract` is that document's compatibility guarantees table
 executed rather than read: the entrypoint, `Cmd`, the user, `PATH`, an exhaustive
 listing of every path in the filesystem with its kind, owner and mode, the build
 settings the executable itself reports, a byte comparison of the IR schema the
-image ships against the artifacts a release attaches, and the entrypoint
-answering `--version` as the image's own user and as an overridden one.
+image ships against the artifacts a release attaches, the entrypoint answering
+`--version` as the image's own user and as an overridden one, and the version
+each of the two executables reports being the version the image was built for
+(#181).
 
 It runs on every platform the image is published for, and reports each platform's
 failures separately — "it holds on amd64 and not on arm64" is the finding. The
@@ -451,10 +453,68 @@ Publish a GitHub release whose tag is a canonical `vX.Y.Z`.
 above, pushes the image, signs the digest, and writes into the release's notes
 which IR version that image speaks.
 
-Nothing else is a step, after the first one. There is no version constant to
-bump — `cmd/cpybkc`'s `version` is a constant in the tree and
-`internal/assemble.Version` is the IR version, and neither is stamped at release
-time — and no tag to push by hand beyond the one the release object carries.
+Nothing else is a step, after the first one. There is no version to bump by hand
+and no tag to push beyond the one the release object carries.
+
+### The version a release publishes is the version it was cut from
+
+Both binaries learn their own version at link time, from the release. The shared
+archetype cross-compiles the CLI with `-X main.version=<version>`, with the flag
+and the variable's name fixed by that module so every z5labs Go application
+answers "which build am I running" the same way;
+[`.dagger/image.go`](.dagger/image.go)'s `generatorBinary` passes the same stamp
+by hand to `cpybkc-gen-go`, which is built through the generic constructor and
+so has nobody upstream to stamp it. A build nobody stamped keeps the value in
+the tree, `v0.0.0-dev`, which is the same string
+[`.dagger/image.go`](.dagger/image.go)'s `devVersion` builds everything that is
+not a release under — so a `go build` from a checkout and an unreleased pipeline
+build are indistinguishable, as they should be.
+
+The version reaches the two programs as the image tag, `v0.2.0`, and each drops
+the leading `v` before printing it: `cpybkc --version` writes a SemVer string
+because [the CLI contract](docs/cli/SPEC.md#--version) requires one, and
+`cpybkc-gen-go` names its version in a refusal in the same scheme. That rule is
+written three times — once in each command and once in the pipeline — because
+the two commands deliberately share nothing (`cmd/cpybkc-gen-go` imports `irpb`
+and the standard library and nothing else of this repository, so that it
+exercises the surface an outside plugin author has) and the pipeline is a Go
+module that cannot import either. What holds the three together is the check
+below rather than an import, exactly as `generatorRepository` and the companion
+module's spelling of it are held together.
+
+**This is the opposite of what this file said before #181, and the reasoning is
+worth keeping.** The version used to be a constant in the source, moved by hand
+in the release that published it, on the argument that *"a stamped version is a
+build whose output depends on how it was invoked, and this repository builds its
+binaries from the tree alone"*. Two things retired it:
+
+- The premise stopped holding. `planRelease` takes the version from the
+  canonical version tag pointing at HEAD and refuses one pointing anywhere else,
+  so the version is a ref of the tree being built rather than something a caller
+  chooses — the same standing the commit that link step also stamps has. Two
+  builds of one commit under one release are still byte-identical, which is what
+  makes [re-running a release](#re-running-a-release-is-safe) safe and is the
+  whole of what that argument was protecting.
+- There stopped being a choice. Since #185 the archetype passes the stamp with
+  no seam to turn it off, and a linker silently ignores a stamp naming a
+  constant — so the constant did not decline the stamp, it hid it. The pipeline
+  appeared to be stamping a version while `--version` kept printing what the tree
+  said, which is how `v0.0.0` shipped an image identifying itself as an
+  unreleased development build.
+
+`dagger call image-contract` is what refuses a version that disagrees with the
+release it was cut from. It runs the published image's `--version` through its
+entrypoint, and runs the generator out of the image on a descriptor stating no
+IR version so that the refusal names the generator's own, and holds both to the
+version the image was built for. `release` runs that same check as its gate,
+over the very containers it is about to push and under the release's tag, so
+nothing is published under a version its binaries disagree with. On a pull
+request the version being checked against is `devVersion` — so the stamp is
+checked by every run, rather than only by the one run that cannot be repeated.
+
+`internal/assemble.Version` is a different number and is not stamped by
+anything: it is the IR version, and `--version` reports it beside the build's
+own.
 
 **The first release needs one manual step, once.** A package that
 `secrets.GITHUB_TOKEN` creates on ghcr.io is private, and nothing the workflow

--- a/cmd/cpybkc-gen-go/main.go
+++ b/cmd/cpybkc-gen-go/main.go
@@ -99,13 +99,20 @@ func run(args []string, stdin io.Reader) error {
 	// all: the version is read off the wire so that a descriptor this generator
 	// does not implement is refused without any part of it having been
 	// interpreted. See versionOf.
-	version, err := versionOf(descriptor)
+	//
+	// `stated` rather than `version`, which is what this was called and what
+	// versionOf calls it internally. There are two versions in this program now
+	// — the IR version the descriptor states and this build's own, the package
+	// variable the linker stamps — and a local named for one of them shadowing
+	// the other is a reader's trap even though the two have different types and
+	// nothing here wants the second.
+	stated, err := versionOf(descriptor)
 	if err != nil {
 		return err
 	}
 
-	if version != supportedIRVersion {
-		return &unsupportedVersionError{Descriptor: version}
+	if stated != supportedIRVersion {
+		return &unsupportedVersionError{Descriptor: stated}
 	}
 
 	// Decoded once the version has been read off the wire, and not before: a

--- a/cmd/cpybkc-gen-go/main_test.go
+++ b/cmd/cpybkc-gen-go/main_test.go
@@ -80,7 +80,7 @@ func TestTheRefusalNamesBothVersionsAndThisGeneratorsOwn(t *testing.T) {
 		fmt.Sprintf("descriptor IR version %d", int32(ahead)),
 		fmt.Sprintf("implements IR version %d", int32(supportedIRVersion)),
 		pluginName,
-		pluginVersion,
+		reportedVersion(),
 	} {
 		if !strings.Contains(written, want) {
 			t.Errorf("the refusal does not name %q:\n%s", want, written)

--- a/cmd/cpybkc-gen-go/version.go
+++ b/cmd/cpybkc-gen-go/version.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"google.golang.org/protobuf/encoding/protowire"
 
@@ -22,16 +23,6 @@ const (
 	// naming whatever path a caller happened to invoke this program by is one
 	// the reader cannot compare against a release.
 	pluginName = "cpybkc-gen-go"
-
-	// pluginVersion is this generator's own version, in this author's scheme,
-	// and it is the third fact a refusal names.
-	//
-	// It is neither the IR's version nor the Go module's: one IR version
-	// outlives many releases of this program, and the user reading a refusal
-	// needs to know which of the two ends is behind. Nothing has been released
-	// yet, which `0.0.0-dev` says out loud; it moves with the repository's
-	// first release tag.
-	pluginVersion = "0.0.0-dev"
 
 	// supportedIRVersion is the highest IR version this generator implements.
 	//
@@ -50,6 +41,60 @@ const (
 	// is what makes reading it first cheap as well as required.
 	versionField = protowire.Number(1)
 )
+
+// version is the version this build was stamped with, in this author's scheme,
+// and the third fact a refusal names. It is not the string the refusal carries;
+// see [reportedVersion] for the one leading `v` between the two.
+//
+// It is neither the IR's version nor the Go module's: one IR version outlives
+// many releases of this program, and the user reading a refusal needs to know
+// which of the two ends is behind.
+//
+// docs/plugin/SPEC.md leaves a plugin's versioning scheme to its author, so
+// what this is pinned to is a convention of this repository rather than a
+// contract: the generator a release publishes reports that release's version,
+// and a build made outside one reports 0.0.0-dev. A generator reporting
+// 0.0.0-dev from a released image would give the "descriptor IR version N;
+// cpybkc-gen-go 0.0.0-dev implements …" refusal a version number nobody can map
+// to a release, which is the whole use the third fact is put to.
+//
+// # How it gets here
+//
+// .dagger/image.go's generatorBinary passes `-X main.version=<version>` when it
+// cross-compiles this program for the generator image, and a build nobody
+// stamped keeps the value written here. It is a var and not a const because the
+// linker silently ignores a stamp naming a constant — the failure #181 was
+// filed for, where the pipeline appears to be stamping a version and the
+// program keeps reporting the tree's.
+//
+// The name is `version` rather than the `pluginVersion` this was called because
+// the stamp names it: the base image's CLI is stamped `main.version` by the
+// shared archetype, with the name fixed by that module, and one convention for
+// "which build am I running" across both of this repository's commands is worth
+// more than a name that repeated what the package it lives in already says.
+//
+// `dagger call image-contract` runs this generator out of the published image
+// on a descriptor it must refuse and holds the version in that refusal to the
+// version the image was built for, so a stamp that stopped landing fails on an
+// ordinary pull request.
+var version = "v0.0.0-dev"
+
+// reportedVersion is the version a refusal carries.
+//
+// The pipeline states a version as an OCI image tag — `v0.2.0`, because that is
+// what the image family is published under — and this generator's scheme, like
+// the CLI's, states it as a SemVer 2.0.0 string, `0.2.0`. One leading `v` is
+// the whole of the difference, and this is where it goes. A version arriving
+// without the `v` is already the reported form and passes through unchanged.
+//
+// cmd/cpybkc carries the same three lines. They are deliberately not shared:
+// this command imports irpb and the standard library and nothing else from this
+// repository, so that the surface it exercises is the one an outside plugin
+// author has, and a rule this small is cheaper written twice than that is worth
+// breaking.
+func reportedVersion() string {
+	return strings.TrimPrefix(version, "v")
+}
 
 // versionOf is the IR version the descriptor's bytes state, read without
 // decoding the rest of the message.
@@ -132,11 +177,11 @@ type unsupportedVersionError struct {
 func (e *unsupportedVersionError) Error() string {
 	if e.Descriptor == irpb.IrVersion_IR_VERSION_UNSPECIFIED {
 		return fmt.Sprintf("the descriptor states no IR version; %s %s implements IR version %d",
-			pluginName, pluginVersion, int32(supportedIRVersion))
+			pluginName, reportedVersion(), int32(supportedIRVersion))
 	}
 
 	return fmt.Sprintf("descriptor IR version %d; %s %s implements IR version %d",
-		int32(e.Descriptor), pluginName, pluginVersion, int32(supportedIRVersion))
+		int32(e.Descriptor), pluginName, reportedVersion(), int32(supportedIRVersion))
 }
 
 // Notes is what follows the refusal as `note:` diagnostics.

--- a/cmd/cpybkc-gen-go/version.go
+++ b/cmd/cpybkc-gen-go/version.go
@@ -73,10 +73,12 @@ const (
 // "which build am I running" across both of this repository's commands is worth
 // more than a name that repeated what the package it lives in already says.
 //
-// `dagger call image-contract` runs this generator out of the published image
-// on a descriptor it must refuse and holds the version in that refusal to the
-// version the image was built for, so a stamp that stopped landing fails on an
-// ordinary pull request.
+// `dagger call image-contract` runs this generator out of the image on a
+// descriptor it must refuse and holds the version in that refusal to the version
+// the image was built for. One of those images is built under a version nothing
+// publishes, and that one is what proves the stamp lands: the version everything
+// unreleased is built under is the same string this file defaults to, so under
+// it a dropped stamp and a landed one give the identical refusal.
 var version = "v0.0.0-dev"
 
 // reportedVersion is the version a refusal carries.

--- a/cmd/cpybkc-gen-go/version_test.go
+++ b/cmd/cpybkc-gen-go/version_test.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"google.golang.org/protobuf/encoding/protowire"
@@ -145,4 +146,80 @@ func nodesFirst(t *testing.T) []byte {
 	stated := descriptorAt(irpb.IrVersion_IR_VERSION_UNSPECIFIED)
 
 	return marshal(t, stated)
+}
+
+// TestAnUnstampedBuildReportsTheDevelopmentVersion is the convention both of
+// this repository's commands keep: a build made outside a release says so.
+//
+// The literal is written out because it is the fact. Derived from the variable
+// it is checking, this test would pass on whatever that variable became — which
+// is how a release ships a generator reporting a number nobody can map to it
+// (#181).
+func TestAnUnstampedBuildReportsTheDevelopmentVersion(t *testing.T) {
+	if got := reportedVersion(); got != "0.0.0-dev" {
+		t.Errorf("an unstamped build reports %q, want %q: a build made outside a release reports the "+
+			"development version, and this build was not stamped", got, "0.0.0-dev")
+	}
+}
+
+// TestTheReportedVersionDropsTheTagsLeadingV is the one difference between the
+// version .dagger/image.go stamps into this generator and the version a refusal
+// names.
+//
+// The pipeline states a version as an OCI image tag, `v0.2.0`, because that is
+// what the image family is published under. This generator's scheme, like the
+// CLI's, is a SemVer 2.0.0 string, and SemVer has no `v` — so a released
+// generator quoting the tag verbatim would give the refusal a version in a
+// vocabulary the CLI's own --version line does not use, which is the one line a
+// reader would be comparing it against.
+//
+// Not parallel: the stamp is a package variable, and Go resumes a paused
+// parallel test only once every serial test has returned, which is what makes a
+// serial test that restores what it moved safe beside them.
+func TestTheReportedVersionDropsTheTagsLeadingV(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		stamped string
+		want    string
+	}{
+		{"a release", "v0.2.0", "0.2.0"},
+		{"a release candidate", "v0.3.0-rc.1", "0.3.0-rc.1"},
+		{"the development version the pipeline builds under", "v0.0.0-dev", "0.0.0-dev"},
+		{"a version already in the reported form", "0.2.0", "0.2.0"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			restore := version
+			t.Cleanup(func() { version = restore })
+
+			version = test.stamped
+
+			if got := reportedVersion(); got != test.want {
+				t.Errorf("a build stamped %q reports %q, want %q", test.stamped, got, test.want)
+			}
+		})
+	}
+}
+
+// TestTheRefusalCarriesTheReportedVersionAndNotTheStamp is the same rule seen
+// from the refusal, which is the only surface this version reaches a user
+// through: docs/plugin/SPEC.md has a plugin name its own version there and
+// nowhere else, so a refusal composed from the variable beside [reportedVersion]
+// rather than from it is a version nobody would see was wrong until a release.
+func TestTheRefusalCarriesTheReportedVersionAndNotTheStamp(t *testing.T) {
+	restore := version
+	t.Cleanup(func() { version = restore })
+
+	version = "v9.8.7"
+
+	refused := (&unsupportedVersionError{Descriptor: irpb.IrVersion_IR_VERSION_UNSPECIFIED}).Error()
+
+	if !strings.Contains(refused, " 9.8.7 ") {
+		t.Errorf("a build stamped %q refused with %q, and the refusal names the version without the tag's `v`",
+			version, refused)
+	}
+
+	if strings.Contains(refused, "v9.8.7") {
+		t.Errorf("a build stamped %q refused with %q, which quotes the image tag rather than this generator's "+
+			"version", version, refused)
+	}
 }

--- a/cmd/cpybkc/main_test.go
+++ b/cmd/cpybkc/main_test.go
@@ -103,7 +103,7 @@ func TestVersionWritesOneLineAndSucceeds(t *testing.T) {
 		t.Errorf("%s wrote %q, want %q", versionFlag, stdout, want)
 	}
 
-	for _, fact := range []string{programName, version, "IR version"} {
+	for _, fact := range []string{programName, reportedVersion(), "IR version"} {
 		if !strings.Contains(stdout, fact) {
 			t.Errorf("the version line does not name %q: %q", fact, stdout)
 		}

--- a/cmd/cpybkc/version.go
+++ b/cmd/cpybkc/version.go
@@ -7,34 +7,89 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Zaba505/cpybkc/internal/assemble"
 )
 
-const (
-	// programName is what this executable is called, and what --version names
-	// first.
-	//
-	// It is stated rather than taken from os.Args[0], because a line naming
-	// whatever path a caller happened to invoke this program by is one the
-	// reader cannot compare against a release — and the published image's
-	// entrypoint is this program under a path of the image's choosing.
-	programName = "cpybkc"
+// programName is what this executable is called, and what --version names
+// first.
+//
+// It is stated rather than taken from os.Args[0], because a line naming
+// whatever path a caller happened to invoke this program by is one the reader
+// cannot compare against a release — and the published image's entrypoint is
+// this program under a path of the image's choosing.
+const programName = "cpybkc"
 
-	// version is this build's own version, and it is the fact --version exists
-	// to report.
-	//
-	// docs/cli/SPEC.md requires the released version for a build made from a
-	// release tag and 0.0.0-dev for one made outside a release. Nothing has
-	// been released yet, which 0.0.0-dev says out loud; it moves with the
-	// repository's first release tag, the way cmd/cpybkc-gen-go's own version
-	// does.
-	//
-	// A constant rather than a variable a linker stamps: a stamped version is a
-	// build whose output depends on how it was invoked, and this repository
-	// builds its binaries from the tree alone.
-	version = "0.0.0-dev"
-)
+// version is the version this build was stamped with, and the fact --version
+// exists to report. It is not the string the line carries; see
+// [reportedVersion] for the one leading `v` between the two.
+//
+// docs/cli/SPEC.md requires the released version for a build made from a
+// release tag and 0.0.0-dev for one made outside a release. The pipeline
+// supplies it: .dagger/image.go builds the published binary through the shared
+// archetype, which cross-compiles it stamped with `-X main.version=<version>`,
+// and a build nobody stamped keeps the value written here — which is
+// .dagger/image.go's devVersion, so a plain `go build` and an unreleased
+// pipeline build report the same thing. `dagger call image-contract` runs the
+// published image's own --version and holds the answer to the version the image
+// was built for, so a stamp that stopped landing fails on an ordinary pull
+// request rather than in a release.
+//
+// # Stamped rather than moved by hand, which is the opposite of what this said
+//
+// It used to be a constant, on the argument that "a stamped version is a build
+// whose output depends on how it was invoked, and this repository builds its
+// binaries from the tree alone". Two things retired that.
+//
+// The first is that the argument's premise no longer holds. The version is not
+// something a caller chooses: .dagger/release.go's planRelease takes it from the
+// canonical version tag pointing at HEAD and refuses a version tag that points
+// anywhere else, so it is a ref of the tree being built, exactly as the commit
+// the same link step stamps is. Two builds of one commit under one release are
+// still byte-identical, which is what "the image is a function of the source"
+// was protecting and what makes re-running a release safe.
+//
+// The second is that there is no longer an option. Since #185 the shared
+// archetype compiles this binary and passes that stamp with no seam to turn it
+// off, and the linker silently ignores a stamp naming a constant — so keeping
+// the constant did not decline the stamp, it hid it. The pipeline would have
+// appeared to be stamping a version while --version kept printing whatever the
+// tree said, which is what shipped v0.0.0 reporting 0.0.0-dev (#181).
+//
+// # main.commit is stamped too, and is deliberately not declared here
+//
+// The same link step passes `-X main.commit=<short sha>`. No such variable
+// exists in this package and none should: docs/cli/SPEC.md puts the rest of a
+// build's provenance off the version line in as many words, so a commit
+// variable here would be one nothing reads. The linker ignoring it is the
+// intended outcome rather than an oversight — which is worth saying, because it
+// is indistinguishable from the oversight that made this file's version a
+// constant.
+var version = "v0.0.0-dev"
+
+// reportedVersion is the version the --version line carries.
+//
+// The pipeline states a version as an OCI image tag — `v0.2.0`, because that is
+// what docs/container/SPEC.md's tag table publishes and what the archetype is
+// handed — and docs/cli/SPEC.md states it as a SemVer 2.0.0 string, `0.2.0`.
+// One leading `v` is the whole of the difference, and this is where it goes.
+//
+// Trimmed here rather than at the seam, because the seam is somebody else's:
+// the archetype fixes the stamp's value to the version it publishes under, so
+// the program printing the line is the only place left that can make the line
+// the shape its own contract requires. A version arriving without the `v` — a
+// plain `go build`, or a stamp somebody passed by hand — is already the reported
+// form and passes through unchanged.
+//
+// cmd/cpybkc-gen-go carries the same three lines for the same reason and they
+// are deliberately not shared: that command imports irpb and the standard
+// library and nothing else from this repository, so that it exercises the
+// surface an outside plugin author has (see its package comment). A rule this
+// small is cheaper written twice than it is worth breaking that for.
+func reportedVersion() string {
+	return strings.TrimPrefix(version, "v")
+}
 
 // producedIRVersion is the IR version this build produces, which is the third
 // fact on the --version line.
@@ -64,5 +119,5 @@ const producedIRVersion = assemble.Version
 // than as the enum's Go spelling, which is a name for a number and not the
 // number a plugin's refusal quotes.
 func versionLine() string {
-	return fmt.Sprintf("%s %s (IR version %d)", programName, version, int32(producedIRVersion))
+	return fmt.Sprintf("%s %s (IR version %d)", programName, reportedVersion(), int32(producedIRVersion))
 }

--- a/cmd/cpybkc/version.go
+++ b/cmd/cpybkc/version.go
@@ -31,10 +31,14 @@ const programName = "cpybkc"
 // archetype, which cross-compiles it stamped with `-X main.version=<version>`,
 // and a build nobody stamped keeps the value written here — which is
 // .dagger/image.go's devVersion, so a plain `go build` and an unreleased
-// pipeline build report the same thing. `dagger call image-contract` runs the
-// published image's own --version and holds the answer to the version the image
-// was built for, so a stamp that stopped landing fails on an ordinary pull
-// request rather than in a release.
+// pipeline build report the same thing.
+//
+// That collision is deliberate and it is also why proving the stamp lands takes
+// a third version: under devVersion a dropped stamp and a landed one write the
+// same line. `dagger call image-contract` builds one image under a version
+// nothing publishes and requires this variable to carry it, which is what makes
+// a `const` here — the #181 defect — fail on an ordinary pull request rather
+// than at a release, where the tag it disagrees with has already been pushed.
 //
 // # Stamped rather than moved by hand, which is the opposite of what this said
 //

--- a/cmd/cpybkc/version_test.go
+++ b/cmd/cpybkc/version_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestAnUnstampedBuildReportsTheDevelopmentVersion is docs/cli/SPEC.md's other
+// half: `0.0.0-dev` for a build made outside a release.
+//
+// Asserted on the package variable's own value rather than through the line, so
+// that it is about what a build nobody stamped carries — a `go build` from a
+// checkout, and every stage of the pipeline that is not publishing a release.
+// The literal is written out because it is the fact: derived from the variable
+// it is checking, this test would pass on whatever the variable became.
+func TestAnUnstampedBuildReportsTheDevelopmentVersion(t *testing.T) {
+	t.Parallel()
+
+	if got := reportedVersion(); got != "0.0.0-dev" {
+		t.Errorf("an unstamped build reports %q, want %q: docs/cli/SPEC.md requires 0.0.0-dev for a build made "+
+			"outside a release, and this build was not stamped", got, "0.0.0-dev")
+	}
+}
+
+// TestTheReportedVersionDropsTheTagsLeadingV is the one difference between the
+// version the pipeline stamps and the version the line carries.
+//
+// The pipeline states a version as an OCI image tag, `v0.2.0`, because that is
+// what docs/container/SPEC.md's tag table publishes and what the shared
+// archetype is handed. docs/cli/SPEC.md states it as a SemVer 2.0.0 string.
+// SemVer has no `v`, so a released build printing the tag verbatim would be
+// answering `--version` in the wrong vocabulary — and it is the vocabulary a
+// script comparing two releases reads.
+//
+// The prerelease case is here because it is the one a release candidate takes,
+// and the already-trimmed case because a stamp passed by hand is not obliged to
+// look like a tag.
+//
+// Not parallel, here or below: the stamp is a package variable, so a test that
+// moves it has to be one nothing else in the package is reading at the time.
+// Go resumes a paused parallel test only once every serial test has returned,
+// which is what makes a serial test that restores what it moved safe beside the
+// parallel ones that read the same variable.
+func TestTheReportedVersionDropsTheTagsLeadingV(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		stamped string
+		want    string
+	}{
+		{"a release", "v0.2.0", "0.2.0"},
+		{"a release candidate", "v0.3.0-rc.1", "0.3.0-rc.1"},
+		{"the development version the pipeline builds under", "v0.0.0-dev", "0.0.0-dev"},
+		{"a version already in the reported form", "0.2.0", "0.2.0"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			restore := version
+			t.Cleanup(func() { version = restore })
+
+			version = test.stamped
+
+			if got := reportedVersion(); got != test.want {
+				t.Errorf("a build stamped %q reports %q, want %q", test.stamped, got, test.want)
+			}
+		})
+	}
+}
+
+// TestTheVersionLineCarriesTheReportedVersionAndNotTheStamp is the same rule
+// seen from the line, which is the surface docs/cli/SPEC.md actually covers.
+//
+// [reportedVersion] being right is worth nothing if the line is composed from
+// the variable beside it, and the two are one character apart — which is exactly
+// the sort of edit that gets made while reading this file and not while reading
+// its test.
+func TestTheVersionLineCarriesTheReportedVersionAndNotTheStamp(t *testing.T) {
+	restore := version
+	t.Cleanup(func() { version = restore })
+
+	version = "v9.8.7"
+
+	line := versionLine()
+
+	if !strings.Contains(line, " 9.8.7 ") {
+		t.Errorf("a build stamped %q wrote %q, and the line carries the version without the tag's `v`", version, line)
+	}
+
+	if strings.Contains(line, "v9.8.7") {
+		t.Errorf("a build stamped %q wrote %q, which is the image tag rather than the SemVer string "+
+			"docs/cli/SPEC.md requires", version, line)
+	}
+}

--- a/docs/cli/SPEC.md
+++ b/docs/cli/SPEC.md
@@ -669,6 +669,18 @@ build's provenance: there is no commit, no build date and no Go version on it,
 because a version number is what identifies a release and the rest is
 recoverable from it.
 
+`<tool-version>` is a SemVer string and carries no leading `v`, which is worth
+saying because the image publishing that same release wears one: [the image tag
+table](../container/SPEC.md#tags-and-what-pinning-one-buys) names `v0.2.0` and
+this line names `0.2.0`, and they are the same release (#181). A reader
+comparing the two is comparing the tag they pulled against the version the
+program in it reports, so the difference between them is one character and it is
+this one.
+
+How a build comes to know which of the two versions above it is remains an
+implementation matter; this one is written down in
+[`CONTRIBUTING.md`](../../CONTRIBUTING.md).
+
 ## Compatibility guarantees
 
 **Covered.** Within a major version of cpybkc each of these holds, and a change
@@ -815,7 +827,7 @@ which is a property of the project.
 | [Exit codes](#exit-codes) | #147 `cli` for the vector's own status and the single place they are emitted from, #148 and #149 `cli` for the failures that reach them |
 | [Cancellation](#cancellation) | #148 `cli` |
 | [The environment](#the-environment) | #41 and #43 `plugin` for the two variables read, #147 `cli` for reading no others |
-| [`--version`](#--version) | #147 `cli`; the IR version it reports, #17 `ir` |
+| [`--version`](#--version) | #147 `cli`; the IR version it reports, #17 `ir`; the version it reports being the release's, #181 `cli` |
 | [Compatibility guarantees](#compatibility-guarantees) | #146 `cli` — decided here, in the shape #54 `container` uses for the image |
 | The project manifest — out of scope, see above | #40 `plugin` |
 | This document | #146 `cli` |


### PR DESCRIPTION
Closes #181

The image `v0.0.0` published identified itself as `0.0.0-dev`, and nothing in
the pipeline compared the version a binary reports against the tag it was cut
from. This adds the comparison, and changes the mechanism the version arrives
by so that there is nothing left to forget.

## The decision: stamp, rather than move a constant by hand

Both constants carried the same argument against stamping — *"a stamped version
is a build whose output depends on how it was invoked, and this repository
builds its binaries from the tree alone"*. Two things retire it:

- **The premise stopped holding.** `planRelease` takes the version from the
  canonical version tag pointing at HEAD and refuses one pointing anywhere
  else, so the version is a ref of the tree being built rather than something a
  caller chooses — the same standing as the commit that link step already
  stamps. Two builds of one commit under one release stay byte-identical, which
  is what that argument was protecting and what makes re-running a release safe.
- **There stopped being a choice.** Since #185 the archetype passes
  `-X main.version` with no seam to turn it off, and the linker silently ignores
  a stamp naming a `const`. The constant did not decline the stamp, it *hid* it:
  the pipeline appeared to be stamping a version while `--version` kept printing
  whatever the tree said. That is precisely how `v0.0.0` shipped.

Keeping the constant was the alternative, with the check refusing a release
whose constant disagreed with the tag. It was rejected because the refusal can
only fire *after* the tag exists — and this repository never repoints a
published tag, so every forgotten commit would burn a version number. Stamping
removes the failure instead of converting it into an expensive one.

## What changed

- `cmd/cpybkc`'s `version` and `cmd/cpybkc-gen-go`'s `pluginVersion` become one
  `var version`, both named `main.version` so the archetype's fixed stamp name
  is the one convention across both commands.
- `.dagger/image.go`'s `generatorBinary` passes the same stamp by hand. The
  generator is built through the generic constructor and so has nobody upstream
  to stamp it, which is why it reported `0.0.0-dev` from a released image.
- Each command drops the tag's leading `v` before reporting: the pipeline states
  a version as an OCI image tag (`v0.2.0`) and both contracts state it as SemVer
  (`0.2.0`). The rule is written three times because the two commands share
  nothing by design (`cmd/cpybkc-gen-go` imports `irpb` and the standard library
  and nothing else of this repository) and `.dagger` is a module that cannot
  import either. The image contract is what holds the three together, exactly as
  `generatorRepository` and the companion module's spelling of it are held.
- `main.commit` is stamped too and deliberately has no variable to land in:
  `docs/cli/SPEC.md` keeps the rest of a build's provenance off the line. That
  is now said out loud in the comment, since it is indistinguishable from the
  oversight that made `version` a constant.

## Where the release refuses a disagreement

In `ImageContract`, which `Release` already runs as its gate over the very
containers it is about to push. It was chosen over a check of its own because
there is exactly one moment at which the version a binary reports and the
version a release is being cut under are both in hand, and that is it — before
anything is pushed. A separate check would rebuild both images to ask, and would
be a second place a release can be refused from.

The version being checked against is `devVersion` on a pull request and the
release's tag at a release, so the check runs on every ordinary change rather
than only in the one build that cannot be repeated.

## Acceptance criteria

- [x] **Decide** whether the version stays a hand-moved constant or becomes the
      value #185's pipeline stamps, and write the reasoning down wherever the
      current argument against stamping lives. Stamping. The reasoning is in
      `cmd/cpybkc/version.go`, `cmd/cpybkc-gen-go/version.go` and
      `CONTRIBUTING.md`'s *Making a release*, which is where the retired
      argument actually lived — `docs/cli/SPEC.md` stated the requirement rather
      than the mechanism, and `docs/CONVENTIONS.md` keeps implementation
      reasoning out of `docs/`. What that spec gains instead is the one thing
      about it that is interface: the reported version carries no leading `v`
      while the image tag for the same release does.
- [x] `cpybkc --version` from a released image reports the released version, and
      `cmd/cpybkc-gen-go` reports it too. Both are stamped; neither is a `const`
      any more, so the stamp lands rather than being dropped.
- [x] **Decide** where a release refuses a version that disagrees with the tag,
      and add it. `ImageContract`, gated inside `Release`; the reasoning is in
      `release.go`'s gate comment.
- [x] The check covers `cpybkc-gen-go`'s version too. It has no `--version` and
      should not grow one — `docs/plugin/SPEC.md` fixes a plugin's vector and
      this repository's own generator carrying a surface no other plugin has is
      the arrangement its package comment refuses — so the check runs it on a
      descriptor stating no IR version and reads the version out of the refusal,
      which is the only surface that version reaches anybody through and the
      only place it is used.
- [x] A build made outside a release still reports `0.0.0-dev`, and the check
      does not fail on one. The source default is `v0.0.0-dev`, the same string
      `devVersion` builds everything that is not a release under, so an
      unstamped `go build` and an unreleased pipeline build are
      indistinguishable.

## How it was verified

`dagger call ci` from an ordinary clone (it cannot run from a worktree since
#185) — green, cold, after a `dagger core engine local-cache prune` cleared a
poisoned `missing shared result` cache entry.

The check was then exercised in both directions in a scratch clone:

- **Positive.** With `devVersion` moved to `v9.9.9`, `image-contract` passes —
  which it can only do if both stamps actually land, since the binaries have to
  report `9.9.9` end to end through the published images.
- **Negative.** Restoring either `version` to a `const` — #181's exact defect —
  fails on both platforms for both binaries:

  ```
  linux/amd64: the base image: as user 65532:65532, cpybkc --version wrote
  "cpybkc 0.0.0-dev (IR version 1)\n", and a build made under v9.9.9 reports
  "9.9.9": the version a release publishes is the version it was cut from, and
  a stamp the linker dropped looks exactly like this

  linux/amd64: the generator image: cpybkc-gen-go in the image refused with
  "error: the descriptor states no IR version; cpybkc-gen-go 0.0.0-dev
  implements IR version 1 …", and an image built under v9.9.9 carries a
  generator naming itself "cpybkc-gen-go 9.9.9"
  ```

Unit tests pin the trim rule and the two surfaces it reaches — the `--version`
line and the generator's refusal — in each command, and `TagScheme` pins the
pipeline's third spelling of it against literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)