### PR TITLE
story(cli): derive a layout scaffold from copybooks and write it

### DIFF
--- a/cmd/cpybkc/main.go
+++ b/cmd/cpybkc/main.go
@@ -162,8 +162,13 @@ func execute(ctx context.Context, args []string, stdout io.Writer, log *slog.Log
 		// `init` no manifest, no layout resolution and no generator, so it
 		// branches above [perform] rather than inside it: a scaffolding run and
 		// a generating run share the vector and nothing else.
+		//
+		// It takes both of what a run can write to for the same reason [perform]
+		// does: the scaffold is data and reaches standard output when `--out -`
+		// asked for it there, and everything it says about the run reaches
+		// standard error through the log this scope built beside that stream.
 		if inv.scaffolding() {
-			return scaffold(ctx, inv)
+			return scaffold(ctx, inv, stdout, log)
 		}
 
 		return perform(ctx, inv, stdout, log)

--- a/cmd/cpybkc/main_test.go
+++ b/cmd/cpybkc/main_test.go
@@ -8,6 +8,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -140,14 +141,12 @@ func TestInitHasItsOwnUsage(t *testing.T) {
 		t.Errorf("`cpybkc %s` wrote %q, want the whole command's usage", helpFlag, whole)
 	}
 
-	// And it says what this build does, which is read the line and fail. A help
-	// text promising a written scaffold while [scaffold] cannot write one would
-	// be documenting a command nobody can run — the fault the usage text avoided
-	// by omitting the verb entirely while it did not parse. #215 deletes the
-	// line and this assertion together, in the commit that makes the promise
-	// true.
-	if !strings.Contains(stdout, "Not implemented in this build") {
-		t.Errorf("init's usage promises a scaffold this build cannot write:\n%s", stdout)
+	// And it promises nothing this build cannot do. It carried a paragraph
+	// saying `init` was not implemented for exactly as long as that was true
+	// (#214); #215 wrote the derivation, so the paragraph went with it rather
+	// than being left as a caveat nobody would notice was stale.
+	if strings.Contains(stdout, "Not implemented") {
+		t.Errorf("init's usage still disclaims a scaffold this build writes:\n%s", stdout)
 	}
 }
 
@@ -221,19 +220,21 @@ func TestAUsageErrorUnderInitIsAnsweredWithInitsUsage(t *testing.T) {
 	}
 }
 
-// TestInitUnderstoodCannotYetBePerformed is the exit status this build owes a
-// line it read and cannot carry out.
+// TestInitUnderstoodAndUnperformableIsAFailureOfTheWork is the exit status
+// docs/cli/SPEC.md owes a line it read and could not carry out.
 //
-// docs/cli/SPEC.md's status 2 promises the vector was not understood and that
-// cpybkc did nothing at all; status 0 promises a scaffold was written. This line
-// is neither, so it is the 1 the document keeps for the faults in the work
-// ([scaffold], #215). Exiting 0 over a scaffold nobody wrote would be the worst
-// of the three: silence is success for a run, and a person would go looking for
-// a file that is not there.
-func TestInitUnderstoodCannotYetBePerformed(t *testing.T) {
+// Status 2 promises the vector was not understood and that cpybkc did nothing at
+// all; status 0 promises a scaffold was written. A `--copybook` naming a file
+// that is not there is neither — the line is well-formed and cpybkc had to open
+// something to find out — so it is the 1 the document keeps for the faults in
+// the work.
+func TestInitUnderstoodAndUnperformableIsAFailureOfTheWork(t *testing.T) {
 	t.Parallel()
 
-	stdout, stderr, code := invoke(initSubcommand, copybookFlag, "posting.cpy", outFlag, "layout.sexpr")
+	stdout, stderr, code := invoke(initSubcommand,
+		copybookFlag, filepath.Join(t.TempDir(), "absent.cpy"),
+		outFlag, filepath.Join(t.TempDir(), "layout.sexpr"),
+	)
 
 	if code != statusFailed {
 		t.Errorf("an understood %s line exited %d, want %d", initSubcommand, code, statusFailed)

--- a/cmd/cpybkc/scaffold.go
+++ b/cmd/cpybkc/scaffold.go
@@ -8,6 +8,12 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
+	"log/slog"
+	"os"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+	scaffolding "github.com/Zaba505/cpybkc/internal/scaffold"
 )
 
 // scaffold is `cpybkc init`: the copybooks the line named, read, and the layout
@@ -15,50 +21,170 @@ import (
 //
 // # What is here, and what is not
 //
-// The vector is here — which copybooks were named, in which order and as they
-// were typed, and where the scaffold goes — because that is the half of
-// docs/cli/SPEC.md's `init` this story lands (#214). The derivation is not: a
-// record per 01-level, an alternative per REDEFINES outside a repeating group,
-// the commented forms whose subject is computable and whose value is not, the
-// destination that is never overwritten and the combination count reported on
-// standard error are all #215's, and they are a reading of a copybook rather
-// than of a command line.
+// This stage opens the files, refuses the ones that are not copybooks it can be
+// handed, reports what a derivation is owed on standard error, and hands the
+// bytes to a destination. What a copybook *decides* is not here: the record per
+// 01-level, the alternative per REDEFINES outside a repeating group, the
+// commented forms whose subject is computable and whose value is not, and the
+// destination that is never overwritten are
+// [github.com/Zaba505/cpybkc/internal/scaffold]'s, and the REDEFINES reading
+// underneath them is [github.com/Zaba505/cpybkc/internal/resolve]'s — the same
+// one a layout is resolved through, so that a copybook has one reading in this
+// tool rather than two.
 //
-// So this build understands the line and cannot perform it, which is exactly the
-// distinction the exit statuses encode: status 1, the run failed, and not status
-// 2, which promises the vector was not understood and that cpybkc did nothing at
-// all. Reporting the vector's own faults correctly while exiting 0 over a
-// scaffold nobody wrote would be the one answer worse than either — silence is
-// success for a run by docs/cli/SPEC.md's rule, and a person would go looking
-// for a file that is not there.
+// The package is imported under a name of its own because this function already
+// has the obvious one. Which is the right way round: `init` is what a person
+// types, so it is what the command's own file is called, and the package it
+// calls is a detail of how.
 //
-// It takes neither stream. Nothing is written to standard output until there is
-// a scaffold to write, and the one line this stage has to say is a failure,
-// which [run] reports on standard error where every other fault is reported.
-// #215 is what gives it the writer, beside the file it writes.
+// # Why a directory is a status 1 and not a 2
 //
-// It does take the invocation, which it does not yet read. That is this stage's
-// whole input — which copybooks, in which order, and where the scaffold goes —
-// and the parse that produces it is what this story lands; a signature that
-// omitted it would have to be changed by #215 in the same commit that reads it,
-// and the branch in [execute] would read as though the vector were beside the
-// point.
-func scaffold(ctx context.Context, inv invocation) error {
-	// A run cancelled before it starts is a cancelled run. The check is here for
-	// the reason it is on the emitting path: there is no output tree to leave
-	// alone, but there is a file about to appear at a path somebody named, and a
-	// signal that arrived first is the answer they are owed rather than whatever
-	// the stage would otherwise have said.
+// A --copybook value naming a directory fails the run rather than the vector.
+// It is not decidable from the line — cpybkc has to look at the path to learn
+// what is there — and docs/cli/SPEC.md draws the statuses on exactly that line:
+// a 2 promises that cpybkc did nothing at all, and by the time a directory is
+// known to be one, files have been opened. It is stated apart from a copybook
+// that cannot be opened because a directory opens perfectly well, and reading
+// one would make the scaffold a function of a directory's contents — a copybook
+// dropped in beside the others later changing what `init` produces, with no file
+// recording the difference.
+//
+// # The two streams
+//
+// The scaffold is data and reaches standard output when, and only when, `--out
+// -` asked for it there. Everything else this stage says is a diagnostic on
+// standard error, including the notes it owes: an 01-level resolving to more
+// than one record type is the size of the work in front of the reader, and
+// docs/cli/SPEC.md holds every line cpybkc writes to being something they can
+// act on.
+//
+// The notes go through the same log a generator's lines reach that stream
+// through, at the level docs/plugin/SPEC.md maps `note:` to, because that log is
+// where the one place that knows which writer standard error is put it. A line
+// through it carrying no generator name is cpybkc's own, which is what
+// docs/cli/SPEC.md makes the absence of a name mean.
+func scaffold(ctx context.Context, inv invocation, stdout io.Writer, log *slog.Logger) error {
+	// A run cancelled before it starts is a cancelled run. The check is here
+	// for the reason it is on the emitting path: there is no output tree to
+	// leave alone, but there is a file about to appear at a path somebody
+	// named, and a signal that arrived first is the answer they are owed rather
+	// than whatever the stage would otherwise have said.
 	if err := ctx.Err(); err != nil {
 		return cancelled(ctx, err)
 	}
 
-	// The message says what the reader can act on and nothing else: the line was
-	// understood, the build cannot carry it out, and no file was written. It
-	// names no issue number — a tracker is not something the person who ran the
-	// command can reach, and the reference belongs in the comment above, where
-	// the reader who can act on it is already looking.
-	return fmt.Errorf("cpybkc %s is not implemented in this build: the arguments were read and understood, "+
-		"and the derivation that writes a scaffold from copybooks is not in it yet; nothing was written",
-		initSubcommand)
+	books, err := copybooks(inv.copybooks)
+	if err != nil {
+		return err
+	}
+
+	derived, err := scaffolding.Derive(books)
+	if err != nil {
+		return err
+	}
+
+	for _, note := range derived.Notes() {
+		log.InfoContext(ctx, note)
+	}
+
+	// A run cancelled between deriving and writing is a cancelled run and not a
+	// written scaffold. The whole file has been derived by here, which is what
+	// makes "no partial file" and "no partial output" one property rather than
+	// two: there is nothing to write until there is all of it.
+	if err := ctx.Err(); err != nil {
+		return cancelled(ctx, err)
+	}
+
+	return scaffolding.Write(inv.out, stdout, derived.Bytes())
+}
+
+// copybooks opens every file the line named, in the order it named them.
+//
+// Every fault is reported rather than the first. A person adopting cpybkc types
+// a `--copybook` per file in one line, and mistyping two of them is two things
+// to fix rather than two runs.
+func copybooks(paths []string) ([]scaffolding.Copybook, error) {
+	var faults diag.List
+
+	books := make([]scaffolding.Copybook, 0, len(paths))
+
+	for _, path := range paths {
+		// Stat rather than opening and finding out, because a directory opens
+		// perfectly well and reading one yields a fault about the read rather
+		// than about what was named.
+		info, err := os.Stat(path)
+		if err != nil {
+			faults.Fail(&unopenableCopybookError{Path: path, Err: err})
+
+			continue
+		}
+
+		if info.IsDir() {
+			faults.Fail(&copybookDirectoryError{Path: path})
+
+			continue
+		}
+
+		source, err := os.ReadFile(path)
+		if err != nil {
+			faults.Fail(&unopenableCopybookError{Path: path, Err: err})
+
+			continue
+		}
+
+		books = append(books, scaffolding.Copybook{Path: path, Source: source})
+	}
+
+	if faults.Failed() {
+		return nil, faults.Err()
+	}
+
+	return books, nil
+}
+
+// unopenableCopybookError is a --copybook value that could not be read.
+//
+// The path is named as it was typed, which is what the person running the
+// command can go and correct: there is no layout under `init` for a second
+// spelling to have come from.
+type unopenableCopybookError struct {
+	Path string
+	Err  error
+}
+
+// Error implements error.
+func (e *unopenableCopybookError) Error() string { return e.Diagnostic().String() }
+
+// Unwrap returns the underlying fault.
+func (e *unopenableCopybookError) Unwrap() error { return e.Err }
+
+// Diagnostic implements [diag.Error].
+func (e *unopenableCopybookError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf("failed to read the copybook %s: %v", e.Path, e.Err),
+		Spans:   []diag.Span{{File: e.Path}},
+	}
+}
+
+// copybookDirectoryError is a --copybook value naming a directory.
+//
+// There is no extension convention to fall back on — `.cpy`, `.cbl`, `.cob` and
+// no extension at all are all in use — so any rule for which files in a
+// directory are copybooks is one cpybkc invented and no adopter can predict. A
+// shell already expands a glob into the flags, in a line a reviewer can read,
+// which is what the message points at.
+type copybookDirectoryError struct {
+	Path string
+}
+
+// Error implements error.
+func (e *copybookDirectoryError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic implements [diag.Error].
+func (e *copybookDirectoryError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf("%s is a directory, and %s takes one copybook per %s; "+
+			"expand the directory in your shell if you meant every file in it", e.Path, copybookFlag, copybookFlag),
+		Spans: []diag.Span{{File: e.Path}},
+	}
 }

--- a/cmd/cpybkc/scaffold_test.go
+++ b/cmd/cpybkc/scaffold_test.go
@@ -1,0 +1,273 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// scaffoldCopybook is two independent REDEFINES runs over one 01-level: six
+// record types, which is what makes a run of `init` over it say something on
+// standard error as well as writing a file.
+//
+// Fixed source format, which is the one `init` reads.
+const scaffoldCopybook = `       01  POSTING-RECORD.
+           05  PST-TYPE            PIC X(2).
+           05  PST-BODY            PIC X(28).
+           05  PST-DEBIT           REDEFINES PST-BODY PIC X(28).
+           05  PST-CREDIT          REDEFINES PST-BODY PIC X(28).
+           05  PST-TAIL            PIC X(8).
+           05  PST-TAIL-REF        REDEFINES PST-TAIL PIC X(8).
+`
+
+// copybookIn writes the copybook a scaffolding test derives from, and returns
+// the directory it is in and the path to it.
+func copybookIn(t *testing.T) (dir, path string) {
+	t.Helper()
+
+	dir = t.TempDir()
+	path = filepath.Join(dir, "posting.cpy")
+
+	writeFile(t, path, scaffoldCopybook)
+
+	return dir, path
+}
+
+func TestInitWritesAScaffoldWhereOutNames(t *testing.T) {
+	t.Parallel()
+
+	dir, copybook := copybookIn(t)
+	dest := filepath.Join(dir, "layout.sexpr")
+
+	stdout, _, code := invoke(initSubcommand, copybookFlag, copybook, outFlag, dest)
+
+	if code != statusOK {
+		t.Fatalf("`cpybkc %s` exited %d, want %d", initSubcommand, code, statusOK)
+	}
+
+	// A run writing to a path writes nothing to standard output at all.
+	if stdout != "" {
+		t.Errorf("a run writing to a path wrote %q to standard output", stdout)
+	}
+
+	written, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("reading back the scaffold: %v", err)
+	}
+
+	for _, want := range []string{
+		"(record POSTING-RECORD-PST-DEBIT-PST-TAIL",
+		`(copybook "` + copybook + `" POSTING-RECORD)`,
+		";; (encoding",
+		";; (sequence",
+	} {
+		if !strings.Contains(string(written), want) {
+			t.Errorf("the scaffold does not carry %q:\n%s", want, written)
+		}
+	}
+}
+
+// docs/cli/SPEC.md: the combination count is reported, not bounded, and it
+// reaches standard error because it is the size of the work in front of the
+// reader.
+func TestTheCombinationCountReachesStandardErrorAsANote(t *testing.T) {
+	t.Parallel()
+
+	dir, copybook := copybookIn(t)
+
+	_, stderr, code := invoke(initSubcommand, copybookFlag, copybook, outFlag, filepath.Join(dir, "layout.sexpr"))
+
+	if code != statusOK {
+		t.Fatalf("`cpybkc %s` exited %d, want %d", initSubcommand, code, statusOK)
+	}
+
+	if !strings.HasPrefix(stderr, severityNote+severitySeparator) {
+		t.Fatalf("the line reads %q, want a %s%s line", stderr, severityNote, severitySeparator)
+	}
+
+	for _, want := range []string{"POSTING-RECORD", "3 REDEFINES", "6 record types"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("the note does not carry %q: %q", want, stderr)
+		}
+	}
+}
+
+func TestInitWritesTheScaffoldToStandardOutputForADash(t *testing.T) {
+	t.Parallel()
+
+	dir, copybook := copybookIn(t)
+
+	stdout, stderr, code := invoke(initSubcommand, copybookFlag, copybook, outFlag, "-")
+
+	if code != statusOK {
+		t.Fatalf("`cpybkc %s` exited %d, want %d", initSubcommand, code, statusOK)
+	}
+
+	if !strings.HasPrefix(stdout, ";; A layout scaffold") {
+		t.Errorf("standard output does not open with the scaffold: %q", stdout)
+	}
+
+	// Nothing else goes there. The note the run owes is on the other stream,
+	// which is what keeps `cpybkc init --out - > layout.sexpr` a file that
+	// parses.
+	if strings.Contains(stdout, severityNote+severitySeparator) {
+		t.Errorf("a diagnostic reached standard output:\n%s", stdout)
+	}
+
+	if !strings.Contains(stderr, severityNote+severitySeparator) {
+		t.Errorf("the note did not reach standard error: %q", stderr)
+	}
+
+	// And no file appeared: "-" is never a relative path.
+	if entries, err := os.ReadDir(dir); err != nil {
+		t.Fatalf("reading the copybook's directory: %v", err)
+	} else if len(entries) != 1 {
+		t.Errorf("the run left %d entries beside the copybook, want only the copybook", len(entries))
+	}
+}
+
+// The one unrecoverable act this command could perform, refused: the derived
+// half of a layout is recomputable and the discriminators and the sequence are
+// not.
+func TestInitNeverWritesOverWhatIsAlreadyThere(t *testing.T) {
+	t.Parallel()
+
+	dir, copybook := copybookIn(t)
+	dest := filepath.Join(dir, "layout.sexpr")
+
+	edited := "(sequence (seq A B))\n"
+	writeFile(t, dest, edited)
+
+	stdout, stderr, code := invoke(initSubcommand, copybookFlag, copybook, outFlag, dest)
+
+	if code != statusFailed {
+		t.Fatalf("writing over an existing layout exited %d, want %d", code, statusFailed)
+	}
+
+	if stdout != "" {
+		t.Errorf("a refused run wrote %q to standard output", stdout)
+	}
+
+	// Both spellings of the path: the one that was typed, and the one cpybkc
+	// looked at.
+	absolute, err := filepath.Abs(dest)
+	if err != nil {
+		t.Fatalf("resolving the destination: %v", err)
+	}
+
+	if !strings.Contains(stderr, dest) || !strings.Contains(stderr, absolute) {
+		t.Errorf("the diagnostic names neither the path as typed nor the absolute path: %q", stderr)
+	}
+
+	kept, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("reading back the destination: %v", err)
+	}
+
+	if string(kept) != edited {
+		t.Errorf("the destination now holds %q, want what was there", kept)
+	}
+}
+
+// docs/cli/SPEC.md: a --copybook naming a directory fails the run rather than
+// the vector, because it is not decidable from the line.
+func TestACopybookNamingADirectoryFailsTheRun(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	named := filepath.Join(dir, "copybooks")
+
+	if err := os.Mkdir(named, 0o755); err != nil {
+		t.Fatalf("preparing the directory: %v", err)
+	}
+
+	stdout, stderr, code := invoke(initSubcommand,
+		copybookFlag, named, outFlag, filepath.Join(dir, "layout.sexpr"))
+
+	if code != statusFailed {
+		t.Fatalf("a --copybook naming a directory exited %d, want %d", code, statusFailed)
+	}
+
+	if stdout != "" {
+		t.Errorf("a failed run wrote %q to standard output", stdout)
+	}
+
+	if !strings.Contains(stderr, named) {
+		t.Errorf("the diagnostic does not name the path as it was typed: %q", stderr)
+	}
+
+	// A failure of the work is not a failure of the vector, so the command set
+	// is not what the reader needs in front of them.
+	if strings.Contains(stderr, "Usage:") {
+		t.Errorf("a status 1 was answered with usage: %q", stderr)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "layout.sexpr")); err == nil {
+		t.Error("a scaffold was written for a run that failed")
+	}
+}
+
+// Nothing is written where anything failed, which is what keeps a run's
+// incompleteness the deliberate kind.
+func TestNothingIsWrittenWhereOneCopybookCouldNotBeRead(t *testing.T) {
+	t.Parallel()
+
+	dir, copybook := copybookIn(t)
+	dest := filepath.Join(dir, "layout.sexpr")
+
+	_, stderr, code := invoke(initSubcommand,
+		copybookFlag, copybook,
+		copybookFlag, filepath.Join(dir, "absent.cpy"),
+		outFlag, dest,
+	)
+
+	if code != statusFailed {
+		t.Fatalf("a run naming a copybook that is not there exited %d, want %d", code, statusFailed)
+	}
+
+	if !strings.Contains(stderr, "absent.cpy") {
+		t.Errorf("the diagnostic does not name the copybook: %q", stderr)
+	}
+
+	if _, err := os.Stat(dest); err == nil {
+		t.Error("a scaffold was written over a copybook that could not be read")
+	}
+}
+
+// docs/cli/SPEC.md requires determinism rather than hoping for it: a scaffold
+// that reordered itself between runs would be undiffable in exactly the review
+// where an adopter is deciding what to keep.
+func TestTwoRunsOverOneSetOfCopybooksWriteByteIdenticalFiles(t *testing.T) {
+	t.Parallel()
+
+	dir, copybook := copybookIn(t)
+
+	first := filepath.Join(dir, "first.sexpr")
+	second := filepath.Join(dir, "second.sexpr")
+
+	for _, dest := range []string{first, second} {
+		if _, _, code := invoke(initSubcommand, copybookFlag, copybook, outFlag, dest); code != statusOK {
+			t.Fatalf("writing %s exited %d, want %d", dest, code, statusOK)
+		}
+	}
+
+	one, err := os.ReadFile(first)
+	if err != nil {
+		t.Fatalf("reading back the first scaffold: %v", err)
+	}
+
+	two, err := os.ReadFile(second)
+	if err != nil {
+		t.Fatalf("reading back the second scaffold: %v", err)
+	}
+
+	if string(one) != string(two) {
+		t.Error("two runs over one copybook wrote different files")
+	}
+}

