### PR TITLE
story(cli): the init subcommand's vector, its refusals and its streams

### DIFF
--- a/.dagger/companion.go
+++ b/.dagger/companion.go
@@ -220,6 +220,29 @@ var companionCoverage = map[string]string{
 	// let a future short flag that is nobody's synonym land with this check green,
 	// and an entry costs one line.
 	"-h": "Run",
+
+	// `init`'s two flags (#183, #214). The module expresses a scaffolding run
+	// through the escape hatch and does not curate one, and that is the answer
+	// rather than a gap left for later.
+	//
+	// A curated function would have to be `Scaffold(copybooks []*dagger.File,
+	// out string) *dagger.File`, and every part of that is wrong here. `init`
+	// writes what a copybook decides and deliberately leaves the adopter's half
+	// blank, so its output is a file somebody edits once and commits — not an
+	// artifact a pipeline rebuilds, which is what every other function on this
+	// module returns. Its destination may be standard output, which a
+	// File-returning function cannot express any more than it can express
+	// --emit-ir's. And a scaffold is generated once per project against
+	// copybooks that are already in the caller's tree; a Dagger function is
+	// worth having for what a pipeline runs on every commit, and this is not
+	// that.
+	//
+	// So `dagger call run --args=init,--copybook,posting.cpy,--out,-` is how it
+	// is reached, and the entrypoint takes the vector exactly as a person would
+	// type it. If a scaffolding function is ever curated, these two entries move
+	// to it in the same commit that adds it, which is what this table is for.
+	"--copybook": "Run",
+	"--out":      "Run",
 }
 
 // CliSurface checks that every flag the CLI accepts is one the companion module
