### PR TITLE
story(cli): specify cpybkc init, which scaffolds a layout from copybooks

### DIFF
--- a/.dagger/companion.go
+++ b/.dagger/companion.go
@@ -225,13 +225,18 @@ var companionCoverage = map[string]string{
 // CliSurface checks that every flag the CLI accepts is one the companion module
 // has an answer for.
 //
-// docs/cli/SPEC.md fixes cpybkc as one command with no subcommands, so the
-// surface that can drift away from the module is the flag table rather than a
-// verb list: a flag added to the CLI is the event that would otherwise leave the
-// module quietly unable to express a run somebody can perform by hand. That is
-// what this fails on, in three directions — a flag no entry covers, an entry
-// naming a function the module does not declare, and an entry naming a flag the
-// CLI no longer accepts.
+// The surface that can drift away from the module is the flag table: a flag
+// added to the CLI is the event that would otherwise leave the module quietly
+// unable to express a run somebody can perform by hand. That is what this fails
+// on, in three directions — a flag no entry covers, an entry naming a function
+// the module does not declare, and an entry naming a flag the CLI no longer
+// accepts.
+//
+// docs/cli/SPEC.md now specifies one subcommand, `init` (#183), so the flag
+// table is no longer the whole surface. It stays the whole of what this checks
+// while the CLI implements no verb; the story that adds the parsing decides
+// whether the companion module expresses a scaffolding run at all, and extends
+// this check if it does (#214).
 //
 // The CLI's side is read from the flag constants the parser matches on, not from
 // what `--help` prints and not from docs/cli/SPEC.md's table. The help text is

--- a/cmd/cpybkc/args.go
+++ b/cmd/cpybkc/args.go
@@ -330,9 +330,13 @@ func isFlag(argument string) bool {
 
 // operandError is a non-flag argument, wherever it appeared.
 //
-// The operand position is reserved and empty on purpose: it is where a
+// The operand position was reserved and left empty on purpose: it is where a
 // subcommand would go, and a CLI that has already spent it on a path can never
-// add one without deciding whether an argument is a file or a verb.
+// add one without deciding whether an argument is a file or a verb. It is spent
+// now — docs/cli/SPEC.md's "The first operand is a subcommand name" gives the
+// head of the vector to `init` — so this message is what every operand gets
+// until that parsing lands (#214), and after it, what every operand that is not
+// the subcommand name gets.
 func operandError(argument string) error {
 	return usagef("cpybkc takes no operand, and %q is one; every input is named by a flag, and the manifest "+
 		"is named by %s", argument, manifestFlag)

--- a/cmd/cpybkc/main_test.go
+++ b/cmd/cpybkc/main_test.go
@@ -65,9 +65,12 @@ func TestUsageNamesTheSettledCommandSet(t *testing.T) {
 		}
 	}
 
-	// No subcommand set, so no line offering one. Generating is what the
-	// command does when nothing else is asked of it, and a usage text that
-	// spelled a verb would be documenting a command set this document refuses.
+	// No verb line yet. Generating is what the command does when nothing else
+	// is asked of it, and that keeps the bare form whatever else the set gains
+	// — but docs/cli/SPEC.md now specifies one subcommand, `init`, which this
+	// build does not implement. A usage text spelling it would document a
+	// command nobody can run; #214 lands both together and flips this
+	// assertion.
 	for _, refused := range []string{"--out", "--include", "--jobs", "--verbose", "--config", "Commands:"} {
 		if strings.Contains(stdout, refused) {
 			t.Errorf("usage offers %s, which cpybkc does not have:\n%s", refused, stdout)

--- a/cmd/cpybkc/usage.go
+++ b/cmd/cpybkc/usage.go
@@ -18,8 +18,11 @@ import (
 // free to the spellings it fixes, and every wording change would read as a
 // change to the surface.
 //
-// The synopsis is the document's, line for line, because the three forms are
-// the command set — one command, no subcommands, and no operand in any of them.
+// The synopsis is the document's, line for line, because the forms are the
+// command set. The three below are the whole of what this build implements:
+// docs/cli/SPEC.md's "One command, and one subcommand" now also specifies
+// `cpybkc init`, and the fourth synopsis line arrives with it (#214). Until
+// then a usage text offering a verb would document a command nobody can run.
 // -h is the one single-hyphen spelling that appears here; the document requires
 // any other to go undocumented.
 const usage = `cpybkc generates code from the copybooks a project's layout names.

--- a/daggerverse/cpybkc/internal/argv/argv.go
+++ b/daggerverse/cpybkc/internal/argv/argv.go
@@ -32,9 +32,9 @@ const standardOutput = "-"
 // the CLI leaving its default action unnamed: generating is what cpybkc does
 // when nothing else is asked of it — a promise that survives the one subcommand
 // docs/cli/SPEC.md specifies (#183) — and the mounted project's own cpybkc.json
-// is what it reads. A manifest names one somewhere else, relative to the mounted project
-// root because that is the working directory the CLI resolves a path typed on
-// the command line against.
+// is what it reads. A manifest names one somewhere else, relative to the mounted
+// project root because that is the working directory the CLI resolves a path
+// typed on the command line against.
 //
 // The dash is refused here rather than passed through for the CLI to refuse,
 // because the two refusals do not cost the same. A vector that reaches the

--- a/daggerverse/cpybkc/internal/argv/argv.go
+++ b/daggerverse/cpybkc/internal/argv/argv.go
@@ -29,9 +29,10 @@ const standardOutput = "-"
 // container's working directory.
 //
 // An empty manifest is a vector of no arguments, which is the whole point of
-// the CLI having no subcommand: generating is what cpybkc does when nothing
-// else is asked of it, and the mounted project's own cpybkc.json is what it
-// reads. A manifest names one somewhere else, relative to the mounted project
+// the CLI leaving its default action unnamed: generating is what cpybkc does
+// when nothing else is asked of it — a promise that survives the one subcommand
+// docs/cli/SPEC.md specifies (#183) — and the mounted project's own cpybkc.json
+// is what it reads. A manifest names one somewhere else, relative to the mounted project
 // root because that is the working directory the CLI resolves a path typed on
 // the command line against.
 //

--- a/docs/cli/SPEC.md
+++ b/docs/cli/SPEC.md
@@ -31,10 +31,11 @@ than the code behind it, which is the whole test.
 
 In scope: the command set; how the project manifest is located; the complete
 argument vector, with every flag's form, default and repeatability; what
-`--emit-ir` does to a run; what standard output and standard error carry and in
-what form; the exit statuses and what each one means; the environment cpybkc
-reads; what `--version` prints; and how much of that a caller may depend on
-across releases.
+`--emit-ir` does to a run; what `init` derives from a copybook, what it leaves
+to the adopter and where it writes it; what standard output and standard error
+carry and in what form; the exit statuses and what each one means; the
+environment cpybkc reads; what `--version` prints; and how much of that a caller
+may depend on across releases.
 
 Out of scope, with reasons, in [Out of Scope](#out-of-scope).
 
@@ -64,7 +65,11 @@ Out of scope, with reasons, in [Out of Scope](#out-of-scope).
 - **[`layout/SPEC.md`](../layout/SPEC.md)** — normative for what a layout
   states, and the source of two questions it hands to the CLI by name: where a
   copybook path is looked for, and where a layout's forms are read from. Both
-  are answered in [Finding the inputs](#finding-the-inputs).
+  are answered in [Finding the inputs](#finding-the-inputs). It is normative a
+  second time for [`init`](#init-scaffolds-a-layout-from-copybooks): which forms
+  a copybook decides, which it cannot, and what a file has to carry before a
+  reader accepts it are all that document's, and the scaffold is held to them
+  rather than to a second description here (#183).
 - **[`container/SPEC.md`](../container/SPEC.md)** — normative for the promise
   that makes this vector a published interface: the image's entrypoint is this
   CLI, its arguments arrive unaltered, and nothing sits between them and it
@@ -91,46 +96,76 @@ Out of scope, with reasons, in [Out of Scope](#out-of-scope).
 the cpybkc CLI and on a caller invoking it, interpreted as described in
 [CONVENTIONS.md](../CONVENTIONS.md). Everything else is descriptive.
 
-## One command, and no subcommands
+## One command, and one subcommand
 
-cpybkc **MUST** be a single command. There are no subcommands: no `generate`,
-no `emit`, no `init`, no `plugin install`. Generating is what the command does
-when nothing else is asked of it (#147, #148).
+cpybkc **MUST** be a single command whose default action is generating. Running
+it with no subcommand generates, and generating **MUST NOT** be given a name of
+its own: there is no `generate`, no `emit`, no `plugin install` (#147, #148).
 
-The product does one thing. A subcommand set exists to name several, and naming
-one of several costs more than it looks: the default action needs a name it
-keeps forever, every document and every CI script gains a word, and the
-container's `Entrypoint` promise turns `docker run image generate` into the
-short form of a command that used to be `docker run image`. What it would buy —
-room for actions nobody has proposed — is bought below for nothing.
+There is exactly one named subcommand,
+[`init`](#init-scaffolds-a-layout-from-copybooks), which scaffolds a layout from
+copybooks (#183). The set is closed at that one member, and a second is a change
+to this section rather than an addition somebody makes on the way past.
 
-### The operand position is reserved and empty
+**The default action keeps the bare form**, and that is the whole of what the
+subcommand costs a caller: nothing. Requiring `cpybkc generate` would break
+every command line already written and every derived image already published,
+because
+the image's `Entrypoint` **is** this CLI and its `Cmd` is empty ([the entrypoint
+promise](../container/SPEC.md#the-entrypoint), #55) — `docker run image` would
+become a usage message for everyone who had followed the instruction to leave
+`Cmd` alone. It would also charge the whole existing user base for a subcommand
+one of them asked for. The bare form is what those callers already type, so
+it is what it keeps meaning.
 
-cpybkc **MUST NOT** accept an operand. Every input is named by a flag, and a
-non-flag argument, wherever it appears and including after `--`, **MUST** be a
-usage error ([Exit codes](#exit-codes), status 2).
+What that costs *this document* is a major version, and the price is written
+down under [How a covered thing would
+change](#how-a-covered-thing-would-change) rather than left for whoever
+implements the subcommand to discover.
 
-That is what keeps the door open. The first operand is where a subcommand would
-go, and a CLI that already spends it on a path — `cpybkc ./cpybkc.json` — can
-never add one without deciding whether an argument is a file or a verb. Leaving
-it empty means a subcommand may be added later as an addition rather than as a
-break, and it costs one flag ([`--manifest`](#finding-the-manifest)) that has
-to be typed in the uncommon case and not at all in the common one.
+### The first operand is a subcommand name
 
-`--` is honoured anyway, as the end of options, so that cpybkc behaves the way
-its neighbours on the system do. Since it can only ever be followed by
-arguments that are usage errors, honouring it is a courtesy to muscle memory
-rather than a way to pass anything.
+The first argument that is not a flag **MUST** be a subcommand name, and the set
+of names is closed at `init`. Any other value **MUST** be a usage error naming
+it ([Exit codes](#exit-codes), status 2), and cpybkc **MUST NOT** open anything
+before reporting one.
+
+A subcommand name **MUST** be the first argument on the line. cpybkc **MUST
+NOT** accept a second operand, wherever it appears — after the flags, after
+`--`, or
+after the subcommand — and **MUST NOT** read a subcommand name anywhere but at
+the head of the vector. Every input is otherwise named by a flag, exactly as
+before.
+
+Requiring it first is what keeps the vector readable without a rule about which
+flags belong to what: everything after the head belongs to the subcommand the
+head names, or to the default action where there is no head. A line that could
+put the verb anywhere would need this document to answer whether `--copybook`
+before `init` is `init`'s flag or a flag the default action does not have, and
+either answer is one somebody has to look up.
+
+That the door was open at all is the reserved operand position's doing, and it
+is the reason this is an addition rather than a redesign. A CLI that had spent
+its first operand on a path — `cpybkc ./cpybkc.json` — could never have added a
+subcommand without deciding whether an argument is a file or a verb. It cost one
+flag ([`--manifest`](#finding-the-manifest)), typed in the uncommon case and not
+at all in the common one, and the door it kept open is now spent on `init`.
+
+`--` is still honoured as the end of options, so that cpybkc behaves the way its
+neighbours on the system do. Since a subcommand name is only read at the head of
+the vector, `cpybkc -- init` is a second-operand usage error and not a way to
+reach the subcommand; and after `--` every argument is a usage error, as before.
 
 ## The argument vector
 
 ```
 cpybkc [--manifest <path>] [--emit-ir <dest> [--emit-ir-format <format>]]
+cpybkc init --copybook <path> … --out <dest>
 cpybkc --version
 cpybkc --help
 ```
 
-That is the whole surface (#147):
+That is the whole surface (#147, #183). The default action's flags are these:
 
 | Flag | Value | Default | May repeat |
 | --- | --- | --- | --- |
@@ -140,10 +175,17 @@ That is the whole surface (#147):
 | `--version` | none | — | no |
 | `--help`, `-h` | none | — | no |
 
-cpybkc **MUST NOT** accept a flag this table does not list, and an unrecognised
-flag **MUST** be a usage error naming it. There is no `--out`, no `--include`,
-no `--jobs`, no `--verbose` and no `--config`; each is refused with its reason
-in [Out of Scope](#out-of-scope).
+With no subcommand named, cpybkc **MUST NOT** accept a flag this table does not
+list, and an unrecognised flag **MUST** be a usage error naming it. There is no
+`--include`, no `--jobs`, no `--verbose` and no `--config`; each is refused with
+its reason in [Out of Scope](#out-of-scope). `--copybook` and `--out` are
+[`init`'s](#the-vector-init-takes) and are usage errors here, named the same
+way.
+
+`init`'s own flags are in [The vector `init` takes](#the-vector-init-takes), and
+the two sets do not overlap: a flag belongs to the default action or to `init`,
+never to both, so a flag on a line is either the one the head admits or a usage
+error naming it and the subcommand it was written under.
 
 ### Flag form
 
@@ -167,15 +209,25 @@ pedantry a shell script never has to suffer.
 
 ### A flag appears at most once
 
-A flag given twice **MUST** be a usage error, even where both occurrences carry
-the same value. Silently taking the last is the rule most argument parsers
-default to, and it makes `cpybkc --manifest a.json --manifest b.json` a command
-that reads a file the line also names as something else.
+A flag whose table says it may not repeat and which is given twice **MUST** be a
+usage error, even where both occurrences carry the same value. Silently taking
+the last is the rule most argument parsers default to, and it makes
+`cpybkc --manifest a.json --manifest b.json` a command that reads a file the
+line also names as something else.
 
 It is the rule the manifest reader already applies to a field written twice
 (#40), for the same reason: the file, and the command line, are things a person
 wrote, and a duplicate is something they did not mean rather than a precedence
 question for the program to answer on their behalf.
+
+[`--copybook`](#where-the-copybooks-come-from) is the one flag that repeats, and
+it is not an exception to the reasoning above but an application of it. Its
+occurrences are a list rather than one value stated several times, so a second
+occurrence adds a copybook instead of replacing one, and nothing the person
+wrote is discarded. What the rule was for survives there too: two occurrences
+carrying **equal** values are a duplicate and **MUST** be a usage error, because
+naming
+one copybook twice states nothing the line did not already state.
 
 ### `--help` and `--version` are answered before anything else
 
@@ -184,6 +236,13 @@ exit 0. When `--version` is present and `--help` is not, it **MUST** write the
 version line to standard output and exit 0. In both cases every other flag on
 the line **MUST** be ignored, including one that would otherwise be a usage
 error, and no manifest is read.
+
+`--help` **MUST** answer for the subcommand the line names, and the top-level
+usage where it names none: `cpybkc init --help` writes `init`'s usage and
+`cpybkc --help` writes the whole command's, which is the one place a subcommand
+changes what these two flags do. `--version` **MUST NOT** vary that way — a
+build has one version whichever action was going to run — so a subcommand on a
+`--version` line is ignored along with everything else.
 
 This is a deliberate exception to [A flag appears at most
 once](#a-flag-appears-at-most-once) and to the refusal of an unrecognised flag.
@@ -352,11 +411,18 @@ pruned from it (#43, #45, #149).
 The alternatives are worse in opposite directions. Emitting *alongside* a
 generation run makes the debugging gesture — "show me the IR" — start every
 generator in the project, which is minutes of work and a mutated output tree in
-exchange for a file the user wanted on its own. Making it a subcommand costs
-the subcommand set [One command](#one-command-and-no-subcommands) declines to
-open. A flag that replaces the action is the reading that leaves nothing
+exchange for a file the user wanted on its own. Making it a subcommand would
+spend a second member of the set [One command, and one
+subcommand](#one-command-and-one-subcommand) keeps at one, and buy nothing the
+flag does not: an emitting run is a run over the project the manifest names,
+with the same inputs and the same resolution, differing only in what comes out
+at the end. A flag that replaces the action is the reading that leaves nothing
 surprising: the user asked for the descriptor, and cpybkc's answer is the
 descriptor.
+
+`init` is the other side of that test, and it is why one of them is a flag and
+the other a verb. It reads no manifest, resolves nothing, and takes inputs this
+vector has no other flag for; there is no run for it to replace.
 
 An emitting run therefore has no generators to fail, and its exit status is
 about the emission alone.
@@ -391,12 +457,444 @@ contract statement of the same rule is at [The
 descriptor](../plugin/SPEC.md#the-descriptor), and it is asserted by a test over
 a real generator process rather than claimed by either document (#157).
 
+## `init` scaffolds a layout from copybooks
+
+```
+cpybkc init --copybook <path> … --out <dest>
+```
+
+`init` reads the copybooks it is given, writes a layout scaffold holding
+everything those copybooks decide, and exits. It resolves nothing, starts no
+generator and reads no manifest (#183).
+
+What it is for is the split in the next subsection. A layout is two kinds of
+statement in one file, and only one of them is knowledge the adopter has;
+today all of it is typed by hand, and the half that is not theirs is the half
+they cannot check by reading.
+
+### What a copybook decides, and what only the adopter can
+
+**Derived, and written into the scaffold complete:**
+
+| Form | Where it comes from |
+| --- | --- |
+| `record` | one per `01`-level, in each copybook named |
+| `alternative` | one per `REDEFINES` outside a repeating group, on each record ([Which alternative a record is](../layout/SPEC.md#which-alternative-a-record-is)) |
+
+**Derived as far as a copybook goes, and left commented** — the form and its
+subject are computable, the value is not:
+
+| Form | What is computable | What is not |
+| --- | --- | --- |
+| `rename` | which records need one, and which record each names | the substitute |
+| `discriminate-variant` | the variant, and one `arm` per alternative | what each arm tests |
+| `copybook-reading` | whether a copybook carries an `OCCURS DEPENDING ON` at all | which reading wrote the data |
+
+**Not derivable at all**, and the whole of what an adopter knows that a copybook
+does not: [`encoding`](../layout/SPEC.md#the-encoding-profile), whose four axes
+have no default for any; [`framing`](../layout/SPEC.md#physical-framing), with
+`lrecl`, `max-segment`, `delimiter` and `placement` behind the spelling;
+[`discriminate`](../layout/SPEC.md#discrimination); and
+[`sequence`](../layout/SPEC.md#sequencing).
+
+`example/ledger.sexpr` is the measure. Six `record` forms, twelve `alternative`
+children and six `rename`s — thirty-odd lines, every one a restatement of
+`posting.cpy` — against eight `discriminate` forms and one `sequence` that are
+the file's actual description. `init` writes the first group and leaves the
+second, and that is the whole of what it claims to do.
+
+### The vector `init` takes
+
+| Flag | Value | Default | May repeat |
+| --- | --- | --- | --- |
+| `--copybook` | a path to a copybook | none; at least one **MUST** be given | yes |
+| `--out` | a path, or `-` for standard output | none; **MUST** be given | no |
+| `--help`, `-h` | none | — | no |
+
+`init` **MUST NOT** accept a flag this table does not list. `--manifest`,
+`--emit-ir` and `--emit-ir-format` are the default action's and **MUST** be
+usage errors under `init`, naming the flag and the subcommand it was written
+under rather than reporting it as unrecognised — it is a real flag of this
+program, in the wrong place, and a message saying otherwise sends the reader to
+check their spelling.
+
+[Flag form](#flag-form) and the rest of [The argument
+vector](#the-argument-vector) apply unchanged: both value spellings are
+accepted, `--copybook` is the one flag that repeats, and a missing value is a
+usage error.
+
+### Where the copybooks come from
+
+Every copybook is named by a `--copybook` flag, repeated once per file. A layout
+is what names a project's copybooks, and there is no layout yet, so this is the
+one input `init` cannot resolve the ordinary way.
+
+A repeatable flag rather than operands after the subcommand, for two reasons.
+Operands would spend the position a *second* subcommand's own subject would
+need, one release after this document spent the first; and it would make `init`
+the only action in this vector taking an input that is not named by a flag, so
+that the rule a reader has just learned holds everywhere but here.
+
+A value is a path, resolved against the working directory as [every path typed
+on the command line is](#a-path-is-relative-to-the-file-that-states-it), and it
+is written into the scaffold's `copybook` child **as it was typed** — a layout's
+own paths are relative to the layout, so a path that reached cpybkc from a
+different directory than the scaffold's is the adopter's to correct, and a path
+cpybkc rewrote on their behalf would be one they cannot find in what they typed.
+
+A value **MUST NOT** be `-`. The scaffold has to state a path for each record's
+copybook, and a copybook arriving on a stream has none to state; the refusal is
+decidable from the vector alone, so it is a usage error and nothing is opened.
+
+**A directory is refused**, with a diagnostic naming the path. Reading one would
+make the scaffold a function of a directory's contents, so a copybook dropped in
+beside the others later changes what `init` produces with no file recording the
+difference — which is the failure [Finding the inputs](#finding-the-inputs)
+refuses a search path for, arriving by a different door. There is no extension
+convention to fall back on either: `.cpy`, `.cbl`, `.cob` and no extension at
+all are all in use, so any rule for which files in a directory are copybooks is
+one cpybkc invented and no adopter can predict. A shell already expands a glob
+into the flags, in a line a reviewer can read.
+
+Whether two `--copybook` values name one file on disk is **not** decided.
+Byte-equal values are a duplicate and a usage error ([A flag appears at most
+once](#a-flag-appears-at-most-once)); two different spellings that resolve to
+one file are two copybooks as far as `init` is concerned, and the scaffold holds
+each `01`-level twice under two record names. That is the same refusal to
+compare spellings that [Finding the inputs](#finding-the-inputs) argues at
+length, and for the same reason: behind a symlink, a bind mount or a
+case-insensitive filesystem there is no comparison that is right every time.
+
+### Where the scaffold is written, and why nothing is ever overwritten
+
+`--out <dest>` names where the scaffold goes. `<dest>` is a path, or `-` for
+standard output. It **MUST** be given, and `init` without it **MUST** be a usage
+error.
+
+There is no default because no default is defensible. A name of cpybkc's own —
+`layout.sexpr` in the working directory — is a name the adopter then has to
+match in the manifest's `layout` field, so the tool would have chosen an
+identifier for a file it does not own. Standard output as the default would make
+the ordinary gesture one that prints thirty lines into a terminal and writes
+nothing, and it would put the scaffold on the data channel without anybody
+naming it there, which [Standard output](#standard-output) refuses in as many
+words. Where the file goes is the one thing in this command the adopter knows
+and cpybkc does not.
+
+**Nothing at `<dest>` is ever replaced.** Where `<dest>` is a path and anything
+exists at it — a regular file, a directory, a symbolic link, including one that
+dangles — cpybkc **MUST** fail the run, write nothing, and report a diagnostic
+naming the path as it was typed and the absolute path it looked at. It **MUST
+NOT** truncate, append to, or write through what it found, and the scaffold
+**MUST** be written in full or not at all, as [`--emit-ir`](#emitting-the-ir)'s
+destination is.
+
+Overwriting a layout an adopter has edited is the one unrecoverable thing this
+command could do. The derived half is recomputable — the copybooks are still
+there and the scaffold is one command away — but the `discriminate` forms and
+the `sequence` are the part no copybook holds, and nothing recovers them. Every
+other rule in this project already implies the refusal: a manifest's unknown
+field is reported rather than ignored (#40), a duplicate flag is refused rather
+than resolved by precedence, and no path is searched for. It is stated here
+rather than assumed because "assumed" is how the opposite gets implemented.
+
+There is **no `--force`**. A flag whose only purpose is to permit the
+unrecoverable act is a flag that gets written into a script once and is never
+reconsidered, and what it saves is one `rm` — a gesture the adopter performs
+deliberately and their shell records.
+
+Whether `init` could instead *extend* a layout that already exists, adding
+records for a copybook a project has taken on, is a real question this document
+does not answer; it is filed on its own (#212). Nothing above forecloses it: an
+existing destination is a failure today, and a future release turning that into
+a defined behaviour behind a flag is the additive direction.
+
+### The scaffold is deliberately incomplete
+
+The file `init` writes is **not a valid layout**, and cpybkc **MUST NOT** write
+one its own reader accepts as complete. It **MUST** parse as S-expressions, and
+it **MUST** fail the layout reader's validation until the adopter finishes it:
+`encoding` and `framing` are absent, every `record` is missing its
+`discriminate`, and there is no `sequence`.
+
+This is the feature rather than a wart, and the reason is a rule this document
+already carries. [More than one fault found in one pass **MUST** be reported
+together](#standard-error-diagnostics), and [every diagnostic carries a
+span](../layout/SPEC.md#every-diagnostic-carries-a-span-and-some-carry-two) — so
+running `cpybkc` against a fresh scaffold reports the entire remainder at once,
+each fault pointing into the file at the place the missing statement belongs.
+That is exactly the checklist the adopter wants next, in the order the file is
+written, in a form their editor can step through, and produced by the reader
+that will have to accept the finished layout rather than by a second description
+of what a layout needs.
+
+Two things follow, and both are requirements rather than consequences.
+
+**cpybkc MUST NOT invent a value for anything an adopter decides.** Not an
+encoding axis, for the reason [All four, always, with no default for
+any](../layout/SPEC.md#all-four-always-with-no-default-for-any) gives; not a
+`recfm`; not a strategy on a `discriminate`; not a shape for the `sequence`. A
+guessed value is the one outcome worse than a blank, because a blank is
+reported and a guess is read.
+
+**The scaffold MUST parse.** A file that failed `sexpr-go` would be reported as
+one lexical fault and nothing else, which turns the remainder back into
+something discovered a form at a time — the opposite of what the incompleteness
+is for. Everything cpybkc cannot state goes in a comment, which is [the only
+shape a layout has](../layout/SPEC.md#tagged-forms-over-s-expressions) for text
+a reader ignores.
+
+A placeholder inside a comment **MUST** be written so that uncommenting it
+without filling it in is a fault the layout reader reports, naming the
+placeholder. The adopter who works down the checklist by deleting `;;` and then
+loses their place is the ordinary case, and a placeholder that happened to be a
+legal value would let them succeed with a layout they never finished writing.
+The spelling this document's examples use is `<charset>` — the placeholder form
+[`layout/SPEC.md`](../layout/SPEC.md#notation-used-below) already writes its
+skeletons in — and the spelling itself is [not
+covered](#compatibility-guarantees).
+
+### What the scaffold states, form by form
+
+In the order [the top-level forms](../layout/SPEC.md#the-top-level-forms) are
+tabled, so that a form the adopter uncomments is already where the format's own
+examples put it, and so that two runs over one set of copybooks produce
+byte-identical files:
+
+1. A header comment saying what the file is, what was derived, and what is left.
+2. `encoding`, commented: the four axis names, each with a placeholder, and no
+   value. The values are not listed even for the three closed axes — a listed
+   value reads as a recommendation, and the charset axis is deliberately
+   open-ended, so any list here goes stale the release a code page is added
+   ([The encoding profile](../layout/SPEC.md#the-encoding-profile)).
+3. `framing`, commented: `recfm` with a placeholder, and a note that which other
+   children are admitted follows from the value chosen.
+4. `record` forms, **uncommented and complete**: one per `01`-level in each
+   copybook, in the order the copybooks were named and, within one, in
+   declaration order; each with its `copybook` child and one `alternative` child
+   per `REDEFINES` outside a repeating group.
+5. `copybook-reading`, commented, when and only when some named copybook carries
+   an `OCCURS DEPENDING ON` — with both readings named and neither chosen. Which
+   compiler wrote the data is not in the copybook.
+6. `rename` forms, commented, one per record over an `01`-level that resolved to
+   more than one record type, with the record name filled in and the substitute
+   a placeholder. See [How a combination's record name is
+   chosen](#how-a-combinations-record-name-is-chosen) for why these are never
+   uncommented.
+7. `discriminate` forms, commented, one per record, with the record name filled
+   in and the strategy a placeholder.
+8. `discriminate-variant` forms, commented, one per `REDEFINES` inside a
+   repeating group, with the variant reference and one `arm` per alternative
+   filled in and each predicate a placeholder.
+9. `sequence`, commented, naming every record once in emission order. It is a
+   list of the record names in a shape that parses and **MUST NOT** be described
+   as an order the file has; the operators are the format's
+   ([Sequencing](../layout/SPEC.md#sequencing)) and choosing among them is the
+   adopter's.
+
+The commented forms are what makes this a scaffold rather than a list of
+records. A commented
+`(discriminate DEBIT-POSTING (equals (item DEBIT-POSTING <item>) <literal>))`
+carries the record name, the reference's root and the shape of the strategy —
+everything about that line except the one thing only the adopter knows — and the
+alternative is an adopter reading two specifications to find out what the form
+is called.
+
+### How a combination's record name is chosen
+
+An `01`-level with two independent two-way `REDEFINES` outside a repeating group
+is four record types, and `init` has to invent four symbols. It **MUST** derive
+them, mechanically:
+
+- An `01`-level carrying no such `REDEFINES` is one record type, and its record
+  name **MUST** be the `01`-level's own name.
+- One carrying any is one record type per combination, and each record name
+  **MUST** be the `01`-level's name followed by the name of each chosen
+  alternative, in the order the redefines appear in the copybook, joined by a
+  single `-` — `POSTING-RECORD-PST-DEBIT-PST-TAIL`.
+- Where that produces one symbol for two combinations, or a symbol another
+  record already carries, cpybkc **MUST** fail the run naming both. Duplicate
+  data names are legal COBOL, so this is reachable; disambiguating it would mean
+  inventing a name whose only property is that it differs from another invented
+  one.
+
+The names are long and nobody would choose them, and that is affordable for a
+reason the format states: a record name is the layout's own identifier, and
+[nothing outside the layout ever sees it as an
+identity](../layout/SPEC.md#record-definitions). So it does not have to be a
+good name. It has to be unique, deterministic, and traceable back to the
+alternatives it selects — because the adopter's next act is writing a
+`discriminate` for it, and they cannot do that without knowing which bytes it
+is.
+
+Numbering fails exactly there. `POSTING-RECORD-1` through `-4` is unique and
+deterministic and says nothing: the adopter has to enumerate the combinations by
+hand to learn which one `-3` is, which is the work this command exists to
+remove. It is also unstable in the way that matters — a copybook gaining an
+alternative renumbers the combinations, so a layout written against one run and
+a scaffold produced by a later one disagree about which record `-3` is, silently
+and in a file no layout is stored beside. A marked placeholder the adopter must
+replace has the same defect and adds a second reason the file does not read.
+
+And cpybkc **MUST NOT** name a record after the data. `example/ledger.sexpr`
+calls its six `DEBIT-POSTING`, `CREDIT-POSTING` and `MEMO-POSTING` crossed with
+`-REF`; that is a reading of what the file *means*, and no copybook holds it.
+
+**No `rename` is emitted**, only a commented one. A rename on a record
+substitutes the name the IR carries — the name a generator turns into an
+identifier in somebody's public API — and a machine-invented substitute would
+land there permanently. It would also silence the one thing that tells an
+adopter they have a problem: several record types over one `01`-level carry one
+name until a rename says otherwise ([A rename may name a
+record](../layout/SPEC.md#a-rename-may-name-a-record)), and `cpybkc-gen-go`
+refuses the collision naming the two that collided rather than munging them
+(#50). That refusal is a checklist item; a substitute cpybkc chose is a name
+nobody agreed to.
+
+### The combination count is reported, not bounded
+
+Three independent three-way redefines is twenty-seven record types out of one
+`01`-level. `init` **MUST** emit all of them, and cpybkc **MUST NOT** refuse a
+copybook for the number of record types it resolves to.
+
+A bound would be a number cpybkc invented, and the first adopter to exceed it
+would have a correct copybook, a layout the format requires to be written that
+way, and nothing to do but type by hand exactly what the tool declined to type.
+The twenty-seven `record` forms are not the cost anyway — the twenty-seven
+`discriminate` forms are, and that cost is the adopter's whether this command
+exists or not.
+
+What it **MUST NOT** be is discovered in the file. Where an `01`-level resolves
+to more than one record type, cpybkc **MUST** write a `note:` diagnostic naming
+the copybook, the `01`-level, how many redefines outside a repeating group it
+carries, and how many record types they produce. It is something the reader has
+to act on — it is the size of the work in front of them — which is the standard
+[Also out of scope](#also-out-of-scope) holds every line cpybkc writes to.
+
+### `init` reads no manifest
+
+cpybkc **MUST NOT** read a manifest under `init`, **MUST NOT** look for
+`cpybkc.json`, and **MUST** treat `--manifest` under `init` as a usage error.
+
+It needs none: `init` resolves no layout and runs no generator, and the manifest
+names the layout, the generators and their options. Reading one would also drag
+a whole validation surface into a command with no use for it — a manifest is
+validated as a unit and an unknown field is a fault (#40) — so `cpybkc init`
+would fail in a project whose manifest is half-written, which is the state a
+project is in at exactly the moment `init` is worth running.
+
+The decisive reason is the destination. `--manifest`'s absence defaults to
+`cpybkc.json` in the working directory, so a run that read one and wrote to the
+path its `layout` names would take its destination from a file the command line
+never mentioned. The one unrecoverable act available to this command is writing
+over an edited layout, and a destination that was discovered rather than typed
+is how that happens with nobody having typed the path — a fresh-looking
+`cpybkc init` in the wrong directory, and a `--out` that is not there to read.
+
+Refusing is also the reversible direction. Admitting `--manifest` later — say,
+defaulting `--out` to the path the manifest's `layout` names — turns a command
+line that was a usage error into one that works, which [How a covered thing
+would change](#how-a-covered-thing-would-change) admits in a minor release.
+Reading a manifest now and withdrawing it later would not be.
+
+### No flag states what only an adopter knows
+
+cpybkc **MUST NOT** accept a flag that states an `encoding` axis, a `framing`
+child, a `discriminate` strategy or any part of a `sequence`, and **MUST NOT**
+write a value for any of them into a scaffold.
+
+The **MUST NOT** default half is [All four, always, with no default for
+any](../layout/SPEC.md#all-four-always-with-no-default-for-any)'s, restated here
+because a scaffold is the obvious place to break it. Whether cpybkc may be
+*told* them — an `--encoding`/`--framing` pair bringing a scaffold closer to
+something a reader accepts — is the question this section answers, and the
+answer is no.
+
+It buys no completeness. Even with both supplied, the scaffold is exactly as
+unreadable as before: `discriminate` is one per `record` and `sequence` is
+required with every record appearing in it, and no argument derives either from
+a copybook. So the pair moves four lines out of a comment and leaves the file
+still failing, which is the whole of what it achieves.
+
+It costs a second notation for something the layout format already spells.
+`framing`'s children are conditional on its `recfm` — `lrecl` under `F` and
+`FB`, `max-segment` under `VBS`, `delimiter` and `placement` under
+`line-sequential` ([Physical framing](../layout/SPEC.md#physical-framing)) — so
+a `--framing` value either re-spells those conditional arities on a command line
+or accepts an incomplete form, and a second spelling of one thing is a second
+thing to keep in agreement.
+
+And a flag is [covered](#compatibility-guarantees): its name, value, default and
+meaning hold for a major version, bought here in exchange for four lines an
+adopter uncomments once per project. The direction is left open — adding the
+flags later leaves every existing command line behaving as it did, so it is a
+minor release's change, made when an adopter has asked for it rather than
+before.
+
+### `init`'s streams and exit codes
+
+Nothing about the diagnostic format changes. `init`'s diagnostics are [the same
+severities, the same separator and the same two-space
+continuation](#standard-error-diagnostics), on standard error. It starts no
+generator, so no line it writes carries a generator's name — and the absence of
+one already means the line is cpybkc's.
+
+The scaffold is data. It reaches standard output when, and only when, `--out -`
+asked for it there; a run writing to a path writes nothing to standard output at
+all ([Standard output](#standard-output)).
+
+The three statuses are unchanged, and `init`'s faults distribute across them:
+
+- `0` — the scaffold was written. It is `0` even though the scaffold is not a
+  valid layout, because [what was asked for was done](#exit-codes): the
+  incompleteness is the answer this command gives, not a failure to give one.
+- `1` — a copybook that cannot be opened, does not parse, or declares no
+  `01`-level (#31); a destination that already exists; a destination that cannot
+  be written; two combinations whose derived record names collide; and a run
+  that is [cancelled](#cancellation), which leaves no partial file.
+- `2` — an unrecognised subcommand; a second operand; `init` with no
+  `--copybook` or no `--out`; `--copybook -`; `--copybook` twice with equal
+  values; and any flag `init` does not carry, including `--manifest`,
+  `--emit-ir` and `--emit-ir-format`. As everywhere else, a `2` means cpybkc did
+  nothing at all — no copybook was opened and no file was created.
+
+### Why this is a subcommand and not a script over the published schema
+
+[`README.md`](../../README.md) already points a shop that generates layouts from
+metadata it holds at the third release asset, `layout-schema.sexpr`. This is the
+in-house case of that, and it is not the same case.
+
+What it derives from is a **copybook**, not metadata a shop already holds. A
+script written against the published schema would have to parse COBOL, resolve
+`REDEFINES`, and apply "exactly one `alternative` per redefine outside a
+repeating group, and none where the copybook writes none" — which is
+`cobol-go`'s parser and `resolve`'s rules (#31, #35), re-implemented. Any drift
+between that re-implementation and cpybkc's own produces a scaffold cpybkc then
+rejects, and the adopter is holding two readings of their copybook with nothing
+to tell them which is wrong.
+
+The schema cannot close that gap, because it is not the kind of thing it says. A
+schema declares the shape of a layout file; the derivation of a layout from a
+copybook is a relation between two files, and no declaration of the first states
+it ([What the schema does not
+say](../layout/SPEC.md#what-the-schema-does-not-say)).
+
+Being in the tool is also what keeps it current. A form added to the layout
+format gains its scaffold line in the same release and the same review; a script
+outside learns about it when a reader rejects its output.
+
+What it is not is a converter. Every statement in the scaffold came from a
+copybook, and the part an adopter is qualified to write is exactly the part left
+blank — which is the honest description of the split, and the reason the command
+can be trusted with the half it does write.
+
 ## Standard output
 
 Standard output is the data channel. cpybkc **MUST** write to it only what was
 asked for by name:
 
 - the descriptor, when `--emit-ir -` asked for it there;
+- the layout scaffold, when `init --out -` asked for it there;
 - the version line, for `--version`;
 - usage, for `--help`.
 
@@ -541,8 +1039,8 @@ Three statuses, and cpybkc **MUST NOT** exit with any other (#147):
 | `1` | The run failed. |
 | `2` | The argument vector could not be understood. |
 
-`0` covers a completed generation, a written descriptor, `--version` and
-`--help`.
+`0` covers a completed generation, a written descriptor, a written layout
+scaffold, `--version` and `--help`.
 
 `1` covers every fault in the work itself: no manifest where one was named or
 defaulted, a manifest that does not parse or does not validate, a layout that
@@ -550,12 +1048,16 @@ does not parse or does not resolve, a copybook that is missing or does not
 declare what a record names, a generator that does not resolve on `PATH`, a
 generator that exits non-zero or is killed by a signal, two generators
 colliding on one output path, a merge or a prune that fails, a descriptor that
-cannot be written, and a run that is cancelled (#148, #149, #150).
+cannot be written, a scaffold that cannot be written or whose destination is
+occupied, and a run that is cancelled (#148, #149, #150, #183).
 
-`2` covers only the vector: an unrecognised flag, a flag repeated, a missing
-value, a non-flag argument, and a flag combination this document refuses. A
-status of 2 means cpybkc did nothing at all — no file was opened, no generator
-was started, and the project's tree was not touched.
+`2` covers only the vector: an unrecognised flag, a flag repeated where its
+table forbids it, a missing value, an operand that is not a subcommand name or
+that is not the first argument, and a flag combination this document refuses —
+including a flag belonging to the other action, which
+[`init`](#the-vector-init-takes) refuses in both directions. A status of 2 means
+cpybkc did nothing at all — no file was opened, no file was created, no
+generator was started, and the project's tree was not touched.
 
 ### Why three, and not one per stage
 
@@ -688,8 +1190,10 @@ to any of them is a breaking change:
 
 | Guarantee | Value |
 | --- | --- |
-| [The command set](#one-command-and-no-subcommands) | One command, no subcommands, no operands |
+| [The command set](#one-command-and-one-subcommand) | One command whose default action is generating, plus `init`; the first operand is a subcommand name from that closed set, and there is no second operand |
 | [The flags](#the-argument-vector) | The five above: each keeps its name, its value, its default and its meaning |
+| [`init`'s flags](#the-vector-init-takes) | `--copybook` and `--out`: each keeps its name, its value, its repeatability and its meaning, and neither set of flags admits the other's |
+| [The scaffold](#the-scaffold-is-deliberately-incomplete) | It parses; it states nothing an adopter has to decide; it is not a layout a reader accepts as complete; and an occupied destination is never replaced |
 | [Manifest discovery](#finding-the-manifest) | `--manifest`, else `cpybkc.json` in the working directory, and no search |
 | [Path resolution](#a-path-is-relative-to-the-file-that-states-it) | A path in a file is relative to that file; a path on the command line is relative to the working directory |
 | [`--emit-ir`](#emitting-the-ir) | Replaces generation; writes the run's one descriptor, which is the same bytes every generator of that run is handed |
@@ -714,6 +1218,16 @@ is depending on something that may change in a patch release, with no notice:
   many run at once.
 - The record a run keeps of what it generated — its name, its location and its
   contents (#45).
+- The scaffold's wording: every comment in it, the placeholder spelling, and its
+  whitespace. What is covered is above — that it parses, that it decides
+  nothing, and that it is incomplete — and the order of its forms, which follows
+  [the layout format's own table](../layout/SPEC.md#the-top-level-forms) and
+  moves if that moves.
+- The record names `init` derives for the combinations of one `01`-level. Two
+  runs of one build **MUST** agree, which is what [How a combination's record
+  name is chosen](#how-a-combinations-record-name-is-chosen) requires; two
+  builds need not, because a record name is the layout's own identifier, nothing
+  outside the file sees it, and the file is scaffolded once and then edited.
 - Anything about the published image, which the [base-image
   contract](../container/SPEC.md) covers on its own terms and separately.
 
@@ -736,6 +1250,36 @@ makes for a moved path. A CI pipeline that runs cpybkc is in a repository this
 project cannot see and cannot warn, and it fails with a message naming a flag
 rather than a version. A release in which both spellings work turns that into a
 deprecation somebody reads instead of a broken build somebody bisects.
+
+#### The subcommand is the first change under this rule, and it breaks it
+
+[`init`](#init-scaffolds-a-layout-from-copybooks) **MUST** appear in a new major
+version. That is worth arguing rather than asserting, because it is not obvious:
+no command line this document admitted before behaves differently now. Every
+existing vector is flags only, an operand was always a usage error, and adding
+`init` leaves all of them doing exactly what they did — which is the test the
+paragraph above uses for an additive change.
+
+It is breaking anyway, on the guarantee itself. The covered value said *no
+subcommands, no operands*, and a caller was entitled to depend on it: a wrapper
+that passes a word of its own user's input through as cpybkc's first argument
+used to receive status 2 for every value of that word, and now receives, for one
+value, a command that writes a file. Turning a refusal into a filesystem write
+is a change of behaviour on a line nobody edited, and it is the kind that is
+found afterwards rather than at the failure.
+
+The transition rule above has nothing to hold in parallel here. What is being
+withdrawn is a rejection, and a rejection has no second spelling to keep alive
+for a minor release — there is no old form to accept at `warning:`, because the
+old form *was* the warning. What the rule asks for instead is that the release
+say the command set gained a member, which is the only shape a deprecation can
+take when the behaviour being replaced was an error message.
+
+Which release *number* carries it is not settled here and is not this document's
+to settle. cpybkc is below 1.0.0, where SemVer leaves a `0.y.z` release outside
+the stability rules altogether, and the published image carries a floating major
+tag whose promise is the [base-image contract](../container/SPEC.md)'s rather
+than this one's. Both questions are filed together (#213).
 
 ## Out of Scope
 
@@ -782,8 +1326,41 @@ prevent (#40). The flags this document does define are the ones that name
 *which* project to run and *what to do instead of running it* — neither of
 which is a property of the project.
 
+### Scaffolding anything but a layout
+
+`init` writes one file, and it is a layout. There is no scaffolding of
+`cpybkc.json`, of a copybook, of a generator's options, or of a project
+directory.
+
+Reason: the manifest is deliberately not a spec (#40) — a handful of fields a
+person writes once, documented in the [README](../../README.md) and free to
+change with the CLI — so a command that wrote one would be committing this
+document to a file whose whole advantage is that it is not committed to. The
+derivation argument does not carry over either: nothing in a copybook says which
+generators a project wants or where their output goes, so a scaffolded manifest
+would be a template rather than a derivation, and a template is a thing an
+adopter copies out of the README in less time than it takes to read a flag. It
+would also make [never
+overwriting](#where-the-scaffold-is-written-and-why-nothing-is-ever-overwritten)
+two rules over two files with two answers, at the moment one of them is already
+the only unrecoverable act this command can perform.
+
 ### Also out of scope
 
+- **Flags that state what only an adopter knows.** No `--encoding`,
+  `--framing`, `--discriminate` or `--sequence`, argued at length in [No flag
+  states what only an adopter
+  knows](#no-flag-states-what-only-an-adopter-knows): they would buy no
+  completeness and cost a second spelling of a notation the layout format
+  already has.
+- **`--force`, and any other way to replace an existing scaffold
+  destination.** Refused where the destination rule is stated, and left there
+  because the flag and the rule are one decision.
+- **Reading copybooks from a directory or from a stream.** Both refused in
+  [Where the copybooks come from](#where-the-copybooks-come-from) — a directory
+  because its contents would decide the scaffold with nothing recording it, a
+  stream because a scaffold has to state a path for each copybook and a stream
+  has none.
 - **A verbosity flag.** No `--verbose`, `--quiet` or `--log-level`. Everything
   cpybkc writes is something a reader has to act on — a fault, a file it
   removed from their tree, or a line a generator wrote — so there is nothing
@@ -814,8 +1391,21 @@ which is a property of the project.
 
 | Section | Implemented by |
 | --- | --- |
-| [One command, and no subcommands](#one-command-and-no-subcommands) | #147 `cli`; the entrypoint promise it answers to, #55 `container` |
-| [The argument vector](#the-argument-vector) | #147 `cli` |
+| [One command, and one subcommand](#one-command-and-one-subcommand) | #147 `cli` for the one command; #183 `cli` decides the subcommand and that the default action keeps the bare form, #214 `cli` implements the dispatch; the entrypoint promise it answers to, #55 and #183 `container` |
+| [The first operand is a subcommand name](#the-first-operand-is-a-subcommand-name) | #147 `cli` reserved the position, #183 `cli` spends it, #214 `cli` parses it |
+| [The argument vector](#the-argument-vector) | #147 `cli`; the second synopsis line, #183 and #214 `cli` |
+| [`init` scaffolds a layout from copybooks](#init-scaffolds-a-layout-from-copybooks) | #183 `cli` specifies it; #214 `cli` the vector, #215 `cli` the derivation and the file |
+| [The vector `init` takes](#the-vector-init-takes) | #183 `cli`, implemented by #214 `cli` |
+| [Where the copybooks come from](#where-the-copybooks-come-from) | #183 `cli`, over the refusal to search #148 `cli` already states |
+| [Where the scaffold is written, and why nothing is ever overwritten](#where-the-scaffold-is-written-and-why-nothing-is-ever-overwritten) | #183 `cli`, implemented by #215 `cli`; whether a layout that exists can be extended, #212 `cli` |
+| [The scaffold is deliberately incomplete](#the-scaffold-is-deliberately-incomplete) | #183 `cli`, over the layout reader #24 `layout` and the batched diagnostics #150 `cli` |
+| [What the scaffold states, form by form](#what-the-scaffold-states-form-by-form) | #183 `cli` decides it, #215 `cli` emits it, against the forms #25–#29 `layout` fix and the alternatives #164 `layout` settled |
+| [How a combination's record name is chosen](#how-a-combinations-record-name-is-chosen) | #183 `cli`, over the alternatives #164 `layout` settled and the collision #50 `gen-go` refuses |
+| [The combination count is reported, not bounded](#the-combination-count-is-reported-not-bounded) | #183 `cli`, implemented by #215 `cli` |
+| [`init` reads no manifest](#init-reads-no-manifest) | #183 `cli`, against the manifest reader #40 `plugin` |
+| [No flag states what only an adopter knows](#no-flag-states-what-only-an-adopter-knows) | #183 `cli`, holding the line #25 `layout` draws for the four axes |
+| [`init`'s streams and exit codes](#inits-streams-and-exit-codes) | #183 `cli`, over the format #150 `cli` and the statuses #147 `cli` fix; implemented by #214 `cli` |
+| [Why this is a subcommand and not a script over the published schema](#why-this-is-a-subcommand-and-not-a-script-over-the-published-schema) | #183 `cli`, against the published schema #23 `layout` and the reader #24 `layout` |
 | [Finding the manifest](#finding-the-manifest) | #148 `cli`, over the manifest reader #40 `plugin` |
 | [A path is relative to the file that states it](#a-path-is-relative-to-the-file-that-states-it) | #148 `cli` |
 | [Finding the inputs](#finding-the-inputs) | #148 `cli`; the diagnostics it owes, #31 `resolve` and #150 `cli`; which copybooks a run reads, and that the manifest does not list them, #157 `cli` |
@@ -828,7 +1418,9 @@ which is a property of the project.
 | [Cancellation](#cancellation) | #148 `cli` |
 | [The environment](#the-environment) | #41 and #43 `plugin` for the two variables read, #147 `cli` for reading no others |
 | [`--version`](#--version) | #147 `cli`; the IR version it reports, #17 `ir`; the version it reports being the release's, #181 `cli` |
-| [Compatibility guarantees](#compatibility-guarantees) | #146 `cli` — decided here, in the shape #54 `container` uses for the image |
+| [Compatibility guarantees](#compatibility-guarantees) | #146 `cli` — decided here, in the shape #54 `container` uses for the image; #183 `cli` for the command set's new value and the first breaking change under it |
+| [How a covered thing would change](#how-a-covered-thing-would-change) | #146 `cli`; the subcommand priced against it, #183 `cli`; which release number pays it and what it does to the image's major tag, #213 `container` |
 | The project manifest — out of scope, see above | #40 `plugin` |
+| Flags that would state an adopter's knowledge, and scaffolding anything but a layout — out of scope, see above | #183 `cli` |
 | This document | #146 `cli` |
 | Conventions this document follows | #15 `setup` |

--- a/docs/cli/SPEC.md
+++ b/docs/cli/SPEC.md
@@ -110,8 +110,8 @@ to this section rather than an addition somebody makes on the way past.
 **The default action keeps the bare form**, and that is the whole of what the
 subcommand costs a caller: nothing. Requiring `cpybkc generate` would break
 every command line already written and every derived image already published,
-because
-the image's `Entrypoint` **is** this CLI and its `Cmd` is empty ([the entrypoint
+because the image's `Entrypoint` **is** this CLI and its `Cmd` is empty ([the
+entrypoint
 promise](../container/SPEC.md#the-entrypoint), #55) — `docker run image` would
 become a usage message for everyone who had followed the instruction to leave
 `Cmd` alone. It would also charge the whole existing user base for a subcommand
@@ -125,24 +125,36 @@ implements the subcommand to discover.
 
 ### The first operand is a subcommand name
 
-The first argument that is not a flag **MUST** be a subcommand name, and the set
-of names is closed at `init`. Any other value **MUST** be a usage error naming
-it ([Exit codes](#exit-codes), status 2), and cpybkc **MUST NOT** open anything
-before reporting one.
+A subcommand name is read at exactly one position, and it is the **first
+argument**. One rule covers the whole vector:
 
-A subcommand name **MUST** be the first argument on the line. cpybkc **MUST
-NOT** accept a second operand, wherever it appears — after the flags, after
-`--`, or
-after the subcommand — and **MUST NOT** read a subcommand name anywhere but at
-the head of the vector. Every input is otherwise named by a flag, exactly as
-before.
+- Where the first argument is `init`, the line is that subcommand's, and every
+  argument after it is read against [the vector `init`
+  takes](#the-vector-init-takes).
+- Where it is anything else — a flag, `--`, or nothing at all — the line is the
+  default action's, and a non-flag argument anywhere in it **MUST** be a usage
+  error naming it ([Exit codes](#exit-codes), status 2).
 
-Requiring it first is what keeps the vector readable without a rule about which
-flags belong to what: everything after the head belongs to the subcommand the
-head names, or to the default action where there is no head. A line that could
-put the verb anywhere would need this document to answer whether `--copybook`
-before `init` is `init`'s flag or a flag the default action does not have, and
-either answer is one somebody has to look up.
+The set of subcommand names is closed at `init`, so a first argument that is a
+non-flag and is not `init` **MUST** be a usage error naming it, and cpybkc
+**MUST NOT** open anything before reporting one. Under either branch cpybkc
+**MUST NOT** accept a second operand, wherever it appears.
+
+It is one rule at one position rather than "the first argument that is not a
+flag" because the two are not the same rule and they disagree on lines somebody
+will type. `cpybkc -- init` and `cpybkc --manifest x.json init` both have `init`
+as their first *non-flag* argument, and under this rule both are the default
+action with an operand in them — a usage error naming `init`. That is the
+answer this document wants: `--` is the end of options and has never introduced
+anything, and a subcommand that could hide behind another action's flags would
+make "which flags belong to what" a question with no answer on the line itself.
+
+Reading it at one fixed position is also what keeps the vector readable without
+such a rule: everything after the head belongs to the subcommand the head names,
+or to the default action where the head is not a subcommand name. A line that
+could put the verb anywhere would need this document to answer whether
+`--copybook` before `init` is `init`'s flag or a flag the default action does
+not have, and either answer is one somebody has to look up.
 
 That the door was open at all is the reserved operand position's doing, and it
 is the reason this is an addition rather than a redesign. A CLI that had spent
@@ -152,9 +164,10 @@ flag ([`--manifest`](#finding-the-manifest)), typed in the uncommon case and not
 at all in the common one, and the door it kept open is now spent on `init`.
 
 `--` is still honoured as the end of options, so that cpybkc behaves the way its
-neighbours on the system do. Since a subcommand name is only read at the head of
-the vector, `cpybkc -- init` is a second-operand usage error and not a way to
-reach the subcommand; and after `--` every argument is a usage error, as before.
+neighbours on the system do. It is not a way to reach a subcommand — after it
+every argument is an operand, and the default action has none — so `cpybkc --
+init` is the usage error the rule above makes it, exactly as `cpybkc -- foo`
+always was.
 
 ## The argument vector
 
@@ -182,10 +195,13 @@ its reason in [Out of Scope](#out-of-scope). `--copybook` and `--out` are
 [`init`'s](#the-vector-init-takes) and are usage errors here, named the same
 way.
 
-`init`'s own flags are in [The vector `init` takes](#the-vector-init-takes), and
-the two sets do not overlap: a flag belongs to the default action or to `init`,
-never to both, so a flag on a line is either the one the head admits or a usage
-error naming it and the subcommand it was written under.
+`init`'s own flags are in [The vector `init` takes](#the-vector-init-takes). No
+flag that names an **input** belongs to both sets, so a flag on a line is either
+one the head admits or a usage error naming it and the subcommand it was written
+under. The two sets share exactly one spelling — `--help` and its `-h` — which
+belongs to neither action in particular for the reason the next subsection
+gives: it, and `--version`, are answered before the vector is interpreted at
+all.
 
 ### Flag form
 
@@ -225,9 +241,9 @@ it is not an exception to the reasoning above but an application of it. Its
 occurrences are a list rather than one value stated several times, so a second
 occurrence adds a copybook instead of replacing one, and nothing the person
 wrote is discarded. What the rule was for survives there too: two occurrences
-carrying **equal** values are a duplicate and **MUST** be a usage error, because
-naming
-one copybook twice states nothing the line did not already state.
+carrying **equal** values are a duplicate and **MUST** be a usage error,
+because naming one copybook twice states nothing the line did not already
+state.
 
 ### `--help` and `--version` are answered before anything else
 
@@ -237,12 +253,20 @@ version line to standard output and exit 0. In both cases every other flag on
 the line **MUST** be ignored, including one that would otherwise be a usage
 error, and no manifest is read.
 
-`--help` **MUST** answer for the subcommand the line names, and the top-level
-usage where it names none: `cpybkc init --help` writes `init`'s usage and
-`cpybkc --help` writes the whole command's, which is the one place a subcommand
-changes what these two flags do. `--version` **MUST NOT** vary that way — a
-build has one version whichever action was going to run — so a subcommand on a
-`--version` line is ignored along with everything else.
+**`--help` and `--version` are answered under every subcommand**, and neither is
+a flag the tables below list. They are read before the first argument is
+classified at all, so no rule about which flags an action carries reaches them:
+`cpybkc init --help` and `cpybkc init --version` are answered, not refused, and
+so is `cpybkc bogus --help`, which writes the top-level usage and exits 0 rather
+than complaining about `bogus`. That last case is the same courtesy this
+subsection already extends to a flag the user was in the middle of getting
+wrong, and an unrecognised verb is the commonest way to arrive here.
+
+What the subcommand does change is *which* usage `--help` writes: cpybkc
+**MUST** write the named subcommand's where the first argument is one, and the
+top-level usage otherwise. `--version` **MUST NOT** vary that way — a build has
+one version whichever action was going to run — so a subcommand on a `--version`
+line is ignored along with everything else.
 
 This is a deliberate exception to [A flag appears at most
 once](#a-flag-appears-at-most-once) and to the refusal of an unrecognised flag.
@@ -464,8 +488,10 @@ cpybkc init --copybook <path> … --out <dest>
 ```
 
 `init` reads the copybooks it is given, writes a layout scaffold holding
-everything those copybooks decide, and exits. It resolves nothing, starts no
-generator and reads no manifest (#183).
+everything those copybooks decide, and exits. It resolves no layout, starts no
+generator and reads no manifest (#183). Paths it is handed are still resolved in
+the ordinary way; what it does not do is the resolution the rest of this
+document means by the word — copybooks against a layout, into a descriptor.
 
 What it is for is the split in the next subsection. A layout is two kinds of
 statement in one file, and only one of them is knowledge the adopter has;
@@ -497,11 +523,14 @@ have no default for any; [`framing`](../layout/SPEC.md#physical-framing), with
 [`discriminate`](../layout/SPEC.md#discrimination); and
 [`sequence`](../layout/SPEC.md#sequencing).
 
-`example/ledger.sexpr` is the measure. Six `record` forms, twelve `alternative`
-children and six `rename`s — thirty-odd lines, every one a restatement of
-`posting.cpy` — against eight `discriminate` forms and one `sequence` that are
-the file's actual description. `init` writes the first group and leaves the
-second, and that is the whole of what it claims to do.
+`example/ledger.sexpr` is the measure. Its postings alone are six `record` forms
+and twelve `alternative` children — thirty-odd lines, every one of them
+recoverable from `posting.cpy` — against the eight `discriminate` forms its
+eight record types need and the one `sequence`, which are the file's actual
+description. Its six `rename`s sit between the two: which records need one is
+recoverable, and the six substitutes are a reading of what the file *means*, so
+`init` writes the question and not the answer. What it claims is that first
+column and nothing beyond it.
 
 ### The vector `init` takes
 
@@ -509,7 +538,6 @@ second, and that is the whole of what it claims to do.
 | --- | --- | --- | --- |
 | `--copybook` | a path to a copybook | none; at least one **MUST** be given | yes |
 | `--out` | a path, or `-` for standard output | none; **MUST** be given | no |
-| `--help`, `-h` | none | — | no |
 
 `init` **MUST NOT** accept a flag this table does not list. `--manifest`,
 `--emit-ir` and `--emit-ir-format` are the default action's and **MUST** be
@@ -517,6 +545,11 @@ usage errors under `init`, naming the flag and the subcommand it was written
 under rather than reporting it as unrecognised — it is a real flag of this
 program, in the wrong place, and a message saying otherwise sends the reader to
 check their spelling.
+
+`--help`, `-h` and `--version` are not flags this table lists and are not
+refused by that rule: they are [answered before the vector is
+interpreted](#--help-and---version-are-answered-before-anything-else) under
+every subcommand, and `cpybkc init --version` prints the version line.
 
 [Flag form](#flag-form) and the rest of [The argument
 vector](#the-argument-vector) apply unchanged: both value spellings are
@@ -546,8 +579,13 @@ A value **MUST NOT** be `-`. The scaffold has to state a path for each record's
 copybook, and a copybook arriving on a stream has none to state; the refusal is
 decidable from the vector alone, so it is a usage error and nothing is opened.
 
-**A directory is refused**, with a diagnostic naming the path. Reading one would
-make the scaffold a function of a directory's contents, so a copybook dropped in
+A value naming a **directory MUST** fail the run ([Exit codes](#exit-codes),
+status 1), with a diagnostic naming the path as it was typed. It is a status 1
+rather than a 2 because it is not decidable from the vector — cpybkc has to look
+at the path to learn what is there — and it is stated separately from a copybook
+that cannot be opened because a directory opens perfectly well. Reading one
+would make the scaffold a function of a directory's contents, so a copybook
+dropped in
 beside the others later changes what `init` produces with no file recording the
 difference — which is the failure [Finding the inputs](#finding-the-inputs)
 refuses a search path for, arriving by a different door. There is no extension
@@ -585,9 +623,19 @@ and cpybkc does not.
 exists at it — a regular file, a directory, a symbolic link, including one that
 dangles — cpybkc **MUST** fail the run, write nothing, and report a diagnostic
 naming the path as it was typed and the absolute path it looked at. It **MUST
-NOT** truncate, append to, or write through what it found, and the scaffold
+NOT** truncate, append to, or write through what it found, and the file
 **MUST** be written in full or not at all, as [`--emit-ir`](#emitting-the-ir)'s
 destination is.
+
+Where `<dest>` is `-` there is nothing to replace and nothing to write
+atomically, so the requirement takes the only form a stream admits: cpybkc
+**MUST NOT** write the first byte of the scaffold to standard output until the
+whole of it has been derived. A stream cannot be un-written, and a run that
+emitted four `record` forms and then failed on the fifth copybook would leave a
+fragment on a pipe that reads as a short layout rather than as a failure. Buying
+that with a buffer is cheap — the scaffold is the size of the copybooks' `01`
+levels — and it is what makes [a cancelled run leave no partial
+file](#cancellation) true for both spellings of the destination rather than one.
 
 Overwriting a layout an adopter has edited is the one unrecoverable thing this
 command could do. The derived half is recomputable — the copybooks are still
@@ -656,10 +704,20 @@ covered](#compatibility-guarantees).
 
 ### What the scaffold states, form by form
 
-In the order [the top-level forms](../layout/SPEC.md#the-top-level-forms) are
-tabled, so that a form the adopter uncomments is already where the format's own
-examples put it, and so that two runs over one set of copybooks produce
-byte-identical files:
+A scaffold **MUST** carry every item of the list below that its copybooks reach,
+**MUST NOT** carry anything else, and **MUST** write them in the order given —
+which is the order [the top-level
+forms](../layout/SPEC.md#the-top-level-forms) are tabled, so that a form the
+adopter uncomments is already where the format's own examples put it. Two runs
+of one build over one set of copybooks **MUST** produce byte-identical files;
+determinism is a requirement here rather than a hoped-for property, because a
+scaffold that reordered itself between runs would be undiffable in exactly the
+review where an adopter is deciding what to keep.
+
+The list is normative in its membership and its order, and descriptive in its
+wording: what each comment *says* is [not
+covered](#compatibility-guarantees), and the examples below are illustrations of
+the shape rather than text an implementation has to reproduce.
 
 1. A header comment saying what the file is, what was derived, and what is left.
 2. `encoding`, commented: the four axis names, each with a placeholder, and no
@@ -848,15 +906,17 @@ The three statuses are unchanged, and `init`'s faults distribute across them:
 - `0` — the scaffold was written. It is `0` even though the scaffold is not a
   valid layout, because [what was asked for was done](#exit-codes): the
   incompleteness is the answer this command gives, not a failure to give one.
-- `1` — a copybook that cannot be opened, does not parse, or declares no
-  `01`-level (#31); a destination that already exists; a destination that cannot
-  be written; two combinations whose derived record names collide; and a run
-  that is [cancelled](#cancellation), which leaves no partial file.
-- `2` — an unrecognised subcommand; a second operand; `init` with no
-  `--copybook` or no `--out`; `--copybook -`; `--copybook` twice with equal
-  values; and any flag `init` does not carry, including `--manifest`,
-  `--emit-ir` and `--emit-ir-format`. As everywhere else, a `2` means cpybkc did
-  nothing at all — no copybook was opened and no file was created.
+- `1` — a `--copybook` value naming a **directory**; one that cannot be opened,
+  does not parse, or declares no `01`-level (#31); a destination that already
+  exists; a destination that cannot be written; two combinations whose derived
+  record names collide; and a run that is [cancelled](#cancellation), which
+  leaves no partial file and, under `--out -`, no partial output.
+- `2` — a first argument that is a non-flag and is not `init`; an operand under
+  either action; `init` with no `--copybook` or no `--out`; `--copybook -`;
+  `--copybook` twice with equal values; and any flag `init` does not carry,
+  including `--manifest`, `--emit-ir` and `--emit-ir-format`. As everywhere
+  else, a `2` means cpybkc did nothing at all — no copybook was opened and no
+  file was created.
 
 ### Why this is a subcommand and not a script over the published schema
 
@@ -1192,7 +1252,7 @@ to any of them is a breaking change:
 | --- | --- |
 | [The command set](#one-command-and-one-subcommand) | One command whose default action is generating, plus `init`; the first operand is a subcommand name from that closed set, and there is no second operand |
 | [The flags](#the-argument-vector) | The five above: each keeps its name, its value, its default and its meaning |
-| [`init`'s flags](#the-vector-init-takes) | `--copybook` and `--out`: each keeps its name, its value, its repeatability and its meaning, and neither set of flags admits the other's |
+| [`init`'s flags](#the-vector-init-takes) | `--copybook` and `--out`: each keeps its name, its value, its repeatability and its meaning, and neither action admits the other's input-naming flags |
 | [The scaffold](#the-scaffold-is-deliberately-incomplete) | It parses; it states nothing an adopter has to decide; it is not a layout a reader accepts as complete; and an occupied destination is never replaced |
 | [Manifest discovery](#finding-the-manifest) | `--manifest`, else `cpybkc.json` in the working directory, and no search |
 | [Path resolution](#a-path-is-relative-to-the-file-that-states-it) | A path in a file is relative to that file; a path on the command line is relative to the working directory |
@@ -1224,8 +1284,8 @@ is depending on something that may change in a patch release, with no notice:
   [the layout format's own table](../layout/SPEC.md#the-top-level-forms) and
   moves if that moves.
 - The record names `init` derives for the combinations of one `01`-level. Two
-  runs of one build **MUST** agree, which is what [How a combination's record
-  name is chosen](#how-a-combinations-record-name-is-chosen) requires; two
+  runs of *one build* agree, which [What the scaffold states, form by
+  form](#what-the-scaffold-states-form-by-form) requires of the whole file; two
   builds need not, because a record name is the layout's own identifier, nothing
   outside the file sees it, and the file is scaffolded once and then edited.
 - Anything about the published image, which the [base-image
@@ -1253,12 +1313,12 @@ deprecation somebody reads instead of a broken build somebody bisects.
 
 #### The subcommand is the first change under this rule, and it breaks it
 
-[`init`](#init-scaffolds-a-layout-from-copybooks) **MUST** appear in a new major
-version. That is worth arguing rather than asserting, because it is not obvious:
-no command line this document admitted before behaves differently now. Every
-existing vector is flags only, an operand was always a usage error, and adding
-`init` leaves all of them doing exactly what they did — which is the test the
-paragraph above uses for an additive change.
+[`init`](#init-scaffolds-a-layout-from-copybooks) is a **breaking** change to
+the command set, and it is worth arguing rather than asserting, because it is
+not obvious: no command line this document admitted before behaves differently
+now. Every existing vector is flags only, an operand was always a usage error,
+and adding `init` leaves all of them doing exactly what they did — which is the
+test the paragraph above uses for an additive change.
 
 It is breaking anyway, on the guarantee itself. The covered value said *no
 subcommands, no operands*, and a caller was entitled to depend on it: a wrapper
@@ -1271,15 +1331,20 @@ found afterwards rather than at the failure.
 The transition rule above has nothing to hold in parallel here. What is being
 withdrawn is a rejection, and a rejection has no second spelling to keep alive
 for a minor release — there is no old form to accept at `warning:`, because the
-old form *was* the warning. What the rule asks for instead is that the release
-say the command set gained a member, which is the only shape a deprecation can
-take when the behaviour being replaced was an error message.
+old form *was* the warning. So the one requirement this section can state and
+have checked is the announcement: the release that first carries `init`
+**MUST** say the command set gained a member. That is the only shape a
+deprecation takes when the behaviour being replaced was an error message.
 
-Which release *number* carries it is not settled here and is not this document's
-to settle. cpybkc is below 1.0.0, where SemVer leaves a `0.y.z` release outside
-the stability rules altogether, and the published image carries a floating major
-tag whose promise is the [base-image contract](../container/SPEC.md)'s rather
-than this one's. Both questions are filed together (#213).
+Which release *number* carries it is deliberately **not** stated as a
+requirement here, and that is why the paragraph above asks for an announcement
+rather than for a version. cpybkc is below 1.0.0, where SemVer leaves a `0.y.z`
+release outside the stability rules altogether, so "a new major version" has no
+number this document could hold a release to; and the published image carries a
+floating major tag whose promise is the [base-image
+contract](../container/SPEC.md)'s rather than this one's. Both questions are
+filed together (#213), and a **MUST** written before they are answered would be
+one nothing could check and nothing could violate.
 
 ## Out of Scope
 
@@ -1395,6 +1460,7 @@ the only unrecoverable act this command can perform.
 | [The first operand is a subcommand name](#the-first-operand-is-a-subcommand-name) | #147 `cli` reserved the position, #183 `cli` spends it, #214 `cli` parses it |
 | [The argument vector](#the-argument-vector) | #147 `cli`; the second synopsis line, #183 and #214 `cli` |
 | [`init` scaffolds a layout from copybooks](#init-scaffolds-a-layout-from-copybooks) | #183 `cli` specifies it; #214 `cli` the vector, #215 `cli` the derivation and the file |
+| [What a copybook decides, and what only the adopter can](#what-a-copybook-decides-and-what-only-the-adopter-can) | #183 `cli` draws the split, over the forms #25–#29 `layout` fix; the derivation itself, #215 `cli` |
 | [The vector `init` takes](#the-vector-init-takes) | #183 `cli`, implemented by #214 `cli` |
 | [Where the copybooks come from](#where-the-copybooks-come-from) | #183 `cli`, over the refusal to search #148 `cli` already states |
 | [Where the scaffold is written, and why nothing is ever overwritten](#where-the-scaffold-is-written-and-why-nothing-is-ever-overwritten) | #183 `cli`, implemented by #215 `cli`; whether a layout that exists can be extended, #212 `cli` |

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -260,10 +260,9 @@ The CLI's command set gained a subcommand — `init`, which scaffolds a layout
 from copybooks — and nothing above changed for it (#183). The arrangement is
 what made that affordable. `Cmd` is empty, so `docker run … <image>` with no
 arguments is still cpybkc's default action, which is generating; every derived
-image already
-published keeps working unaltered, and no `docker run` line in a repository this
-project cannot see had to be edited. A caller who wants the subcommand types it
-where they type every other argument:
+image already published keeps working unaltered, and no `docker run` line in a
+repository this project cannot see had to be edited. A caller who wants the
+subcommand types it where they type every other argument:
 
 ```console
 $ docker run --rm -v "$PWD:/src" -w /src ghcr.io/zaba505/cpybkc:v0 \
@@ -273,8 +272,9 @@ $ docker run --rm -v "$PWD:/src" -w /src ghcr.io/zaba505/cpybkc:v0 \
 A derived image **MAY** set `Cmd` to a subcommand and its flags, which is the
 permission this section already gives for default arguments and needs no new
 one. What a derived image **MUST NOT** do is assume the first argument reaching
-the entrypoint is a flag: it is a subcommand name or nothing, and which names
-are admitted is [the
+the entrypoint is *always* a flag. It may be a flag, as it is for every
+invocation published before this — the CLI's default action is all flags — or it
+may now be a subcommand name; which names are admitted is [the
 CLI's](../cli/SPEC.md#the-first-operand-is-a-subcommand-name) rather than this
 document's. Whether a breaking change to that command set moves
 this image's own major tag is a separate question, filed as #213.

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -254,6 +254,31 @@ only on its behaviour: it accepts cpybkc's arguments. The array itself is
 detail](#the-clis-own-path-is-not-part-of-the-contract), which is what allows
 the CLI to move without a major version.
 
+### The arrangement survives a subcommand
+
+The CLI's command set gained a subcommand — `init`, which scaffolds a layout
+from copybooks — and nothing above changed for it (#183). The arrangement is
+what made that affordable. `Cmd` is empty, so `docker run … <image>` with no
+arguments is still cpybkc's default action, which is generating; every derived
+image already
+published keeps working unaltered, and no `docker run` line in a repository this
+project cannot see had to be edited. A caller who wants the subcommand types it
+where they type every other argument:
+
+```console
+$ docker run --rm -v "$PWD:/src" -w /src ghcr.io/zaba505/cpybkc:v0 \
+    init --copybook cpy/posting.cpy --out layout.sexpr
+```
+
+A derived image **MAY** set `Cmd` to a subcommand and its flags, which is the
+permission this section already gives for default arguments and needs no new
+one. What a derived image **MUST NOT** do is assume the first argument reaching
+the entrypoint is a flag: it is a subcommand name or nothing, and which names
+are admitted is [the
+CLI's](../cli/SPEC.md#the-first-operand-is-a-subcommand-name) rather than this
+document's. Whether a breaking change to that command set moves
+this image's own major tag is a separate question, filed as #213.
+
 ## The user
 
 The image runs as UID **65532**, GID **65532** — `User` is the literal string
@@ -1370,6 +1395,7 @@ Go install with no document that applies to them.
 | [Where this project's own generators are published](#where-this-projects-own-generators-are-published) | #180 `container` decides the rule is covered rather than internal, and publishes the first image under it |
 | [The CLI's own path is not part of the contract](#the-clis-own-path-is-not-part-of-the-contract) | #55 `container`; #185 `container` is where it was spent |
 | [The entrypoint](#the-entrypoint) | #55 `container` |
+| [The arrangement survives a subcommand](#the-arrangement-survives-a-subcommand) | #183 `cli` adds the subcommand and restates the promise here; #213 `container` decides what a breaking CLI change does to this image's major tag |
 | [The user](#the-user) | #55 `container` |
 | [Shell or no shell](#shell-or-no-shell) | #55 `container` |
 | [Tags and what pinning one buys](#tags-and-what-pinning-one-buys) | #59 `container`; #185 `container` moves the family's derivation to the shared pipeline |


### PR DESCRIPTION
Closes #183.

`docs/cli/SPEC.md` gains `init`, the first subcommand, and writes down what it
costs: the command set is a **covered** guarantee, so this lands in a new major
version. The document specifies the command and does not implement it; #214 and
#215 are filed for that, blocked by this one.

## The decisions

**The default action keeps the bare form.** `cpybkc --manifest x.json` still
generates, with `init` as the only named subcommand, so every existing command
line and every derived image already published work unaltered. Requiring
`cpybkc generate` would turn `docker run image` into a usage message for every
image that followed the instruction to leave `Cmd` alone, and would charge the
whole existing user base for a subcommand one of them asked for.
`docs/container/SPEC.md`'s entrypoint promise is **restated** in the same change
rather than left to contradict this one.

**Copybooks arrive by a repeatable `--copybook`**, not as operands: operands
would spend the position a second subcommand's own subject needs, one release
after this document spent the first. A **directory is refused** — its contents
would decide the scaffold with nothing recording it, which is the failure
*Finding the inputs* refuses a search path for, and there is no extension
convention (`.cpy`, `.cbl`, `.cob`, none) that is not cpybkc's invention. `-` is
refused too: a scaffold has to state a path per copybook.

**`--out` is required and never replaces anything.** No default is defensible —
a name of cpybkc's own is one the manifest then has to match, and standard
output as a default puts the scaffold on the data channel unnamed. An occupied
destination fails the run writing nothing, and there is **no `--force`**:
overwriting an edited layout is the one unrecoverable act available, because the
`discriminate` forms and the `sequence` are the part nothing recomputes.

**The scaffold is deliberately incomplete, and must parse.** cpybkc must not
write a layout its own reader accepts as complete, and must not invent a value
for anything an adopter decides. Because the reader already reports every fault
of one pass together with spans, running `cpybkc` on a fresh scaffold reports
the whole remainder at once — the checklist, produced by the reader that will
have to accept the finished file. It must parse, because a lexical fault would
report one thing and stop.

**The missing forms are `;;` comments with their subjects filled in** — a
`discriminate` per record, a `discriminate-variant` per variant with one `arm`
per alternative, a `rename` per record sharing an `01`-level, a `sequence`
naming every record, and `copybook-reading` only where a copybook has an
`OCCURS DEPENDING ON`. A placeholder must be spelled so that uncommenting it
unfilled is a fault the reader names.

**No flag injects a layout form.** It buys no completeness — `discriminate` is
one per record and `sequence` is required, so the file still fails — and costs a
second spelling of a notation the layout format already has, with `framing`'s
conditional arities re-expressed on a command line. Left open as the additive
direction.

**A combination's record name is derived mechanically**: the `01`-level's name
followed by each chosen alternative's name. Long, but a record name is the
layout's own identifier that nothing outside the file sees, so it needs to be
unique, deterministic and traceable — which numbering is not, and which is what
the adopter needs to write the `discriminate`. A collision fails the run naming
both. **No `rename` is emitted**, only a commented one: a machine-invented
substitute lands in a generated public API permanently and silences #50's
refusal.

**The count is reported, not bounded.** Twenty-seven record types is what the
format requires for that copybook, and a bound is a number cpybkc invented that
leaves the adopter typing what the tool declined to. A `note:` names the
copybook, the `01`-level, the redefines and the count.

**`init` reads no manifest.** It needs none, a manifest is validated as a unit
so a half-written one would fail a command that is useful precisely then, and —
decisively — a destination taken from a file the command line never named is how
the unrecoverable write happens with nobody having typed the path. Refusing is
the reversible direction.

## Acceptance criteria

- [x] **Default action keeps the bare form, argued** — *One command, and one
      subcommand*; `docs/container/SPEC.md` gains *The arrangement survives a
      subcommand* restating the `Entrypoint`/`Cmd` promise.
- [x] **Where the copybooks come from** — repeatable `--copybook`; directory and
      stream refused, with reasons.
- [x] **Where the scaffold is written, and collisions** — `--out`, required;
      never replaces; no `--force`.
- [x] **Whether the scaffold is deliberately invalid** — yes, and it must parse;
      the reader's batched diagnostics are the feature.
- [x] **How the missing forms are spelled** — `;;` comments with subjects filled
      in, values as placeholders that fail if uncommented unfilled.
- [x] **What flags may inject** — none; `MUST NOT` default any of the four axes
      and `MUST NOT` accept a flag stating one. `Out of Scope` carries it.
- [x] **How record types of a combination are named** — derived from the
      `01`-level and the alternatives; collision refused; `rename` commented
      only, against #50.
- [x] **Whether the count is bounded** — not bounded; reported at `note:`.
- [x] **Streams and exit codes** — unrecognised subcommand is `2` with nothing
      opened; the scaffold reaches stdout only via `--out -`; the diagnostic
      format is unchanged; `0` even though the scaffold is incomplete.
- [x] **Whether `init` reads a manifest** — no, and `--manifest` under `init` is
      a usage error.
- [x] **Why it belongs in the tool** — the derivation is from a *copybook*, so a
      script over `layout-schema.sexpr` would re-implement cobol-go's parser and
      `resolve`'s `REDEFINES` rules, and any drift produces a scaffold cpybkc
      rejects. A schema states the shape of one file, not a relation between two.
- [x] **Compatibility, Out of Scope, Appendix, and the open questions filed** —
      the command set row, `init`'s flags and the scaffold are covered; the
      wording and the derived names are not; *The subcommand is the first change
      under this rule, and it breaks it* prices it; two `Out of Scope` entries
      and three `Also out of scope` bullets; sixteen Appendix rows across both
      documents. Filed: #212, #213, #214, #215.

## Judgment calls

- **Breaking, but not because a command line stops working.** Every existing
  vector behaves identically. It is breaking on the guarantee: a wrapper passing
  a user's word through as the first argument used to get status 2 for every
  value and now gets a filesystem write for one. The transition rule has nothing
  to hold in parallel, because what is withdrawn is a rejection.
- **Which release number pays it is not settled here.** cpybkc is below 1.0.0,
  and the image publishes a floating `v0`. Filed as #213 rather than guessed.
- **The subcommand must be the first argument**, so every flag after the head
  belongs to what the head names and this document never has to answer whether
  `--copybook` before `init` is `init`'s.
- **`--copybook` is the first repeatable flag** — an application of *A flag
  appears at most once* rather than an exception: occurrences are a list, and
  byte-equal values are still a usage error.
- **README is not updated.** It documents what an adopter can run, and `init` is
  specified but not implemented; #214 is where it reaches the README.
- **Five code comments corrected, no behaviour changed.** `cmd/cpybkc/usage.go`,
  `args.go`, `main_test.go`, `.dagger/companion.go` and
  `daggerverse/cpybkc/internal/argv/argv.go` each cited "one command, no
  subcommands" as the document's position. Each now says what the document says
  and which story flips the code (#214).

## Verified

`dagger call ci` — green, run cold from an ordinary clone as `CONTRIBUTING.md`
requires (a worktree's `.git` is a file). A first run reported the known
`missing shared result` cache fault; `dagger core engine local-cache prune` and
a cold re-run passed in 1m33s. Anchors were checked mechanically across
`docs/`: no broken intra-repository link, and no reference left pointing at the
two renamed sections. Every added line is within 80 columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