--- a/cmd/cpybkc/usage.go
+++ b/cmd/cpybkc/usage.go
@@ -66,14 +66,10 @@ given once per file. docs/cli/SPEC.md is the contract this summarises.
 // exactly the part left blank, which is the reason the command can be trusted
 // with the half it does write.
 //
-// The last line is the other half of that honesty, and it is the reason this
-// text can exist before the derivation does. #214 lands the vector and #215 the
-// scaffold, so `cpybkc init` currently reads its line and fails; a help text
-// promising a written file would be documenting a command nobody can run, which
-// is what the comment above [usage] refused for the verb itself while it did not
-// parse. Saying so here is what lets --help be answered — docs/cli/SPEC.md
-// requires it under every subcommand — without it being a promise. The line goes
-// when the promise becomes true.
+// It carried one more paragraph while the derivation did not exist — #214 landed
+// the vector and `cpybkc init` read its line and failed — because a help text
+// promising a written file would have documented a command nobody could run.
+// #215 made the promise true, so the paragraph went with it.
 const initUsage = `cpybkc init writes a layout scaffold from the copybooks it is given.
 
 Usage:
@@ -93,9 +89,6 @@ a valid layout until you have. init reads no manifest and starts no generator.
 
 --help and --version are answered under every subcommand and are not init's own
 flags. docs/cli/SPEC.md is the contract this summarises.
-
-Not implemented in this build: init reads its arguments and reports that it
-cannot derive a scaffold from them yet. It exits 1 without writing anything.
 `
 
 // writeUsage writes the usage of the action named to w.

--- a/internal/resolve/shape.go
+++ b/internal/resolve/shape.go
@@ -1,0 +1,221 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package resolve
+
+import "github.com/Zaba505/cobol-go/copybook"
+
+// Alternation is one run of a record's bytes that a REDEFINES describes more
+// than one way.
+//
+// It is the unit `REDEFINES` is read in: an item, every description of it, and
+// the one question that decides which resolution the clause takes — whether the
+// run stands inside a group that repeats (docs/ir/SPEC.md, "Members never
+// overlap, and `REDEFINES` is resolved away").
+type Alternation struct {
+	// Item is the redefined item: the first alternative, the one every
+	// REDEFINES of it names.
+	Item *copybook.Field
+
+	// Alternatives are the descriptions of the run, the redefined item first
+	// and each REDEFINES of it after it in declaration order. There are always
+	// two or more — a run described once is not an alternation.
+	Alternatives []*copybook.Field
+
+	// InTable reports the run standing inside a group that repeats, which is
+	// what makes it a variant chosen once per occurrence rather than one
+	// record type per alternative.
+	InTable bool
+}
+
+// Shape is what a copybook record decides on its own, before any layout has
+// said anything about it.
+//
+// It is the half of a record a layout cannot state and does not need to be
+// told: which runs of bytes carry more than one description, which of those are
+// chosen per record and which per occurrence, how many record types the first
+// kind multiply out to, and whether the record's length depends on its own
+// data. A layout states the other half — what selects each of them — and
+// [Resolve] is where the two meet.
+type Shape struct {
+	// Alternations are the record's runs carrying more than one description,
+	// in containment order: outermost and earliest first.
+	Alternations []Alternation
+
+	// Combinations are the record types the alternations outside a repeating
+	// group multiply out to, one entry per record type. Each entry names the
+	// alternative chosen at each such run, in the order [Alternations] gives
+	// them.
+	//
+	// A record whose copybook writes no such run has exactly one entry, and
+	// that entry is empty: one record type, chosen at nothing.
+	Combinations [][]*copybook.Field
+
+	// Tables are the items carrying an OCCURS DEPENDING ON, in source order.
+	// It is empty for a record whose length is a constant.
+	Tables []*copybook.Field
+}
+
+// Describe reads what record decides on its own: [Shape].
+//
+// It exists so that a caller with no layout in hand — `cpybkc init`, which
+// derives a layout scaffold from copybooks and has none by construction
+// (docs/cli/SPEC.md, "`init` scaffolds a layout from copybooks") — reads a
+// copybook's REDEFINES clauses through the same rules [Resolve] applies rather
+// than through a second reading of its own. The primitives are shared outright:
+// the clustering of an item with the items redefining it, and the one question
+// that decides which resolution a clause takes, are the functions [Resolve]
+// calls. Two readings of one copybook is the failure docs/cli/SPEC.md, "Why
+// this is a subcommand and not a script over the published schema", refuses a
+// script outside the tool for, and it is no more acceptable inside it.
+//
+// What it does *not* do is resolve. There is no encoding profile, no framing,
+// no reading of an OCCURS DEPENDING ON and no statement of what selects an
+// alternative, because a scaffold is written before any of those exist — so no
+// width is computed beyond the ones `cobol-go` needs to lay the record out, and
+// none of the faults [Resolve] raises about a layout can be raised here. A
+// copybook a layout has not been written for yet is not a copybook with a fault
+// in it.
+//
+// The dialect is the caller's for [Resolve]'s reason: what a REDEFINES longer
+// than what it redefines means is a compiler's answer and not this package's.
+//
+// It reports whatever `cobol-go` says is wrong with the record — a PICTURE it
+// cannot read, a level sequence that does not nest, a REDEFINES the dialect
+// refuses — and nothing of its own.
+func Describe(record *copybook.Field, dialect copybook.Dialect) (Shape, error) {
+	if record == nil {
+		return Shape{}, ErrNilRecord
+	}
+
+	laid, err := copybook.NewLayout(record, dialect)
+	if err != nil {
+		return Shape{}, err
+	}
+
+	shape := Shape{}
+
+	for _, table := range tables(laid.Items()) {
+		shape.Tables = append(shape.Tables, table.Field)
+	}
+
+	shape.Alternations, shape.Combinations = describe(laid.Record)
+
+	return shape, nil
+}
+
+// describe walks one item, returning the alternations under it and the
+// combinations of the choices they admit.
+//
+// It mirrors the shape of [resolver.group] and [resolver.cluster], over the same
+// clusters and the same [inTable] question, with everything those two compute
+// about *nodes* left out — the encoding each member is resolved under, the slack
+// the alternatives leave, the arms a variant becomes. What is left is the
+// arithmetic: a cluster of one contributes its members' own choices, a cluster
+// inside a repeating group contributes none because the choice is not a record
+// type's, and any other cluster multiplies what came before it by its
+// alternatives.
+//
+// The combination lists are in containment order — outermost and earliest first
+// — which is the order [Resolve] documents and the order docs/cli/SPEC.md, "How
+// a combination's record name is chosen", builds a name in.
+func describe(item *copybook.Item) ([]Alternation, [][]*copybook.Field) {
+	var alternations []Alternation
+
+	// One combination, chosen at nothing, is what an item with no alternation
+	// under it resolves to. It is the identity the products below are built
+	// on, and it is why an elementary item needs no case of its own.
+	combinations := [][]*copybook.Field{nil}
+
+	for _, c := range clustersOf(item) {
+		var choices [][]*copybook.Field
+
+		switch {
+		case len(c.members) == 1:
+			nested, under := describe(c.members[0])
+
+			alternations = append(alternations, nested...)
+			choices = under
+
+		case inTable(c.members[0]):
+			// A redefine inside a repeating group is chosen once per
+			// occurrence, so it multiplies nothing: it is one variant in
+			// every record type rather than a record type per alternative.
+			// Its members are still walked, because a redefine nested under
+			// one is a variant of its own that a layout has to state.
+			alternations = append(alternations, alternationOf(c, true))
+
+			for _, member := range c.members {
+				nested, _ := describe(member)
+
+				alternations = append(alternations, nested...)
+			}
+
+			choices = [][]*copybook.Field{nil}
+
+		default:
+			alternations = append(alternations, alternationOf(c, false))
+
+			for _, member := range c.members {
+				nested, under := describe(member)
+
+				alternations = append(alternations, nested...)
+
+				// The member leads what was chosen beneath it, because the
+				// run it describes contains them: containment order is the
+				// order the alternations were listed in above, and a name
+				// built from a combination has to read in the same one.
+				for _, combination := range under {
+					chosen := make([]*copybook.Field, 0, len(combination)+1)
+					chosen = append(chosen, member.Field)
+					chosen = append(chosen, combination...)
+
+					choices = append(choices, chosen)
+				}
+			}
+		}
+
+		combinations = crossed(combinations, choices)
+	}
+
+	return alternations, combinations
+}
+
+// alternationOf is one cluster as the caller of [Describe] reads it.
+func alternationOf(c cluster, table bool) Alternation {
+	fields := make([]*copybook.Field, 0, len(c.members))
+	for _, member := range c.members {
+		fields = append(fields, member.Field)
+	}
+
+	return Alternation{Item: c.members[0].Field, Alternatives: fields, InTable: table}
+}
+
+// crossed multiplies the combinations found so far by the choices one cluster
+// admits, leaving the later cluster varying fastest.
+//
+// Which varies fastest is not arbitrary and is not free to change: a scaffold is
+// diffed against the one a later run produces (docs/cli/SPEC.md, "What the
+// scaffold states, form by form"), and reordering the record types would make
+// every one of them look edited.
+func crossed(lists, choices [][]*copybook.Field) [][]*copybook.Field {
+	if len(choices) == 0 {
+		return lists
+	}
+
+	next := make([][]*copybook.Field, 0, len(lists)*len(choices))
+
+	for _, list := range lists {
+		for _, choice := range choices {
+			joined := make([]*copybook.Field, 0, len(list)+len(choice))
+			joined = append(joined, list...)
+			joined = append(joined, choice...)
+
+			next = append(next, joined)
+		}
+	}
+
+	return next
+}