@@ -232,11 +255,26 @@ var companionCoverage = map[string]string{
 // the module does not declare, and an entry naming a flag the CLI no longer
 // accepts.
 //
-// docs/cli/SPEC.md now specifies one subcommand, `init` (#183), so the flag
-// table is no longer the whole surface. It stays the whole of what this checks
-// while the CLI implements no verb; the story that adds the parsing decides
-// whether the companion module expresses a scaffolding run at all, and extends
-// this check if it does (#214).
+// The CLI has a verb now — `init` (#183, #214) — and the flag table is still the
+// whole of what this checks. That is a decision rather than an omission, and it
+// is worth stating because the obvious reading of "the surface grew" is that
+// this check should have grown with it.
+//
+// The subcommand *name* is not read, for two reasons. It cannot drift the way a
+// flag can: the set is closed at one member by docs/cli/SPEC.md, and a second is
+// a change to that document, reviewed, rather than a constant somebody adds on
+// the way past. And the reading itself would be unsound — internal/surface keeps
+// the string constants shaped like a flag, and a verb is not one, so the only
+// way to pick `init` out of this package's constants is to know its spelling in
+// advance, which is a check that cannot discover anything it was not told.
+//
+// What the verb does add is two flags, and those *are* read, exactly as every
+// other flag is: --copybook and --out reach this table through the same
+// constants the parser matches on, and the companion module's answer for them is
+// recorded above beside everything else. So the event this guard exists for —
+// the CLI growing a flag the module cannot express — is covered for `init`'s
+// flags on the day they landed, without this check learning anything about
+// subcommands.
 //
 // The CLI's side is read from the flag constants the parser matches on, not from
 // what `--help` prints and not from docs/cli/SPEC.md's table. The help text is

--- a/cmd/cpybkc/args.go
+++ b/cmd/cpybkc/args.go
@@ -6,7 +6,9 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/Zaba505/cpybkc/internal/emit"
@@ -15,13 +17,20 @@ import (
 // The whole argument vector docs/cli/SPEC.md fixes, and nothing else:
 //
 //	cpybkc [--manifest <path>] [--emit-ir <dest> [--emit-ir-format <format>]]
+//	cpybkc init --copybook <path> … --out <dest>
 //	cpybkc --version
 //	cpybkc --help
 //
 // A flag this list does not carry is a usage error naming it. There is no
-// --out, no --include, no --jobs, no --verbose and no --config; that document's
-// "Out of Scope" refuses each one with its reason, and the refusal is only real
-// if the parser has no case for it.
+// --include, no --jobs, no --verbose and no --config; that document's "Out of
+// Scope" refuses each one with its reason, and the refusal is only real if the
+// parser has no case for it.
+//
+// The two sets are disjoint in the flags that name an **input**, and that is
+// what makes a flag written under the wrong action a fault this parser can
+// report as such rather than as an unrecognised one: --manifest, --emit-ir and
+// --emit-ir-format are the default action's, --copybook and --out are `init`'s,
+// and each is a real flag of this program in the wrong place.
 //
 // Every spelling here is a literal, including the two
 // [github.com/Zaba505/cpybkc/internal/emit] also names. These constants are what
@@ -35,6 +44,8 @@ const (
 	manifestFlag     = "--manifest"
 	emitIRFlag       = "--emit-ir"
 	emitIRFormatFlag = "--emit-ir-format"
+	copybookFlag     = "--copybook"
+	outFlag          = "--out"
 	versionFlag      = "--version"
 	helpFlag         = "--help"
 
@@ -46,12 +57,34 @@ const (
 	// fingers.
 	shortHelpFlag = "-h"
 
-	// endOfOptions is POSIX's delimiter. cpybkc defines no operand, so it can
-	// only ever be followed by arguments that are usage errors; it is honoured
-	// anyway, as the end of options, so that this program behaves the way its
-	// neighbours on the system do.
+	// endOfOptions is POSIX's delimiter. Neither action takes an operand, so it
+	// can only ever be followed by arguments that are usage errors; it is
+	// honoured anyway, as the end of options, so that this program behaves the
+	// way its neighbours on the system do.
+	//
+	// It is not a way to reach a subcommand. docs/cli/SPEC.md reads the
+	// subcommand name at the first argument and nowhere else, so `cpybkc --
+	// init` is the default action with an operand in it — the usage error
+	// `cpybkc -- foo` always was.
 	endOfOptions = "--"
 )
+
+// initSubcommand is the one subcommand name cpybkc has, and the set is closed at
+// it (docs/cli/SPEC.md, "One command, and one subcommand"). A second member is a
+// change to that document rather than a case somebody adds on the way past.
+//
+// It is spelled here as a constant with no hyphens, so the companion module's
+// CLI-surface check reads it as what it is: that check evaluates this package's
+// string constants and keeps the ones shaped like a flag, and a verb is not one.
+// The set of subcommands is not the flag table, and the check says so in its own
+// words rather than by accident (.dagger/companion.go).
+const initSubcommand = "init"
+
+// defaultAction is the subcommand a line names when it names none: generating,
+// which docs/cli/SPEC.md deliberately gives no name of its own so that the bare
+// form keeps meaning what every existing command line and every published image
+// already means by it.
+const defaultAction = ""
 
 // The encodings --emit-ir-format selects between.
 //
@@ -107,6 +140,25 @@ type invocation struct {
 	// answer is what the line asked for.
 	answer answer
 
+	// subcommand is the action the line named: [initSubcommand] where the first
+	// argument was that word, and [defaultAction] otherwise.
+	//
+	// It is set on a help answer too, because docs/cli/SPEC.md makes --help
+	// write the named subcommand's usage where the first argument is one. It is
+	// deliberately not set on a version answer: a build has one version
+	// whichever action was going to run, so a subcommand on a --version line is
+	// ignored along with everything else.
+	subcommand string
+
+	// copybooks are the paths --copybook named, in the order they were given
+	// and as they were typed. A layout's own paths are relative to the layout,
+	// so a path cpybkc rewrote on the adopter's behalf would be one they cannot
+	// find in what they typed.
+	copybooks []string
+
+	// out is where --out says the scaffold goes: a path, or [standardOutput].
+	out string
+
 	// manifest is the path --manifest named, empty where it named none.
 	// [invocation.manifestPath] is what a run reads.
 	manifest string
@@ -138,6 +190,10 @@ func (inv invocation) manifestPath() string {
 // emitting reports whether this run writes a descriptor instead of generating.
 func (inv invocation) emitting() bool { return inv.emitIR != "" }
 
+// scaffolding reports whether this line is `init`'s rather than the default
+// action's.
+func (inv invocation) scaffolding() bool { return inv.subcommand == initSubcommand }
+
 // format is the encoding [emit.Write] is asked for.
 //
 // The conversion is safe by [parse]'s own rule rather than by assertion: a value
@@ -163,12 +219,84 @@ func parse(args []string) (invocation, error) {
 	// is has usually typed the rest of the line already, and answering with a
 	// complaint about a flag they were in the middle of getting wrong teaches
 	// them nothing they asked to learn.
+	//
+	// It is asked before the head is classified, too, which is what makes
+	// `cpybkc bogus --help` write the top-level usage and exit 0 rather than
+	// complaining about a verb nobody has: an unrecognised verb is the commonest
+	// way to arrive at that question.
 	if asked, ok := answerAsked(args); ok {
-		return invocation{answer: asked}, nil
+		inv := invocation{answer: asked}
+
+		// Which usage --help writes is the one thing the subcommand changes
+		// here. --version is unchanged by it on purpose, so it is not read from
+		// the head at all.
+		if asked == answerHelp {
+			inv.subcommand, _ = head(args)
+		}
+
+		return inv, nil
 	}
 
+	// docs/cli/SPEC.md: the set of subcommand names is closed at `init`, so a
+	// first argument that is a non-flag and is not that word is a usage error
+	// naming it, decided before anything is opened. It is a sentence of its own
+	// rather than the operand refusal below, because the position it is in is
+	// the one a verb goes in and a reader who typed a verb needs to be told
+	// which verbs there are.
+	if len(args) > 0 && !isFlag(args[0]) && args[0] != initSubcommand {
+		return invocation{}, subcommandError(args[0])
+	}
+
+	subcommand, rest := head(args)
+
+	inv, err := vector(subcommand, rest)
+	if err != nil {
+		// The usage a reader needs is the one whose flags they were using, and
+		// the only place that knows which action the line was written under is
+		// here, above the walk. [run] reads it back off the error.
+		return invocation{}, under(subcommand, err)
+	}
+
+	return inv, nil
+}
+
+// head reads the subcommand name off the front of the vector, and hands back
+// what is left for the action's own flags.
+//
+// docs/cli/SPEC.md reads a subcommand name at exactly one position, the first
+// argument, and the rule is one rule at one position rather than "the first
+// argument that is not a flag". The two disagree on lines somebody will type:
+// `cpybkc -- init` and `cpybkc --manifest x.json init` both have `init` as their
+// first non-flag argument, and under this rule both are the default action with
+// an operand in them — the usage error [operandError] reports. A subcommand that
+// could hide behind another action's flags would make "which flags belong to
+// what" a question with no answer on the line itself.
+//
+// Everything else is the default action's, including a first argument that is
+// neither a flag nor a subcommand name: [parse] refuses that one above, so that
+// this reads as the two-way split docs/cli/SPEC.md states.
+func head(args []string) (subcommand string, rest []string) {
+	if len(args) > 0 && args[0] == initSubcommand {
+		return initSubcommand, args[1:]
+	}
+
+	return defaultAction, args
+}
+
+// vector walks one action's flags: everything after the head, read against the
+// set the head admits.
+//
+// One walk for both actions rather than one each. The shape of the vector —
+// the two value spellings, the end of options, a missing value, a flag that
+// repeats when it may not — is docs/cli/SPEC.md's "The argument vector", which
+// says it applies to `init` unchanged; two walks would be two places for that to
+// stop being true, and the second would be the one nobody re-read. What differs
+// between the actions is which flags they carry, what a flag they do not carry
+// is reported as, and what is required at the end, and those are the three
+// functions below.
+func vector(subcommand string, args []string) (invocation, error) {
 	var (
-		inv  invocation
+		inv  = invocation{subcommand: subcommand}
 		seen = map[string]bool{}
 	)
 
@@ -176,9 +304,9 @@ func parse(args []string) (invocation, error) {
 		argument := args[at]
 
 		if argument == endOfOptions {
-			// Everything after it is an operand by definition, and cpybkc
-			// takes none. The delimiter itself is honoured; what follows it
-			// cannot be.
+			// Everything after it is an operand by definition, and neither
+			// action takes one. The delimiter itself is honoured; what follows
+			// it cannot be.
 			if operands := args[at+1:]; len(operands) > 0 {
 				return invocation{}, operandError(operands[0])
 			}
@@ -194,15 +322,16 @@ func parse(args []string) (invocation, error) {
 		// flag from its value, so a value may itself contain one.
 		name, value, joined := strings.Cut(argument, "=")
 
-		if !takesAValue(name) {
+		if !takesAValue(subcommand, name) {
 			// A value-less flag written with one is a vector this parser
 			// refuses rather than one it strips a value off: --version=2 asks
-			// for something --version does not do.
+			// for something --version does not do. It is asked under both
+			// actions, because both answer those three flags.
 			if joined && (name == versionFlag || name == helpFlag || name == shortHelpFlag) {
 				return invocation{}, usagef("%s takes no value, and %q gives it one", name, argument)
 			}
 
-			return invocation{}, unrecognisedError(name)
+			return invocation{}, refuse(subcommand, name)
 		}
 
 		if !joined {
@@ -218,31 +347,89 @@ func parse(args []string) (invocation, error) {
 		// both occurrences carry the same value. Taking the last is the rule
 		// most parsers default to, and it makes a line that names one file
 		// twice a line that reads the file it also names as something else.
-		if seen[name] {
+		//
+		// --copybook is the one flag that repeats, and it is not an exception to
+		// that reasoning: its occurrences are a list rather than one value
+		// stated several times, so nothing the person wrote is discarded. What
+		// the rule was for survives there too, in [setCopybook], which refuses
+		// two occurrences carrying equal values.
+		if seen[name] && name != copybookFlag {
 			return invocation{}, usagef("%s appears more than once, and each flag appears at most once", name)
 		}
 
 		seen[name] = true
 
-		switch name {
-		case manifestFlag:
-			if err := setManifest(&inv, value); err != nil {
-				return invocation{}, err
-			}
-		case emitIRFlag:
-			if value == "" {
-				return invocation{}, usagef("%s names nowhere to write the descriptor", emitIRFlag)
-			}
-
-			inv.emitIR = value
-		case emitIRFormatFlag:
-			if value != binaryFormat && value != jsonFormat {
-				return invocation{}, usagef("%s is %s or %s, and %q is neither",
-					emitIRFormatFlag, binaryFormat, jsonFormat, value)
-			}
-
-			inv.emitIRFormat = value
+		if err := set(&inv, name, value); err != nil {
+			return invocation{}, err
 		}
+	}
+
+	if err := required(&inv, seen); err != nil {
+		return invocation{}, err
+	}
+
+	return inv, nil
+}
+
+// set applies one flag occurrence to the invocation being built.
+//
+// Every name reaching here is one the action carries: [takesAValue] has already
+// said so, and a flag the action does not carry was refused above with a
+// sentence of its own. So this switch is about values and not about membership.
+func set(inv *invocation, name, value string) error {
+	switch name {
+	case manifestFlag:
+		return setManifest(inv, value)
+	case copybookFlag:
+		return setCopybook(inv, value)
+	case outFlag:
+		if value == "" {
+			return usagef("%s names nowhere to write the scaffold", outFlag)
+		}
+
+		inv.out = value
+	case emitIRFlag:
+		if value == "" {
+			return usagef("%s names nowhere to write the descriptor", emitIRFlag)
+		}
+
+		inv.emitIR = value
+	case emitIRFormatFlag:
+		if value != binaryFormat && value != jsonFormat {
+			return usagef("%s is %s or %s, and %q is neither",
+				emitIRFormatFlag, binaryFormat, jsonFormat, value)
+		}
+
+		inv.emitIRFormat = value
+	}
+
+	return nil
+}
+
+// required is what each action needs before it can be performed, asked once the
+// whole vector has been read.
+//
+// It is here rather than at each flag's own case because none of these faults is
+// a property of one occurrence: a missing flag is a property of the line, and so
+// is a flag whose meaning depends on another that never arrived.
+func required(inv *invocation, seen map[string]bool) error {
+	if inv.scaffolding() {
+		// docs/cli/SPEC.md: at least one --copybook MUST be given, and --out
+		// MUST be. There is no default for either. A copybook cannot be
+		// defaulted because the layout that would name one is the file this
+		// command is writing; a destination cannot, because a name of cpybkc's
+		// own is one the adopter then has to correct, and a scaffold written
+		// somewhere they did not name is one they may not find.
+		switch {
+		case len(inv.copybooks) == 0:
+			return usagef("%s reads the copybooks %s names, and this line names none",
+				initSubcommand, copybookFlag)
+		case inv.out == "":
+			return usagef("%s writes the scaffold where %s says, and this line says nowhere",
+				initSubcommand, outFlag)
+		}
+
+		return nil
 	}
 
 	// docs/cli/SPEC.md: --emit-ir-format given without --emit-ir is a usage
@@ -250,7 +437,7 @@ func parse(args []string) (invocation, error) {
 	// a flag on a command line that reads as configuration and does nothing is
 	// the same fault an unknown field in a manifest is.
 	if seen[emitIRFormatFlag] && !inv.emitting() {
-		return invocation{}, usagef("%s selects the encoding %s writes, and this line asks for no emission",
+		return usagef("%s selects the encoding %s writes, and this line asks for no emission",
 			emitIRFormatFlag, emitIRFlag)
 	}
 
@@ -258,7 +445,7 @@ func parse(args []string) (invocation, error) {
 		inv.emitIRFormat = binaryFormat
 	}
 
-	return inv, nil
+	return nil
 }
 
 // setManifest applies --manifest.
@@ -282,14 +469,97 @@ func setManifest(inv *invocation, value string) error {
 	return nil
 }
 
-// takesAValue reports whether a flag is one of the three that carry one.
-func takesAValue(name string) bool {
+// setCopybook applies one --copybook occurrence.
+//
+// It appends rather than replaces, because docs/cli/SPEC.md makes this the one
+// flag that repeats: its occurrences are a list, one per file, and a layout is
+// what would otherwise name a project's copybooks — there is no layout yet, so
+// this is the one input `init` cannot resolve the ordinary way.
+//
+// The value is kept exactly as it was typed. A layout's own paths are relative
+// to the layout, so a path that reached cpybkc from a different directory than
+// the scaffold's is the adopter's to correct, and one cpybkc rewrote on their
+// behalf would be one they cannot find in what they typed.
+//
+// Two occurrences carrying byte-equal values are the duplicate the at-most-once
+// rule is really about: naming one copybook twice states nothing the line did
+// not already state. Two different spellings are two copybooks, and nothing here
+// asks what they resolve to — behind a symlink, a bind mount or a
+// case-insensitive filesystem there is no comparison that is right every time,
+// and the scaffold simply holds each 01-level twice under two record names.
+func setCopybook(inv *invocation, value string) error {
+	switch value {
+	case "":
+		return usagef("%s names no copybook to read", copybookFlag)
+	case standardOutput:
+		return usagef("%s cannot be %q: the scaffold states a path for each record's copybook, "+
+			"and a copybook on a stream has none to state", copybookFlag, standardOutput)
+	}
+
+	if slices.Contains(inv.copybooks, value) {
+		return usagef("%s names %q more than once, and naming one copybook twice states nothing "+
+			"the line did not already state", copybookFlag, value)
+	}
+
+	inv.copybooks = append(inv.copybooks, value)
+
+	return nil
+}
+
+// takesAValue reports whether a flag is one the given action carries and one
+// that carries a value.
+//
+// The two questions are one question, because every flag either action carries
+// takes a value: --version, --help and -h are answered before the vector is
+// interpreted at all, so they never reach this. A flag that is false here is
+// refused, and [refuse] is what decides which of the two refusals it gets.
+func takesAValue(subcommand, name string) bool {
 	switch name {
+	case copybookFlag, outFlag:
+		return subcommand == initSubcommand
 	case manifestFlag, emitIRFlag, emitIRFormatFlag:
-		return true
+		return subcommand == defaultAction
 	default:
 		return false
 	}
+}
+
+// refuse is a flag the action does not carry.
+//
+// docs/cli/SPEC.md asks for two different sentences here, and the difference is
+// what a reader has to do next. A flag of this program written under the action
+// it does not belong to is a real flag in the wrong place, and reporting it as
+// unrecognised sends the reader to check their spelling — a search that ends
+// nowhere, because the spelling is right. So each direction names the flag and
+// the action it belongs to, and neither reads like [unrecognisedError].
+func refuse(subcommand, name string) error {
+	switch {
+	case subcommand == initSubcommand && (name == manifestFlag || name == emitIRFlag || name == emitIRFormatFlag):
+		return usagef("%s is not one of %s's flags: it is the default action's, and this line is %s's",
+			name, initSubcommand, initSubcommand)
+	case subcommand == defaultAction && (name == copybookFlag || name == outFlag):
+		return usagef("%s is one of %s's flags, and this line names no subcommand; "+
+			"`cpybkc %s %s …` is where it belongs", name, initSubcommand, initSubcommand, name)
+	default:
+		return unrecognisedError(name)
+	}
+}
+
+// under stamps a usage error with the action the line was written under, so that
+// the usage accompanying it on standard error is the one whose flags the reader
+// was using.
+//
+// It is applied once, where the head was read, rather than at each refusal: a
+// message that has to remember to say which action it came from is one that
+// eventually does not, and every fault below the head belongs to the same action
+// by construction.
+func under(subcommand string, err error) error {
+	var usage *usageError
+	if errors.As(err, &usage) {
+		usage.subcommand = subcommand
+	}
+
+	return err
 }
 
 // answerAsked reports whether the line asks what cpybkc is rather than for a
@@ -328,22 +598,38 @@ func isFlag(argument string) bool {
 	return strings.HasPrefix(argument, "-") && argument != standardOutput
 }
 
-// operandError is a non-flag argument, wherever it appeared.
+// operandError is a non-flag argument in a position no subcommand name is read
+// at: anywhere but the head, under either action, and anywhere at all after
+// [endOfOptions].
 //
-// The operand position was reserved and left empty on purpose: it is where a
-// subcommand would go, and a CLI that has already spent it on a path can never
-// add one without deciding whether an argument is a file or a verb. It is spent
-// now — docs/cli/SPEC.md's "The first operand is a subcommand name" gives the
-// head of the vector to `init` — so this message is what every operand gets
-// until that parsing lands (#214), and after it, what every operand that is not
-// the subcommand name gets.
+// The head is spent — docs/cli/SPEC.md's "The first operand is a subcommand
+// name" gives it to `init`, and [subcommandError] is what a first argument that
+// is not that word gets. Everywhere else the answer is unchanged: neither action
+// takes an operand, and every input is named by a flag. That includes the
+// arguments after `init`, which are its flags and not a list of copybooks;
+// operands there would spend the position a second subcommand's own subject
+// would need, one release after this document spent the first.
 func operandError(argument string) error {
-	return usagef("cpybkc takes no operand, and %q is one; every input is named by a flag, and the manifest "+
-		"is named by %s", argument, manifestFlag)
+	return usagef("cpybkc takes no operand, and %q is one; every input is named by a flag — the manifest "+
+		"by %s, and a copybook by %s under %s", argument, manifestFlag, copybookFlag, initSubcommand)
 }
 
-// unrecognisedError is a flag this vector does not carry, named as it was
-// typed.
+// subcommandError is a first argument that is a non-flag and is not a subcommand
+// name.
+//
+// It names what was typed and the one verb there is. docs/cli/SPEC.md closes the
+// set at `init`, and a reader who typed a verb has already decided they are
+// looking at a program with verbs; telling them cpybkc takes no operand answers
+// a question they did not ask.
+func subcommandError(argument string) error {
+	return usagef("%q is not a cpybkc subcommand, and %s is the only one; cpybkc with no subcommand generates, "+
+		"and takes no operand", argument, initSubcommand)
+}
+
+// unrecognisedError is a flag neither action carries, named as it was typed.
+//
+// A flag this program does carry, written under the action it does not belong
+// to, is [refuse]'s other case and reads differently on purpose.
 func unrecognisedError(name string) error {
 	return usagef("%s is not a cpybkc flag", name)
 }
@@ -362,6 +648,12 @@ func usagef(format string, a ...any) error {
 // to survive the trip from the parser to the exit path.
 type usageError struct {
 	message string
+
+	// subcommand is the action the line was written under, and it decides which
+	// usage accompanies this error on standard error. It travels on the error
+	// because the vector is what knows it and [run] is where usage is written,
+	// and between the two there is nothing left of the line but this.
+	subcommand string
 }
 
 // Error implements the error interface.

--- a/cmd/cpybkc/args.go
+++ b/cmd/cpybkc/args.go
@@ -376,6 +376,14 @@ func vector(subcommand string, args []string) (invocation, error) {
 // Every name reaching here is one the action carries: [takesAValue] has already
 // said so, and a flag the action does not carry was refused above with a
 // sentence of its own. So this switch is about values and not about membership.
+//
+// The default is what keeps that sentence true rather than merely intended. A
+// flag added to [flagOwner] and not to this switch would be accepted, carry a
+// value and do nothing — a flag on a command line that reads as configuration
+// and has no effect, which is the fault the --emit-ir-format rule below exists
+// to refuse, arriving from inside the program instead. It is a failure rather
+// than a panic for [execute]'s reason: a case missing here is a bug in cpybkc,
+// and a bug is a run that failed.
 func set(inv *invocation, name, value string) error {
 	switch name {
 	case manifestFlag:
@@ -401,6 +409,9 @@ func set(inv *invocation, name, value string) error {
 		}
 
 		inv.emitIRFormat = value
+	default:
+		return fmt.Errorf("cpybkc accepted %s and then did nothing with the value it carries, "+
+			"which is a bug in cpybkc", name)
 	}
 
 	return nil
@@ -506,6 +517,30 @@ func setCopybook(inv *invocation, value string) error {
 	return nil
 }
 
+// flagOwner is which action each flag belongs to, and it is the whole of that
+// question: whether a flag is accepted, and what it is refused as when it is
+// not, are both read from here.
+//
+// One table rather than a case in each of [takesAValue] and [refuse]. The two
+// answers have to agree — a flag missing from the second is reported as
+// unrecognised, which docs/cli/SPEC.md refuses for a real flag of this program
+// in the wrong place — and nothing but the table would make them agree. That
+// failure is silent in the direction that matters: a flag added to one action's
+// case and forgotten in the other refusal produces a sentence that reads like a
+// spelling mistake, and the reader goes looking for one that is not there.
+//
+// The three flags docs/cli/SPEC.md answers before the vector is interpreted —
+// --version, --help and -h — are deliberately absent. They belong to no action,
+// they never reach a lookup here, and an entry claiming otherwise would be an
+// action's answer for a flag that is answered above the action.
+var flagOwner = map[string]string{
+	manifestFlag:     defaultAction,
+	emitIRFlag:       defaultAction,
+	emitIRFormatFlag: defaultAction,
+	copybookFlag:     initSubcommand,
+	outFlag:          initSubcommand,
+}
+
 // takesAValue reports whether a flag is one the given action carries and one
 // that carries a value.
 //
@@ -514,14 +549,9 @@ func setCopybook(inv *invocation, value string) error {
 // interpreted at all, so they never reach this. A flag that is false here is
 // refused, and [refuse] is what decides which of the two refusals it gets.
 func takesAValue(subcommand, name string) bool {
-	switch name {
-	case copybookFlag, outFlag:
-		return subcommand == initSubcommand
-	case manifestFlag, emitIRFlag, emitIRFormatFlag:
-		return subcommand == defaultAction
-	default:
-		return false
-	}
+	owner, known := flagOwner[name]
+
+	return known && owner == subcommand
 }
 
 // refuse is a flag the action does not carry.
@@ -532,17 +562,23 @@ func takesAValue(subcommand, name string) bool {
 // unrecognised sends the reader to check their spelling — a search that ends
 // nowhere, because the spelling is right. So each direction names the flag and
 // the action it belongs to, and neither reads like [unrecognisedError].
+//
+// Which direction is read off [flagOwner] rather than restated, so that a flag
+// added to that table gets the right sentence without this function being
+// touched at all.
 func refuse(subcommand, name string) error {
-	switch {
-	case subcommand == initSubcommand && (name == manifestFlag || name == emitIRFlag || name == emitIRFormatFlag):
-		return usagef("%s is not one of %s's flags: it is the default action's, and this line is %s's",
-			name, initSubcommand, initSubcommand)
-	case subcommand == defaultAction && (name == copybookFlag || name == outFlag):
-		return usagef("%s is one of %s's flags, and this line names no subcommand; "+
-			"`cpybkc %s %s …` is where it belongs", name, initSubcommand, initSubcommand, name)
-	default:
+	owner, known := flagOwner[name]
+	if !known {
 		return unrecognisedError(name)
 	}
+
+	if owner == defaultAction {
+		return usagef("%s is not one of %s's flags: it is the default action's, and this line is %s's",
+			name, subcommand, subcommand)
+	}
+
+	return usagef("%s is one of %s's flags, and this line names no subcommand; "+
+		"`cpybkc %s %s …` is where it belongs", name, owner, owner, name)
 }
 
 // under stamps a usage error with the action the line was written under, so that
@@ -554,9 +590,9 @@ func refuse(subcommand, name string) error {
 // eventually does not, and every fault below the head belongs to the same action
 // by construction.
 func under(subcommand string, err error) error {
-	var usage *usageError
-	if errors.As(err, &usage) {
-		usage.subcommand = subcommand
+	var usageErr *usageError
+	if errors.As(err, &usageErr) {
+		usageErr.subcommand = subcommand
 	}
 
 	return err

--- a/cmd/cpybkc/args_test.go
+++ b/cmd/cpybkc/args_test.go
@@ -344,6 +344,63 @@ func TestInitWritesToStandardOutput(t *testing.T) {
 	}
 }
 
+// TestInitAcceptsBothValueFormsForBothFlags is docs/cli/SPEC.md's "Flag form",
+// which applies to `init` unchanged: both of its flags accept the separated and
+// the joined spelling, and the value arrives the same either way.
+//
+// --copybook is exercised in both forms elsewhere; this is what keeps --out from
+// being asserted only in the separated one, where a joined value that never
+// reached [invocation.out] would pass every other test in this file.
+func TestInitAcceptsBothValueFormsForBothFlags(t *testing.T) {
+	t.Parallel()
+
+	for _, args := range [][]string{
+		{initSubcommand, copybookFlag, "posting.cpy", outFlag, "layout.sexpr"},
+		{initSubcommand, copybookFlag + "=posting.cpy", outFlag + "=layout.sexpr"},
+		{initSubcommand, copybookFlag, "posting.cpy", outFlag + "=layout.sexpr"},
+		{initSubcommand, copybookFlag + "=posting.cpy", outFlag, "layout.sexpr"},
+	} {
+		inv, err := parse(args)
+		if err != nil {
+			t.Errorf("parse(%q): %v", args, err)
+
+			continue
+		}
+
+		if !slices.Equal(inv.copybooks, []string{"posting.cpy"}) {
+			t.Errorf("parse(%q) read the copybooks %q", args, inv.copybooks)
+		}
+
+		if inv.out != "layout.sexpr" {
+			t.Errorf("parse(%q) read %s as %q", args, outFlag, inv.out)
+		}
+	}
+}
+
+// TestASeparatedValueIsWhateverFollows pins what a flag written with no value of
+// its own takes: the next argument, whatever it looks like.
+//
+// docs/cli/SPEC.md fixes the two value spellings and says nothing about a value
+// that resembles a flag, and there is no rule that could be applied here without
+// inventing one — a path may legitimately begin with a hyphen, and refusing it
+// would make a file nobody can name. So `--copybook --out layout.sexpr` reads
+// --out as the copybook's value, and layout.sexpr as the operand neither action
+// takes: a line that is refused, with a message naming the argument that has no
+// place. That is the rule --manifest has always had, applied to a flag that
+// repeats.
+func TestASeparatedValueIsWhateverFollows(t *testing.T) {
+	t.Parallel()
+
+	inv, err := parse([]string{initSubcommand, copybookFlag, outFlag, "layout.sexpr"})
+	if err == nil {
+		t.Fatalf("parse returned %+v, want the usage error the trailing operand is", inv)
+	}
+
+	if !strings.Contains(err.Error(), "no operand") {
+		t.Errorf("parse reads %q, and does not name the argument that has no place", err)
+	}
+}
+
 // TestTwoSpellingsAreTwoCopybooks is what docs/cli/SPEC.md deliberately does not
 // decide: whether two --copybook values name one file on disk.
 //

--- a/cmd/cpybkc/args_test.go
+++ b/cmd/cpybkc/args_test.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -154,8 +155,8 @@ func TestParseRefusesTheVector(t *testing.T) {
 	}{
 		{
 			name: "an unrecognised flag",
-			args: []string{"--out", "gen"},
-			says: "--out",
+			args: []string{"--nope", "gen"},
+			says: "--nope",
 		},
 		{
 			name: "a flag this document refuses by name",
@@ -163,14 +164,42 @@ func TestParseRefusesTheVector(t *testing.T) {
 			says: "--verbose",
 		},
 		{
+			name: "a subcommand's flag with no subcommand",
+			args: []string{outFlag, "layout.sexpr"},
+			says: initSubcommand,
+		},
+		{
+			name: "a subcommand's repeatable flag with no subcommand",
+			args: []string{copybookFlag, "posting.cpy"},
+			says: initSubcommand,
+		},
+		{
+			name: "a first argument that is a verb nobody has",
+			args: []string{"generate"},
+			says: "not a cpybkc subcommand",
+		},
+		{
+			name: "the subcommand name behind the end of options",
+			args: []string{endOfOptions, initSubcommand},
+			says: "no operand",
+		},
+		{
+			name: "the subcommand name behind another action's flag",
+			args: []string{manifestFlag, defaultManifest, initSubcommand},
+			says: "no operand",
+		},
+		{
 			name: "a single-hyphen synonym nothing documents",
 			args: []string{"-manifest", "cpybkc.json"},
 			says: "-manifest",
 		},
 		{
-			name: "an operand",
+			// The head is the subcommand's position now, so a first argument
+			// that is a non-flag is refused as the verb it is not, rather than
+			// as the operand it would have been.
+			name: "a first argument that is neither a flag nor a subcommand name",
 			args: []string{"cpybkc.json"},
-			says: "no operand",
+			says: "not a cpybkc subcommand",
 		},
 		{
 			name: "an operand after the end of options",
@@ -178,9 +207,9 @@ func TestParseRefusesTheVector(t *testing.T) {
 			says: "no operand",
 		},
 		{
-			name: "a lone dash, which POSIX makes an operand",
+			name: "a lone dash, which POSIX makes an operand and not a flag",
 			args: []string{standardOutput},
-			says: "no operand",
+			says: "not a cpybkc subcommand",
 		},
 		{
 			name: "an operand between two flags",
@@ -253,6 +282,321 @@ func TestParseRefusesTheVector(t *testing.T) {
 				t.Errorf("parse(%q) reads %q, and does not name %q", test.args, err, test.says)
 			}
 		})
+	}
+}
+
+// TestParseReadsTheInitVector is the second synopsis line docs/cli/SPEC.md
+// fixes: the subcommand at the head, one --copybook per file, and --out.
+//
+// The copybooks arrive in the order they were given and as they were typed. A
+// layout's own paths are relative to the layout, so a path cpybkc rewrote on the
+// adopter's behalf would be one they cannot find in what they typed.
+func TestParseReadsTheInitVector(t *testing.T) {
+	t.Parallel()
+
+	inv, err := parse([]string{
+		initSubcommand,
+		copybookFlag, "copybooks/posting.cpy",
+		copybookFlag + "=copybooks/account.cpy",
+		outFlag, "layout.sexpr",
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if !inv.scaffolding() {
+		t.Errorf("the line names %s and the invocation says the subcommand is %q", initSubcommand, inv.subcommand)
+	}
+
+	if inv.answer != answerRun {
+		t.Errorf("the line asks for answer %d, want a run", inv.answer)
+	}
+
+	want := []string{"copybooks/posting.cpy", "copybooks/account.cpy"}
+	if !slices.Equal(inv.copybooks, want) {
+		t.Errorf("the copybooks are %q, want %q", inv.copybooks, want)
+	}
+
+	if inv.out != "layout.sexpr" {
+		t.Errorf("%s is %q", outFlag, inv.out)
+	}
+
+	// init reads no manifest, so the line naming none is not the line defaulting
+	// to one: nothing on this path ever asks [invocation.manifestPath].
+	if inv.manifest != "" {
+		t.Errorf("an %s line named the manifest %q", initSubcommand, inv.manifest)
+	}
+}
+
+// TestInitWritesToStandardOutput covers the destination that is not a path.
+// `--out -` is the one spelling that puts the scaffold on standard output, and
+// it is the same reading of a dash the rest of this program uses.
+func TestInitWritesToStandardOutput(t *testing.T) {
+	t.Parallel()
+
+	inv, err := parse([]string{initSubcommand, copybookFlag, "posting.cpy", outFlag, standardOutput})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if inv.out != standardOutput {
+		t.Errorf("%s is %q, want %q", outFlag, inv.out, standardOutput)
+	}
+}
+
+// TestTwoSpellingsAreTwoCopybooks is what docs/cli/SPEC.md deliberately does not
+// decide: whether two --copybook values name one file on disk.
+//
+// Byte-equal values are a duplicate and refused. Two different spellings that
+// resolve to one file are two copybooks, and the scaffold holds each 01-level
+// twice under two record names — because behind a symlink, a bind mount or a
+// case-insensitive filesystem there is no comparison that is right every time.
+func TestTwoSpellingsAreTwoCopybooks(t *testing.T) {
+	t.Parallel()
+
+	inv, err := parse([]string{
+		initSubcommand,
+		copybookFlag, "posting.cpy",
+		copybookFlag, "./posting.cpy",
+		outFlag, standardOutput,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if len(inv.copybooks) != 2 {
+		t.Errorf("two spellings of one path parsed as %q, want two copybooks", inv.copybooks)
+	}
+}
+
+// TestParseRefusesTheInitVector is every way docs/cli/SPEC.md says an `init`
+// line can fail to be understood. Each is status 2, and each is decided with
+// nothing opened and nothing created.
+func TestParseRefusesTheInitVector(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name string
+		args []string
+		says string
+	}{
+		{
+			name: "no copybook at all",
+			args: []string{initSubcommand, outFlag, "layout.sexpr"},
+			says: copybookFlag,
+		},
+		{
+			name: "no destination",
+			args: []string{initSubcommand, copybookFlag, "posting.cpy"},
+			says: outFlag,
+		},
+		{
+			name: "no flags at all",
+			args: []string{initSubcommand},
+			says: copybookFlag,
+		},
+		{
+			name: "a copybook on a stream",
+			args: []string{initSubcommand, copybookFlag, standardOutput, outFlag, "layout.sexpr"},
+			says: "has none to state",
+		},
+		{
+			name: "one copybook named twice",
+			args: []string{
+				initSubcommand,
+				copybookFlag, "posting.cpy",
+				copybookFlag + "=posting.cpy",
+				outFlag, "layout.sexpr",
+			},
+			says: "more than once",
+		},
+		{
+			name: "a destination named twice",
+			args: []string{
+				initSubcommand,
+				copybookFlag, "posting.cpy",
+				outFlag, "one.sexpr",
+				outFlag, "two.sexpr",
+			},
+			says: "more than once",
+		},
+		{
+			name: "an empty copybook",
+			args: []string{initSubcommand, copybookFlag + "=", outFlag, "layout.sexpr"},
+			says: "names no copybook",
+		},
+		{
+			name: "an empty destination",
+			args: []string{initSubcommand, copybookFlag, "posting.cpy", outFlag + "="},
+			says: "names nowhere",
+		},
+		{
+			name: "a missing value",
+			args: []string{initSubcommand, copybookFlag},
+			says: "takes a value",
+		},
+		{
+			name: "an operand after the subcommand",
+			args: []string{initSubcommand, "posting.cpy"},
+			says: "no operand",
+		},
+		{
+			name: "a second operand after the subcommand's flags",
+			args: []string{initSubcommand, copybookFlag, "posting.cpy", outFlag, "layout.sexpr", "extra"},
+			says: "no operand",
+		},
+		{
+			name: "an operand after the end of options",
+			args: []string{initSubcommand, endOfOptions, "posting.cpy"},
+			says: "no operand",
+		},
+		{
+			name: "a flag no action carries",
+			args: []string{initSubcommand, "--nope"},
+			says: "not a cpybkc flag",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			inv, err := parse(test.args)
+			if err == nil {
+				t.Fatalf("parse(%q) returned %+v, want a usage error", test.args, inv)
+			}
+
+			if !errors.As(err, new(*usageError)) {
+				t.Errorf("parse(%q) returned %T, want a usage error", test.args, err)
+			}
+
+			if got := statusOf(err); got != statusUsage {
+				t.Errorf("parse(%q) failed with status %d, want %d", test.args, got, statusUsage)
+			}
+
+			if !strings.Contains(err.Error(), test.says) {
+				t.Errorf("parse(%q) reads %q, and does not name %q", test.args, err, test.says)
+			}
+		})
+	}
+}
+
+// TestAFlagUnderTheWrongActionIsNotUnrecognised is the distinction
+// docs/cli/SPEC.md asks for in both directions: a real flag of this program,
+// written under the action it does not belong to, names the flag and the
+// subcommand rather than reporting it as unrecognised.
+//
+// The difference is what a reader does next. "--manifest is not a cpybkc flag"
+// sends them to check a spelling that is already right, and the search ends
+// nowhere.
+func TestAFlagUnderTheWrongActionIsNotUnrecognised(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name string
+		args []string
+		flag string
+	}{
+		{name: "the manifest under init", args: []string{initSubcommand, manifestFlag, defaultManifest},
+			flag: manifestFlag},
+		{name: "an emission under init", args: []string{initSubcommand, emitIRFlag, standardOutput},
+			flag: emitIRFlag},
+		{name: "an emission format under init", args: []string{initSubcommand, emitIRFormatFlag, jsonFormat},
+			flag: emitIRFormatFlag},
+		{name: "a copybook with no subcommand", args: []string{copybookFlag, "posting.cpy"}, flag: copybookFlag},
+		{name: "a destination with no subcommand", args: []string{outFlag, "layout.sexpr"}, flag: outFlag},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := parse(test.args)
+			if err == nil {
+				t.Fatalf("parse(%q) returned no error, want a usage error", test.args)
+			}
+
+			for _, want := range []string{test.flag, initSubcommand} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("parse(%q) reads %q, and does not name %q", test.args, err, want)
+				}
+			}
+
+			if strings.Contains(err.Error(), unrecognisedError(test.flag).Error()) {
+				t.Errorf("parse(%q) reports a flag of this program as unrecognised: %q", test.args, err)
+			}
+		})
+	}
+}
+
+// TestAUsageErrorCarriesTheActionItWasWrittenUnder is what decides which usage
+// accompanies it on standard error. The parser is the only place that knows, and
+// [run] is where usage is written; between the two there is nothing left of the
+// line but the error.
+func TestAUsageErrorCarriesTheActionItWasWrittenUnder(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		args []string
+		want string
+	}{
+		{args: []string{initSubcommand, "--nope"}, want: initSubcommand},
+		{args: []string{initSubcommand, copybookFlag, "posting.cpy"}, want: initSubcommand},
+		{args: []string{"--nope"}, want: defaultAction},
+		{args: []string{endOfOptions, "posting.cpy"}, want: defaultAction},
+
+		// The head itself was never classified, so the error belongs to no
+		// action and the whole command's usage is what answers it.
+		{args: []string{"bogus"}, want: defaultAction},
+	} {
+		_, err := parse(test.args)
+
+		var usage *usageError
+		if !errors.As(err, &usage) {
+			t.Errorf("parse(%q) returned %v, want a usage error", test.args, err)
+
+			continue
+		}
+
+		if usage.subcommand != test.want {
+			t.Errorf("parse(%q) is reported under %q, want %q", test.args, usage.subcommand, test.want)
+		}
+	}
+}
+
+// TestHelpUnderASubcommandIsTheSubcommands is docs/cli/SPEC.md's rule that
+// --help and --version are answered under every subcommand, and that only
+// --help varies with the head.
+func TestHelpUnderASubcommandIsTheSubcommands(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		args   []string
+		answer answer
+		under  string
+	}{
+		{args: []string{initSubcommand, helpFlag}, answer: answerHelp, under: initSubcommand},
+		{args: []string{initSubcommand, shortHelpFlag}, answer: answerHelp, under: initSubcommand},
+		{args: []string{initSubcommand, copybookFlag, helpFlag}, answer: answerHelp, under: initSubcommand},
+		{args: []string{helpFlag}, answer: answerHelp, under: defaultAction},
+
+		// A verb nobody has is not complained about: the question is answered,
+		// with the top-level usage.
+		{args: []string{"bogus", helpFlag}, answer: answerHelp, under: defaultAction},
+
+		// A build has one version whichever action was going to run.
+		{args: []string{initSubcommand, versionFlag}, answer: answerVersion, under: defaultAction},
+	} {
+		inv, err := parse(test.args)
+		if err != nil {
+			t.Errorf("parse(%q): %v", test.args, err)
+
+			continue
+		}
+
+		if inv.answer != test.answer {
+			t.Errorf("parse(%q) asks for answer %d, want %d", test.args, inv.answer, test.answer)
+		}
+
+		if inv.subcommand != test.under {
+			t.Errorf("parse(%q) is answered under %q, want %q", test.args, inv.subcommand, test.under)
+		}
 	}
 }
 

--- a/cmd/cpybkc/main.go
+++ b/cmd/cpybkc/main.go
@@ -6,6 +6,7 @@
 // Command cpybkc is the executable a person runs.
 //
 //	cpybkc [--manifest <path>] [--emit-ir <dest> [--emit-ir-format <format>]]
+//	cpybkc init --copybook <path> … --out <dest>
 //	cpybkc --version
 //	cpybkc --help
 //
@@ -14,6 +15,11 @@
 // descriptor the layout and its copybooks resolve to — or, where --emit-ir asks
 // for it, writes that descriptor and stops. Then it turns whatever happened into
 // an exit status and reports it.
+//
+// The one named subcommand is `init`, which scaffolds a layout from copybooks
+// and reads no manifest ([scaffold]). Generating keeps the bare form and is
+// given no name of its own, so every command line already written and every
+// published image whose entrypoint is this CLI still means what it meant.
 //
 // # What is here, and what is not
 //
@@ -114,13 +120,18 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) status {
 	// caller can fix without knowing anything about the project, and the
 	// command set is what they need in front of them to fix it.
 	//
+	// Which usage is the action the line was written under, which the error
+	// carries: a reader who typed `cpybkc init` and got a flag wrong needs
+	// init's flags in front of them, not the default action's.
+	//
 	// A blank line first, because usage is the one thing on this stream that is
 	// not a diagnostic and nothing about it should read as one — a reader, and
 	// a script scanning for `^error: `, both see where the diagnostics ended.
-	if errors.As(err, new(*usageError)) {
+	var usage *usageError
+	if errors.As(err, &usage) {
 		_, _ = io.WriteString(stderr, "\n")
 
-		writeUsage(stderr)
+		writeUsage(stderr, usage.subcommand)
 	}
 
 	return statusOf(err)
@@ -136,7 +147,7 @@ func execute(ctx context.Context, args []string, stdout io.Writer, log *slog.Log
 
 	switch inv.answer {
 	case answerHelp:
-		writeUsage(stdout)
+		writeUsage(stdout, inv.subcommand)
 
 		return nil
 	case answerVersion:
@@ -144,6 +155,15 @@ func execute(ctx context.Context, args []string, stdout io.Writer, log *slog.Log
 
 		return nil
 	case answerRun:
+		// The subcommand is the one thing that decides which action runs, and
+		// this is the only place it is read for that. docs/cli/SPEC.md gives
+		// `init` no manifest, no layout resolution and no generator, so it
+		// branches above [perform] rather than inside it: a scaffolding run and
+		// a generating run share the vector and nothing else.
+		if inv.scaffolding() {
+			return scaffold(ctx, inv)
+		}
+
 		return perform(ctx, inv, stdout, log)
 	}
 

--- a/cmd/cpybkc/main.go
+++ b/cmd/cpybkc/main.go
@@ -127,11 +127,13 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) status {
 	// A blank line first, because usage is the one thing on this stream that is
 	// not a diagnostic and nothing about it should read as one — a reader, and
 	// a script scanning for `^error: `, both see where the diagnostics ended.
-	var usage *usageError
-	if errors.As(err, &usage) {
+	// usageErr rather than usage, which is the help text three lines from here
+	// and a package-level constant this scope would otherwise shadow.
+	var usageErr *usageError
+	if errors.As(err, &usageErr) {
 		_, _ = io.WriteString(stderr, "\n")
 
-		writeUsage(stderr, usage.subcommand)
+		writeUsage(stderr, usageErr.subcommand)
 	}
 
 	return statusOf(err)

--- a/cmd/cpybkc/main_test.go
+++ b/cmd/cpybkc/main_test.go
@@ -80,6 +80,13 @@ func TestUsageNamesTheSettledCommandSet(t *testing.T) {
 		t.Errorf("the synopsis does not lead with the bare form:\n%s", stdout)
 	}
 
+	// The at-most-once rule is stated with its one exception. --copybook is the
+	// flag that repeats, and a summary asserting the rule without it would be
+	// telling the reader the second synopsis line is a usage error.
+	if strings.Contains(stdout, "at most once.") {
+		t.Errorf("usage states the at-most-once rule without naming %s's exception:\n%s", copybookFlag, stdout)
+	}
+
 	// The flags docs/cli/SPEC.md's "Out of Scope" refuses by name, each with its
 	// reason. A usage text offering one would document a flag the parser has no
 	// case for.
@@ -131,6 +138,16 @@ func TestInitHasItsOwnUsage(t *testing.T) {
 	// The whole command's usage is unchanged by the subcommand existing.
 	if whole, _, _ := invoke(helpFlag); whole != usage {
 		t.Errorf("`cpybkc %s` wrote %q, want the whole command's usage", helpFlag, whole)
+	}
+
+	// And it says what this build does, which is read the line and fail. A help
+	// text promising a written scaffold while [scaffold] cannot write one would
+	// be documenting a command nobody can run — the fault the usage text avoided
+	// by omitting the verb entirely while it did not parse. #215 deletes the
+	// line and this assertion together, in the commit that makes the promise
+	// true.
+	if !strings.Contains(stdout, "Not implemented in this build") {
+		t.Errorf("init's usage promises a scaffold this build cannot write:\n%s", stdout)
 	}
 }
 

--- a/cmd/cpybkc/main_test.go
+++ b/cmd/cpybkc/main_test.go
@@ -47,7 +47,8 @@ func TestHelpIsWrittenToStandardOutputAndSucceeds(t *testing.T) {
 }
 
 // TestUsageNamesTheSettledCommandSet holds the help text to the surface
-// docs/cli/SPEC.md fixes: the three forms, the five flags, and no sixth.
+// docs/cli/SPEC.md fixes: the four forms, the one subcommand, and no flag this
+// command does not have.
 //
 // The wording is explicitly not a covered guarantee, so this asserts what is
 // named rather than how it reads.
@@ -56,25 +57,183 @@ func TestUsageNamesTheSettledCommandSet(t *testing.T) {
 
 	stdout, _, _ := invoke(helpFlag)
 
+	// The verb is named now, and the two flags that reach it are named with it.
+	// #214 implements the subcommand this document specified at #183, so a usage
+	// text that omitted it would hide a command that runs — which is the inverse
+	// of the fault the omission was avoiding while the parsing did not exist.
+	// The synopsis carries the second form for the same reason: the forms are
+	// the command set, so all four lines are the document's, line for line.
 	for _, want := range []string{
 		manifestFlag, emitIRFlag, emitIRFormatFlag, versionFlag, helpFlag, shortHelpFlag,
 		binaryFormat, jsonFormat, defaultManifest,
+		initSubcommand, copybookFlag, outFlag,
 	} {
 		if !strings.Contains(stdout, want) {
 			t.Errorf("usage does not name %s:\n%s", want, stdout)
 		}
 	}
 
-	// No verb line yet. Generating is what the command does when nothing else
-	// is asked of it, and that keeps the bare form whatever else the set gains
-	// — but docs/cli/SPEC.md now specifies one subcommand, `init`, which this
-	// build does not implement. A usage text spelling it would document a
-	// command nobody can run; #214 lands both together and flips this
-	// assertion.
-	for _, refused := range []string{"--out", "--include", "--jobs", "--verbose", "--config", "Commands:"} {
+	// The bare form still leads, because generating keeps it: it is what every
+	// command line already written and every published image whose entrypoint is
+	// this CLI already means by `cpybkc`.
+	if !strings.Contains(stdout, "  cpybkc [--manifest") {
+		t.Errorf("the synopsis does not lead with the bare form:\n%s", stdout)
+	}
+
+	// The flags docs/cli/SPEC.md's "Out of Scope" refuses by name, each with its
+	// reason. A usage text offering one would document a flag the parser has no
+	// case for.
+	for _, refused := range []string{"--include", "--jobs", "--verbose", "--config"} {
 		if strings.Contains(stdout, refused) {
 			t.Errorf("usage offers %s, which cpybkc does not have:\n%s", refused, stdout)
 		}
+	}
+}
+
+// TestInitHasItsOwnUsage is docs/cli/SPEC.md's rule about which usage --help
+// writes: the named subcommand's where the first argument is one, and the whole
+// command's otherwise.
+//
+// A reader who has typed a verb has narrowed what they are asking about, so the
+// answer is `init`'s flags and not an action they are not running.
+func TestInitHasItsOwnUsage(t *testing.T) {
+	t.Parallel()
+
+	stdout, stderr, code := invoke(initSubcommand, helpFlag)
+
+	if code != statusOK {
+		t.Errorf("`cpybkc %s %s` exited %d, want %d", initSubcommand, helpFlag, code, statusOK)
+	}
+
+	if stderr != "" {
+		t.Errorf("`cpybkc %s %s` wrote %q to standard error, and usage that was asked for is not a diagnostic",
+			initSubcommand, helpFlag, stderr)
+	}
+
+	if stdout != initUsage {
+		t.Errorf("`cpybkc %s %s` wrote %q, want init's usage", initSubcommand, helpFlag, stdout)
+	}
+
+	for _, want := range []string{initSubcommand, copybookFlag, outFlag} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("init's usage does not name %s:\n%s", want, stdout)
+		}
+	}
+
+	// The default action's input flags are usage errors under init, so offering
+	// them here would document a line that is refused.
+	for _, refused := range []string{manifestFlag, emitIRFlag, emitIRFormatFlag} {
+		if strings.Contains(stdout, refused) {
+			t.Errorf("init's usage offers %s, which is a usage error under %s:\n%s", refused, initSubcommand, stdout)
+		}
+	}
+
+	// The whole command's usage is unchanged by the subcommand existing.
+	if whole, _, _ := invoke(helpFlag); whole != usage {
+		t.Errorf("`cpybkc %s` wrote %q, want the whole command's usage", helpFlag, whole)
+	}
+}
+
+// TestAnUnknownVerbIsStillAnsweredByHelp is the courtesy docs/cli/SPEC.md
+// extends to a reader who is in the middle of getting the line wrong, at the
+// position an unrecognised verb is the commonest way to arrive at it: the
+// question is answered, with the top-level usage, and the verb is not
+// complained about.
+func TestAnUnknownVerbIsStillAnsweredByHelp(t *testing.T) {
+	t.Parallel()
+
+	stdout, stderr, code := invoke("bogus", helpFlag)
+
+	if code != statusOK {
+		t.Errorf("`cpybkc bogus %s` exited %d, want %d", helpFlag, code, statusOK)
+	}
+
+	if stdout != usage {
+		t.Errorf("`cpybkc bogus %s` wrote %q, want the whole command's usage", helpFlag, stdout)
+	}
+
+	if stderr != "" {
+		t.Errorf("`cpybkc bogus %s` wrote %q to standard error", helpFlag, stderr)
+	}
+}
+
+// TestVersionIgnoresASubcommand is the other half of that rule. A build has one
+// version whichever action was going to run, so --version does not vary with the
+// head the way --help does.
+func TestVersionIgnoresASubcommand(t *testing.T) {
+	t.Parallel()
+
+	stdout, stderr, code := invoke(initSubcommand, versionFlag)
+
+	if code != statusOK {
+		t.Errorf("`cpybkc %s %s` exited %d, want %d", initSubcommand, versionFlag, code, statusOK)
+	}
+
+	if stderr != "" {
+		t.Errorf("`cpybkc %s %s` wrote %q to standard error", initSubcommand, versionFlag, stderr)
+	}
+
+	if want := versionLine() + "\n"; stdout != want {
+		t.Errorf("`cpybkc %s %s` wrote %q, want %q", initSubcommand, versionFlag, stdout, want)
+	}
+}
+
+// TestAUsageErrorUnderInitIsAnsweredWithInitsUsage holds the other half of
+// docs/cli/SPEC.md's rule about which usage is written: usage accompanies a
+// usage error on standard error, and the one a reader needs is the one whose
+// flags they were using.
+func TestAUsageErrorUnderInitIsAnsweredWithInitsUsage(t *testing.T) {
+	t.Parallel()
+
+	stdout, stderr, code := invoke(initSubcommand, copybookFlag, "posting.cpy")
+
+	if code != statusUsage {
+		t.Errorf("`cpybkc %s` with no %s exited %d, want %d", initSubcommand, outFlag, code, statusUsage)
+	}
+
+	if stdout != "" {
+		t.Errorf("a usage error wrote %q to standard output", stdout)
+	}
+
+	if !strings.Contains(stderr, initUsage) {
+		t.Errorf("a usage error under %s was answered with %q, want init's usage", initSubcommand, stderr)
+	}
+
+	if strings.Contains(stderr, emitIRFlag) {
+		t.Errorf("a usage error under %s was answered with the default action's flags: %q", initSubcommand, stderr)
+	}
+}
+
+// TestInitUnderstoodCannotYetBePerformed is the exit status this build owes a
+// line it read and cannot carry out.
+//
+// docs/cli/SPEC.md's status 2 promises the vector was not understood and that
+// cpybkc did nothing at all; status 0 promises a scaffold was written. This line
+// is neither, so it is the 1 the document keeps for the faults in the work
+// ([scaffold], #215). Exiting 0 over a scaffold nobody wrote would be the worst
+// of the three: silence is success for a run, and a person would go looking for
+// a file that is not there.
+func TestInitUnderstoodCannotYetBePerformed(t *testing.T) {
+	t.Parallel()
+
+	stdout, stderr, code := invoke(initSubcommand, copybookFlag, "posting.cpy", outFlag, "layout.sexpr")
+
+	if code != statusFailed {
+		t.Errorf("an understood %s line exited %d, want %d", initSubcommand, code, statusFailed)
+	}
+
+	if stdout != "" {
+		t.Errorf("`cpybkc %s` wrote %q to standard output, and no scaffold was written", initSubcommand, stdout)
+	}
+
+	if !strings.HasPrefix(stderr, severityError+severitySeparator) {
+		t.Errorf("the diagnostic reads %q, want an %s%s line", stderr, severityError, severitySeparator)
+	}
+
+	// A failure of the work is not a failure of the vector, so the command set
+	// is not what the reader needs in front of them.
+	if strings.Contains(stderr, "Usage:") {
+		t.Errorf("`cpybkc %s` was answered with usage, and the vector was understood: %q", initSubcommand, stderr)
 	}
 }
 
@@ -132,10 +291,15 @@ func TestVersionCarriesNoBuildProvenance(t *testing.T) {
 // TestAUsageErrorExitsTwoAndSaysSoOnStandardError is the status a caller can
 // act on without knowing anything about the project, and the stream the
 // diagnostic owes.
+//
+// The flag is one no action carries. `--out` used to stand here, and it is a
+// real flag now — `init`'s — so it is a usage error for a different reason and
+// reads differently; the two refusals are told apart in args_test.go, and this
+// test wants the plain one.
 func TestAUsageErrorExitsTwoAndSaysSoOnStandardError(t *testing.T) {
 	t.Parallel()
 
-	stdout, stderr, code := invoke("--out", "gen")
+	stdout, stderr, code := invoke("--nope", "gen")
 
 	if code != statusUsage {
 		t.Errorf("an unrecognised flag exited %d, want %d", code, statusUsage)
@@ -152,7 +316,7 @@ func TestAUsageErrorExitsTwoAndSaysSoOnStandardError(t *testing.T) {
 		t.Errorf("the diagnostic reads %q, want an %s%s line", stderr, severityError, severitySeparator)
 	}
 
-	if !strings.Contains(stderr, "--out") {
+	if !strings.Contains(stderr, "--nope") {
 		t.Errorf("the diagnostic does not name the flag that was refused: %q", stderr)
 	}
 
@@ -223,6 +387,13 @@ func TestEveryEnumeratedStatusIsReachable(t *testing.T) {
 		{"--nope"},
 		{"an-operand"},
 		{emitIRFormatFlag, jsonFormat},
+
+		// The subcommand reaches the same three and no fourth: a line it
+		// understood and cannot yet perform is the run failing, and a flag
+		// written under the wrong action is the vector.
+		{initSubcommand, copybookFlag, "posting.cpy", outFlag, standardOutput},
+		{initSubcommand, manifestFlag, defaultManifest},
+		{copybookFlag, "posting.cpy"},
 	} {
 		_, _, code := invoke(args...)
 		reached[code] = append(reached[code], strings.Join(args, " "))

--- a/cmd/cpybkc/scaffold.go
+++ b/cmd/cpybkc/scaffold.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import (
+	"context"
+	"fmt"
+)
+
+// scaffold is `cpybkc init`: the copybooks the line named, read, and the layout
+// scaffold they decide, written where --out says.
+//
+// # What is here, and what is not
+//
+// The vector is here — which copybooks were named, in which order and as they
+// were typed, and where the scaffold goes — because that is the half of
+// docs/cli/SPEC.md's `init` this story lands (#214). The derivation is not: a
+// record per 01-level, an alternative per REDEFINES outside a repeating group,
+// the commented forms whose subject is computable and whose value is not, the
+// destination that is never overwritten and the combination count reported on
+// standard error are all #215's, and they are a reading of a copybook rather
+// than of a command line.
+//
+// So this build understands the line and cannot perform it, which is exactly the
+// distinction the exit statuses encode: status 1, the run failed, and not status
+// 2, which promises the vector was not understood and that cpybkc did nothing at
+// all. Reporting the vector's own faults correctly while exiting 0 over a
+// scaffold nobody wrote would be the one answer worse than either — silence is
+// success for a run by docs/cli/SPEC.md's rule, and a person would go looking
+// for a file that is not there.
+//
+// It takes neither stream. Nothing is written to standard output until there is
+// a scaffold to write, and the one line this stage has to say is a failure,
+// which [run] reports on standard error where every other fault is reported.
+// #215 is what gives it the writer, beside the file it writes.
+func scaffold(ctx context.Context, inv invocation) error {
+	// A run cancelled before it starts is a cancelled run. The check is here for
+	// the reason it is on the emitting path: there is no output tree to leave
+	// alone, but there is a file about to appear at a path somebody named, and a
+	// signal that arrived first is the answer they are owed rather than whatever
+	// the stage would otherwise have said.
+	if err := ctx.Err(); err != nil {
+		return cancelled(ctx, err)
+	}
+
+	return fmt.Errorf(
+		"cpybkc %s read its vector — %d copybook(s), writing to %q — and this build cannot derive a scaffold "+
+			"from them; the derivation is the story that follows this one (#215), and until it lands %s is a "+
+			"line cpybkc understands and cannot perform",
+		initSubcommand, len(inv.copybooks), inv.out, initSubcommand)
+}

--- a/cmd/cpybkc/scaffold.go
+++ b/cmd/cpybkc/scaffold.go
@@ -36,6 +36,13 @@ import (
 // a scaffold to write, and the one line this stage has to say is a failure,
 // which [run] reports on standard error where every other fault is reported.
 // #215 is what gives it the writer, beside the file it writes.
+//
+// It does take the invocation, which it does not yet read. That is this stage's
+// whole input — which copybooks, in which order, and where the scaffold goes —
+// and the parse that produces it is what this story lands; a signature that
+// omitted it would have to be changed by #215 in the same commit that reads it,
+// and the branch in [execute] would read as though the vector were beside the
+// point.
 func scaffold(ctx context.Context, inv invocation) error {
 	// A run cancelled before it starts is a cancelled run. The check is here for
 	// the reason it is on the emitting path: there is no output tree to leave
@@ -46,9 +53,12 @@ func scaffold(ctx context.Context, inv invocation) error {
 		return cancelled(ctx, err)
 	}
 
-	return fmt.Errorf(
-		"cpybkc %s read its vector — %d copybook(s), writing to %q — and this build cannot derive a scaffold "+
-			"from them; the derivation is the story that follows this one (#215), and until it lands %s is a "+
-			"line cpybkc understands and cannot perform",
-		initSubcommand, len(inv.copybooks), inv.out, initSubcommand)
+	// The message says what the reader can act on and nothing else: the line was
+	// understood, the build cannot carry it out, and no file was written. It
+	// names no issue number — a tracker is not something the person who ran the
+	// command can reach, and the reference belongs in the comment above, where
+	// the reader who can act on it is already looking.
+	return fmt.Errorf("cpybkc %s is not implemented in this build: the arguments were read and understood, "+
+		"and the derivation that writes a scaffold from copybooks is not in it yet; nothing was written",
+		initSubcommand)
 }

--- a/cmd/cpybkc/usage.go
+++ b/cmd/cpybkc/usage.go
@@ -48,8 +48,8 @@ Flags:
   -h, --help                 print this help and exit
 
 Every input is named by a flag: cpybkc takes no operand beyond the subcommand
-name, and each flag appears at most once. docs/cli/SPEC.md is the contract this
-summarises.
+name, and each flag appears at most once — except init's --copybook, which is
+given once per file. docs/cli/SPEC.md is the contract this summarises.
 `
 
 // initUsage is what `cpybkc init --help` prints, and what accompanies a usage
@@ -65,6 +65,15 @@ summarises.
 // the split and not a caveat: the part an adopter is qualified to write is
 // exactly the part left blank, which is the reason the command can be trusted
 // with the half it does write.
+//
+// The last line is the other half of that honesty, and it is the reason this
+// text can exist before the derivation does. #214 lands the vector and #215 the
+// scaffold, so `cpybkc init` currently reads its line and fails; a help text
+// promising a written file would be documenting a command nobody can run, which
+// is what the comment above [usage] refused for the verb itself while it did not
+// parse. Saying so here is what lets --help be answered — docs/cli/SPEC.md
+// requires it under every subcommand — without it being a promise. The line goes
+// when the promise becomes true.
 const initUsage = `cpybkc init writes a layout scaffold from the copybooks it is given.
 
 Usage:
@@ -75,7 +84,7 @@ Flags:
                              once, and each path is written into the scaffold
                              as it was typed
   --out <dest>               where the scaffold is written, or - for standard
-                             output; it is never overwritten if it exists
+                             output
 
 The scaffold holds what a copybook decides — a record per 01-level, an
 alternative per REDEFINES — and leaves the rest for you: the encoding, the
@@ -84,6 +93,9 @@ a valid layout until you have. init reads no manifest and starts no generator.
 
 --help and --version are answered under every subcommand and are not init's own
 flags. docs/cli/SPEC.md is the contract this summarises.
+
+Not implemented in this build: init reads its arguments and reports that it
+cannot derive a scaffold from them yet. It exits 1 without writing anything.
 `
 
 // writeUsage writes the usage of the action named to w.

--- a/cmd/cpybkc/usage.go
+++ b/cmd/cpybkc/usage.go
@@ -19,18 +19,23 @@ import (
 // change to the surface.
 //
 // The synopsis is the document's, line for line, because the forms are the
-// command set. The three below are the whole of what this build implements:
-// docs/cli/SPEC.md's "One command, and one subcommand" now also specifies
-// `cpybkc init`, and the fourth synopsis line arrives with it (#214). Until
-// then a usage text offering a verb would document a command nobody can run.
-// -h is the one single-hyphen spelling that appears here; the document requires
-// any other to go undocumented.
+// command set. The fourth line arrived with the subcommand (#183, #214): the
+// bare form still leads, because generating is what this command does when
+// nothing else is asked of it and that is what every existing command line and
+// every published image already means by `cpybkc`. -h is the one single-hyphen
+// spelling that appears here; the document requires any other to go
+// undocumented.
 const usage = `cpybkc generates code from the copybooks a project's layout names.
 
 Usage:
   cpybkc [--manifest <path>] [--emit-ir <dest> [--emit-ir-format <format>]]
+  cpybkc init --copybook <path> … --out <dest>
   cpybkc --version
   cpybkc --help
+
+Commands:
+  init                       write a layout scaffold from the copybooks it
+                             names; cpybkc init --help is its own usage
 
 Flags:
   --manifest <path>          the project manifest to read (default: cpybkc.json
@@ -42,16 +47,63 @@ Flags:
   --version                  print the version and exit
   -h, --help                 print this help and exit
 
-Every input is named by a flag: cpybkc takes no operand, and each flag appears
-at most once. docs/cli/SPEC.md is the contract this summarises.
+Every input is named by a flag: cpybkc takes no operand beyond the subcommand
+name, and each flag appears at most once. docs/cli/SPEC.md is the contract this
+summarises.
 `
 
-// writeUsage writes usage to w.
+// initUsage is what `cpybkc init --help` prints, and what accompanies a usage
+// error on a line written under `init`.
+//
+// A usage of its own rather than the whole command's, because docs/cli/SPEC.md
+// says which usage --help writes: the named subcommand's where the first
+// argument is one. A reader who has typed a verb has already narrowed what they
+// are asking about, and answering with every flag of an action they are not
+// running is answering a question they did not ask.
+//
+// What it says about the scaffold's incompleteness is the honest description of
+// the split and not a caveat: the part an adopter is qualified to write is
+// exactly the part left blank, which is the reason the command can be trusted
+// with the half it does write.
+const initUsage = `cpybkc init writes a layout scaffold from the copybooks it is given.
+
+Usage:
+  cpybkc init --copybook <path> … --out <dest>
+
+Flags:
+  --copybook <path>          a copybook to read; given once per file, at least
+                             once, and each path is written into the scaffold
+                             as it was typed
+  --out <dest>               where the scaffold is written, or - for standard
+                             output; it is never overwritten if it exists
+
+The scaffold holds what a copybook decides — a record per 01-level, an
+alternative per REDEFINES — and leaves the rest for you: the encoding, the
+framing, the discrimination and the sequence are yours to write, and it is not
+a valid layout until you have. init reads no manifest and starts no generator.
+
+--help and --version are answered under every subcommand and are not init's own
+flags. docs/cli/SPEC.md is the contract this summarises.
+`
+
+// writeUsage writes the usage of the action named to w.
 //
 // Which w is the whole of what makes `cpybkc --help | less` work while keeping
 // a failing run's output off the data channel: usage goes to standard output
 // when it was asked for and to standard error when it accompanies a usage
 // error, and nothing else about it changes between the two.
-func writeUsage(w io.Writer) {
-	_, _ = fmt.Fprint(w, usage)
+//
+// Which usage is decided here rather than at the two call sites, so that a line
+// written under a subcommand gets the same answer whether it asked for usage or
+// earned it. An action this does not know is the whole command's usage, which is
+// what `cpybkc bogus --help` is owed: docs/cli/SPEC.md answers the question
+// rather than complaining about the verb, and an unrecognised verb is the
+// commonest way to arrive at it.
+func writeUsage(w io.Writer, subcommand string) {
+	text := usage
+	if subcommand == initSubcommand {
+		text = initUsage
+	}
+
+	_, _ = fmt.Fprint(w, text)
 }


### PR DESCRIPTION
Closes #214

`docs/cli/SPEC.md` specified `cpybkc init` at #183. This lands the half of it that is
the argument vector: the subcommand's position, its two flags, every refusal, and the
streams and statuses it answers on. The derivation that turns copybooks into a scaffold
is #215's.

## Acceptance criteria

- [x] **The first argument, and only the first, is read as a subcommand name; the set is
  closed at `init`; any other value is a usage error naming it, with nothing opened.
  `cpybkc -- init` is a usage error, and so is a second operand wherever it appears** —
  `head` in `cmd/cpybkc/args.go` reads the head at one fixed position, so `cpybkc -- init`
  and `cpybkc --manifest x.json init` are both the default action with an operand in them.
  A first argument that is a non-flag and is not `init` gets `subcommandError`, which names
  the argument and the one verb there is; every other operand keeps `operandError`.
- [x] **`--copybook` is repeatable and required at least once; `--out` is required; both
  accept the separated and joined value forms** — one walk (`vector`) reads both actions,
  so `docs/cli/SPEC.md`'s "The argument vector" applies to `init` unchanged rather than
  being restated in a second loop. `required` asks for the two at the end of the walk.
- [x] **Two `--copybook` occurrences carrying byte-equal values are a usage error; two
  different spellings are two copybooks, and nothing compares what they resolve to** —
  `setCopybook`, which compares values and never paths.
- [x] **`--copybook -` is a usage error. `--manifest`, `--emit-ir` and `--emit-ir-format`
  under `init` are usage errors naming the flag **and** the subcommand, distinguishably
  from an unrecognised flag; `--copybook` and `--out` without a subcommand are the same in
  the other direction** — `refuse` writes both directions, and
  `TestAFlagUnderTheWrongActionIsNotUnrecognised` asserts each names the flag and `init`
  and does not read like `unrecognisedError`.
- [x] **`cpybkc init --help` writes `init`'s usage to standard output and exits 0;
  `cpybkc --help` still writes the whole command's; `--version` ignores a subcommand** —
  `initUsage` in `cmd/cpybkc/usage.go`; the head is read for a help answer and deliberately
  not for a version one. `cpybkc bogus --help` still answers with the top-level usage
  rather than complaining about the verb. A usage *error* under `init` is answered with
  `init`'s usage too: the error carries the action it was written under.
- [x] **Exit statuses follow the spec: `2` for every fault above with nothing opened and
  nothing created, `1` for the faults in the work, `0` for a written scaffold** — see the
  judgment call below for the `0`.
- [x] **`cmd/cpybkc/usage.go`'s synopsis is the document's, line for line, including the
  `init` form; the wording stays hand-written for the reason the file already gives** —
  four lines, bare form first, and a `Commands:` block naming the verb. The comment
  explaining why the block is written out rather than generated is unchanged.
- [x] **`.dagger/companion.go`'s `CliSurface` and its comment are read against a command
  set that now has a verb, and the companion module's coverage question is answered rather
  than left stale** — the check still reads the flag table, and its comment now says why
  that is a decision rather than an omission: the verb cannot drift (the set is closed by
  the document) and could only be found by telling the check its spelling in advance, while
  the two flags it adds are read exactly like every other flag. `--copybook` and `--out`
  are recorded against `Run`, with the reasoning for not curating a scaffolding function.
- [x] **`cmd/cpybkc/main_test.go`'s usage assertions are updated with their reasoning, not
  just their expectations** — `TestUsageNamesTheSettledCommandSet` now requires the verb
  and its flags and keeps refusing the four flags "Out of Scope" names;
  `TestAUsageErrorExitsTwoAndSaysSoOnStandardError` moved off `--out`, which is a real flag
  now, onto one no action carries.

## Judgment calls

**A line `init` understands and cannot yet perform exits 1, not 0.** The derivation and the
file are #215's, so this build reads the vector and has nothing to write. Status 2 promises
the vector was not understood and that cpybkc did nothing at all, which would be false;
status 0 promises a scaffold was written, which would send a person looking for a file that
is not there. So `scaffold` in the new `cmd/cpybkc/scaffold.go` returns the failure, and 1
is the status `docs/cli/SPEC.md` keeps for the faults in the work. The `0` in the criteria
is reachable only once #215 lands.

**`scaffold` takes neither stream.** Nothing goes to standard output until there is a
scaffold to write, and the one thing this stage has to say is a failure, which `run`
already reports on standard error. #215 gives it the writer beside the file it writes.

**The usage error carries its action.** `usageError` gained a `subcommand` field, stamped
once by `parse` where the head was read rather than at each refusal — a message that has to
remember which action it came from is one that eventually does not.

## Verified

- `dagger call ci` — green, from an ordinary clone of `issue-214` (a worktree's `.git` is a
  file, which the image stages cannot read). The first attempt after a re-run hit a stale
  engine memo (`resolve result 47742: missing shared result`, with the module's `source`
  reported `Missing`); restarting the local dagger engine cleared it and the full 1m34s run
  passed. That was the tool's state, not the tree's.
- `go test ./...` and `gofmt -l .` from the worktree, plus `go test ./internal/...` in
  `.dagger`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review (local rung), and what changed after it

The adversarial review found no mis-parsed line and seven things worth fixing. All seven
are addressed in `7257d94`; each thread carries the reply.

- **`flagOwner`** — one table mapping each flag to the action that owns it. `takesAValue`
  and `refuse` are both derived from it, so "is this flag accepted" and "what is it refused
  as" can no longer disagree; the reviewer's point was that the disagreement is silent and
  produces exactly the "is not a cpybkc flag" message the criteria forbid for a real flag in
  the wrong place. `set` gained a `default`, so a flag added to the table and forgotten
  there fails loudly instead of parsing and doing nothing.
- **The usage text stopped contradicting the build** — the whole command's summary named
  the at-most-once rule while `--copybook` repeats; it now names the exception, and a test
  fails if the rule is restated without it. `init`'s own usage no longer promises the
  destination rule that belongs to #215, and ends with `Not implemented in this build`,
  asserted by `TestInitHasItsOwnUsage` so that #215 removes the line and the assertion
  together.
- **The `init` diagnostic** names no issue number and echoes no vector.
- **Tests** for all four combinations of the separated and joined spellings across both
  `init` flags, and for a separated value that is itself a flag
  (`init --copybook --out layout.sexpr`), which pins the unchanged rule that a flag's value
  is whatever follows it.
- **Shadowing** — the `usageError` locals in `run` and `under` were named `usage`, three
  lines from the help-text constant; renamed.
