### PR TITLE
story(conformance): the value language is specified where a second implementation can read it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1122,10 +1122,12 @@ patched at the call site.
 
 [`testdata/conformance/`](testdata/conformance/) is a set of small files with the
 right answer written down: a layout and its copybooks, the IR they resolve to,
-the bytes of a file laid out that way, and the values those bytes decode to. Its
-README is the format, and it is the whole of the documentation — the corpus is
-test infrastructure, so it documents itself where it lives rather than under
-`docs/` ([`docs/CONVENTIONS.md`](docs/CONVENTIONS.md), *What belongs here*).
+the bytes of a file laid out that way, and the values those bytes decode to. The
+format is [`docs/conformance/SPEC.md`](docs/conformance/SPEC.md) — a generator
+author in another language implements it, which is the test
+[`docs/CONVENTIONS.md`](docs/CONVENTIONS.md), *What belongs here*, applies — and
+the corpus's README is what stays with the corpus: which entries there are, what
+each was derived from, and how to add one.
 
 ```sh
 go test ./internal/conformance/...
@@ -1142,8 +1144,9 @@ matrix: the matrix is a matrix of `dagger call ci`, and a conformance job of its
 own would be a second gate that a platform added to the matrix would silently not
 carry. What it is not is a check of the bytes the writer produced —
 [`docs/ir/SPEC.md`](docs/ir/SPEC.md)'s *Writing a file* makes byte identity a
-claim about a record and not about a file, and the corpus README's *Why the
-writing direction is checked by reading* is the rest of the argument.
+claim about a record and not about a file, and
+[`docs/conformance/SPEC.md`](docs/conformance/SPEC.md)'s *Why the writing
+direction is checked by reading* is the rest of the argument.
 
 It exists because cpybkc is strictly a generator: nothing here reads a data file
 except the code a generator emitted, so nothing else holds two generators in two
@@ -1152,13 +1155,14 @@ citation, and the README says how.
 
 ## Specs
 
-Four of this project's interfaces are built against from outside it — the file
-layout format, the resolved IR, the plugin CLI contract and the container
-base-image contract — and each is far harder to change than the code behind it.
-Each has a `SPEC.md` under [`docs/`](docs/), linked from
-[README.md](README.md), which is the only list of them.
+Six of this project's interfaces are built against from outside it — the command
+line, the file layout format, the resolved IR, the plugin CLI contract, the
+container base-image contract and the conformance corpus format — and each is
+far harder to change than the code behind it. Each has a `SPEC.md` under
+[`docs/`](docs/), linked from [README.md](README.md), which is the only list of
+them.
 
-[`docs/CONVENTIONS.md`](docs/CONVENTIONS.md) is what those four agree on: the
+[`docs/CONVENTIONS.md`](docs/CONVENTIONS.md) is what those six agree on: the
 conformance language, the section set every spec carries, how sources are cited
 and how requirements are traced back to stories. It is defined there once and
 referenced, never restated — the same argument this file already makes about the
@@ -1168,11 +1172,12 @@ pipeline and the lint configuration, applied to the word **MUST**.
 
 [`cobol-go`](https://github.com/Zaba505/cobol-go) puts `codec/SPEC.md` next to
 package `codec`, and it is the model these specs follow in every other respect.
-It is not followed here because three of the four specify things that are not Go
-packages: a text file format, a CLI contract for executables that may be shell
-scripts, and an OCI image. Package-adjacency would have conjured an empty
-`container/` package into existence to hold one markdown file, and would have
-scattered four documents that are peers — a reader comparing what the plugin
+It is not followed here because five of the six specify things that are not Go
+packages: a command line, a text file format, a CLI contract for executables
+that may be shell scripts, an OCI image, and a directory of test fixtures.
+Package-adjacency would have conjured an empty `container/` package into
+existence to hold one markdown file, and would have
+scattered six documents that are peers — a reader comparing what the plugin
 contract promises against what the image provides should not have to know the
 package tree to find both.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A modular code generator for files composed COBOL copybook records
 
 ## Specs
 
-Five interfaces are built against from outside this repository, so each is
+Six interfaces are built against from outside this repository, so each is
 specified rather than merely implemented:
 
 - [The command-line interface](docs/cli/SPEC.md) — what a person types, where
@@ -16,9 +16,11 @@ specified rather than merely implemented:
   `cpybkc-gen-<name>` has to implement.
 - [The container base-image contract](docs/container/SPEC.md) — what a
   Dockerfile building `FROM` the published image may rely on.
+- [The conformance corpus format](docs/conformance/SPEC.md) — what a generator
+  in any language is held to, and the language the answer is written in.
 
 [docs/CONVENTIONS.md](docs/CONVENTIONS.md) defines the conformance language all
-five use, and what else they have in common.
+six use, and what else they have in common.
 
 A generator plugin written in Go imports the resolved IR from
 [`irpb`](irpb/) — `github.com/Zaba505/cpybkc/irpb`, a module of its own, so that

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -1,15 +1,15 @@
 # Spec conventions
 
-Five of cpybkc's interfaces are things other people build against rather than
+Six of cpybkc's interfaces are things other people build against rather than
 things it is free to change: the command line itself, the file layout format,
-the resolved IR, the generator plugin CLI contract, and the container
-base-image contract. Each is harder to change than the code behind it, so each
-gets a `SPEC.md` under this directory. They are linked from the
-[README](../README.md), which is the only list of them — a second list here
-would be a second answer to what the specs are, and two answers drift.
+the resolved IR, the generator plugin CLI contract, the container base-image
+contract, and the conformance corpus format. Each is harder to change than the
+code behind it, so each gets a `SPEC.md` under this directory. They are linked
+from the [README](../README.md), which is the only list of them — a second list
+here would be a second answer to what the specs are, and two answers drift.
 
 This document is what those specs agree on. It exists because the alternative is
-five documents that each invent a shape and each define **MUST** in their own
+six documents that each invent a shape and each define **MUST** in their own
 wording, so that having read one teaches you nothing about how to read the next.
 
 The model throughout is [`cobol-go`'s `codec/SPEC.md`][codec-spec] — the spec
@@ -29,9 +29,14 @@ That is the whole test, and it excludes more than it admits:
   `ir/SPEC.md`. A second document describing how it computes that would drift
   from the code the first time an optimisation landed, and nobody outside this
   repository builds against it.
-- **Test infrastructure documents itself where it lives.** The conformance
-  corpus is a `testdata/` format, run by a harness here and by third-party
-  generators against their own output. It is documented with the corpus.
+- **Test infrastructure documents itself where it lives — until a third party
+  implements it.** A `testdata/` format read only by a harness here is
+  documented with the fixtures. The conformance corpus stopped being one: a
+  generator author in another language implements its value language to be
+  compared at all, so the *format* is a spec (`conformance/SPEC.md`) while the
+  corpus's own entries, their derivations and how to add one stay with the
+  corpus. The test is who has to implement it, never which directory it sits
+  in.
 - **Conveniences over a contract are not contracts.** The Dagger module that
   runs cpybkc for a caller wraps the container contract; what it needs to say is
   said by its module comment and `dagger call --help`.

--- a/docs/conformance/SPEC.md
+++ b/docs/conformance/SPEC.md
@@ -1,0 +1,660 @@
+# The Conformance Corpus Format
+
+## Overview
+
+Nothing in cpybkc reads a data file. It is strictly a code generator, so the
+only thing that ever decodes a record is the code a generator emitted, in
+whatever language it emitted it — and nothing in a descriptor obliges two
+generators handed the same bytes to agree about what those bytes hold. The
+conformance corpus is the mechanism that holds them to each other: a set of
+small files with the right answer written down, so that a generator written by
+somebody who has never seen this repository can be asked the same question
+`cpybkc-gen-go` is asked, and the two answers compared without a decoder in the
+middle.
+
+This document specifies the files that question and its answer are written in:
+what an entry is made of, the value language a decoded record is written in, and
+the answer document a runner writes on standard output. It is the half a third
+party implements. It is deliberately language-neutral throughout — a comparison
+of two answers needs neither the descriptor nor a decoder, which is what makes a
+runner for a language this repository has never seen comparable by exactly the
+same rules as its own.
+
+What a value *means* is not here. How wide a `PIC S9(5) COMP-3` item is, which
+nibble carries its sign, where one record ends and the next begins, and which
+record type a run of bytes is are the [resolved IR](../ir/SPEC.md)'s and, below
+it, [`cobol-go`'s `codec/SPEC.md`][codec-spec]'s. How a generator is found and
+invoked is the [plugin contract](../plugin/SPEC.md)'s. Which entries the corpus
+holds, why each of them is there and how to add one are the corpus's own, in
+[`testdata/conformance/README.md`](../../testdata/conformance/README.md), which
+is where the corpus documents itself.
+
+What the bytes mean belongs there; how the answer to "what do they decode to" is
+written down belongs here.
+
+[codec-spec]: https://github.com/Zaba505/cobol-go/blob/main/codec/SPEC.md
+
+### Scope
+
+In scope: the directory an entry is, the members it holds and the one member
+that is reserved; the value language every decoded record is written in, down to
+the admissible spelling of each scalar; how a file the generated reader refused
+is reported; what a runner is asked to do and what it is deliberately not asked
+to do; and the answer document it writes.
+
+Out of scope, with reasons, in [Out of Scope](#out-of-scope).
+
+### Governing sources
+
+- **[`ir/SPEC.md`](../ir/SPEC.md)**, *The resolved IR* — normative for the
+  descriptor an entry carries and for every node kind the value language has to
+  write down. The value language names groups, tables, variants and slack; what
+  each of those *is* is defined there, and this document never restates one.
+- **[`cobol-go`'s `codec/SPEC.md`][codec-spec]**, *the codec specification* —
+  normative for what a field's bytes decode to, which is the answer an entry
+  writes down. Its Appendix A is where most of the corpus's entries are derived
+  from, and an entry that disagrees with it is a wrong entry.
+- **RFC 8259**, *The JavaScript Object Notation (JSON) Data Interchange Format*
+  — normative for every document specified here. It is what fixes that a member
+  name is a string, that a document is one value, and what an implementation may
+  assume about a JSON number, which is why the value language uses so few of
+  them. <https://www.rfc-editor.org/rfc/rfc8259>
+- **RFC 4648**, *The Base16, Base32, and Base64 Data Encodings* — normative for
+  the base64 form, and specifically for section 4's alphabet as against section
+  5's. A run of bytes needs one spelling and this is where it is defined.
+  <https://www.rfc-editor.org/rfc/rfc4648>
+- **ISO/IEC 9899:2018**, *Programming languages — C*, 6.4.4.2 and the `%a`
+  conversion of 7.21.6.1 — the hexadecimal floating notation a floating-point
+  item is written in. Cited because the notation is C's rather than this
+  project's: a form invented here would be one no implementation's library
+  already reads or writes.
+  <https://www.iso.org/standard/74528.html>
+- **IEEE 754-2019**, *Standard for Floating-Point Arithmetic* — normative for
+  what a `COMP-1` or `COMP-2` item holds under the IEEE profile, and for the
+  distinction between a positive and a negative zero that the float form is
+  required to preserve. <https://standards.ieee.org/ieee/754/6210/>
+- **IBM z/Architecture Principles of Operation**, *Hexadecimal-Floating-Point
+  Instructions* — normative for what the same item holds under the HFP profile.
+  It is cited here for one property: HFP long carries a 56-bit fraction where an
+  IEEE double carries 53, so a form that could only spell a double would be a
+  form that cannot spell every value this corpus is about.
+  <https://www.ibm.com/docs/en/zos/3.1.0?topic=set-hexadecimal-floating-point-instructions>
+
+> **Ambiguity:** the sources do not overlap, and this document resolves nothing
+> between them. Where it appears to contradict [`ir/SPEC.md`](../ir/SPEC.md)
+> about what a descriptor carries, that document wins and this one has a bug;
+> where it appears to contradict [`codec/SPEC.md`][codec-spec] about what bytes
+> decode to, that document wins for the same reason. This document specifies how
+> an answer is written down and never what the answer is — the one place the two
+> could collide is a spelling rule that made a correct answer unwritable, and
+> that is a defect in this document by definition.
+
+### Conformance language
+
+**MUST**, **MUST NOT**, **SHOULD** and **MAY** are normative requirements on a
+corpus entry, on a runner, and on a harness that loads or compares either,
+interpreted as described in [CONVENTIONS.md](../CONVENTIONS.md). Everything else
+is descriptive.
+
+## An entry
+
+An entry is one directory, named for what it is about. The name is what every
+diagnostic about the entry quotes, so it is the entry's identity and nothing
+else is.
+
+| File | What it is | Required |
+|---|---|---|
+| `entry.json` | What the entry is about, and the section its expected answer came from. | yes |
+| `layout.sexpr` | The [layout](../layout/SPEC.md) the file is laid out by. | yes |
+| `*.cpy` | The copybooks that layout names, at the paths it spells them. | one or more |
+| `ir.json` | The [IR](../ir/SPEC.md) the layout and those copybooks resolve to. | yes |
+| `input.bin` | The bytes of one file laid out that way. | yes |
+| `values.json` | What those bytes decode to. | yes |
+| `offsets.json` | Reserved. See [below](#offsetsjson-is-reserved). | no |
+
+An entry directory **MUST** hold each required member, under exactly the name
+above, and at least one file whose name ends in `.cpy`. It **MAY** hold
+`offsets.json`. It **MUST NOT** hold any other file, and it **MUST NOT** hold a
+subdirectory (#66).
+
+A file the format has no place for is refused rather than ignored, which is the
+rule the [project manifest](../plugin/SPEC.md) already applies to an unknown
+field: a file somebody added to an entry in the expectation that something reads
+it is worse than one whose author is told nothing does.
+
+The member names are fixed by this document rather than declared in `entry.json`
+because a tuple whose members could be anywhere is a tuple every reader has to
+be told about, and a third-party runner should be able to open a file without
+parsing something else first.
+
+### `entry.json`
+
+```json
+{
+  "description": "A fixed-length dataset of one record type: ...",
+  "source": "cobol-go codec/SPEC.md, \"Storage Widths\"; docs/ir/SPEC.md, \"Physical framing\""
+}
+```
+
+Both members are required, both are non-empty strings, and there is no third
+member. An unknown member **MUST** be refused.
+
+`source` is what a failing run prints beside the entry's name. Whoever reads
+that report has to decide whether the generator is wrong or the entry is, and
+that decision starts at where the expected answer came from — so an entry
+recorded from what a generator printed, rather than derived from a
+specification, is an entry that passes forever including through the bug it was
+written to catch.
+
+### `layout.sexpr` and the copybooks
+
+The layout is read by [`layout/SPEC.md`](../layout/SPEC.md)'s rules and the
+copybooks by the COBOL standard's; neither is restated here. Which copybooks the
+layout names is the layout's business. What this document requires is only that
+the files it names are in the directory beside it, at the paths it spells them,
+so that an entry is self-contained: a runner clones the corpus and nothing else.
+
+### `ir.json`
+
+The descriptor, in the canonical JSON rendering — protobuf's own field names,
+field-number order, two-space indent — which is what `cpybkc --emit-ir
+--emit-ir-format json` writes and what [the rendering is
+normalized](../ir/SPEC.md#the-rendering-is-normalized) specifies.
+
+`ir.json` **MUST** be a descriptor that is valid under
+[`ir/SPEC.md`](../ir/SPEC.md), and it **MUST** be byte for byte the canonical
+rendering of the descriptor it carries. An entry is written and reviewed by
+hand, so it is reviewed as a diff of its content; a rendering that varied would
+make every review of an entry a review of its whitespace.
+
+It is JSON rather than the binary form for the same reason: an entry is
+authored by a person. A runner that would rather have the bytes a plugin is
+handed — which is what [`plugin/SPEC.md`](../plugin/SPEC.md) says a generator
+receives — encodes what it read, and any protobuf runtime turns one into the
+other with the schema every release attaches.
+
+The descriptor is hand-authored, which is what makes it an oracle rather than a
+recording of what `resolve` happens to do today. An entry therefore states two
+independent things: that the layout and its copybooks resolve to this
+descriptor, which is a claim about a *producer*; and that this descriptor,
+handed to a generator, produces code that decodes `input.bin` into
+`values.json`, which is a claim about a *consumer*. Carrying both is what lets a
+failure be attributed, because an author who disagrees with cpybkc about what a
+layout means and one who disagrees about what a descriptor means have different
+bugs.
+
+### `input.bin`
+
+The bytes of one file laid out the way the layout says. A file of no bytes is
+admitted: an empty file is a file, and a layout whose sequencing expression
+accepts nothing is exactly what one entry ought to be about.
+
+### `values.json`
+
+What those bytes decode to, in the value language below.
+
+```json
+{
+  "records": [
+    {
+      "name": "ORDER-RECORD",
+      "value": {
+        "ORDER-ID": "A001",
+        "ORDER-QTY": "42",
+        "ORDER-LINE": [
+          {"LINE-SKU": "SK1"},
+          {"LINE-SKU": "SK2"}
+        ]
+      }
+    }
+  ]
+}
+```
+
+A values document **MUST** carry `records`, an array of the records read in file
+order, and **MAY** carry `failure`. It **MUST NOT** carry any other member, and
+a reader **MUST** refuse one — a key an author wrote expecting it to mean
+something is a typo, and a document that ignores it passes for the wrong reason.
+
+Each record carries `name` and `value`, both required and neither empty.
+
+`name` **MUST** be the record's name as the copybook spells it — the `original`
+of the record node's [names](../ir/SPEC.md#names), never an identifier a
+generator munged out of it. Two generators munge differently and a corpus keyed
+to one of them would be a corpus only that one can pass.
+
+`value` is what the record's top-level node holds, written as [the value
+language](#the-value-language) says.
+
+### `offsets.json` is reserved
+
+An entry **MAY** carry a file named `offsets.json`, and a loader **MUST NOT**
+refuse an entry that carries one. Its content is **not specified by this
+document**, nothing reads it, and no entry in the corpus carries one. An entry
+**SHOULD NOT** carry one until a story specifies what is in it.
+
+The name is reserved now because reserving it is free now. Adding a member to a
+published format is a coordinated change across every runner that validates an
+entry's listing, and this format is still private; a generator that never opens
+`input.bin` — a diagram, a schema translation, a documentation generator — runs
+the same position sum a decoder runs and gets it wrong in the same way, so there
+is a plausible second oracle here whose shape is an offset table. Whether the
+corpus is where that oracle belongs is open, and that discussion is #193's, not
+this document's.
+
+## The value language
+
+Every decoded value is JSON, and every scalar is a JSON string. The language is
+small on purpose: the comparison of two answers is then structural, needs
+neither the descriptor nor a decoder, and can be run by a harness that has never
+heard of COBOL.
+
+### Which form a value takes is decided by the descriptor
+
+For an elementary item, the form is a function of the descriptor's `usage` and
+`category` alone, in this order (#66):
+
+1. `USAGE_COMP_1` or `USAGE_COMP_2` — [a floating-point
+   item](#a-float-is-written-exactly-and-never-as-a-json-number).
+2. `USAGE_INDEX`, `USAGE_POINTER` or `USAGE_NATIONAL` — [a run of
+   bytes](#index-pointer-and-national-are-base64).
+3. Otherwise `CATEGORY_NUMERIC` — [a number](#a-number-is-a-decimal-string).
+4. Otherwise — `CATEGORY_ALPHABETIC`, `CATEGORY_ALPHANUMERIC`,
+   `CATEGORY_NUMERIC_EDITED` or `CATEGORY_ALPHANUMERIC_EDITED` —
+   [characters](#characters-and-why-trailing-spaces-do-not-survive).
+
+Usage is read before category because the two floating-point usages carry
+`CATEGORY_NUMERIC` and are not written as numbers, and because a national item
+is characters in a character encoding this format does not decide. An
+implementation that keyed on category alone would write a `COMP-1` as decimal
+digits and be wrong for every value with a fraction.
+
+### A group, a table and a variant
+
+| The node | Written as |
+|---|---|
+| A group | An object, one member per node it holds, keyed by the copybook's name for that node. |
+| An item that repeats | An array, one element per occurrence, in file order. |
+| A variant | One key per arm in the enclosing object, of which the occurrence carries exactly one; an arm the occurrence does not hold has no key at all. |
+| A slack node | Nothing at all. |
+
+A repeating node is an array whether it is a group or an elementary item, and
+whether it occurs a fixed number of times or a variable one; the array's length
+is the number of occurrences the file actually holds. A repeating node
+**MUST NOT** be written as anything but an array, including where it happens to
+hold one occurrence — a value language in which a table of one and a scalar look
+the same is one in which a generator that lost a table passes.
+
+A variant occurrence carries exactly one arm, which is what [a variant is chosen
+once per occurrence](../ir/SPEC.md#a-variant-is-chosen-once-per-occurrence)
+requires. An arm the occurrence does not hold **MUST** have no key, rather than
+a key whose value is `null`: a comparison then reports an unheld arm as the
+selection difference it is, instead of as a value that differs.
+
+### Slack is not a value
+
+A slack node **MUST NOT** appear in a values document. Its bytes travel with the
+record — [slack survives a read](../ir/SPEC.md#slack-survives-a-read) is what a
+reader does with them and a writer puts them back — but they are not something
+anybody decoded, and a value language that surfaced them would be asking two
+generators to agree about padding rather than about data.
+
+### Characters, and why trailing spaces do not survive
+
+An item in one of the four character categories is written as a JSON string of
+its characters, after the file's charset has been applied, with every trailing
+space removed (#66).
+
+- A writer of a values document **MUST** remove every trailing U+0020 SPACE.
+- It **MUST NOT** remove a leading or an interior space.
+- An item holding nothing but spaces is therefore written `""`.
+- It **MUST NOT** remove any other character — not a tab, not a NUL, not a
+  character that a charset happens to render as blank.
+
+Trailing spaces are how COBOL pads an alphanumeric item to its declared width,
+and the padding is not data: `HDR-NAME PIC X(15)` holding `BATCH-0001` and five
+spaces holds a ten-character name in a fifteen-character field, and every
+generator that keeps the padding would have to agree with every other about a
+detail none of them was told. The round trip is unaffected, because a writer
+pads back out to the declared width from the value it was given.
+
+The cost is stated rather than hidden: an item whose data genuinely ends in a
+space cannot be told apart from one that was padded, and this format has no way
+to write that item down. That is accepted. Space padding is universal in the
+files this corpus is about, and a rule that preserved the padding would make
+every entry's expected value depend on a width the value language does not
+carry.
+
+The rule is stated in terms of the *characters*, not of the bytes, so it holds
+identically for an EBCDIC file whose pad byte is `0x40` and an ASCII one whose
+pad byte is `0x20`.
+
+### A number is a decimal string
+
+A numeric item — zoned, packed, `COMP-6`, binary or `COMP-5` — is written as a
+JSON string of its decimal digits (#66).
+
+```abnf
+number  = "0" / [ "-" ] NONZERO *DIGIT
+NONZERO = %x31-39   ; 1-9
+```
+
+- It **MUST NOT** be written as a JSON number. JSON numbers are doubles in most
+  readers, and a `PIC S9(18)` item holds values a double cannot represent.
+- It **MUST NOT** carry a leading `+`. One spelling per value, and the negative
+  case already needs its sign.
+- It **MUST NOT** carry a leading zero. `"07"` and `"7"` are the same value and
+  a format that admitted both would compare two correct generators as
+  disagreeing.
+- It **MUST NOT** be `"-0"`. Zero is written `"0"` whatever sign the bytes
+  carry, and a packed `00 0D` — a legitimate negative zero as a byte pattern —
+  decodes to `"0"`.
+- It **MUST NOT** carry a decimal point, an exponent, a space, a grouping
+  separator, or any character outside the grammar above.
+- The digits are the **unscaled** ones. An implied decimal point is not applied,
+  for the same reason a generated accessor does not apply one: the point is in
+  the descriptor, and applying it here would apply it twice by the time a caller
+  saw the value.
+
+Negative zero is excluded rather than admitted because a COBOL numeric item does
+not have one. The standard makes the sign of zero insignificant — arithmetic
+produces an unsigned zero and a comparison of `-0` against `+0` is equality — so
+`"-0"` would be a spelling of a *byte pattern* rather than of a value, and two
+generators would be compared on which sign nibble their source file happened to
+carry. It would also make the writing direction unpassable: a writer given zero
+emits the positive sign nibble its convention prescribes, so an entry demanding
+`"-0"` back would demand bytes no correct writer produces.
+
+An entry that is *about* a negative-zero byte pattern is still perfectly
+writable. The pattern goes in `input.bin`, and what it decodes to is `"0"`.
+
+### A float is written exactly, and never as a JSON number
+
+A `COMP-1` or `COMP-2` item is written as a JSON string: either one of three
+sentinels, or the exact value in hexadecimal significand notation (#194, #195).
+
+```abnf
+float       = "NaN" / infinity / hex
+infinity    = [ "-" ] "Infinity"
+hex         = [ "-" ] "0x" significand "p" sign exponent
+significand = "0" / ( "1" [ "." 1*LOWHEX ] )
+sign        = "+" / "-"
+exponent    = "0" / NONZERO *DIGIT
+LOWHEX      = DIGIT / %x61-66   ; 0-9 a-f
+NONZERO     = %x31-39           ; 1-9
+```
+
+The value is significand × 2^exponent, where the significand is read as a
+hexadecimal fraction. `0x1p+0` is 1, `0x1.2p+3` is 9, `0x1p-5` is 0.03125, and
+`-0x0p+0` is negative zero.
+
+One value has one spelling, which is what lets a comparison be string equality:
+
+- `x`, `p` and every hexadecimal digit **MUST** be lowercase.
+- The significand **MUST** be `0` if and only if the value is zero, and `1`
+  otherwise. Every non-zero value, including a subnormal one, is normalized.
+- The fraction **MUST NOT** end in `0`, and the `.` **MUST** be absent when
+  there is no fraction.
+- The exponent's sign **MUST** be written, even where it is `+`, and the
+  exponent **MUST NOT** carry a leading zero. A zero exponent is `+0`.
+- `"NaN"` is every NaN. Its sign and its payload are **not** distinguished.
+- A value **MUST NOT** be written as a JSON number, and **MUST NOT** be written
+  in decimal at all.
+
+Four things break under a JSON number, and each is why this form exists. NaN and
+the infinities are not JSON numbers and most writers refuse them outright, which
+turns a generator's correct answer into a harness that could not write a
+document. `-0.0` and `0.0` compare equal under IEEE equality, so a generator
+that lost the sign of a zero passes silently. An authored decimal like `0.1` is
+not a `COMP-1` value at all, so every correct implementation would have to write
+`0.10000000149011612` and an entry's author would have to compute it. And HFP
+long carries a 56-bit fraction where an IEEE double carries 53, so there are
+values a correct HFP decoder produces that no double spells — a form that went
+through a double would be a form that cannot state them.
+
+The notation is C's hexadecimal floating constant, which is `%a` in `printf`,
+`strconv.FormatFloat(f, 'x', -1, 64)` in Go, `float.hex()` in Python and
+`Double.toHexString` in Java. Every one of those spells the same values and none
+of them spells them in exactly the canonical form above — Go pads the exponent
+to two digits, Python writes a fixed-width fraction, Java omits the `+` — so an
+implementation normalizes its library's output rather than printing it. That is
+a few lines in any language, and the alternative was a form whose parser nobody
+already has.
+
+Hexadecimal rather than base64 of the stored bytes, which was the other
+candidate: base64 of the bytes states what the *file* holds, and what an entry
+has to state is what a *reader made of them*. Under
+[`float-hfp-read-as-ieee`](../../testdata/conformance/float-hfp-read-as-ieee)
+one run of bytes is read two ways on purpose — as HFP it is 1, as IEEE it is 9 —
+and a form that echoed the bytes would make both readings identical and the
+entry vacuous.
+
+The corpus's own float entries are written in this form by #195, which is also
+where the comparison stops being IEEE equality. They are the only members of the
+corpus that do not carry it yet.
+
+### `INDEX`, `POINTER` and `NATIONAL` are base64
+
+An item whose usage is `USAGE_INDEX`, `USAGE_POINTER` or `USAGE_NATIONAL` is
+written as a JSON string of its bytes in base64 (#66).
+
+- The alphabet **MUST** be RFC 4648 section 4's — `A`–`Z`, `a`–`z`, `0`–`9`, `+`
+  and `/`. The URL-safe alphabet of section 5 **MUST NOT** be used: these values
+  never appear in a URL, and section 4's is what every language's default
+  encoder produces.
+- The encoding **MUST** be padded with `=` to a multiple of four characters.
+- It **MUST NOT** carry a line break, a space, or any character outside the
+  alphabet and the padding.
+- The unused bits of the final quantum **MUST** be zero, which is the canonical
+  encoding RFC 4648 section 3.5 describes.
+- An item of no bytes is written `""`.
+
+These three are bytes rather than characters because their content is not this
+format's to interpret. An `INDEX` or a `POINTER` holds an implementation's own
+representation, and a `NATIONAL` item holds a character encoding the descriptor
+records and this document does not decide; base64 states exactly what was there
+and claims nothing about what it means.
+
+### A file the reader refused
+
+A file the generated reader refuses is an answer, not a crash. The values
+document carries a `failure` beside the records it did read:
+
+```json
+{
+  "records": [ ... ],
+  "failure": "the sign nibble is not one of the four the convention admits"
+}
+```
+
+`failure` **MUST** be present exactly when reading stopped before the end of the
+file, and absent otherwise. `records` **MUST** hold the records that were read
+before the failure, in file order.
+
+The text is a note for whoever reads the report and **MUST NOT** be compared: a
+diagnostic is a generator's own wording in its own language, so an entry
+demanding particular words would be an entry only one generator could pass. What
+is compared is that reading failed, and that it failed after the records listed.
+
+### Comparison is over the written form
+
+A harness comparing two values documents **MUST** compare a scalar by its
+written form — string equality — and **MUST NOT** decode either side into a
+numeric type first (#196).
+
+That is the whole reason the language spells everything exactly. Comparing
+decoded numbers would make an eighteen-digit item equal to a different
+eighteen-digit item that rounds to the same double, and — the case that has
+actually bitten — would make a negative zero equal a positive one under IEEE
+equality, so a generator that lost the sign of a zero would pass.
+
+A loader **SHOULD** refuse a values document whose scalars are not in the forms
+above, rather than leaving the difference to be reported by a comparison against
+a generator (#196). An author who writes `"012"` where the format says `"12"`
+should be told by the thing that read their file, not by a generator appearing
+to disagree with them.
+
+## What a runner does
+
+A runner is the language-specific half, and there is one per generator language.
+Given an entry it:
+
+1. hands `ir.json` — as the binary encoding, which is what
+   [`plugin/SPEC.md`](../plugin/SPEC.md) says a plugin is given — to the
+   generator under test, with whatever options that generator needs;
+2. compiles what came back;
+3. reads `input.bin` with it, top to bottom;
+4. where that read reached the end of the file, writes those records back out
+   with the generated writer and reads *that* file with the generated reader;
+5. writes an answer document on standard output.
+
+A runner **MUST** write exactly one JSON document on standard output and nothing
+else on that stream.
+
+A runner **MUST NOT** exit non-zero because the generated reader refused the
+file, or because the generated writer refused a record: those are answers, an
+entry is allowed to expect one, and only the comparison knows whether this entry
+did. A runner **MUST** exit non-zero when it could not produce an answer at all
+— the generator would not run, its output would not compile, or the document
+could not be written.
+
+A runner is not asked to explain a difference. That is the comparison's job, and
+a runner that argued its own case would be a runner whose report had to be
+trusted.
+
+### The answer document
+
+```json
+{
+  "decoded": {
+    "records": [ ... ]
+  },
+  "written": {
+    "records": [ ... ]
+  }
+}
+```
+
+`decoded` is required and is what the generated reader made of `input.bin`.
+`written` is optional and is what the generated reader makes of the file the
+generated *writer* produced from those records. Both are values documents, in
+exactly the form `values.json` is written in, and an unknown member **MUST** be
+refused.
+
+Both are compared against `values.json` — against the entry rather than against
+each other, because a reader and a writer that are wrong the same way agree with
+each other and only the entry knows what the file holds.
+
+`written` **MUST** be absent in two cases: where the read did not reach the end
+of the file, since a run that stopped at a failure holds no complete set of
+records to write back; and where the generator emits no writer at all, which
+[*Writing a file*](../ir/SPEC.md#writing-a-file) leaves to the generator. It is
+present and carries a `failure` where the writer refused a record it was given.
+
+### Why the writing direction is checked by reading, and not by comparing bytes
+
+The obvious check is that the bytes the writer produced are `input.bin` again,
+and it is the wrong check twice over.
+
+[*Writing a file*](../ir/SPEC.md#writing-a-file) makes byte identity a claim
+about a **record** and deliberately not about a file: under an optional
+terminator a writer emits a final delimiter the input need not have carried, and
+under segmented framing it lays a record into as few segments as the largest
+allows, whatever the input did. A corpus demanding the input's bytes back would
+fail two of the four framings by design.
+
+It is wrong at the field level too, and the corpus already holds the case:
+[`packed-ascii`](../../testdata/conformance/packed-ascii) carries the lenient
+sign nibble `A`, which a reader admits as positive and a writer has no reason to
+emit — it writes the `C` the convention prescribes. The same goes for every
+encoding that admits more than one spelling of one value.
+
+What *Writing a file* does make normative of a file is that a file a writer
+produces is one that a reader built from the same descriptor reads back as the
+records the writer was given. That holds for all four framings and every
+encoding, it is what `written` states, and it needs nothing of a runner that the
+reading direction did not already need.
+
+## Out of Scope
+
+### What a value means
+
+How many bytes an item occupies, which nibble carries its sign, how a record is
+framed, and which record type a run of bytes is are **not specified here**.
+
+Reason: they are [`ir/SPEC.md`](../ir/SPEC.md)'s and, beneath it,
+[`codec/SPEC.md`][codec-spec]'s. This document specifies how the answer is
+written down, and it is useful precisely because it is independent of the answer
+— a comparison of two values documents needs no decoder, which is what lets a
+harness compare a runner for a language it knows nothing about. Restating any of
+the byte-level rules here would produce a second description for the two to
+disagree about.
+
+### The corpus's own entries
+
+Which entries exist, what each covers, which specification section it was
+derived from, and how to add one are **not specified here**.
+
+Reason: they are the corpus's, and the corpus documents itself where it lives
+([`testdata/conformance/README.md`](../../testdata/conformance/README.md), and
+[CONVENTIONS.md](../CONVENTIONS.md)'s *What belongs here*). The catalogue
+changes every time an entry is added; this document changes when the format
+does, which should be almost never. Binding them into one document would make
+every new entry a change to a published interface.
+
+### The content of `offsets.json`
+
+The member name is reserved and its content is **not specified here**.
+
+Reason: whether a corpus entry is the right home for an offset oracle at all is
+an open question (#193), and specifying a member before deciding that would be
+specifying it twice. What is cheap now and expensive later is the *name*, which
+is why the name is reserved and nothing else is.
+
+### How a generator is invoked
+
+The argument vector, the `PATH` search, the exit codes and the option syntax are
+**not specified here**.
+
+Reason: they are the [plugin contract](../plugin/SPEC.md)'s (#39). A runner
+invokes a generator through that contract like any other caller, and a second
+description of it here would be one a plugin author could find and follow into
+disagreement.
+
+### Also out of scope
+
+- **A test framework.** Nothing here says how a runner is built, what a harness
+  reports, or what exit code a failing comparison produces. `go test
+  ./internal/conformance/...` is this repository's answer and it is one answer
+  among many.
+- **A conformance level or a badge.** There is no partial conformance, no
+  profile and no score. An entry either compares equal or it does not.
+- **A wire protocol between a harness and a runner.** A runner is a process that
+  writes a document on standard output, for the same reason a plugin is an
+  executable rather than a server.
+- **A descriptive generator's oracle.** A generator that never reads bytes has
+  no values document to write, and what it should be held to instead is #193's.
+
+## Appendix: Mapping to Stories
+
+| Section | Implemented by |
+|---|---|
+| [An entry](#an-entry) | #66 `conformance` for the format and the loader that holds a directory to it |
+| [`entry.json`](#entryjson) | #66 `conformance` |
+| [`ir.json`](#irjson) | #66 `conformance`; the canonical rendering it is held to, #20 `ir` |
+| [`values.json`](#valuesjson) | #66 `conformance` |
+| [`offsets.json` is reserved](#offsetsjson-is-reserved) | #194 `conformance` for the reservation; the discussion it comes from is #193, and no story specifies its content |
+| [Which form a value takes is decided by the descriptor](#which-form-a-value-takes-is-decided-by-the-descriptor) | #66 `conformance`; #194 `conformance` for stating it as a procedure over `usage` and `category` |
+| [A group, a table and a variant](#a-group-a-table-and-a-variant) | #66 `conformance` |
+| [Characters, and why trailing spaces do not survive](#characters-and-why-trailing-spaces-do-not-survive) | #66 `conformance` for the behaviour the corpus already expects; #194 `conformance` for deciding it and writing it down |
+| [A number is a decimal string](#a-number-is-a-decimal-string) | #66 `conformance` for the form; #194 `conformance` for the canonical spelling, including negative zero; #196 `conformance` for the loader that enforces it |
+| [A float is written exactly, and never as a JSON number](#a-float-is-written-exactly-and-never-as-a-json-number) | #194 `conformance` decides the form; #195 `conformance` writes and compares it, and migrates the float entries |
+| [`INDEX`, `POINTER` and `NATIONAL` are base64](#index-pointer-and-national-are-base64) | #66 `conformance` for base64; #194 `conformance` for the alphabet and the padding; #196 `conformance` for enforcing them |
+| [A file the reader refused](#a-file-the-reader-refused) | #66 `conformance` |
+| [Comparison is over the written form](#comparison-is-over-the-written-form) | #68 `conformance` for the comparison; #195 and #196 `conformance` for it being over the written form |
+| [What a runner does](#what-a-runner-does) | #68 `conformance` for the Go runner that implements it |
+| [The answer document](#the-answer-document) | #68 `conformance` |
+| [Why the writing direction is checked by reading](#why-the-writing-direction-is-checked-by-reading-and-not-by-comparing-bytes) | #68 `conformance`; the rule it rests on, *Writing a file*, #17 `ir` |
+| The corpus's entries, and what each covers | #67 `conformance`, and one story per entry since |
+| This document | #194 `conformance` |
+| Conventions this document follows | #15 `setup` |

--- a/docs/conformance/SPEC.md
+++ b/docs/conformance/SPEC.md
@@ -59,6 +59,12 @@ Out of scope, with reasons, in [Out of Scope](#out-of-scope).
   name is a string, that a document is one value, and what an implementation may
   assume about a JSON number, which is why the value language uses so few of
   them. <https://www.rfc-editor.org/rfc/rfc8259>
+- **RFC 5234**, *Augmented BNF for Syntax Specifications: ABNF*, and **RFC
+  7405**, *Case-Sensitive String Support in ABNF* — the notation the two
+  grammars below are written in, and the reason they are written with `%s`
+  literals: 5234's default is case-insensitive, and every spelling rule here is
+  case-sensitive because the comparison is string equality.
+  <https://www.rfc-editor.org/rfc/rfc5234> <https://www.rfc-editor.org/rfc/rfc7405>
 - **RFC 4648**, *The Base16, Base32, and Base64 Data Encodings* — normative for
   the base64 form, and specifically for section 4's alphabet as against section
   5's. A run of bytes needs one spelling and this is where it is defined.
@@ -216,7 +222,11 @@ order, and **MAY** carry `failure`. It **MUST NOT** carry any other member, and
 a reader **MUST** refuse one — a key an author wrote expecting it to mean
 something is a typo, and a document that ignores it passes for the wrong reason.
 
-Each record carries `name` and `value`, both required and neither empty.
+Each record carries `name` and `value`, and both are required. `name`
+**MUST NOT** be empty. `value` **MAY** be `""` or `{}` — an all-space
+alphanumeric item and a group holding nothing but slack decode to exactly those,
+so a rule refusing an empty value would refuse an answer the language elsewhere
+requires.
 
 `name` **MUST** be the record's name as the copybook spells it — the `original`
 of the record node's [names](../ir/SPEC.md#names), never an identifier a
@@ -275,7 +285,7 @@ digits and be wrong for every value with a fraction.
 |---|---|
 | A group | An object, one member per node it holds, keyed by the copybook's name for that node. |
 | An item that repeats | An array, one element per occurrence, in file order. |
-| A variant | One key per arm in the enclosing object, of which the occurrence carries exactly one; an arm the occurrence does not hold has no key at all. |
+| A variant | The one arm the occurrence carries, written as a member of the *enclosing* object; the variant contributes no key of its own, and an arm the occurrence does not hold has no key at all. |
 | A slack node | Nothing at all. |
 
 A repeating node is an array whether it is a group or an elementary item, and
@@ -291,6 +301,16 @@ requires. An arm the occurrence does not hold **MUST** have no key, rather than
 a key whose value is `null`: a comparison then reports an unheld arm as the
 selection difference it is, instead of as a value that differs.
 
+The arms are members of the enclosing group's object and the variant's own name
+appears nowhere in the document. That is a decision rather than an omission —
+the name a copybook gives a variant is not a name the record's data has, and a
+key for it would be a level of nesting no other generator could be expected to
+invent identically. Its cost is stated rather than hidden: two arms of the same
+name in one group — whether in one variant or in two — would be one key, and an
+entry whose copybook does that is one this format cannot write down. No entry
+does, and an entry that needed to would be the case for revisiting this
+decision rather than for working around it.
+
 ### Slack is not a value
 
 A slack node **MUST NOT** appear in a values document. Its bytes travel with the
@@ -301,9 +321,11 @@ generators to agree about padding rather than about data.
 
 ### Characters, and why trailing spaces do not survive
 
-An item in one of the four character categories is written as a JSON string of
-its characters, after the file's charset has been applied, with every trailing
-space removed (#66).
+An item in any of the four character categories — `CATEGORY_ALPHABETIC`,
+`CATEGORY_ALPHANUMERIC`, `CATEGORY_NUMERIC_EDITED` and
+`CATEGORY_ALPHANUMERIC_EDITED` — is written as a JSON string of its characters,
+after the file's charset has been applied, with every trailing space removed
+(#66).
 
 - A writer of a values document **MUST** remove every trailing U+0020 SPACE.
 - It **MUST NOT** remove a leading or an interior space.
@@ -324,6 +346,19 @@ to write that item down. That is accepted. Space padding is universal in the
 files this corpus is about, and a rule that preserved the padding would make
 every entry's expected value depend on a width the value language does not
 carry.
+
+The rule covers the two **edited** categories as well, and that part is a
+decision rather than a consequence of the argument above: a trailing blank in an
+edited item can be produced by the PICTURE rather than by padding — the sign
+position of `PIC 999-` holding a positive value, or an inserted `B` at the end
+of the string. It is included anyway because the alternative is worse. A runner
+would have to consult the category to know whether to trim, two implementations
+would have to agree about which edit characters count as data, and the
+distinction would be invisible in the file: an edited item padded to its width
+and one whose edit ends in a blank are the same bytes. No entry in the corpus
+holds an edited item today, so nothing changes; an entry that needs the trailing
+blank of an edit to be visible is the case for reopening this, and it can state
+the bytes in `input.bin` meanwhile.
 
 The rule is stated in terms of the *characters*, not of the bytes, so it holds
 identically for an EBCDIC file whose pad byte is `0x40` and an ASCII one whose
@@ -373,10 +408,22 @@ writable. The pattern goes in `input.bin`, and what it decodes to is `"0"`.
 A `COMP-1` or `COMP-2` item is written as a JSON string: either one of three
 sentinels, or the exact value in hexadecimal significand notation (#194, #195).
 
+> **The corpus does not carry this form yet.** Five entries of
+> [`testdata/conformance/`](../../testdata/conformance) hold a float —
+> `float-ieee754`, `float-ieee754-little-endian`, `float-hfp`,
+> `float-hfp-read-as-ieee` and `float-ieee-read-as-hfp` — and each of their
+> `values.json` still carries the JSON number this section
+> forbids, which is the form that was specified before this one. #195 migrates
+> them and makes the comparison stop being IEEE equality. Until it lands, a
+> runner writing `"0x1p+0"` will be reported as differing from those five
+> entries and from no others; nothing else in the corpus holds a float. This is
+> the one place where the corpus and this document disagree, and it is named
+> here rather than left to be discovered.
+
 ```abnf