--- a/internal/resolve/shape.go
+++ b/internal/resolve/shape.go
@@ -46,11 +46,22 @@ type Shape struct {
 
 	// Combinations are the record types the alternations outside a repeating
 	// group multiply out to, one entry per record type. Each entry names the
-	// alternative chosen at each such run, in the order [Alternations] gives
-	// them.
+	// alternative chosen at each such run it passes through, in containment
+	// order: outermost and earliest first, which is the order [Alternations] is
+	// in.
 	//
 	// A record whose copybook writes no such run has exactly one entry, and
 	// that entry is empty: one record type, chosen at nothing.
+	//
+	// **An entry is not positionally aligned with [Alternations], and two
+	// entries need not be the same length.** A run nested inside one
+	// alternative of another run only exists where that alternative was chosen,
+	// so a combination that took a sibling passes through fewer runs and names
+	// fewer alternatives. Reading a choice back to the run it was made at is
+	// therefore a walk of the copybook and not an index into this slice; what
+	// this promises is that the names are in containment order, which is what
+	// docs/cli/SPEC.md, "How a combination's record name is chosen", builds a
+	// name out of.
 	Combinations [][]*copybook.Field
 
 	// Tables are the items carrying an OCCURS DEPENDING ON, in source order.

--- a/internal/resolve/shape_test.go
+++ b/internal/resolve/shape_test.go
@@ -1,0 +1,233 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package resolve
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cobol-go/copybook"
+)
+
+// describeOf reads the shape of the first record of a copybook source, under the
+// dialect every other reader in this repository uses.
+func describeOf(t *testing.T, src string) Shape {
+	t.Helper()
+
+	shape, err := Describe(recordOf(t, src), copybook.IBMEnterprise())
+	if err != nil {
+		t.Fatalf("describing the record: %v", err)
+	}
+
+	return shape
+}
+
+// chosenNames is what a combination chose, for a message and a comparison.
+func chosenNames(combination []*copybook.Field) []string {
+	chosen := make([]string, 0, len(combination))
+	for _, field := range combination {
+		chosen = append(chosen, field.Name)
+	}
+
+	return chosen
+}
+
+func TestARecordWithNoRedefinesIsOneRecordTypeChosenAtNothing(t *testing.T) {
+	t.Parallel()
+
+	shape := describeOf(t, `01 TXN.
+   05 KIND PIC X.
+   05 BODY PIC X(24).
+`)
+
+	if len(shape.Alternations) != 0 {
+		t.Errorf("found %d alternations, want none", len(shape.Alternations))
+	}
+
+	if len(shape.Combinations) != 1 {
+		t.Fatalf("resolved to %d record types, want one", len(shape.Combinations))
+	}
+
+	if got := chosenNames(shape.Combinations[0]); len(got) != 0 {
+		t.Errorf("the one record type chose %v, want nothing", got)
+	}
+}
+
+func TestTwoIndependentRedefinesMultiplyIntoRecordTypes(t *testing.T) {
+	t.Parallel()
+
+	// The worked example's shape: two independent runs, one described three
+	// ways and one described twice, so six record types come out of one
+	// 01-level.
+	shape := describeOf(t, `01 POSTING.
+   05 PST-BODY PIC X(24).
+   05 PST-DEBIT REDEFINES PST-BODY PIC X(24).
+   05 PST-CREDIT REDEFINES PST-BODY PIC X(24).
+   05 PST-TAIL PIC X(8).
+   05 PST-TAIL-REF REDEFINES PST-TAIL PIC X(8).
+`)
+
+	if len(shape.Alternations) != 2 {
+		t.Fatalf("found %d alternations, want two", len(shape.Alternations))
+	}
+
+	for _, alternation := range shape.Alternations {
+		if alternation.InTable {
+			t.Errorf("%s was read as a variant, and nothing here repeats", alternation.Item.Name)
+		}
+	}
+
+	if got := chosenNames(shape.Alternations[0].Alternatives); strings.Join(got, ",") != "PST-BODY,PST-DEBIT,PST-CREDIT" {
+		t.Errorf("the first run is described by %v, want the redefined item first", got)
+	}
+
+	// Six, in the order that leaves the later run varying fastest: a scaffold
+	// is diffed against the one a later run produces, so the order is fixed
+	// rather than incidental.
+	want := []string{
+		"PST-BODY,PST-TAIL",
+		"PST-BODY,PST-TAIL-REF",
+		"PST-DEBIT,PST-TAIL",
+		"PST-DEBIT,PST-TAIL-REF",
+		"PST-CREDIT,PST-TAIL",
+		"PST-CREDIT,PST-TAIL-REF",
+	}
+
+	if len(shape.Combinations) != len(want) {
+		t.Fatalf("resolved to %d record types, want %d", len(shape.Combinations), len(want))
+	}
+
+	for at, combination := range shape.Combinations {
+		if got := strings.Join(chosenNames(combination), ","); got != want[at] {
+			t.Errorf("record type %d chose %s, want %s", at, got, want[at])
+		}
+	}
+}
+
+func TestARedefineInsideARepeatingGroupIsAVariantAndMultipliesNothing(t *testing.T) {
+	t.Parallel()
+
+	shape := describeOf(t, `01 ORDER.
+   05 LINE-COUNT PIC 9(2).
+   05 LINE OCCURS 10 TIMES.
+      10 LN-BODY PIC X(12).
+      10 LN-CARD REDEFINES LN-BODY PIC X(12).
+`)
+
+	if len(shape.Alternations) != 1 {
+		t.Fatalf("found %d alternations, want one", len(shape.Alternations))
+	}
+
+	alternation := shape.Alternations[0]
+	if !alternation.InTable {
+		t.Error("a redefine inside a repeating group was read as an alternative")
+	}
+
+	if got := chosenNames(alternation.Alternatives); strings.Join(got, ",") != "LN-BODY,LN-CARD" {
+		t.Errorf("the variant is described by %v, want LN-BODY then LN-CARD", got)
+	}
+
+	// The choice is made once per occurrence, so it is not a record type.
+	if len(shape.Combinations) != 1 {
+		t.Fatalf("resolved to %d record types, want one", len(shape.Combinations))
+	}
+
+	if got := chosenNames(shape.Combinations[0]); len(got) != 0 {
+		t.Errorf("the one record type chose %v, want nothing", got)
+	}
+}
+
+func TestARedefineOutsideATableIsStillOneWhereAnotherRunRepeats(t *testing.T) {
+	t.Parallel()
+
+	shape := describeOf(t, `01 ORDER.
+   05 HDR-BODY PIC X(6).
+   05 HDR-CARD REDEFINES HDR-BODY PIC X(6).
+   05 LINE OCCURS 4 TIMES.
+      10 LN-BODY PIC X(12).
+      10 LN-CARD REDEFINES LN-BODY PIC X(12).
+`)
+
+	if len(shape.Alternations) != 2 {
+		t.Fatalf("found %d alternations, want two", len(shape.Alternations))
+	}
+
+	if shape.Alternations[0].InTable {
+		t.Error("the header's redefine was read as a variant")
+	}
+
+	if !shape.Alternations[1].InTable {
+		t.Error("the line's redefine was read as an alternative")
+	}
+
+	if len(shape.Combinations) != 2 {
+		t.Fatalf("resolved to %d record types, want two", len(shape.Combinations))
+	}
+}
+
+func TestAnOccursDependingOnTableIsReported(t *testing.T) {
+	t.Parallel()
+
+	shape := describeOf(t, `01 ORDER.
+   05 LINE-COUNT PIC 9(2).
+   05 LINE OCCURS 1 TO 10 TIMES DEPENDING ON LINE-COUNT.
+      10 LN-BODY PIC X(12).
+`)
+
+	if len(shape.Tables) != 1 {
+		t.Fatalf("found %d tables, want one", len(shape.Tables))
+	}
+
+	if got := shape.Tables[0].Name; got != "LINE" {
+		t.Errorf("the table is %s, want LINE", got)
+	}
+}
+
+func TestARecordWithNoTableReportsNone(t *testing.T) {
+	t.Parallel()
+
+	shape := describeOf(t, `01 ORDER.
+   05 LINE OCCURS 10 TIMES PIC X(4).
+`)
+
+	if len(shape.Tables) != 0 {
+		t.Errorf("a fixed table was reported as an OCCURS DEPENDING ON: %v", shape.Tables)
+	}
+}
+
+func TestDescribingNoRecordIsRefused(t *testing.T) {
+	t.Parallel()
+
+	if _, err := Describe(nil, copybook.IBMEnterprise()); !errors.Is(err, ErrNilRecord) {
+		t.Errorf("describing nothing gave %v, want %v", err, ErrNilRecord)
+	}
+}
+
+// A copybook a layout has not been written for yet is not a copybook with a
+// fault in it: nothing an encoding profile, a framing or a discriminator would
+// have said is required here, and none of the faults Resolve raises about a
+// layout can be raised without one.
+func TestDescribingNeedsNoLayout(t *testing.T) {
+	t.Parallel()
+
+	src := `01 ORDER.
+   05 LINE-COUNT PIC 9(2).
+   05 LINE OCCURS 1 TO 10 TIMES DEPENDING ON LINE-COUNT.
+      10 LN-BODY PIC X(12).
+      10 LN-CARD REDEFINES LN-BODY PIC X(12).
+`
+
+	if _, err := Describe(recordOf(t, src), copybook.IBMEnterprise()); err != nil {
+		t.Fatalf("describing a record an unwritten layout would be refused for: %v", err)
+	}
+
+	// The same record through Resolve, which is what a layout is held to: an
+	// unstated reading of the table is a fault there and says nothing here.
+	if _, err := Resolve(recordOf(t, src), Options{Dialect: copybook.IBMEnterprise()}); err == nil {
+		t.Error("resolving with no encoding profile and no reading succeeded")
+	}
+}

--- a/internal/scaffold/derive.go
+++ b/internal/scaffold/derive.go
@@ -129,6 +129,15 @@ func dialect() copybook.Dialect { return copybook.IBMEnterprise() }
 // is a file whose `sequence` is short and whose incompleteness reads exactly
 // like the incompleteness that is deliberate.
 func Derive(books []Copybook) (*Scaffold, error) {
+	// A scaffold over no copybooks is not an empty scaffold: `sequence` names
+	// every record once, and there is no shape for it to take over none. The
+	// command line already refuses this as a usage error — `--copybook` is
+	// required and appears at least once — and the check is here as well
+	// because this function is reachable without one.
+	if len(books) == 0 {
+		return nil, ErrNoCopybooks
+	}
+
 	var faults diag.List
 
 	s := new(Scaffold)
@@ -238,6 +247,18 @@ func (s *Scaffold) take(
 	// per record: they are properties of the 01-level.
 	several := len(shape.Combinations) > 1
 
+	// The note is written before the records it is about rather than after
+	// them. Both counts are known as soon as the shape is, so there is nothing
+	// to wait for, and a copybook whose combinations are numerous enough to be
+	// worth warning about is the one where the work that follows this line is
+	// the expensive part.
+	if several {
+		s.notes = append(s.notes, fmt.Sprintf(
+			"%s: %s carries %d REDEFINES outside a repeating group, which resolve to %d record types",
+			book.Path, item.Name, redefines(shape), len(shape.Combinations),
+		))
+	}
+
 	root := ""
 
 	for _, combination := range shape.Combinations {
@@ -297,12 +318,6 @@ func (s *Scaffold) take(
 		}
 	}
 
-	if several {
-		s.notes = append(s.notes, fmt.Sprintf(
-			"%s: %s carries %d REDEFINES outside a repeating group, which resolve to %d record types",
-			book.Path, item.Name, redefines(shape), len(shape.Combinations),
-		))
-	}
 }
 
 // recordName is the symbol one combination is called, per docs/cli/SPEC.md, "How
@@ -357,24 +372,23 @@ func pathTo(root, field *copybook.Field) []string {
 	return path
 }
 
-// unreachable is the first item in shape that a layout could not write a
-// reference to, or nil where every one of them can be named.
+// unreachable is the first item in shape that a layout could not name, or nil
+// where every one of them can be named.
 //
-// An alternative or a variant with no data-name — one written FILLER, or one
-// whose name was simply omitted — has no spelling in an item reference, and
-// neither has an unnamed group between it and the 01-level. Finding it here is
-// what keeps a reference cpybkc wrote from being reported against the adopter
-// later.
+// An item with no data-name — one written FILLER, or one whose name was simply
+// omitted — has no spelling in an item reference or in an `arm`, and neither has
+// an unnamed group between it and the 01-level. Finding it here is what keeps a
+// reference cpybkc wrote from being reported against the adopter later.
+//
+// Every alternative of every alternation is walked, in a table and out of one.
+// Out of one each alternative is named by an `alternative` child; in one the
+// redefined item is named by the variant's reference and each alternative by an
+// `arm`, so there is no alternative a layout does not have to spell either way.
 func unreachable(root *copybook.Field, shape resolve.Shape) *copybook.Field {
 	for _, alternation := range shape.Alternations {
-		targets := alternation.Alternatives
-		if alternation.InTable {
-			targets = []*copybook.Field{alternation.Item}
-		}
-
-		for _, target := range targets {
+		for _, target := range alternation.Alternatives {
 			for at := target; at != nil && at != root; at = at.Parent {
-				if at.Name == "" {
+				if unnamed(at) {
 					return at
 				}
 			}
@@ -383,3 +397,13 @@ func unreachable(root *copybook.Field, shape resolve.Shape) *copybook.Field {
 
 	return nil
 }
+
+// unnamed reports an item nothing in a layout can refer to.
+//
+// Both halves are tested rather than only the empty name. `cobol-go` documents
+// Name as empty for a FILLER item, so today the second is implied by the first —
+// but Filler is the field that *means* "this item has no data-name", and
+// [read] already tests the pair when it decides which top-level items are
+// records. A guard whose whole job is to catch an item no reference can name is
+// the wrong place to depend on two spellings of that staying in agreement.
+func unnamed(field *copybook.Field) bool { return field.Name == "" || field.Filler }

--- a/internal/scaffold/derive.go
+++ b/internal/scaffold/derive.go
@@ -1,0 +1,385 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package scaffold
+
+import (
+	"bytes"
+	"fmt"
+	"slices"
+	"strings"
+
+	cobol "github.com/Zaba505/cobol-go"
+	"github.com/Zaba505/cobol-go/copybook"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+	"github.com/Zaba505/cpybkc/internal/resolve"
+)
+
+// Copybook is one `--copybook` value: the path as it was typed, and the bytes
+// found at it.
+//
+// The path is carried as typed and is written into the scaffold's `copybook`
+// child unchanged. A layout's own paths are relative to the layout, so a path
+// that reached cpybkc from a different directory than the scaffold's is the
+// adopter's to correct — and a path cpybkc rewrote on their behalf would be one
+// they cannot find in what they typed.
+type Copybook struct {
+	// Path is the --copybook value, exactly as it was written on the command
+	// line.
+	Path string
+
+	// Source is the file's bytes.
+	Source []byte
+}
+
+// Scaffold is the layout scaffold one set of copybooks decides.
+//
+// It is a value with no filesystem in it: [Scaffold.Bytes] renders it and
+// [Write] puts it somewhere, and neither can be reached by accident from the
+// other. That is what makes "the file is written in full or not at all" and
+// "nothing reaches standard output until the whole scaffold has been derived"
+// one property rather than two — there is nothing to write until the derivation
+// is over.
+type Scaffold struct {
+	// records are the record types, in the order the copybooks were named and,
+	// within one copybook, in declaration order.
+	records []record
+
+	// variants are the redefines inside a repeating group, in the order they
+	// were met.
+	variants []variant
+
+	// renamed are the records over an 01-level that resolved to more than one
+	// record type, which are the ones a rename is raised for.
+	renamed []string
+
+	// tables reports that some copybook carries an OCCURS DEPENDING ON, which
+	// is the whole of what decides whether a `copybook-reading` is raised.
+	tables bool
+
+	// notes are the lines the run owes standard error, in the order the
+	// 01-levels they are about were met.
+	notes []string
+}
+
+// record is one `record` form: what it is called, which copybook and 01-level it
+// is over, and which description of each redefined run it means.
+type record struct {
+	name         string
+	path         string
+	item         string
+	alternatives []reference
+}
+
+// variant is one `discriminate-variant` form: the redefined item inside a
+// repeating group, and the alternatives an arm is owed for.
+type variant struct {
+	item reference
+	arms []string
+}
+
+// reference is an item reference as a layout writes one: rooted at a record, and
+// carrying one name per level down to the item with the 01-level's own name not
+// repeated (docs/layout/SPEC.md, "An item reference").
+type reference struct {
+	record string
+	path   []string
+}
+
+// String renders the reference as the layout format spells it.
+func (r reference) String() string {
+	return "(item " + strings.Join(append([]string{r.record}, r.path...), " ") + ")"
+}
+
+// Notes are the `note:` diagnostics the run owes, one per 01-level that resolved
+// to more than one record type.
+//
+// They are here rather than written from here because docs/cli/SPEC.md puts
+// every line cpybkc says about a run on standard error and this package holds
+// neither stream. Each names the copybook, the 01-level, how many REDEFINES
+// outside a repeating group it carries and how many record types they produce:
+// it is the size of the work in front of the reader, which is a thing they have
+// to act on rather than discover in the file.
+func (s *Scaffold) Notes() []string { return slices.Clone(s.notes) }
+
+// dialect is the compiler whose answers the derivation is read under.
+//
+// The same one [github.com/Zaba505/cpybkc/internal/project] resolves under, for
+// the reason the derivation shares its REDEFINES reading at all: a scaffold
+// derived under one dialect and resolved under another would disagree with
+// itself about a copybook neither of them changed. What the dialect decides here
+// is narrow — whether a redefining item longer than what it redefines is legal —
+// and it decides nothing about which forms the scaffold carries.
+func dialect() copybook.Dialect { return copybook.IBMEnterprise() }
+
+// Derive reads every copybook and returns the scaffold they decide.
+//
+// The copybooks are taken in the order they were given, and their 01-levels in
+// declaration order, because that is the order the `record` forms are written in
+// and a scaffold has to be byte-identical between two runs over one set of
+// copybooks.
+//
+// Every fault it finds is reported rather than the first: a set of copybooks
+// goes wrong in the same way in more than one file at once, and a reader that
+// stopped would be run once per copybook. Nothing is returned where anything
+// failed — a scaffold missing the records of the copybook that could not be read
+// is a file whose `sequence` is short and whose incompleteness reads exactly
+// like the incompleteness that is deliberate.
+func Derive(books []Copybook) (*Scaffold, error) {
+	var faults diag.List
+
+	s := new(Scaffold)
+
+	// The names already derived, so that a second record type deriving one of
+	// them is refused naming both. It is read and never ranged over, which is
+	// what keeps the derivation a function of its inputs.
+	claimed := make(map[string]record)
+
+	for _, book := range books {
+		items, err := read(book)
+		if err != nil {
+			faults.Fail(err)
+
+			continue
+		}
+
+		for _, item := range items {
+			shape, err := resolve.Describe(item, dialect())
+			if err != nil {
+				faults.Fail(&SourceError{Path: book.Path, Err: err})
+
+				continue
+			}
+
+			s.take(&faults, claimed, book, item, shape)
+		}
+	}
+
+	if faults.Failed() {
+		return nil, faults.Err()
+	}
+
+	return s, nil
+}
+
+// read parses one copybook and returns the 01-levels a `record` form can be
+// written over.
+//
+// Level-77 items and an 01-level with no data-name are not among them. A
+// level-77 is a standalone work item rather than a record description, and an
+// unnamed 01-level is one no `record` form could name; a copybook holding
+// nothing else declares no record, which is reported rather than passed over.
+func read(book Copybook) ([]*copybook.Field, error) {
+	// Fixed format, which is what a copybook out of a mainframe library is
+	// written in and what every other reader in this repository assumes.
+	// Nothing states a reference format, and `init` is handed a file rather
+	// than a project, so there is nowhere else the answer could come from.
+	file, err := cobol.Parse(
+		bytes.NewReader(book.Source),
+		cobol.WithFragment(),
+		cobol.WithSourceFormat(cobol.FixedFormat),
+	)
+	if err != nil {
+		return nil, &SourceError{Path: book.Path, Err: err}
+	}
+
+	if file.Fragment == nil {
+		return nil, &NoRecordError{Path: book.Path}
+	}
+
+	items, err := copybook.Build(file.Fragment.Entries)
+	if err != nil {
+		return nil, &SourceError{Path: book.Path, Err: err}
+	}
+
+	records := make([]*copybook.Field, 0, len(items))
+
+	for _, item := range items {
+		if item.Level == 1 && !item.Filler && item.Name != "" {
+			records = append(records, item)
+		}
+	}
+
+	if len(records) == 0 {
+		return nil, &NoRecordError{Path: book.Path}
+	}
+
+	return records, nil
+}
+
+// take turns one 01-level's shape into the forms it decides.
+func (s *Scaffold) take(
+	faults *diag.List,
+	claimed map[string]record,
+	book Copybook,
+	item *copybook.Field,
+	shape resolve.Shape,
+) {
+	if len(shape.Tables) > 0 {
+		s.tables = true
+	}
+
+	if unnamed := unreachable(item, shape); unnamed != nil {
+		faults.Fail(&UnnamedAlternativeError{
+			Path:   book.Path,
+			Item:   item.Name,
+			Line:   unnamed.Pos.Line,
+			Column: unnamed.Pos.Column,
+		})
+
+		return
+	}
+
+	// More than one record type over one 01-level is what raises a rename and
+	// what the run owes a note about. Both are decided once, here, rather than
+	// per record: they are properties of the 01-level.
+	several := len(shape.Combinations) > 1
+
+	root := ""
+
+	for _, combination := range shape.Combinations {
+		name := recordName(item.Name, combination)
+
+		if held, taken := claimed[name]; taken {
+			faults.Fail(&NameCollisionError{
+				Name:      name,
+				Path:      held.path,
+				Item:      held.item,
+				Other:     book.Path,
+				OtherItem: item.Name,
+			})
+
+			continue
+		}
+
+		derived := record{name: name, path: book.Path, item: item.Name}
+		for _, alternative := range combination {
+			derived.alternatives = append(derived.alternatives, reference{
+				record: name,
+				path:   pathTo(item, alternative),
+			})
+		}
+
+		claimed[name] = derived
+		s.records = append(s.records, derived)
+
+		if several {
+			s.renamed = append(s.renamed, name)
+		}
+
+		if root == "" {
+			root = name
+		}
+	}
+
+	// A redefine inside a repeating group is one variant however many record
+	// types the 01-level resolves to, so the reference is rooted at the first
+	// of them; where a layout carries the others it carries a form of its own
+	// for each, which is a thing the adopter is writing anyway.
+	if root != "" {
+		for _, alternation := range shape.Alternations {
+			if !alternation.InTable {
+				continue
+			}
+
+			arms := make([]string, 0, len(alternation.Alternatives))
+			for _, alternative := range alternation.Alternatives {
+				arms = append(arms, alternative.Name)
+			}
+
+			s.variants = append(s.variants, variant{
+				item: reference{record: root, path: pathTo(item, alternation.Item)},
+				arms: arms,
+			})
+		}
+	}
+
+	if several {
+		s.notes = append(s.notes, fmt.Sprintf(
+			"%s: %s carries %d REDEFINES outside a repeating group, which resolve to %d record types",
+			book.Path, item.Name, redefines(shape), len(shape.Combinations),
+		))
+	}
+}
+
+// recordName is the symbol one combination is called, per docs/cli/SPEC.md, "How
+// a combination's record name is chosen".
+//
+// One record type over an 01-level is the 01-level's own name. More than one is
+// the 01-level's name followed by the name of each chosen alternative, in the
+// order the redefines appear in the copybook, joined by a single hyphen. The
+// names are long and nobody would choose them, which is affordable because a
+// record name is the layout's own identifier and nothing outside the layout ever
+// sees it as an identity — it has to be unique, deterministic, and traceable
+// back to the bytes it selects, and numbering is what fails at the third.
+func recordName(item string, combination []*copybook.Field) string {
+	parts := make([]string, 0, len(combination)+1)
+	parts = append(parts, item)
+
+	for _, alternative := range combination {
+		parts = append(parts, alternative.Name)
+	}
+
+	return strings.Join(parts, "-")
+}
+
+// redefines is how many REDEFINES clauses outside a repeating group the record
+// carries.
+//
+// A run described three ways carries two of them, which is what the copybook
+// writes and what the reader counts when they go and look.
+func redefines(shape resolve.Shape) int {
+	count := 0
+
+	for _, alternation := range shape.Alternations {
+		if !alternation.InTable {
+			count += len(alternation.Alternatives) - 1
+		}
+	}
+
+	return count
+}
+
+// pathTo is the item reference path from the 01-level down to field: one name
+// per level, outermost first, with the 01-level's own name not repeated.
+func pathTo(root, field *copybook.Field) []string {
+	var path []string
+
+	for at := field; at != nil && at != root; at = at.Parent {
+		path = append(path, at.Name)
+	}
+
+	slices.Reverse(path)
+
+	return path
+}
+
+// unreachable is the first item in shape that a layout could not write a
+// reference to, or nil where every one of them can be named.
+//
+// An alternative or a variant with no data-name — one written FILLER, or one
+// whose name was simply omitted — has no spelling in an item reference, and
+// neither has an unnamed group between it and the 01-level. Finding it here is
+// what keeps a reference cpybkc wrote from being reported against the adopter
+// later.
+func unreachable(root *copybook.Field, shape resolve.Shape) *copybook.Field {
+	for _, alternation := range shape.Alternations {
+		targets := alternation.Alternatives
+		if alternation.InTable {
+			targets = []*copybook.Field{alternation.Item}
+		}
+
+		for _, target := range targets {
+			for at := target; at != nil && at != root; at = at.Parent {
+				if at.Name == "" {
+					return at
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/scaffold/derive_test.go
+++ b/internal/scaffold/derive_test.go
@@ -1,0 +1,448 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package scaffold
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+	"github.com/Zaba505/cpybkc/internal/layout"
+	"github.com/Zaba505/cpybkc/internal/layoutmodel"
+)
+
+// The copybooks below are written in the fixed source format, which is what a
+// copybook out of a mainframe library is written in and the one format `init`
+// reads. Writing them any other way here would test a parse the command never
+// performs.
+const (
+	// header is one 01-level and no REDEFINES: one record type, named after the
+	// 01-level itself.
+	header = `       01  LEDGER-HEADER.
+           05  HDR-TYPE            PIC X(2).
+           05  HDR-COUNT           PIC 9(6).
+`
+
+	// posting is two independent runs, one described three ways and one twice:
+	// six record types out of one 01-level.
+	posting = `       01  POSTING-RECORD.
+           05  PST-TYPE            PIC X(2).
+           05  PST-BODY            PIC X(28).
+           05  PST-DEBIT           REDEFINES PST-BODY PIC X(28).
+           05  PST-CREDIT          REDEFINES PST-BODY PIC X(28).
+           05  PST-TAIL            PIC X(8).
+           05  PST-TAIL-REF        REDEFINES PST-TAIL PIC X(8).
+`
+
+	// table is a REDEFINES inside a repeating group, which is a variant chosen
+	// once per occurrence and never a record type.
+	table = `       01  ORDER-RECORD.
+           05  ORD-COUNT           PIC 9(2).
+           05  ORD-LINE            OCCURS 10 TIMES.
+               10  LN-BODY         PIC X(12).
+               10  LN-CARD         REDEFINES LN-BODY PIC X(12).
+`
+
+	// depending carries an OCCURS DEPENDING ON, which is the whole of what
+	// raises a `copybook-reading`.
+	depending = `       01  BATCH-RECORD.
+           05  BAT-COUNT  PIC 9(2).
+           05  BAT-LINE  OCCURS 1 TO 10 TIMES DEPENDING ON BAT-COUNT.
+               10  BLN-BODY  PIC X(12).
+`
+
+	// work is a member holding nothing but a level-77 item: it parses, and
+	// there is no record in it to write a `record` form over.
+	work = `       77  WORK-COUNT              PIC 9(4).
+`
+
+	// pair is two 01-levels in one copybook, which is how declaration order
+	// within a file is told from the order the copybooks were given.
+	pair = `       01  SECOND-RECORD.
+           05  SND-TYPE            PIC X(2).
+       01  FIRST-RECORD.
+           05  FST-TYPE            PIC X(2).
+`
+)
+
+// deriveOf is the scaffold one set of copybooks decides, or a fatal test.
+func deriveOf(t *testing.T, books ...Copybook) *Scaffold {
+	t.Helper()
+
+	derived, err := Derive(books)
+	if err != nil {
+		t.Fatalf("deriving the scaffold: %v", err)
+	}
+
+	return derived
+}
+
+// book is one copybook named by a path a test chose.
+func book(path, source string) Copybook {
+	return Copybook{Path: path, Source: []byte(source)}
+}
+
+// recordNames is what the scaffold called each record type, in emission order.
+func recordNames(s *Scaffold) []string {
+	names := make([]string, 0, len(s.records))
+	for _, r := range s.records {
+		names = append(names, r.name)
+	}
+
+	return names
+}
+
+func TestOneRecordPerZeroOneLevelInTheOrderTheCopybooksWereGiven(t *testing.T) {
+	t.Parallel()
+
+	derived := deriveOf(t, book("a/header.cpy", header), book("b/order.cpy", table))
+
+	want := []string{"LEDGER-HEADER", "ORDER-RECORD"}
+	if got := recordNames(derived); !slices.Equal(got, want) {
+		t.Errorf("derived %v, want %v", got, want)
+	}
+
+	if got := derived.records[0].path; got != "a/header.cpy" {
+		t.Errorf("the first record names the copybook %q, want the path as it was typed", got)
+	}
+}
+
+func TestWithinOneCopybookTheOrderIsDeclarationOrder(t *testing.T) {
+	t.Parallel()
+
+	// Declaration order rather than any order of cpybkc's: the names here are
+	// deliberately the wrong way round alphabetically, so a sort would show.
+	derived := deriveOf(t, book("pair.cpy", pair))
+
+	want := []string{"SECOND-RECORD", "FIRST-RECORD"}
+	if got := recordNames(derived); !slices.Equal(got, want) {
+		t.Errorf("derived %v, want %v", got, want)
+	}
+}
+
+func TestThePathIsWrittenAsItWasTypedAndNeverResolved(t *testing.T) {
+	t.Parallel()
+
+	// A path a layout's own reader would resolve against the layout, handed to
+	// `init` from somewhere else entirely. cpybkc writes it back unchanged: a
+	// path it rewrote on the adopter's behalf is one they cannot find in what
+	// they typed.
+	derived := deriveOf(t, book("../shared/copybooks/header.cpy", header))
+
+	if got := string(derived.Bytes()); !strings.Contains(got, `(copybook "../shared/copybooks/header.cpy" LEDGER-HEADER)`) {
+		t.Errorf("the copybook child does not carry the path as typed:\n%s", got)
+	}
+}
+
+func TestNoAlternativeChildWhereTheCopybookWritesNoRedefines(t *testing.T) {
+	t.Parallel()
+
+	derived := deriveOf(t, book("header.cpy", header))
+
+	if got := len(derived.records[0].alternatives); got != 0 {
+		t.Errorf("a record over a copybook with no REDEFINES carries %d alternatives, want none", got)
+	}
+
+	if got := string(derived.Bytes()); strings.Contains(got, "(alternative") {
+		t.Errorf("an alternative was written for a copybook that writes no REDEFINES:\n%s", got)
+	}
+}
+
+func TestOneRecordPerCombinationWithAnAlternativeChildPerRedefine(t *testing.T) {
+	t.Parallel()
+
+	derived := deriveOf(t, book("posting.cpy", posting))
+
+	want := []string{
+		"POSTING-RECORD-PST-BODY-PST-TAIL",
+		"POSTING-RECORD-PST-BODY-PST-TAIL-REF",
+		"POSTING-RECORD-PST-DEBIT-PST-TAIL",
+		"POSTING-RECORD-PST-DEBIT-PST-TAIL-REF",
+		"POSTING-RECORD-PST-CREDIT-PST-TAIL",
+		"POSTING-RECORD-PST-CREDIT-PST-TAIL-REF",
+	}
+
+	if got := recordNames(derived); !slices.Equal(got, want) {
+		t.Fatalf("derived %v,\nwant %v", got, want)
+	}
+
+	for _, r := range derived.records {
+		if len(r.alternatives) != 2 {
+			t.Errorf("%s carries %d alternatives, want one per REDEFINES run", r.name, len(r.alternatives))
+		}
+
+		for _, alternative := range r.alternatives {
+			// The reference is rooted at the record whose choice it is
+			// stating, which is what makes it an ordinary item reference.
+			if alternative.record != r.name {
+				t.Errorf("%s carries an alternative rooted at %s", r.name, alternative.record)
+			}
+		}
+	}
+
+	if got := derived.records[2].alternatives[0].String(); got != "(item POSTING-RECORD-PST-DEBIT-PST-TAIL PST-DEBIT)" {
+		t.Errorf("the alternative reads %s", got)
+	}
+}
+
+func TestARedefineInsideARepeatingGroupIsNeverAnAlternative(t *testing.T) {
+	t.Parallel()
+
+	derived := deriveOf(t, book("order.cpy", table))
+
+	if got := recordNames(derived); !slices.Equal(got, []string{"ORDER-RECORD"}) {
+		t.Errorf("derived %v, want one record type", got)
+	}
+
+	if got := len(derived.records[0].alternatives); got != 0 {
+		t.Errorf("a variant was written as %d alternative children", got)
+	}
+
+	if len(derived.variants) != 1 {
+		t.Fatalf("raised %d variant discriminators, want one", len(derived.variants))
+	}
+
+	variant := derived.variants[0]
+	if got := variant.item.String(); got != "(item ORDER-RECORD ORD-LINE LN-BODY)" {
+		t.Errorf("the variant is %s, want the redefined item under the group that repeats", got)
+	}
+
+	if got := variant.arms; !slices.Equal(got, []string{"LN-BODY", "LN-CARD"}) {
+		t.Errorf("the arms are %v, want one per alternative", got)
+	}
+}
+
+func TestADerivedNameCollidingWithAnotherFailsTheRunNamingBoth(t *testing.T) {
+	t.Parallel()
+
+	// Two copybooks declaring one 01-level name is the ordinary way to reach
+	// this: duplicate data names are legal COBOL, and two spellings of one file
+	// reach it too.
+	_, err := Derive([]Copybook{book("one.cpy", header), book("two.cpy", header)})
+	if err == nil {
+		t.Fatal("two record types deriving one name were accepted")
+	}
+
+	var collision *NameCollisionError
+	if !errors.As(err, &collision) {
+		t.Fatalf("the fault is %v, want a name collision", err)
+	}
+
+	rendered := diag.Render(err)
+	for _, want := range []string{"LEDGER-HEADER", "one.cpy", "two.cpy"} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("the diagnostic does not name %s:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestANoteNamesTheCopybookTheLevelTheRedefinesAndTheRecordTypes(t *testing.T) {
+	t.Parallel()
+
+	derived := deriveOf(t, book("header.cpy", header), book("posting.cpy", posting))
+
+	notes := derived.Notes()
+	if len(notes) != 1 {
+		t.Fatalf("wrote %d notes, want one per 01-level resolving to more than one record type: %v", len(notes), notes)
+	}
+
+	// Three REDEFINES over two runs, six record types. The count is reported
+	// and never bounded: a copybook is not refused for the number of record
+	// types it resolves to.
+	for _, want := range []string{"posting.cpy", "POSTING-RECORD", "3 REDEFINES", "6 record types"} {
+		if !strings.Contains(notes[0], want) {
+			t.Errorf("the note does not carry %q:\n%s", want, notes[0])
+		}
+	}
+}
+
+func TestCopybookReadingIsRaisedForAnOccursDependingOnAndNotOtherwise(t *testing.T) {
+	t.Parallel()
+
+	without := string(deriveOf(t, book("order.cpy", table)).Bytes())
+	if strings.Contains(without, "copybook-reading") {
+		t.Errorf("a copybook-reading was raised over a fixed table:\n%s", without)
+	}
+
+	with := string(deriveOf(t, book("order.cpy", depending)).Bytes())
+	if !strings.Contains(with, "(copybook-reading") {
+		t.Fatalf("no copybook-reading was raised over an OCCURS DEPENDING ON:\n%s", with)
+	}
+
+	// Both readings named, neither chosen: which compiler wrote the data is
+	// not in the copybook.
+	for _, want := range []string{"odoslide", "noodoslide", "(occurs-depending-on " + readingHole + ")"} {
+		if !strings.Contains(with, want) {
+			t.Errorf("the copybook-reading block does not carry %q:\n%s", want, with)
+		}
+	}
+}
+
+func TestTheCommentedFormsCarryTheirSubjectsAndNoValues(t *testing.T) {
+	t.Parallel()
+
+	text := string(deriveOf(t, book("posting.cpy", posting), book("order.cpy", table)).Bytes())
+
+	// Every commented form, with its subject filled in and its value a
+	// placeholder. A `sequence` names every record once.
+	want := []string{
+		";; (encoding",
+		";;   (charset " + charsetHole + ")",
+		";; (framing",
+		";;   (recfm " + recfmHole + "))",
+		";; (rename POSTING-RECORD-PST-BODY-PST-TAIL " + substituteHole + ")",
+		";; (discriminate POSTING-RECORD-PST-DEBIT-PST-TAIL-REF " + strategyHole + ")",
+		";; (discriminate ORDER-RECORD " + strategyHole + ")",
+		";; (discriminate-variant (item ORDER-RECORD ORD-LINE LN-BODY)",
+		";;   (arm LN-CARD " + predicateHole + "))",
+		";; (sequence",
+		";;   (" + operatorHole,
+	}
+
+	for _, line := range want {
+		if !strings.Contains(text, line) {
+			t.Errorf("the scaffold does not carry %q:\n%s", line, text)
+		}
+	}
+
+	// One rename per record over an 01-level with more than one record type,
+	// and none for a record that stands alone.
+	if strings.Contains(text, "(rename ORDER-RECORD") {
+		t.Errorf("a rename was raised for the only record type over an 01-level:\n%s", text)
+	}
+
+	// Every record is sequenced once.
+	for _, name := range recordNames(deriveOf(t, book("posting.cpy", posting), book("order.cpy", table))) {
+		if got := strings.Count(text, ";;     "+name+"\n") + strings.Count(text, ";;     "+name+"))\n"); got != 1 {
+			t.Errorf("%s is named %d times in the sequence, want once", name, got)
+		}
+	}
+}
+
+func TestTwoRunsOverOneSetOfCopybooksProduceByteIdenticalFiles(t *testing.T) {
+	t.Parallel()
+
+	books := []Copybook{book("header.cpy", header), book("posting.cpy", posting), book("order.cpy", depending)}
+
+	first := deriveOf(t, books...).Bytes()
+	second := deriveOf(t, books...).Bytes()
+
+	if string(first) != string(second) {
+		t.Error("two derivations over one set of copybooks differ, and a scaffold has to be diffable")
+	}
+}
+
+func TestACopybookThatIsNotOneIsReportedByThePathThatWasTyped(t *testing.T) {
+	t.Parallel()
+
+	_, err := Derive([]Copybook{book("broken.cpy", "       01  PIC PIC PIC.\n")})
+	if err == nil {
+		t.Fatal("a copybook that is not COBOL was accepted")
+	}
+
+	if got := diag.Render(err); !strings.Contains(got, "broken.cpy") {
+		t.Errorf("the diagnostic does not name the copybook:\n%s", got)
+	}
+}
+
+func TestACopybookDeclaringNoZeroOneLevelIsReported(t *testing.T) {
+	t.Parallel()
+
+	_, err := Derive([]Copybook{book("work.cpy", work)})
+	if err == nil {
+		t.Fatal("a copybook declaring no 01-level was accepted")
+	}
+
+	var missing *NoRecordError
+	if !errors.As(err, &missing) {
+		t.Fatalf("the fault is %v, want a missing record", err)
+	}
+}
+
+func TestEveryFaultIsReportedRatherThanTheFirst(t *testing.T) {
+	t.Parallel()
+
+	_, err := Derive([]Copybook{book("first.cpy", work), book("second.cpy", work)})
+	if err == nil {
+		t.Fatal("two unusable copybooks were accepted")
+	}
+
+	if got := len(diag.Diagnostics(err)); got != 2 {
+		t.Errorf("reported %d faults over two bad copybooks, want both", got)
+	}
+}
+
+// The measure docs/cli/SPEC.md sets: the worked example's postings are six
+// record types over one 01-level with twelve `alternative` children, and every
+// one of them is recoverable from the copybook. What the layout has that the
+// scaffold does not is the names — a reading of what the file means — and the
+// forms the scaffold leaves commented.
+func TestTheWorkedExampleDerivesLedgersRecordsAndAlternatives(t *testing.T) {
+	t.Parallel()
+
+	source, err := os.ReadFile(filepath.Join("..", "..", "example", "posting.cpy"))
+	if err != nil {
+		t.Fatalf("reading the worked example's copybook: %v", err)
+	}
+
+	// The path as `example/ledger.sexpr` spells it, which is what makes the
+	// two comparable.
+	derived := deriveOf(t, book("posting.cpy", string(source)))
+
+	file, err := layout.ParseFile(filepath.Join("..", "..", "example", "ledger.sexpr"))
+	if err != nil {
+		t.Fatalf("parsing the worked example's layout: %v", err)
+	}
+
+	written, err := layoutmodel.ReadRecords(file)
+	if err != nil {
+		t.Fatalf("reading the worked example's records: %v", err)
+	}
+
+	var want []string
+
+	for _, record := range written {
+		if record.Path != "posting.cpy" {
+			continue
+		}
+
+		chosen := make([]string, 0, len(record.Alternatives))
+		for _, alternative := range record.Alternatives {
+			chosen = append(chosen, alternative.Name())
+		}
+
+		want = append(want, strings.Join(chosen, "+"))
+	}
+
+	var got []string
+
+	for _, record := range derived.records {
+		chosen := make([]string, 0, len(record.alternatives))
+		for _, alternative := range record.alternatives {
+			chosen = append(chosen, alternative.path[len(alternative.path)-1])
+		}
+
+		got = append(got, strings.Join(chosen, "+"))
+	}
+
+	if len(got) != 6 || len(want) != 6 {
+		t.Fatalf("derived %d record types against the layout's %d, want six each", len(got), len(want))
+	}
+
+	// Compared as sets. Which combination is written first is the layout
+	// author's and the derivation's own order, and neither is a statement
+	// about the copybook; which twelve alternatives are chosen is.
+	slices.Sort(got)
+	slices.Sort(want)
+
+	if !slices.Equal(got, want) {
+		t.Errorf("derived the combinations\n%v\nand the layout states\n%v", got, want)
+	}
+}

--- a/internal/scaffold/derive_test.go
+++ b/internal/scaffold/derive_test.go
@@ -70,6 +70,26 @@ const (
        01  FIRST-RECORD.
            05  FST-TYPE            PIC X(2).
 `
+
+	// both is one 01-level carrying a redefine outside a repeating group and
+	// one inside: several record types and a variant over them.
+	both = `       01  BOTH-RECORD.
+           05  BTH-BODY            PIC X(6).
+           05  BTH-CARD            REDEFINES BTH-BODY PIC X(6).
+           05  BTH-LINE            OCCURS 4 TIMES.
+               10  BLN-BODY        PIC X(12).
+               10  BLN-CARD        REDEFINES BLN-BODY PIC X(12).
+`
+
+	// filler describes a run of bytes a second way with an item that has no
+	// data-name, which no item reference can spell. `cobol-go` refuses the
+	// mirror image — a REDEFINES *of* a FILLER cannot name its target — so this
+	// is the reachable half.
+	filler = `       01  FILLER-RECORD.
+           05  FLR-TYPE            PIC X(2).
+           05  FLR-BODY            PIC X(6).
+           05  FILLER              REDEFINES FLR-BODY PIC X(6).
+`
 )
 
 // deriveOf is the scaffold one set of copybooks decides, or a fatal test.
@@ -216,6 +236,75 @@ func TestARedefineInsideARepeatingGroupIsNeverAnAlternative(t *testing.T) {
 
 	if got := variant.arms; !slices.Equal(got, []string{"LN-BODY", "LN-CARD"}) {
 		t.Errorf("the arms are %v, want one per alternative", got)
+	}
+}
+
+// A variant is chosen once per occurrence, so it is one form however many
+// record types the 01-level resolves to — and the reference it carries has to
+// be rooted at one of them.
+func TestAVariantIsOneFormOverAnLevelThatResolvesToSeveralRecordTypes(t *testing.T) {
+	t.Parallel()
+
+	derived := deriveOf(t, book("both.cpy", both))
+
+	if got := len(derived.records); got != 2 {
+		t.Fatalf("derived %d record types, want one per alternative of the redefine outside the table", got)
+	}
+
+	if got := len(derived.variants); got != 1 {
+		t.Fatalf("raised %d variant discriminators, want one per redefine inside a repeating group", got)
+	}
+
+	// Rooted at the first record type over the 01-level, which is the one an
+	// adopter reads the form beside; a layout carrying the others writes a form
+	// of its own for each, which they are writing anyway.
+	if got := derived.variants[0].item.String(); got != "(item BOTH-RECORD-BTH-BODY BTH-LINE BLN-BODY)" {
+		t.Errorf("the variant is %s, want it rooted at the first record type", got)
+	}
+
+	if got := derived.variants[0].arms; !slices.Equal(got, []string{"BLN-BODY", "BLN-CARD"}) {
+		t.Errorf("the arms are %v, want one per alternative", got)
+	}
+
+	// And the redefine outside the table is still an alternative on each
+	// record, rather than being swallowed by the variant beside it.
+	for _, r := range derived.records {
+		if len(r.alternatives) != 1 {
+			t.Errorf("%s carries %d alternatives, want one", r.name, len(r.alternatives))
+		}
+	}
+}
+
+// A layout names an alternative with an item reference, and a reference is a
+// path of names, so an item with no data-name is one no layout could name.
+// Refusing beats writing a reference with a hole in it that would parse and then
+// be reported against a line cpybkc wrote.
+func TestARedefineOverAnItemWithNoDataNameIsRefused(t *testing.T) {
+	t.Parallel()
+
+	_, err := Derive([]Copybook{book("filler.cpy", filler)})
+	if err == nil {
+		t.Fatal("a REDEFINES over an unnamed item was accepted")
+	}
+
+	var unnameable *UnnamedAlternativeError
+	if !errors.As(err, &unnameable) {
+		t.Fatalf("the fault is %v, want an alternative no layout could name", err)
+	}
+
+	if got := diag.Render(err); !strings.Contains(got, "filler.cpy") || !strings.Contains(got, "FILLER-RECORD") {
+		t.Errorf("the diagnostic names neither the copybook nor the 01-level:\n%s", got)
+	}
+}
+
+// `sequence` names every record once, and there is no shape it could take over
+// none — so a scaffold over no copybooks is not an empty scaffold, it is a
+// question that was not asked.
+func TestDerivingFromNoCopybooksIsRefused(t *testing.T) {
+	t.Parallel()
+
+	if _, err := Derive(nil); !errors.Is(err, ErrNoCopybooks) {
+		t.Errorf("deriving from nothing gave %v, want %v", err, ErrNoCopybooks)
 	}
 }
 
@@ -415,7 +504,11 @@ func TestTheWorkedExampleDerivesLedgersRecordsAndAlternatives(t *testing.T) {
 
 		chosen := make([]string, 0, len(record.Alternatives))
 		for _, alternative := range record.Alternatives {
-			chosen = append(chosen, alternative.Name())
+			// The whole containment path rather than the leaf name. A
+			// reference into the wrong group has the same leaf, so comparing
+			// leaves would let this test pass over a scaffold naming bytes
+			// nobody meant.
+			chosen = append(chosen, strings.Join(alternative.Path, " "))
 		}
 
 		want = append(want, strings.Join(chosen, "+"))
@@ -426,7 +519,11 @@ func TestTheWorkedExampleDerivesLedgersRecordsAndAlternatives(t *testing.T) {
 	for _, record := range derived.records {
 		chosen := make([]string, 0, len(record.alternatives))
 		for _, alternative := range record.alternatives {
-			chosen = append(chosen, alternative.path[len(alternative.path)-1])
+			if len(alternative.path) == 0 {
+				t.Fatalf("%s carries an alternative with no path, which no layout could name", record.name)
+			}
+
+			chosen = append(chosen, strings.Join(alternative.path, " "))
 		}
 
 		got = append(got, strings.Join(chosen, "+"))

--- a/internal/scaffold/doc.go
+++ b/internal/scaffold/doc.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Package scaffold derives a layout scaffold from copybooks and writes it where
+// `cpybkc init --out` names.
+//
+// # The split it implements
+//
+// A layout is two kinds of statement in one file and only one of them is
+// knowledge the adopter has (docs/cli/SPEC.md, "What a copybook decides, and
+// what only the adopter can"). This package writes the first kind complete —
+// one `record` per 01-level, one `alternative` child per REDEFINES outside a
+// repeating group — and writes the second kind as commented forms with their
+// subjects filled in and their values left as placeholders.
+//
+// It invents nothing. Not an encoding axis, not a record format, not a
+// discrimination strategy and not a sequencing operator: a guessed value is the
+// one outcome worse than a blank, because a blank is reported and a guess is
+// read. Every placeholder is spelled so that uncommenting the form it is in
+// without filling it in is a fault the layout reader reports naming it — an
+// adopter who works down the checklist by deleting `;;` and loses their place
+// is the ordinary case, and a placeholder that happened to be a legal value
+// would let them finish a layout they never wrote.
+//
+// # The file it writes is deliberately not a layout
+//
+// The scaffold parses as S-expressions and fails the layout reader's
+// validation, and both halves are requirements. It parses because a file that
+// failed the grammar would be reported as one lexical fault and nothing else,
+// which turns the remainder back into something discovered a form at a time. It
+// fails validation because the reader that will have to accept the finished
+// layout is a better checklist than a second description of what a layout needs:
+// running cpybkc over a fresh scaffold reports the entire remainder at once,
+// each fault at the place the missing statement belongs.
+//
+// # One reading of a copybook, not two
+//
+// Which REDEFINES clauses become record types and which become variants is
+// [github.com/Zaba505/cpybkc/internal/resolve.Describe]'s answer, over the same
+// clusters and the same enclosing-table question the resolver itself uses. This
+// package computes nothing about a copybook on its own. That is the whole
+// reason the command is in the tool rather than a script over the published
+// schema: a second reading that drifted would produce a scaffold cpybkc then
+// rejected, and the adopter would be holding two readings of their copybook with
+// nothing to say which is wrong.
+//
+// # What is here, and what is not
+//
+// [Derive] takes copybooks that have already been read, as bytes beside the path
+// they were named by, and is a function of them alone — so two runs over one set
+// of copybooks produce byte-identical files, which docs/cli/SPEC.md requires
+// rather than hopes for. Opening the files, refusing a directory and reporting
+// what could not be read are the command's, beside every other diagnostic it
+// writes.
+//
+// [Write] is the destination rule, and it is not
+// [github.com/Zaba505/cpybkc/internal/emit]'s: that package replaces what it
+// finds, because a descriptor is derived entirely from its inputs and
+// re-emitting is the point of the flag. A layout is not. Overwriting one an
+// adopter has edited is the one unrecoverable thing this command could do — the
+// derived half is recomputable and the `discriminate` forms and the `sequence`
+// are not — so nothing at the destination is ever replaced, written through or
+// appended to.
+package scaffold

--- a/internal/scaffold/errors.go
+++ b/internal/scaffold/errors.go
@@ -1,0 +1,202 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package scaffold
+
+import (
+	"fmt"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+)
+
+// Every fault here leads with the copybook or the destination it is about and
+// says nothing else about where it is. There is no layout under `init` — that is
+// the whole point of the command — so a path has one spelling rather than two,
+// and the one it has is the one that was typed on the command line, which is
+// what the person running it can go and correct.
+
+// SourceError is a copybook `init` was given that cannot be read as COBOL this
+// build understands.
+//
+// The cause is carried on a continuation rather than reworded: what `cobol-go`
+// found is more specific than anything this package could say about it, and a
+// continuation is how a second line reaches standard error without being read as
+// a diagnostic of its own.
+type SourceError struct {
+	// Path is the --copybook value as it was typed.
+	Path string
+
+	// Err is what the reader said.
+	Err error
+}
+
+// Error implements error.
+func (e *SourceError) Error() string { return e.Diagnostic().String() }
+
+// Unwrap returns the underlying fault, so that a caller can assert on whatever
+// `cobol-go` raised.
+func (e *SourceError) Unwrap() error { return e.Err }
+
+// Diagnostic implements [diag.Error].
+func (e *SourceError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: "this is not a copybook this build can read",
+		Spans:   []diag.Span{{File: e.Path}, {Note: e.Err.Error()}},
+	}
+}
+
+// NoRecordError is a copybook that parsed and declares nothing a `record` form
+// could be written over.
+//
+// A copybook is a record description, and one holding no named 01-level
+// contributes no record to a scaffold. Reporting it is what stops a run
+// succeeding over a file the adopter expected records out of — a member holding
+// nothing but level-77 work items is the ordinary way to arrive here, and it
+// parses perfectly well.
+type NoRecordError struct {
+	// Path is the --copybook value as it was typed.
+	Path string
+}
+
+// Error implements error.
+func (e *NoRecordError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic implements [diag.Error].
+func (e *NoRecordError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: "this copybook declares no named 01-level, so there is no record to derive from it",
+		Spans:   []diag.Span{{File: e.Path}},
+	}
+}
+
+// NameCollisionError is two record types whose derived names are one symbol.
+//
+// docs/cli/SPEC.md, "How a combination's record name is chosen", requires the
+// run to fail naming both rather than disambiguating: duplicate data names are
+// legal COBOL, so this is reachable, and the only way past it is a name whose
+// single property is that it differs from another invented one. Both places are
+// named because the answer is to rename one of them, and the adopter cannot tell
+// which without seeing the pair.
+type NameCollisionError struct {
+	// Name is the symbol both record types derived.
+	Name string
+
+	// Path and Item are the copybook and 01-level of the record type already
+	// carrying it; Other and OtherItem are the ones that collided with it.
+	Path      string
+	Item      string
+	Other     string
+	OtherItem string
+}
+
+// Error implements error.
+func (e *NameCollisionError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic implements [diag.Error].
+func (e *NameCollisionError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"the record name %s is derived twice, here from the 01-level %s and again from %s below, "+
+				"and a layout cannot carry one name on two record types",
+			e.Name, e.Item, e.OtherItem,
+		),
+		Spans: []diag.Span{
+			{File: e.Path},
+			{File: e.Other, Note: "and again here"},
+		},
+	}
+}
+
+// UnnamedAlternativeError is a REDEFINES over an item a layout could not name.
+//
+// A layout says which alternative a record is with an item reference, and a
+// reference is a path of names — so an alternative written FILLER, or one under
+// a group whose data-name was omitted, is one no layout can name. The scaffold
+// refuses rather than writing a reference with a hole in it, which would parse
+// and then be reported against a line cpybkc wrote.
+type UnnamedAlternativeError struct {
+	// Path is the --copybook value as it was typed, and Item the 01-level.
+	Path string
+	Item string
+
+	// Line and Column are where the unnamed item is declared.
+	Line   int
+	Column int
+}
+
+// Error implements error.
+func (e *UnnamedAlternativeError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic implements [diag.Error].
+func (e *UnnamedAlternativeError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: fmt.Sprintf(
+			"%s overlays a run of bytes with an item that has no data-name, "+
+				"and a layout names an alternative with an item reference",
+			e.Item,
+		),
+		Spans: []diag.Span{{File: e.Path, Line: e.Line, Column: e.Column}},
+	}
+}
+
+// DestinationError is a --out path with something already at it.
+//
+// docs/cli/SPEC.md, "Where the scaffold is written, and why nothing is ever
+// overwritten": whatever is there — a regular file, a directory, a symbolic
+// link, including one that dangles — the run fails and nothing is written. Both
+// paths are named because a relative path in a shared tree sends a reader to the
+// wrong directory, and the path as typed is the one they can find in what they
+// wrote.
+type DestinationError struct {
+	// Path is the --out value as it was typed, and Absolute the path cpybkc
+	// looked at.
+	Path     string
+	Absolute string
+}
+
+// Error implements error.
+func (e *DestinationError) Error() string { return e.Diagnostic().String() }
+
+// Diagnostic implements [diag.Error].
+func (e *DestinationError) Diagnostic() diag.Diagnostic {
+	return diag.Diagnostic{
+		Message: "there is already something here, and cpybkc never writes over what it finds; " +
+			"remove it, or name somewhere else",
+		Spans: []diag.Span{{File: e.Path}, {Note: "cpybkc looked at " + e.Absolute}},
+	}
+}
+
+// WriteError is a destination that was free and still could not be written.
+type WriteError struct {
+	// Path is the --out value as it was typed, or [Stdout].
+	Path string
+
+	// Err is what the write failed with.
+	Err error
+}
+
+// Error implements error.
+func (e *WriteError) Error() string { return e.Diagnostic().String() }
+
+// Unwrap returns the underlying fault.
+func (e *WriteError) Unwrap() error { return e.Err }
+
+// Diagnostic implements [diag.Error].
+//
+// Standard output is named in the message rather than led with as a file,
+// because "-" is not a place a reader can go and look at.
+func (e *WriteError) Diagnostic() diag.Diagnostic {
+	if e.Path == Stdout {
+		return diag.Diagnostic{
+			Message: "the scaffold could not be written to standard output",
+			Spans:   []diag.Span{{Note: e.Err.Error()}},
+		}
+	}
+
+	return diag.Diagnostic{
+		Message: "the scaffold could not be written here",
+		Spans:   []diag.Span{{File: e.Path}, {Note: e.Err.Error()}},
+	}
+}

--- a/internal/scaffold/errors.go
+++ b/internal/scaffold/errors.go
@@ -6,10 +6,23 @@
 package scaffold
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/Zaba505/cpybkc/internal/diag"
 )
+
+// ErrNoCopybooks is [Derive] handed nothing to derive from.
+//
+// It is an ordinary error rather than a [diag.Error] because it is not a fault
+// in anybody's file: it says the caller asked for a scaffold over no copybooks,
+// which the command line refuses as a usage error before this package is
+// reached.
+var ErrNoCopybooks = errors.New("there is no copybook to derive a scaffold from")
+
+// ErrNoDestination is [Write] handed nowhere to put the scaffold, for
+// [ErrNoCopybooks]'s reason.
+var ErrNoDestination = errors.New("name a file to write the scaffold to, or " + Stdout + " for standard output")
 
 // Every fault here leads with the copybook or the destination it is about and
 // says nothing else about where it is. There is no layout under `init` — that is

--- a/internal/scaffold/render.go
+++ b/internal/scaffold/render.go
@@ -5,7 +5,12 @@
 
 package scaffold
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
 
 // The two shapes a line of a scaffold takes.
 //
@@ -311,12 +316,55 @@ func line(out *strings.Builder, text string) {
 
 // quote renders a path as the string literal a `copybook` child takes.
 //
-// Only the two characters the grammar needs escaped are escaped, and nothing
-// else is touched: the path is written as it was typed, and a path cpybkc
-// re-spelled — a non-ASCII byte turned into an escape sequence, say — would be
-// one the adopter cannot find in the command line they wrote.
+// The escape set is the grammar's own — the one `sexpr-go`'s printer writes and
+// its tokenizer reads back — because the scaffold has to parse whatever a
+// copybook is called, and a POSIX path may hold any byte but a slash and a NUL.
+// A newline in a path is rare and it is legal, and writing one raw would produce
+// the single failure the incompleteness is not allowed to be: a file reported as
+// one lexical fault instead of as the checklist it is meant to be.
+//
+// Nothing beyond that set is touched. A non-ASCII path goes out as itself rather
+// than as a run of escapes, because the path is written as it was typed and one
+// cpybkc re-spelled would be one the adopter cannot find in the command line
+// they wrote.
 func quote(path string) string {
-	escaped := strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(path)
+	var out strings.Builder
 
-	return `"` + escaped + `"`
+	out.Grow(len(path) + 2)
+	out.WriteByte('"')
+
+	for _, r := range path {
+		switch r {
+		case '"':
+			out.WriteString(`\"`)
+		case '\\':
+			out.WriteString(`\\`)
+		case '\n':
+			out.WriteString(`\n`)
+		case '\r':
+			out.WriteString(`\r`)
+		case '\t':
+			out.WriteString(`\t`)
+		case '\b':
+			out.WriteString(`\b`)
+		case '\f':
+			out.WriteString(`\f`)
+		default:
+			// Every other control character has no short escape in this
+			// grammar, and a byte that is not valid UTF-8 would not survive
+			// being written raw, so both go out as \uXXXX. unicode.IsControl
+			// covers DEL and the C1 range as well as C0.
+			if unicode.IsControl(r) || r == utf8.RuneError {
+				_, _ = fmt.Fprintf(&out, `\u%04X`, r)
+
+				continue
+			}
+
+			out.WriteRune(r)
+		}
+	}
+
+	out.WriteByte('"')
+
+	return out.String()
 }

--- a/internal/scaffold/render.go
+++ b/internal/scaffold/render.go
@@ -1,0 +1,322 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package scaffold
+
+import "strings"
+
+// The two shapes a line of a scaffold takes.
+//
+// A comment is the only place a layout has for text its reader ignores
+// (docs/layout/SPEC.md, "Tagged forms over S-expressions"), and it is therefore
+// where everything cpybkc cannot state goes. Two semicolons rather than one,
+// which is what the format's own examples and `example/ledger.sexpr` use.
+const (
+	commentMark   = ";;"
+	commentPrefix = commentMark + " "
+
+	// indent is one level of a form's children. Two spaces, which is what the
+	// layout format is written with everywhere else in this repository.
+	indent = "  "
+)
+
+// The placeholders. Each is a symbol rather than a value of the sort the
+// position takes, which is what makes uncommenting a form without filling it in
+// a fault the layout reader reports naming the placeholder rather than a layout
+// that quietly means something nobody wrote.
+//
+// The spelling is docs/layout/SPEC.md's own skeleton notation, so a reader who
+// has the format in front of them meets the same convention in both. It is
+// explicitly not covered by the compatibility guarantees, which is what leaves
+// the wording of everything around it free as well.
+const (
+	charsetHole        = "<charset>"
+	signConventionHole = "<sign-convention>"
+	byteOrderHole      = "<byte-order>"
+	floatFormatHole    = "<float-format>"
+	recfmHole          = "<recfm>"
+	readingHole        = "<reading>"
+	substituteHole     = "<substitute>"
+	strategyHole       = "<strategy>"
+	predicateHole      = "<predicate>"
+	operatorHole       = "<operator>"
+)
+
+// Bytes renders the scaffold.
+//
+// The forms come in the order docs/layout/SPEC.md tables the top-level forms in,
+// so that a form the adopter uncomments is already where the format's own
+// examples put it, and a scaffold carries every item of that order its copybooks
+// reach and nothing else.
+//
+// It is a function of the scaffold and of nothing else — no clock, no
+// environment, no map iterated — so two runs of one build over one set of
+// copybooks produce byte-identical files. That is a requirement rather than a
+// hoped-for property: a scaffold that reordered itself between runs would be
+// undiffable in exactly the review where an adopter is deciding what to keep.
+func (s *Scaffold) Bytes() []byte {
+	var out strings.Builder
+
+	s.header(&out)
+	s.encoding(&out)
+	s.framing(&out)
+	s.definitions(&out)
+	s.reading(&out)
+	s.renames(&out)
+	s.discriminators(&out)
+	s.variantDiscriminators(&out)
+	s.sequence(&out)
+
+	return []byte(out.String())
+}
+
+// header says what the file is, what was derived and what is left.
+func (s *Scaffold) header(out *strings.Builder) {
+	comment(out,
+		"A layout scaffold, written by `cpybkc init` from the copybooks it was given.",
+		"",
+		"What is uncommented below is what those copybooks decide: one record per",
+		"01-level, and one alternative child per REDEFINES outside a repeating group.",
+		"What is commented is what a copybook does not decide and you do -- the",
+		"encoding, the physical framing, what tells one record type from another, and",
+		"the order they may appear in.",
+		"",
+		"So this is not a layout yet. Run cpybkc against it and everything still",
+		"missing is reported at once, each at the place it belongs; work down that",
+		"list, uncomment the form it names and fill in every <placeholder>. A",
+		"placeholder left as it stands is reported by name, so a form uncommented and",
+		"left half-written is never quietly accepted.",
+	)
+}
+
+// encoding raises the four axes and states none of them.
+//
+// The values are not listed even for the three closed axes. A listed value reads
+// as a recommendation, and the charset axis is deliberately open-ended, so any
+// list here goes stale the release a code page is added.
+func (s *Scaffold) encoding(out *strings.Builder) {
+	blank(out)
+	comment(out, "The encoding profile: all four axes, always, with no default for any.")
+	comment(out,
+		"(encoding",
+		indent+"(charset "+charsetHole+")",
+		indent+"(sign-convention "+signConventionHole+")",
+		indent+"(byte-order "+byteOrderHole+")",
+		indent+"(float-format "+floatFormatHole+"))",
+	)
+}
+
+// framing raises the record format and says that the rest of the form follows
+// from it.
+func (s *Scaffold) framing(out *strings.Builder) {
+	blank(out)
+	comment(out,
+		"How the dataset frames a record. Which other children `framing` takes",
+		"follows from the record format chosen: an lrecl under F and FB, a maximum",
+		"segment under VBS, a delimiter and its placement under line-sequential.",
+	)
+	comment(out,
+		"(framing",
+		indent+"(recfm "+recfmHole+"))",
+	)
+}
+
+// definitions writes the `record` forms, which are the whole of what this
+// command states outright.
+func (s *Scaffold) definitions(out *strings.Builder) {
+	blank(out)
+	comment(out,
+		"The record types these copybooks resolve to. Each names the copybook and the",
+		"01-level it is a description of and -- where a REDEFINES outside a repeating",
+		"group gives that 01-level more than one description -- which one it means.",
+	)
+
+	for _, r := range s.records {
+		if len(r.alternatives) == 0 {
+			line(out, "(record "+r.name+" "+r.copybookChild()+")")
+
+			continue
+		}
+
+		line(out, "(record "+r.name)
+		line(out, indent+r.copybookChild())
+
+		for at, alternative := range r.alternatives {
+			closing := ""
+			if at == len(r.alternatives)-1 {
+				closing = ")"
+			}
+
+			line(out, indent+"(alternative "+alternative.String()+")"+closing)
+		}
+	}
+}
+
+// copybookChild is the `copybook` child naming the file as it was typed and the
+// 01-level inside it.
+func (r record) copybookChild() string {
+	return "(copybook " + quote(r.path) + " " + r.item + ")"
+}
+
+// reading raises the OCCURS DEPENDING ON question, when and only when some
+// copybook carries the clause, and names both readings without choosing one.
+func (s *Scaffold) reading(out *strings.Builder) {
+	if !s.tables {
+		return
+	}
+
+	blank(out)
+	comment(out,
+		"A copybook here carries an OCCURS DEPENDING ON, so the layout has to say",
+		"which reading the program that wrote your file used: `odoslide`, under which",
+		"every item behind such a table moves with the count, or `noodoslide`, under",
+		"which the table is fixed at the copybook's declared maximum and the count is",
+		"an ordinary field beside it. It is a property of that compiler, and no",
+		"copybook holds it.",
+	)
+	comment(out,
+		"(copybook-reading",
+		indent+"(occurs-depending-on "+readingHole+"))",
+	)
+}
+
+// renames raises one question per record over an 01-level that resolved to more
+// than one record type, and answers none of them.
+//
+// No rename is emitted, only a commented one. A rename substitutes the name the
+// IR carries — the name a generator turns into an identifier in somebody's
+// public API — and a machine-invented substitute would land there permanently.
+func (s *Scaffold) renames(out *strings.Builder) {
+	if len(s.renamed) == 0 {
+		return
+	}
+
+	blank(out)
+	comment(out,
+		"Several record types over one 01-level carry one name between them -- the",
+		"one that 01-level gives them -- until a rename says otherwise, and a",
+		"generator that cannot spell two of them alike refuses the collision rather",
+		"than munging it. What each should be called is a reading of what the file",
+		"means, and no copybook holds it.",
+	)
+
+	for _, name := range s.renamed {
+		comment(out, "(rename "+name+" "+substituteHole+")")
+	}
+}
+
+// discriminators raises one `discriminate` per record and states no strategy.
+func (s *Scaffold) discriminators(out *strings.Builder) {
+	blank(out)
+	comment(out,
+		"What selects each record type: exactly one of these per record, including",
+		"for a record carrying nothing to test -- requiring it is what makes that a",
+		"statement you made rather than a gap in the file.",
+	)
+
+	for _, r := range s.records {
+		comment(out, "(discriminate "+r.name+" "+strategyHole+")")
+	}
+}
+
+// variantDiscriminators raises one `discriminate-variant` per redefine inside a
+// repeating group, with the variant and its arms filled in.
+func (s *Scaffold) variantDiscriminators(out *strings.Builder) {
+	if len(s.variants) == 0 {
+		return
+	}
+
+	blank(out)
+	comment(out,
+		"A REDEFINES inside a repeating group is chosen once per occurrence rather",
+		"than once per record, so it is a variant with an arm per alternative and",
+		"never an alternative child. Which names are alternatives there is the",
+		"copybook's; what selects each one is yours.",
+	)
+
+	for _, v := range s.variants {
+		lines := make([]string, 0, len(v.arms)+1)
+		lines = append(lines, "(discriminate-variant "+v.item.String())
+
+		for at, arm := range v.arms {
+			closing := ""
+			if at == len(v.arms)-1 {
+				closing = ")"
+			}
+
+			lines = append(lines, indent+"(arm "+arm+" "+predicateHole+")"+closing)
+		}
+
+		comment(out, lines...)
+	}
+}
+
+// sequence names every record once and states no order.
+//
+// The operator is a placeholder rather than one of the format's, and that is the
+// point: which of `seq`, `alt`, `*`, `+`, `?`, `times` and `when` describes a
+// file is not in a copybook, and a `seq` written here would be an order cpybkc
+// invented sitting one keystroke away from being believed.
+func (s *Scaffold) sequence(out *strings.Builder) {
+	blank(out)
+	comment(out,
+		"The order records may appear in. Every record is named once below and the",
+		"operator is deliberately left blank: this states no order, and which of",
+		"seq, alt, *, +, ?, times and when describes your file is yours to choose.",
+	)
+
+	lines := make([]string, 0, len(s.records)+2)
+	lines = append(lines, "(sequence", indent+"("+operatorHole)
+
+	for at, r := range s.records {
+		closing := ""
+		if at == len(s.records)-1 {
+			closing = "))"
+		}
+
+		lines = append(lines, indent+indent+r.name+closing)
+	}
+
+	comment(out, lines...)
+}
+
+// comment writes each line as a comment, so that everything cpybkc cannot state
+// is text the reader of a layout ignores.
+//
+// A line with nothing in it becomes a bare comment mark rather than an empty
+// line, which is what keeps a paragraph one block a reader can uncomment or
+// delete in one gesture.
+func comment(out *strings.Builder, lines ...string) {
+	for _, text := range lines {
+		if text == "" {
+			line(out, commentMark)
+
+			continue
+		}
+
+		line(out, commentPrefix+text)
+	}
+}
+
+// blank separates two blocks of the file.
+func blank(out *strings.Builder) { out.WriteString("\n") }
+
+// line writes one line of the scaffold.
+func line(out *strings.Builder, text string) {
+	out.WriteString(text)
+	out.WriteString("\n")
+}
+
+// quote renders a path as the string literal a `copybook` child takes.
+//
+// Only the two characters the grammar needs escaped are escaped, and nothing
+// else is touched: the path is written as it was typed, and a path cpybkc
+// re-spelled — a non-ASCII byte turned into an escape sequence, say — would be
+// one the adopter cannot find in the command line they wrote.
+func quote(path string) string {
+	escaped := strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(path)
+
+	return `"` + escaped + `"`
+}

--- a/internal/scaffold/render_test.go
+++ b/internal/scaffold/render_test.go
@@ -209,24 +209,45 @@ func TestTheFormsComeInTheOrderTheLayoutFormatTablesThem(t *testing.T) {
 			t.Fatalf("the scaffold does not carry %q, or carries it out of order:\n%s", form, text)
 		}
 
-		at += found
+		// Past the match, not to it: advancing only to the start would let the
+		// next search re-scan text this one has already accepted, which asserts
+		// non-decreasing positions rather than an order.
+		at += found + len(form)
 	}
 }
 
 // The one thing a scaffold has to be is readable as S-expressions, whatever its
 // copybooks are called.
+//
+// A POSIX path may hold any byte but a slash and a NUL, so a newline or a tab in
+// one is rare and legal — and writing it raw would produce the single failure
+// the incompleteness is not allowed to be: a file reported as one lexical fault
+// instead of as the checklist it is meant to be.
 func TestAPathWithACharacterTheGrammarEscapesStillParses(t *testing.T) {
 	t.Parallel()
 
-	derived := deriveOf(t, book(`odd"name\.cpy`, header))
+	for _, test := range []struct {
+		name string
+		path string
+		want string
+	}{
+		{"a quote and a backslash", `odd"name\.cpy`, `"odd\"name\\.cpy"`},
+		{"a newline and a tab", "odd\nname\t.cpy", `"odd\nname\t.cpy"`},
+		{"a control character with no short escape", "odd\x01name.cpy", `"odd\u0001name.cpy"`},
+		{"a non-ASCII name, written as itself", "copies/naïve.cpy", `"copies/naïve.cpy"`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 
-	text := string(derived.Bytes())
+			text := string(deriveOf(t, book(test.path, header)).Bytes())
 
-	if err := readLayout(t, text); err == nil {
-		t.Fatal("the layout reader accepted a scaffold")
-	}
+			if err := readLayout(t, text); err == nil {
+				t.Fatal("the layout reader accepted a scaffold")
+			}
 
-	if !strings.Contains(text, `(copybook "odd\"name\\.cpy" LEDGER-HEADER)`) {
-		t.Errorf("the path was not escaped as the grammar needs:\n%s", text)
+			if !strings.Contains(text, "(copybook "+test.want+" LEDGER-HEADER)") {
+				t.Errorf("the path was not written as %s:\n%s", test.want, text)
+			}
+		})
 	}
 }

--- a/internal/scaffold/render_test.go
+++ b/internal/scaffold/render_test.go
@@ -1,0 +1,232 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package scaffold
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+	"github.com/Zaba505/cpybkc/internal/layout"
+	"github.com/Zaba505/cpybkc/internal/layoutmodel"
+)
+
+// readLayout parses text as a layout and reads every layer of it, collecting the
+// faults rather than stopping at the first.
+//
+// It is the layout reader as [github.com/Zaba505/cpybkc/internal/project] runs
+// it, which is the point: what a scaffold is missing is reported by the reader
+// that will have to accept the finished layout, and never by a second
+// description of what a layout needs.
+func readLayout(t *testing.T, text string) error {
+	t.Helper()
+
+	file, err := layout.Parse("scaffold.sexpr", strings.NewReader(text))
+	if err != nil {
+		t.Fatalf("the scaffold does not parse, which is the one thing it has to do:\n%v\n\n%s", err, text)
+	}
+
+	var faults diag.List
+
+	_, err = layoutmodel.ReadRecords(file)
+	faults.Fail(err)
+
+	_, err = layoutmodel.ReadProfile(file)
+	faults.Fail(err)
+
+	_, err = layoutmodel.ReadFraming(file)
+	faults.Fail(err)
+
+	_, err = layoutmodel.ReadDiscrimination(file)
+	faults.Fail(err)
+
+	_, err = layoutmodel.ReadSequence(file)
+	faults.Fail(err)
+
+	_, err = layoutmodel.ReadRenames(file)
+	faults.Fail(err)
+
+	_, err = layoutmodel.ReadCopybookReading(file)
+	faults.Fail(err)
+
+	return faults.Err()
+}
+
+// uncomment strips the comment marks from the first commented form whose tag is
+// tag, leaving everything else as it was.
+//
+// It is the gesture the scaffold is written for and the one the placeholders
+// exist to survive: an adopter works down the reader's checklist by deleting
+// `;;`, and the file has to report what they have not filled in rather than
+// accepting it.
+func uncomment(t *testing.T, text, tag string) string {
+	t.Helper()
+
+	lines := strings.Split(text, "\n")
+	out := make([]string, 0, len(lines))
+
+	depth := 0
+	found := false
+
+	for _, line := range lines {
+		body, isComment := strings.CutPrefix(line, commentPrefix)
+
+		switch {
+		case isComment && depth > 0:
+			out = append(out, body)
+			depth += strings.Count(body, "(") - strings.Count(body, ")")
+		case isComment && !found && opens(body, tag):
+			found = true
+
+			out = append(out, body)
+			depth += strings.Count(body, "(") - strings.Count(body, ")")
+		default:
+			out = append(out, line)
+		}
+	}
+
+	if !found {
+		t.Fatalf("the scaffold carries no commented %s form:\n%s", tag, text)
+	}
+
+	return strings.Join(out, "\n")
+}
+
+// opens reports whether a comment's text is the first line of a form tagged tag.
+//
+// A form written on one line has its argument after a space and one broken over
+// several has nothing after the tag at all, so both spellings are matched — and
+// the space is what keeps `discriminate` from matching `discriminate-variant`.
+func opens(body, tag string) bool {
+	return body == "("+tag || strings.HasPrefix(body, "("+tag+" ")
+}
+
+// A fresh scaffold is the adopter's next checklist, and the whole of it comes
+// out at once: docs/cli/SPEC.md, "The scaffold is deliberately incomplete".
+func TestTheScaffoldParsesAndTheReaderReportsTheWholeRemainder(t *testing.T) {
+	t.Parallel()
+
+	derived := deriveOf(t, book("header.cpy", header), book("posting.cpy", posting))
+
+	err := readLayout(t, string(derived.Bytes()))
+	if err == nil {
+		t.Fatal("the layout reader accepted a scaffold, which is not a layout")
+	}
+
+	rendered := diag.Render(err)
+
+	// The missing encoding, the missing framing, one missing discriminator per
+	// record, and the missing sequence — reported together rather than one per
+	// run.
+	for _, want := range []string{"encoding", "framing", "sequence"} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("the reader said nothing about the missing %s:\n%s", want, rendered)
+		}
+	}
+
+	discriminators := strings.Count(rendered, "carries no discriminator")
+	if discriminators != len(derived.records) {
+		t.Errorf("the reader reported %d records with no discriminator, want one per record (%d):\n%s",
+			discriminators, len(derived.records), rendered)
+	}
+}
+
+// A placeholder that happened to be a legal value would let an adopter succeed
+// with a layout they never finished writing, which is the one failure the
+// incompleteness is there to prevent.
+func TestEveryPlaceholderUncommentedIsAFaultTheReaderNames(t *testing.T) {
+	t.Parallel()
+
+	// Every commented form the scaffold can carry, over copybooks that reach
+	// all of them: a record type per combination raises a rename, a variant
+	// raises a discriminate-variant, and an OCCURS DEPENDING ON raises a
+	// copybook-reading.
+	text := string(deriveOf(t,
+		book("posting.cpy", posting),
+		book("order.cpy", table),
+		book("lines.cpy", depending),
+	).Bytes())
+
+	for _, test := range []struct {
+		form        string
+		placeholder string
+	}{
+		{"encoding", charsetHole},
+		{"framing", recfmHole},
+		{"copybook-reading", readingHole},
+		{"rename", substituteHole},
+		{"discriminate", strategyHole},
+		{"discriminate-variant", predicateHole},
+		{"sequence", operatorHole},
+	} {
+		t.Run(test.form, func(t *testing.T) {
+			t.Parallel()
+
+			err := readLayout(t, uncomment(t, text, test.form))
+			if err == nil {
+				t.Fatalf("an uncommented %s with nothing filled in was accepted", test.form)
+			}
+
+			if got := diag.Render(err); !strings.Contains(got, test.placeholder) {
+				t.Errorf("the reader did not name %s:\n%s", test.placeholder, got)
+			}
+		})
+	}
+}
+
+// docs/cli/SPEC.md fixes the membership and the order of what a scaffold
+// carries: it is the order docs/layout/SPEC.md tables the top-level forms in, so
+// that a form the adopter uncomments is already where the format's own examples
+// put it.
+func TestTheFormsComeInTheOrderTheLayoutFormatTablesThem(t *testing.T) {
+	t.Parallel()
+
+	text := string(deriveOf(t,
+		book("posting.cpy", posting),
+		book("order.cpy", table),
+		book("lines.cpy", depending),
+	).Bytes())
+
+	order := []string{
+		"(encoding",
+		"(framing",
+		"(record ",
+		"(copybook-reading",
+		"(rename ",
+		"(discriminate ",
+		"(discriminate-variant ",
+		"(sequence",
+	}
+
+	at := 0
+
+	for _, form := range order {
+		found := strings.Index(text[at:], form)
+		if found < 0 {
+			t.Fatalf("the scaffold does not carry %q, or carries it out of order:\n%s", form, text)
+		}
+
+		at += found
+	}
+}
+
+// The one thing a scaffold has to be is readable as S-expressions, whatever its
+// copybooks are called.
+func TestAPathWithACharacterTheGrammarEscapesStillParses(t *testing.T) {
+	t.Parallel()
+
+	derived := deriveOf(t, book(`odd"name\.cpy`, header))
+
+	text := string(derived.Bytes())
+
+	if err := readLayout(t, text); err == nil {
+		t.Fatal("the layout reader accepted a scaffold")
+	}
+
+	if !strings.Contains(text, `(copybook "odd\"name\\.cpy" LEDGER-HEADER)`) {
+		t.Errorf("the path was not escaped as the grammar needs:\n%s", text)
+	}
+}

--- a/internal/scaffold/write.go
+++ b/internal/scaffold/write.go
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package scaffold
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// Stdout is the `--out` operand asking for the scaffold on standard output
+// rather than in a file.
+//
+// POSIX's Utility Conventions give "-" this meaning as an operand, which is the
+// reading `--emit-ir` and the plugin contract's `--descriptor` already take. A
+// dash is therefore never a relative path here, and a caller wanting a file of
+// that name spells it "./-".
+const Stdout = "-"
+
+// scaffoldPerm is the mode a scaffold is created with, before the process umask
+// is applied to it: an ordinary text file the adopter is about to open in their
+// editor.
+const scaffoldPerm = 0o644
+
+// tempAttempts is how many names [createBeside] will try before giving up.
+//
+// The names are counted rather than drawn at random, so this is not a collision
+// bound: it is how many temporaries may be sitting beside one destination before
+// a write fails. A loop that never gave up would hang on a directory that cannot
+// be written to at all.
+const tempAttempts = 64
+
+// Write puts b where dest names: a filesystem path, or [Stdout], in which case
+// the bytes go to out and out alone.
+//
+// # Nothing at dest is ever replaced
+//
+// Whatever is at the path — a regular file, a directory, a symbolic link,
+// including one that dangles — the run fails, nothing is written, and the
+// diagnostic names the path as it was typed beside the absolute path cpybkc
+// looked at. Nothing is truncated, appended to or written through.
+//
+// That is the opposite of what [github.com/Zaba505/cpybkc/internal/emit] does
+// with a descriptor, and deliberately: a descriptor is derived entirely from its
+// inputs, so re-emitting after a layout changed is the whole point of the flag,
+// while a layout carries the `discriminate` forms and the `sequence` that no
+// copybook holds and nothing recovers. Overwriting one an adopter has edited is
+// the single unrecoverable act available to this command, and there is no
+// `--force` to permit it: a flag whose only purpose is to permit the
+// unrecoverable is one that gets written into a script once and never
+// reconsidered, and what it saves is one `rm`.
+//
+// # In full or not at all
+//
+// The bytes go to a temporary file beside dest and are linked onto it, so a
+// write interrupted by a full disk leaves nothing at the destination rather than
+// a prefix of a scaffold that parses as far as it goes. The link is what makes
+// the refusal atomic as well as checked: [os.Link] fails rather than following a
+// symlink or replacing a file, so a destination that appeared between the check
+// and the write is refused exactly as one that was there all along.
+//
+// A path whose parent directory does not exist is an error rather than a
+// directory this creates. The operand is a path somebody typed, where a missing
+// parent is far more often a typo than an intention.
+func Write(dest string, out io.Writer, b []byte) error {
+	if dest == "" {
+		return fmt.Errorf("name a file to write the scaffold to, or %q for standard output", Stdout)
+	}
+
+	if dest == Stdout {
+		if _, err := out.Write(b); err != nil {
+			return &WriteError{Path: dest, Err: err}
+		}
+
+		return nil
+	}
+
+	return writeFile(dest, b)
+}
+
+// writeFile puts b at dest, refusing whatever is already there.
+func writeFile(dest string, b []byte) error {
+	// Lstat rather than Stat, because a symbolic link is one of the things
+	// that must not be written through and Stat would report whatever it
+	// points at — or nothing at all, for one that dangles, which is exactly the
+	// case the rule names.
+	if _, err := os.Lstat(dest); err == nil {
+		return occupied(dest)
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return &WriteError{Path: dest, Err: err}
+	}
+
+	temp, err := createBeside(dest)
+	if err != nil {
+		return &WriteError{Path: dest, Err: err}
+	}
+
+	name := temp.Name()
+
+	// Removed on every return, including the successful one, where the link
+	// has already put the bytes at the destination and this drops the second
+	// name for them. A process killed outright between the create and the link
+	// leaves it behind; the leading dot is what keeps that out of the way of
+	// anything reading the directory.
+	defer func() { _ = os.Remove(name) }()
+
+	if err := write(temp, b); err != nil {
+		return &WriteError{Path: dest, Err: err}
+	}
+
+	if err := os.Link(name, dest); err != nil {
+		if errors.Is(err, fs.ErrExist) {
+			return occupied(dest)
+		}
+
+		return &WriteError{Path: dest, Err: err}
+	}
+
+	return nil
+}
+
+// write puts the bytes in the temporary and closes it.
+//
+// The flush is before the close because a full disk is reported at the flush
+// rather than at the write where allocation is delayed: linking an unflushed
+// file is how ENOSPC becomes a short scaffold and a successful return.
+func write(temp *os.File, b []byte) error {
+	if _, err := temp.Write(b); err != nil {
+		_ = temp.Close()
+
+		return err
+	}
+
+	if err := temp.Sync(); err != nil {
+		_ = temp.Close()
+
+		return err
+	}
+
+	return temp.Close()
+}
+
+// occupied is the refusal, carrying both spellings of the path.
+//
+// The absolute path is what cpybkc looked at and the typed one is what the
+// adopter can find in the line they wrote; a relative path in a shared tree
+// sends a reader to the wrong directory without the pair. A path that cannot be
+// made absolute is reported as itself rather than failing the failure.
+func occupied(dest string) error {
+	absolute, err := filepath.Abs(dest)
+	if err != nil {
+		absolute = dest
+	}
+
+	return &DestinationError{Path: dest, Absolute: absolute}
+}
+
+// createBeside makes a file next to dest that nothing else holds, at the mode a
+// scaffold is created with.
+//
+// It is [os.CreateTemp] with two differences. CreateTemp fixes the mode at 0600,
+// which is not a mode this package is entitled to give somebody's layout; and it
+// picks its names with a random number, which would make what a run writes a
+// function of something other than its inputs. O_EXCL is what the names are
+// counted around: a create that loses a race fails rather than opening what is
+// already there, so two runs writing beside one destination cannot share a
+// temporary and a name anybody guessed cannot be pre-created for this to write
+// through.
+func createBeside(dest string) (*os.File, error) {
+	dir, base := filepath.Split(dest)
+
+	for attempt := range tempAttempts {
+		name := filepath.Join(dir, fmt.Sprintf(".%s.%d.tmp", base, attempt))
+
+		file, err := os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_EXCL, scaffoldPerm)
+
+		switch {
+		case err == nil:
+			return file, nil
+		case errors.Is(err, fs.ErrExist):
+			continue
+		default:
+			return nil, err
+		}
+	}
+
+	return nil, fmt.Errorf("every one of the %d temporary names beside it is taken, which is usually %d runs "+
+		"killed mid-write leaving a .%s.<n>.tmp behind", tempAttempts, tempAttempts, base)
+}

--- a/internal/scaffold/write.go
+++ b/internal/scaffold/write.go
@@ -70,7 +70,7 @@ const tempAttempts = 64
 // parent is far more often a typo than an intention.
 func Write(dest string, out io.Writer, b []byte) error {
 	if dest == "" {
-		return fmt.Errorf("name a file to write the scaffold to, or %q for standard output", Stdout)
+		return ErrNoDestination
 	}
 
 	if dest == Stdout {

--- a/internal/scaffold/write_test.go
+++ b/internal/scaffold/write_test.go
@@ -1,0 +1,244 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package scaffold
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/diag"
+)
+
+// scaffoldBytes is what a write puts somewhere. Its content does not matter to
+// any test here; that it arrives whole and only where it was asked for does.
+var scaffoldBytes = []byte(";; a scaffold\n(record A (copybook \"a.cpy\" A))\n")
+
+// refused asserts that dest was left exactly as it was found, and that the
+// diagnostic names both spellings of it.
+func refused(t *testing.T, dest string, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("an occupied destination was written to")
+	}
+
+	var occupied *DestinationError
+	if !errors.As(err, &occupied) {
+		t.Fatalf("the fault is %v, want an occupied destination", err)
+	}
+
+	rendered := diag.Render(err)
+
+	absolute, absErr := filepath.Abs(dest)
+	if absErr != nil {
+		t.Fatalf("resolving the destination: %v", absErr)
+	}
+
+	if !strings.Contains(rendered, dest) || !strings.Contains(rendered, absolute) {
+		t.Errorf("the diagnostic names neither the path as typed nor the absolute path:\n%s", rendered)
+	}
+}
+
+// leftovers is every entry in dir other than the ones named, which is how a
+// temporary a failed write forgot to remove is caught.
+func leftovers(t *testing.T, dir string, expected ...string) []string {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading the destination's directory: %v", err)
+	}
+
+	var found []string
+
+	for _, entry := range entries {
+		if !contains(expected, entry.Name()) {
+			found = append(found, entry.Name())
+		}
+	}
+
+	return found
+}
+
+func contains(names []string, name string) bool {
+	for _, each := range names {
+		if each == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func TestAFreeDestinationIsWrittenInFull(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "layout.sexpr")
+
+	if err := Write(dest, io.Discard, scaffoldBytes); err != nil {
+		t.Fatalf("writing the scaffold: %v", err)
+	}
+
+	written, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("reading back the scaffold: %v", err)
+	}
+
+	if !bytes.Equal(written, scaffoldBytes) {
+		t.Errorf("wrote %q, want %q", written, scaffoldBytes)
+	}
+
+	// The temporary the bytes went through is gone: it is a second name for
+	// the file for as long as the link takes, and no longer.
+	if left := leftovers(t, dir, "layout.sexpr"); len(left) > 0 {
+		t.Errorf("the write left %v behind", left)
+	}
+}
+
+func TestAFileAtTheDestinationIsNeverReplaced(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "layout.sexpr")
+
+	// A layout an adopter has edited: the derived half is recomputable and the
+	// discriminators and the sequence are not, so this is the one
+	// unrecoverable act the command could perform.
+	edited := []byte("(sequence (seq A B))\n")
+	if err := os.WriteFile(dest, edited, 0o644); err != nil {
+		t.Fatalf("preparing the destination: %v", err)
+	}
+
+	refused(t, dest, Write(dest, io.Discard, scaffoldBytes))
+
+	kept, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("reading back the destination: %v", err)
+	}
+
+	if !bytes.Equal(kept, edited) {
+		t.Errorf("the destination now holds %q, want what was there", kept)
+	}
+
+	if left := leftovers(t, dir, "layout.sexpr"); len(left) > 0 {
+		t.Errorf("the refusal left %v behind", left)
+	}
+}
+
+func TestADirectoryAtTheDestinationIsRefused(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "layout.sexpr")
+
+	if err := os.Mkdir(dest, 0o755); err != nil {
+		t.Fatalf("preparing the destination: %v", err)
+	}
+
+	refused(t, dest, Write(dest, io.Discard, scaffoldBytes))
+}
+
+func TestASymbolicLinkIsRefusedAndNeverWrittenThrough(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "elsewhere.sexpr")
+	dest := filepath.Join(dir, "layout.sexpr")
+
+	kept := []byte("(sequence (seq A B))\n")
+	if err := os.WriteFile(target, kept, 0o644); err != nil {
+		t.Fatalf("preparing the link's target: %v", err)
+	}
+
+	if err := os.Symlink(target, dest); err != nil {
+		t.Skipf("this filesystem does not do symbolic links: %v", err)
+	}
+
+	refused(t, dest, Write(dest, io.Discard, scaffoldBytes))
+
+	through, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("reading back the link's target: %v", err)
+	}
+
+	if !bytes.Equal(through, kept) {
+		t.Errorf("the link's target now holds %q, want what was there", through)
+	}
+}
+
+func TestADanglingSymbolicLinkIsRefused(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "layout.sexpr")
+
+	// Nothing at the other end, so a Stat would report the destination as
+	// free. It is not: something is at the path, and the rule is about the
+	// path.
+	if err := os.Symlink(filepath.Join(dir, "nothing.sexpr"), dest); err != nil {
+		t.Skipf("this filesystem does not do symbolic links: %v", err)
+	}
+
+	refused(t, dest, Write(dest, io.Discard, scaffoldBytes))
+}
+
+// Not parallel, because it changes the working directory: "-" is never a
+// relative path, and the only way to say so is to look at the directory a
+// relative path would have landed in.
+func TestStandardOutputTakesTheBytesAndNoFileIsMade(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Chdir(dir)
+
+	var out bytes.Buffer
+
+	if err := Write(Stdout, &out, scaffoldBytes); err != nil {
+		t.Fatalf("writing the scaffold to standard output: %v", err)
+	}
+
+	if !bytes.Equal(out.Bytes(), scaffoldBytes) {
+		t.Errorf("wrote %q, want %q", out.Bytes(), scaffoldBytes)
+	}
+
+	if left := leftovers(t, dir); len(left) > 0 {
+		t.Errorf("a file named %v was made for a stream destination", left)
+	}
+}
+
+func TestAMissingParentDirectoryIsAFaultRatherThanATreeThisMakes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "nowhere", "layout.sexpr")
+
+	err := Write(dest, io.Discard, scaffoldBytes)
+	if err == nil {
+		t.Fatal("a destination under a directory that does not exist was written")
+	}
+
+	var failed *WriteError
+	if !errors.As(err, &failed) {
+		t.Errorf("the fault is %v, want a failed write", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "nowhere")); err == nil {
+		t.Error("the missing parent directory was created")
+	}
+}
+
+func TestNamingNoDestinationIsRefused(t *testing.T) {
+	t.Parallel()
+
+	if err := Write("", io.Discard, scaffoldBytes); err == nil {
+		t.Error("a scaffold with nowhere to go was accepted")
+	}
+}