-float       = "NaN" / infinity / hex
-infinity    = [ "-" ] "Infinity"
-hex         = [ "-" ] "0x" significand "p" sign exponent
+float       = %s"NaN" / infinity / hex
+infinity    = [ "-" ] %s"Infinity"
+hex         = [ "-" ] %s"0x" significand %s"p" sign exponent
 significand = "0" / ( "1" [ "." 1*LOWHEX ] )
 sign        = "+" / "-"
 exponent    = "0" / NONZERO *DIGIT
@@ -384,19 +431,32 @@ LOWHEX      = DIGIT / %x61-66   ; 0-9 a-f
 NONZERO     = %x31-39           ; 1-9
 ```
 
+Every literal above is case-sensitive, in the `%s` notation RFC 7405 adds to
+ABNF, because the default in RFC 5234 is case-*in*sensitive and a comparison
+that is string equality cannot afford `0X1P+3` and `0x1p+3` to be two spellings
+of one value.
+
 The value is significand × 2^exponent, where the significand is read as a
 hexadecimal fraction. `0x1p+0` is 1, `0x1.2p+3` is 9, `0x1p-5` is 0.03125, and
 `-0x0p+0` is negative zero.
 
 One value has one spelling, which is what lets a comparison be string equality:
 
-- `x`, `p` and every hexadecimal digit **MUST** be lowercase.
+- `x`, `p` and every hexadecimal digit **MUST** be lowercase, and the two
+  sentinels are spelled exactly `NaN` and `Infinity`.
 - The significand **MUST** be `0` if and only if the value is zero, and `1`
   otherwise. Every non-zero value, including a subnormal one, is normalized.
 - The fraction **MUST NOT** end in `0`, and the `.` **MUST** be absent when
   there is no fraction.
 - The exponent's sign **MUST** be written, even where it is `+`, and the
-  exponent **MUST NOT** carry a leading zero. A zero exponent is `+0`.
+  exponent **MUST NOT** carry a leading zero.
+- A zero exponent **MUST** be written `+0`; `p-0` is not admissible.
+- Where the significand is `0` the exponent **MUST** be `+0`, so that zero is
+  exactly `0x0p+0` and negative zero exactly `-0x0p+0`. A grammar that let the
+  exponent of a zero vary would give one value the infinitely many spellings a
+  stored exponent can take, and two correct generators would be reported as
+  disagreeing about zero — the failure `"-0"` is excluded from [a
+  number](#a-number-is-a-decimal-string) to avoid.
 - `"NaN"` is every NaN. Its sign and its payload are **not** distinguished.
 - A value **MUST NOT** be written as a JSON number, and **MUST NOT** be written
   in decimal at all.
@@ -429,9 +489,8 @@ one run of bytes is read two ways on purpose — as HFP it is 1, as IEEE it is 9
 and a form that echoed the bytes would make both readings identical and the
 entry vacuous.
 
-The corpus's own float entries are written in this form by #195, which is also
-where the comparison stops being IEEE equality. They are the only members of the
-corpus that do not carry it yet.
+The migration of the five entries that predate this form is #195's, and it is
+called out in full at the top of this section.
 
 ### `INDEX`, `POINTER` and `NATIONAL` are base64
 
@@ -467,9 +526,17 @@ document carries a `failure` beside the records it did read:
 }
 ```
 
-`failure` **MUST** be present exactly when reading stopped before the end of the
-file, and absent otherwise. `records` **MUST** hold the records that were read
-before the failure, in file order.
+`failure` **MUST** be present exactly when the direction the document describes
+did not complete, and absent otherwise.
+
+- For a document describing a **read** — an entry's `values.json`, and the
+  `decoded` half of an [answer](#the-answer-document) — that is a read that
+  stopped before the end of the file, and `records` **MUST** hold the records
+  read before it stopped, in file order.
+- For the **`written`** half of an answer it is a writer that refused a record
+  it was given, or a file it could not complete. `records` is then empty: the
+  file was never finished, so nothing was read back out of it, and there is
+  nothing for the entry to be compared against.
 
 The text is a note for whoever reads the report and **MUST NOT** be compared: a
 diagnostic is a generator's own wording in its own language, so an entry

--- a/internal/conformance/corpus.go
+++ b/internal/conformance/corpus.go
@@ -51,6 +51,19 @@ const (
 	// ValuesName is what those bytes decode to.
 	ValuesName = "values.json"
 
+	// OffsetsName is a member of an entry that is reserved and not specified:
+	// an entry may carry one, nothing reads it, and no entry does (#194).
+	//
+	// The name is admitted here rather than left to be added later because
+	// adding a member to a published format is a coordinated change across
+	// every runner that holds an entry's listing to the set of names it knows,
+	// and reserving one before the format is public costs nothing. What would
+	// go in it is a per-field offset table — the oracle a generator that never
+	// reads bytes could be held to, since it runs the same position sum a
+	// decoder runs (#193) — and whether a corpus entry is where that belongs is
+	// open, which is why the name is reserved and the content is not specified.
+	OffsetsName = "offsets.json"
+
 	// CopybookExt is the extension every copybook of an entry carries. The
 	// layout names them; what this decides is only which files in the directory
 	// are allowed to be there.
@@ -213,7 +226,8 @@ func LoadEntry(dir string) (*Entry, error) {
 }
 
 // readListing holds the directory to the set of files an entry is made of: the
-// five members, and one or more copybooks.
+// five members, one or more copybooks, and the reserved [OffsetsName] nothing
+// reads.
 //
 // A file the format has no place for is a fault rather than something ignored,
 // which is the rule README.md's "The project manifest" already states about an
@@ -234,6 +248,10 @@ func (e *Entry) readListing(listing []os.DirEntry) error {
 		switch {
 		case name == MetadataName, name == LayoutName, name == DescriptorName,
 			name == InputName, name == ValuesName:
+		case name == OffsetsName:
+			// Reserved and optional: admitted so that an entry carrying one is
+			// not a fault, read by nothing (docs/conformance/SPEC.md,
+			// "offsets.json is reserved").
 		case strings.HasSuffix(name, CopybookExt):
 			e.Copybooks = append(e.Copybooks, filepath.Join(e.Dir, name))
 		default:

--- a/internal/conformance/corpus_test.go
+++ b/internal/conformance/corpus_test.go
@@ -6,8 +6,10 @@
 package conformance
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -207,41 +209,63 @@ func TestAnEntryTheFormatRefuses(t *testing.T) {
 }
 
 // TestTheReservedMemberIsAdmittedAndReadByNothing holds [OffsetsName] to what
-// reserving a name means.
+// reserving a name means: the entry loads with it there, and loads to exactly
+// what it loads to without it.
 //
-// Two halves, and the second is the one that decays quietly. An entry carrying
-// the member loads, which is what makes the name reserved rather than merely
-// documented — the loader refuses every other file it has no place for, so
-// without this the reservation would be a sentence nobody could act on. And no
-// entry in the shipped corpus carries one, because the member has no content
-// specified and no consumer (#194): an entry that started carrying one would be
-// carrying a file whose meaning nothing had agreed, which is the thing the
-// reservation exists to postpone.
+// The content is deliberately not a document. Nothing specifies what is in this
+// member (#194), so an entry carrying JSON would pass whether the loader
+// ignores the file, parses it, or holds it to some shape somebody added later —
+// and only the third of those is a change to what was reserved. Bytes no reader
+// could accept fail the day the member acquires a consumer without acquiring a
+// specification first, which is the direction this reservation has to be
+// defended in.
 func TestTheReservedMemberIsAdmittedAndReadByNothing(t *testing.T) {
 	dir := entryCopy(t)
 
-	write(t, filepath.Join(dir, OffsetsName), `{"reserved": true}`)
+	without, err := LoadEntry(dir)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
 
-	entry, err := LoadEntry(dir)
+	write(t, filepath.Join(dir, OffsetsName), "not a document {")
+
+	with, err := LoadEntry(dir)
 	if err != nil {
 		t.Fatalf("an entry carrying the reserved %s: %v", OffsetsName, err)
 	}
 
-	for _, copybook := range entry.Copybooks {
-		if filepath.Base(copybook) == OffsetsName {
-			t.Errorf("%s was read as a copybook, and nothing reads it", OffsetsName)
-		}
+	if !slices.Equal(with.Copybooks, without.Copybooks) {
+		t.Errorf("the entry's copybooks are %v with %s beside them and %v without it",
+			with.Copybooks, OffsetsName, without.Copybooks)
 	}
 
+	if with.Layout != without.Layout || with.Description != without.Description ||
+		with.Source != without.Source || !bytes.Equal(with.Input, without.Input) {
+		t.Errorf("the entry loaded differently with %s beside it, and nothing reads it", OffsetsName)
+	}
+}
+
+// TestNoShippedEntryCarriesTheReservedMember is the half of the reservation
+// that decays quietly.
+//
+// The member has no content specified and no consumer, so an entry that started
+// carrying one would carry a file whose meaning nothing had agreed — which is
+// exactly what reserving the name postpones. It is a test of its own because it
+// is a claim about the corpus rather than about the loader, and a failure here
+// sends its reader somewhere else entirely.
+func TestNoShippedEntryCarriesTheReservedMember(t *testing.T) {
 	entries, err := Load(CorpusPath(repoRoot(t)))
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
 
-	for _, shipped := range entries {
-		if _, err := os.Stat(filepath.Join(shipped.Dir, OffsetsName)); err == nil {
+	for _, entry := range entries {
+		switch _, err := os.Stat(filepath.Join(entry.Dir, OffsetsName)); {
+		case err == nil:
 			t.Errorf("%s carries %s, and the member is reserved with nothing specified to be in it",
-				shipped.Name, OffsetsName)
+				entry.Name, OffsetsName)
+		case !os.IsNotExist(err):
+			t.Errorf("%s: %v", entry.Name, err)
 		}
 	}
 }

--- a/internal/conformance/corpus_test.go
+++ b/internal/conformance/corpus_test.go
@@ -206,6 +206,46 @@ func TestAnEntryTheFormatRefuses(t *testing.T) {
 	}
 }
 
+// TestTheReservedMemberIsAdmittedAndReadByNothing holds [OffsetsName] to what
+// reserving a name means.
+//
+// Two halves, and the second is the one that decays quietly. An entry carrying
+// the member loads, which is what makes the name reserved rather than merely
+// documented — the loader refuses every other file it has no place for, so
+// without this the reservation would be a sentence nobody could act on. And no
+// entry in the shipped corpus carries one, because the member has no content
+// specified and no consumer (#194): an entry that started carrying one would be
+// carrying a file whose meaning nothing had agreed, which is the thing the
+// reservation exists to postpone.
+func TestTheReservedMemberIsAdmittedAndReadByNothing(t *testing.T) {
+	dir := entryCopy(t)
+
+	write(t, filepath.Join(dir, OffsetsName), `{"reserved": true}`)
+
+	entry, err := LoadEntry(dir)
+	if err != nil {
+		t.Fatalf("an entry carrying the reserved %s: %v", OffsetsName, err)
+	}
+
+	for _, copybook := range entry.Copybooks {
+		if filepath.Base(copybook) == OffsetsName {
+			t.Errorf("%s was read as a copybook, and nothing reads it", OffsetsName)
+		}
+	}
+
+	entries, err := Load(CorpusPath(repoRoot(t)))
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	for _, shipped := range entries {
+		if _, err := os.Stat(filepath.Join(shipped.Dir, OffsetsName)); err == nil {
+			t.Errorf("%s carries %s, and the member is reserved with nothing specified to be in it",
+				shipped.Name, OffsetsName)
+		}
+	}
+}
+
 // entryCopy is a copy of the shipped entry, in a directory of the test's own, so
 // that a case may break it without breaking the corpus.
 func entryCopy(t *testing.T) string {

--- a/internal/conformance/doc.go
+++ b/internal/conformance/doc.go
@@ -6,12 +6,12 @@
 // Package conformance reads the conformance corpus and compares a runner's
 // answer against what an entry expects.
 //
-// The corpus is testdata/conformance/, it is documented where it lives — in
-// that directory's README.md, per docs/CONVENTIONS.md's "What belongs here" —
-// and this package is the reading of that document which this repository runs.
-// An entry is the tuple the README describes: the layout and the copybooks it
-// names, the IR they resolve to, the bytes of a file laid out that way, and the
-// values those bytes decode to (#66).
+// The corpus is testdata/conformance/, its format is docs/conformance/SPEC.md,
+// and this package is the reading of that specification which this repository
+// runs. An entry is the tuple the spec describes: the layout and the copybooks
+// it names, the IR they resolve to, the bytes of a file laid out that way, and
+// the values those bytes decode to (#66). Which entries there are and what each
+// was derived from stay with the corpus, in that directory's README.md.
 //
 // # Why a corpus exists at all
 //

--- a/internal/conformance/values.go
+++ b/internal/conformance/values.go
@@ -22,7 +22,7 @@ import (
 // It is both halves of the comparison — what an entry's values.json states and
 // what a runner writes on standard output — because a runner and an entry that
 // spoke different dialects would need a translation nobody could test. See
-// testdata/conformance/README.md, "What a runner does", for the whole of the
+// docs/conformance/SPEC.md, "What a runner does", for the whole of the
 // contract this type is the Go reading of.
 type Values struct {
 	// Records are the records read, in file order.
@@ -45,9 +45,10 @@ type Record struct {
 	// the record node's names, never an identifier munged from it.
 	Name string `json:"name"`
 
-	// Value is what the record's top-level node holds, in the shape the
-	// corpus's README describes: an object for a group, an array for an item
-	// that repeats, and a scalar for an elementary item.
+	// Value is what the record's top-level node holds, in the shape
+	// docs/conformance/SPEC.md's "The value language" describes: an object for
+	// a group, an array for an item that repeats, and a scalar for an
+	// elementary item.
 	Value any `json:"value"`
 }
 

--- a/testdata/conformance/README.md
+++ b/testdata/conformance/README.md
@@ -67,11 +67,16 @@ What each member holds, and the language a decoded record is written in — a
 group, a table, a variant, characters, a number, a float, a run of bytes, and a
 file the reader refused — are [*An
 entry*](../../docs/conformance/SPEC.md#an-entry) and [*The value
-language*](../../docs/conformance/SPEC.md#the-value-language). Four rules that
-were prose here and are now decided: that trailing spaces on an alphanumeric
-item do not survive, how a decimal string may be spelled and that there is no
-negative zero, that a float is written exactly and never as a JSON number, and
-which base64 (#194).
+language*](../../docs/conformance/SPEC.md#the-value-language). Four rules moved
+with it and are now decided (#194). Three were never written here at all, which
+is the argument for the move rather than a slip: whether trailing spaces on an
+alphanumeric item survive, how a decimal string may be spelled and whether a
+negative zero is one, and which base64 alphabet and padding. The fourth is a
+reversal — this file said a `COMP-1` or `COMP-2` item was a JSON number, and the
+spec says it is a string in hexadecimal significand notation, exactly so that a
+NaN, an infinity and a negative zero can be written at all. The corpus's five
+float entries still carry the old form and are migrated by #195, which the spec
+says in full.
 
 `values.json` is one half of the comparison and a runner's answer document is
 the other, written in exactly the same language. What a runner is asked to do,

--- a/testdata/conformance/README.md
+++ b/testdata/conformance/README.md
@@ -16,37 +16,35 @@ Every entry here is authored by hand. Slower growth is the trade, and what it
 buys is that each entry is traceable to the section it was derived from rather
 than to a run of the code it is supposed to be checking (#67).
 
-## Why the format is documented here and not under `docs/`
+## Where the format is written down, and what is written down here
 
-[`docs/CONVENTIONS.md`](../../docs/CONVENTIONS.md), *What belongs here*, admits a
-document under `docs/` when it specifies an interface a third party builds
-against and the interface is harder to change than the code behind it. Test
-infrastructure documents itself where it lives, and this is that document: the
-corpus is a `testdata/` format, run by a harness in this repository and by
-third-party generators against their own output.
+The format is [`docs/conformance/SPEC.md`](../../docs/conformance/SPEC.md): what
+an entry is made of, the value language a decoded record is written in, and the
+answer document a runner writes. It is a spec under `docs/` rather than a
+section of this file because a third-party generator author has to implement it,
+which is the test [`docs/CONVENTIONS.md`](../../docs/CONVENTIONS.md), *What
+belongs here*, applies — while this repository held the only reader of the
+format, prose here was enough, and the day a second implementation exists every
+unstated rule becomes a coordinated migration (#194).
 
-So there are no bolded conformance keywords below. The four specs use them; this
-file describes a directory of files, and a rule here is enforced by the loader
-rather than by a reader deciding what a **MUST** binds.
+What stays here is the corpus rather than the format: why it exists, why every
+entry is hand-authored, which entries there are and what each was derived from,
+and how to add one. Those change every time an entry is added and are nobody
+else's interface.
+
+So there are no bolded conformance keywords below. The specs use them; this file
+describes a directory of entries, and where it says what a member holds it is
+recalling the spec rather than defining it.
 
 ## An entry
 
-One directory per entry, named for what it is about. The directory holds five
-members and the copybooks the layout names, and nothing else — a file the format
-has no place for is refused rather than ignored, for the reason the project
-manifest refuses an unknown field.
+One directory per entry, named for what it is about. It holds five members and
+the copybooks the layout names; that list, the one reserved name it may also
+carry, and what each member is held to are [*An
+entry*](../../docs/conformance/SPEC.md#an-entry).
 
-| File | What it is |
-|---|---|
-| `entry.json` | What the entry is about, and the section its expected answer came from. |
-| `layout.sexpr` | The [layout](../../docs/layout/SPEC.md) the file is laid out by. |
-| `*.cpy` | The copybooks that layout names, at the paths it spells them. |
-| `ir.json` | The [IR](../../docs/ir/SPEC.md) the layout and those copybooks resolve to. |
-| `input.bin` | The bytes of one file laid out that way. |
-| `values.json` | What those bytes decode to. |
-
-An entry therefore states two independent things, and they are checked by
-different readers:
+An entry states two independent things, and they are checked by different
+readers:
 
 - **The layout and its copybooks resolve to `ir.json`.** That is a claim about a
   producer. The descriptor is hand-authored, so it is an oracle rather than a
@@ -63,174 +61,23 @@ disagrees with cpybkc about what a *layout* means and one who disagrees about
 what a *descriptor* means have different bugs, and an entry carrying three of the
 four members could not tell them apart.
 
-### `entry.json`
+### The members, and the value language
 
-```json
-{
-  "description": "A fixed-length dataset of one record type: ...",
-  "source": "cobol-go codec/SPEC.md, \"Storage Widths\"; docs/ir/SPEC.md, \"Physical framing\""
-}
-```
+What each member holds, and the language a decoded record is written in — a
+group, a table, a variant, characters, a number, a float, a run of bytes, and a
+file the reader refused — are [*An
+entry*](../../docs/conformance/SPEC.md#an-entry) and [*The value
+language*](../../docs/conformance/SPEC.md#the-value-language). Four rules that
+were prose here and are now decided: that trailing spaces on an alphanumeric
+item do not survive, how a decimal string may be spelled and that there is no
+negative zero, that a float is written exactly and never as a JSON number, and
+which base64 (#194).
 
-Both are required and there is no third key. `source` is what a failing run
-prints beside the entry's name: whoever reads the report has to decide whether
-the generator is wrong or the entry is, and that decision starts at where the
-expected answer came from.
-
-### `ir.json`
-
-The descriptor, in the canonical JSON rendering — protobuf's own field names,
-field-number order, two-space indent — which is exactly what
-`cpybkc --emit-ir --emit-ir-format json` writes and what
-`internal/emit.MarshalJSON` produces. The loader re-renders what it read and
-refuses a file that is not byte for byte the same, so an entry is reviewed as a
-diff of its content rather than of its whitespace.
-
-JSON rather than the binary form because an entry is written and reviewed by
-hand. A runner that would rather have the bytes a plugin is handed encodes what
-it read: the binary encoding is canonical for a *plugin*, and any protobuf
-runtime turns one into the other with the schema, which every release attaches as
-`ir.binpb` and `ir-protos.tar.gz`.
-
-### `values.json`
-
-The records the file holds, in file order.
-
-```json
-{
-  "records": [
-    {
-      "name": "ORDER-RECORD",
-      "value": {
-        "ORDER-ID": "A001",
-        "ORDER-QTY": "42",
-        "ORDER-LINE": [
-          {"LINE-SKU": "SK1"},
-          {"LINE-SKU": "SK2"}
-        ]
-      }
-    }
-  ]
-}
-```
-
-`name` is the record's name as the copybook spells it — the `original` of the
-record node's names, never an identifier a generator munged out of it. `value` is
-what the record's top-level node holds.
-
-The value language is small, and every part of it is language-neutral on purpose:
-
-| The node | Written as |
-|---|---|
-| A group | An object, one key per member, keyed by the copybook's name for it. |
-| An item that repeats | An array, one element per occurrence, in order. |
-| Alphabetic, alphanumeric and both edited categories | A JSON string of the characters, after the charset has been applied. |
-| Any numeric item — zoned, packed or binary | A JSON string of the decimal digits, with a leading `-` where it is negative, and no leading zeros. |
-| `COMP-1` and `COMP-2` | A JSON number. |
-| `INDEX`, `POINTER` and `NATIONAL` | A JSON string of the bytes in base64. |
-| A variant | One key per arm in the enclosing object, of which the occurrence carries exactly one; an arm the occurrence does not hold has no key at all. |
-| A slack node | Nothing. Its bytes travel with the record and are not a value anybody decoded. |
-
-A number is a string rather than a JSON number because JSON numbers are doubles
-in most readers, and a `PIC S9(18)` item holds values a double cannot represent.
-The digits are the *unscaled* ones — an implied decimal point is not applied, for
-the same reason a generated accessor does not apply one: the point is in the
-descriptor, and applying it here would apply it twice by the time a caller saw
-the value.
-
-A file the generated reader refuses carries a `failure` beside the records it did
-read:
-
-```json
-{
-  "records": [ ... ],
-  "failure": "the sign nibble is not one of the four the convention admits"
-}
-```
-
-What is compared is that reading failed, and that it failed after the records
-listed. The text is a note for whoever reads the report and is deliberately not
-compared: a diagnostic is a generator's own wording in its own language, so an
-entry demanding particular words would be an entry only one generator could pass.
-
-## What a runner does
-
-A runner is the language-specific half, and there is one per generator language.
-Given an entry it:
-
-1. hands `ir.json` — as the binary encoding, which is what
-   [`docs/plugin/SPEC.md`](../../docs/plugin/SPEC.md) says a plugin is given — to
-   the generator under test, with whatever options that generator needs;
-2. compiles what came back;
-3. reads `input.bin` with it, top to bottom;
-4. where that read reached the end of the file, writes those records back out
-   with the generated writer and reads *that* file with the generated reader;
-5. writes an answer document on standard output, carrying a values document for
-   each direction.
-
-The comparison is then a comparison of values documents and needs neither the
-descriptor nor a decoder, which is what makes a runner for a language this
-repository has never seen comparable by the same rules.
-
-Two things a runner is not asked for. It is not asked to explain a difference —
-that is the comparison's — and it does not exit non-zero for a file the generated
-reader refused, or for a record the generated writer refused: those are answers,
-written as `failure`, because an entry is allowed to expect one and only the
-comparison knows whether this entry did. A non-zero exit means the runner itself
-failed: the generator would not run, its output would not compile, or the runner
-could not write a document.
-
-### The answer document
-
-```json
-{
-  "decoded": {
-    "records": [ ... ]
-  },
-  "written": {
-    "records": [ ... ]
-  }
-}
-```
-
-`decoded` is what the generated reader made of `input.bin`. `written` is what the
-generated reader makes of the file the generated *writer* produced from those
-records. Both are values documents, in exactly the form `values.json` is written
-in, and both are compared against `values.json` — against the entry rather than
-against each other, because a reader and a writer that are wrong the same way
-agree with each other and only the entry knows what the file holds.
-
-`written` is absent in two cases: where the read did not reach the end of the
-file, since a run that stopped at a failure holds no complete set of records to
-write back; and where the generator emits no writer at all, which
-[`docs/ir/SPEC.md`](../../docs/ir/SPEC.md)'s *Writing a file* leaves to the
-generator. It is present and carries a `failure` where the writer refused a
-record it was given.
-
-### Why the writing direction is checked by reading, and not by comparing bytes
-
-The obvious check is that the bytes the writer produced are `input.bin` again,
-and it is the wrong check twice over.
-
-*Writing a file* makes byte identity a claim about a **record** and deliberately
-not about a file: under an optional terminator a writer emits a final delimiter
-the input need not have carried, and under segmented framing it lays a record
-into as few segments as the largest allows, whatever the input did. A corpus
-demanding the input's bytes back would fail two of the four framings by design.
-
-It is wrong at the field level too, and this corpus already holds the case:
-[`packed-ascii`](packed-ascii) carries the lenient sign nibble `A`, which a
-reader admits as positive and a writer has no reason to emit — it writes the `C`
-the convention prescribes. The same goes for every encoding that admits more than
-one spelling of one value. Demanding the bytes back would make those entries
-unpassable by a correct generator, and dropping them would cost the corpus
-exactly the vectors it was seeded from.
-
-What *Writing a file* does make normative of a file is that a file a writer
-produces is one that a reader built from the same descriptor reads back as the
-records the writer was given. That holds for all four framings and every
-encoding, it is what `written` states, and it needs nothing of a runner that the
-reading direction did not already need.
+`values.json` is one half of the comparison and a runner's answer document is
+the other, written in exactly the same language. What a runner is asked to do,
+what it is deliberately not asked to do, and why the writing direction is
+checked by reading rather than by comparing bytes are [*What a runner
+does*](../../docs/conformance/SPEC.md#what-a-runner-does).
 
 ## What this repository runs
 


### PR DESCRIPTION
Closes #194

The value language was prose in `testdata/conformance/README.md`. That was the
right place while this repository held the only reader of it, and the wrong one
for a format a third-party generator author has to implement — so it becomes a
sixth spec, [`docs/conformance/SPEC.md`](docs/conformance/SPEC.md), and the four
rules the prose left unstated are decided there.

This story writes decisions, not behaviour. The corpus is unchanged and still
passes; the code changes are #195 and #196.

## The four decisions

**A float is written exactly, and never as a JSON number.** Hexadecimal
significand notation — C's `%a`, Go's `strconv.FormatFloat(f, 'x', -1, 64)`,
Python's `float.hex()` — as a JSON *string*, canonicalised so that one value has
one spelling: lowercase, normalized significand, no trailing zeros in the
fraction, an explicit exponent sign and no leading zeros in it. `0x1p+0` is 1,
`0x1.2p+3` is 9, `-0x0p+0` is negative zero. `"NaN"`, `"Infinity"` and
`"-Infinity"` are the three sentinels, and every NaN is `"NaN"` — sign and
payload are not distinguished, because COBOL has no NaN semantics and HFP has no
NaN at all.

Chosen over base64 of the stored bytes, the other candidate #195 named, because
base64 states what the *file* holds and an entry has to state what a *reader made
of it*: under `float-hfp-read-as-ieee` one run of bytes is read two ways on
purpose, and a form that echoed the bytes would make the entry vacuous.
Hexadecimal also spells values a double cannot hold, which matters because HFP
long carries a 56-bit fraction against an IEEE double's 53.

**Trailing spaces on an alphanumeric item do not survive.** Every trailing
U+0020 is removed, after the charset has been applied; leading and interior
spaces survive; an item of nothing but spaces is `""`. That is what the corpus
already expects — `batch-fixed`'s `HDR-NAME` and `TRL-FILLER` — and it is stated
in terms of characters, so it holds for an EBCDIC `0x40` and an ASCII `0x20`
alike. The cost is written down rather than hidden: an item whose data genuinely
ends in a space cannot be told apart from one that was padded.

**A decimal string has one spelling, and there is no negative zero.** `"0"`, or
an optional `-` then a non-zero leading digit. No leading `+`, no leading zeros,
no decimal point, and `"-0"` is inadmissible: a COBOL numeric item has no
negative zero, so `"-0"` would spell a *byte pattern* rather than a value, and a
writer given zero emits its convention's positive sign nibble — an entry
demanding `"-0"` back would demand bytes no correct writer produces. A packed
`00 0D` is still perfectly writable as an entry; it decodes to `"0"`.

**Base64 is RFC 4648 section 4 with padding.** The standard alphabet, not the
URL-safe one; padded to a multiple of four; no line breaks; canonical trailing
bits. That is `base64.StdEncoding`, which is what the driver already emits.

## `offsets.json`

Reserved as an optional member of an entry (#193). The loader admits the name so
that an entry carrying one is not a fault, its content is not specified, and
nothing reads it. A test asserts both halves — that an entry carrying one loads,
and that no shipped entry carries one, so the reservation cannot decay into an
unspecified member somebody started using.

## Judgment calls worth reviewing

- **A sixth spec rather than a `SPEC.md` beside the corpus.**
  `docs/CONVENTIONS.md`'s *What belongs here* previously said test
  infrastructure documents itself where it lives, with the corpus as its
  example. That bullet is amended rather than contradicted: the test is who has
  to implement the thing, and a generator author in another language implements
  this value language to be compared at all. The corpus's own entries, their
  derivations and how to add one stay in `testdata/conformance/README.md`, which
  changes every time an entry is added and is nobody else's interface.
- **The normative text moved rather than being duplicated.** The corpus README
  now points at the spec for the members, the value language and the runner
  contract, and keeps its rationale and its catalogue. Two answers drift.
- **Which form a value takes is stated as a procedure over `usage` then
  `category`**, rather than as the old table. Usage has to be read first:
  `COMP-1` carries `CATEGORY_NUMERIC` and is not written as a number.

## Verified

- `dagger call ci` — green, from an ordinary clone and cold after
  `dagger core engine local-cache prune` (the run before the prune reproduced
  the known `missing shared result` cache fault).
- `go test ./internal/conformance/...` — green, including the new
  `TestTheReservedMemberIsAdmittedAndReadByNothing`.
- Every shipped `values.json` audited against the decided rules: no trailing
  spaces, no leading `+`, no leading zeros, no `-0`. The only values not yet in
  the specified form are the seven JSON-number floats, which #195 migrates and
  which the spec names.

## Acceptance criteria

- [x] The value language is specified somewhere a third party consumes, not only in `testdata/conformance/README.md` — `docs/conformance/SPEC.md`, listed in `README.md` beside the other five.
- [x] How a float is written is stated, and it is not a JSON number.
- [x] Whether trailing spaces on an alphanumeric item survive is stated, and it matches what the corpus already expects.
- [x] The admissible spelling of a decimal string is stated, including negative zero, a leading `+`, and leading zeros.
- [x] The base64 alphabet and padding are stated.
- [x] `offsets.json` is reserved as an optional member of an entry, with no consumer yet.
- [x] No behaviour changes in this story; the corpus still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VycsyoGntP12ghL9nAbbSF