### PR DESCRIPTION
Closes #215

`cpybkc init` now performs the derivation #214 landed the vector for: the copybooks it is given, read, and the layout scaffold they decide, written where `--out` says.

## Acceptance criteria

- [x] **One `record` per `01`-level, per copybook named, in the order the copybooks were given and within one in declaration order; the `copybook` child states the path as it was typed.** `Derive` walks the copybooks in order and their level-01 items in declaration order. The path is carried and written back unchanged — a layout's own paths are relative to the layout, so one cpybkc rewrote would be one the adopter cannot find in what they typed.
- [x] **One `alternative` child per `REDEFINES` outside a repeating group, and none where the copybook writes none; one `record` per combination where there is more than one such redefine.**
- [x] **Record names follow *How a combination's record name is chosen*, and a derived name colliding with another fails the run naming both.** One record type is the `01`-level's own name; several are the `01`-level's name followed by each chosen alternative, joined by a single `-`. A collision is `NameCollisionError`, which names both copybooks and both `01`-levels.
- [x] **The commented forms are emitted with their subjects filled in and their values as placeholders** — `encoding`, `framing`, one `rename` per record over a multi-record-type `01`-level, one `discriminate` per record, one `discriminate-variant` per redefine inside a repeating group with one `arm` per alternative, and a `sequence` naming every record once.
- [x] **`copybook-reading` is emitted, commented, when and only when some named copybook carries an `OCCURS DEPENDING ON`, with both readings named and neither chosen.**
- [x] **A `note:` names the copybook, the `01`-level, the redefine count and the record-type count wherever one `01`-level resolves to more than one record type; no bound and no refusal.** It reaches standard error through the same log a generator's lines do, carrying no generator name — which is what makes it cpybkc's own.
- [x] **No value is invented for an `encoding` axis, a `recfm`, a `discriminate` strategy or a `sequence` shape, and a placeholder uncommented without being filled in is a fault the layout reader reports naming it.** `TestEveryPlaceholderUncommentedIsAFaultTheReaderNames` uncomments each of the seven forms in turn and asserts the reader names the placeholder.
- [x] **A test asserts the scaffold parses and that the layout reader reports the whole remainder at once.** `TestTheScaffoldParsesAndTheReaderReportsTheWholeRemainder`: the missing `encoding`, the missing `framing`, one missing discriminator per record and the missing `sequence`, together.
- [x] **A test runs the derivation over `example/posting.cpy` and checks the derived forms against `example/ledger.sexpr`'s.** `TestTheWorkedExampleDerivesLedgersRecordsAndAlternatives`: six record types over one `01`-level with the same twelve `alternative` children.
- [x] **`--out` writes in full or not at all, refuses an occupied destination naming the path as typed and the absolute path, never writes through a symbolic link; `--out -` writes the scaffold to standard output and nothing else goes there.**
- [x] **Two runs over one set of copybooks produce byte-identical files.** Asserted in both the package and end to end.

## Judgment calls that shaped the public API

**`resolve.Describe` is new, and it is why there is one reading of a copybook rather than two.** The issue asks for `resolve`'s `REDEFINES` reading, and `Resolve` itself cannot be used here: it requires a complete encoding profile, an `OCCURS DEPENDING ON` reading and a statement of what selects every variant — none of which exist before a layout does. So `Describe` answers the narrower question, over the *same* `clustersOf` and the same `inTable` predicate `Resolve` calls. `Shape` carries the alternations, the combinations they multiply out to, and the `OCCURS DEPENDING ON` tables. A copybook a layout has not been written for yet is not a copybook with a fault in it, and `TestDescribingNeedsNoLayout` pins that.

**`internal/scaffold.Write` is not `internal/emit.Write`.** `emit` replaces what it finds, deliberately: a descriptor is derived entirely from its inputs, so re-emitting is the point of the flag. A layout is not — the `discriminate` forms and the `sequence` are what no copybook holds. So the destination rule is the opposite one, and it lives with the scaffold rather than being a flag on `emit`. The bytes go through a temporary beside the destination and are `link`ed on, so the refusal is atomic rather than merely checked, and a dangling symlink is refused like anything else.

**The `sequence` operator is a placeholder, not `seq`.** *What the scaffold states, form by form* asks for "a list of the record names in a shape that parses"; *The scaffold is deliberately incomplete* requires uncommenting a form without filling it in to be a reported fault. `(sequence (seq A B))` satisfies the first and fails the second — it is a legal sequence, and one cpybkc invented. `(sequence (<operator> A B))` satisfies both: every record is named once, it parses, and the reader reports the unknown operator by name.

**A record is derived for a level-01 item only.** A level-77 is a standalone work item rather than a record description, and an unnamed `01`-level is one no `record` form could name. A copybook holding neither is `NoRecordError` — status 1, the *declares no `01`-level* case.

**A `REDEFINES` over an item with no data-name is refused.** A layout names an alternative with an item reference, and a reference is a path of names, so an unnamed alternative is one no layout can write. Refusing beats emitting a reference with a hole in it that would parse and then be reported against a line cpybkc wrote.

## How it was verified

`dagger call ci` green, from an ordinary clone of this branch — `CONTRIBUTING.md`'s *The pipeline does not run from a git worktree*. `gofmt`, `go vet ./...` and `go test -race ./...` clean in the worktree as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019UM47HrC2iHccR1opzwUmm