### PR TITLE
story(dagger): curate a scaffolding function so init is not reached through Run

### DIFF
--- a/.dagger/companion.go
+++ b/.dagger/companion.go
@@ -170,7 +170,7 @@ const cliPackageDir = "cmd/cpybkc"
 
 // companionCoverage is what the companion module answers each of the CLI's
 // flags with. It is the record the curation of #62 is worth having: the module
-// maps the run a caller almost always wants and hands the rest to one escape
+// maps the two runs a caller asks for by name and hands the rest to one escape
 // hatch, and without a written record of which flag went where, "curated" and
 // "forgotten" are the same thing to read.
 //
@@ -185,10 +185,10 @@ const cliPackageDir = "cmd/cpybkc"
 // accident.
 //
 // Every value names a function on daggerverse/cpybkc's own type, checked to
-// exist rather than taken on trust. Run appears six times over because it is the
+// exist rather than taken on trust. Run appears five times over because it is the
 // escape hatch and that is what an escape hatch looks like when it is working; a
 // flag moving from Run to a curated argument is an edit here in the same commit
-// that adds the argument.
+// that adds the argument, which is what happened to `init`'s two below.
 //
 // This is a table in the pipeline rather than a list in the module because it is
 // this repository's opinion about the module, in the file that already holds the
@@ -221,28 +221,29 @@ var companionCoverage = map[string]string{
 	// and an entry costs one line.
 	"-h": "Run",
 
-	// `init`'s two flags (#183, #214). The module expresses a scaffolding run
-	// through the escape hatch and does not curate one, and that is the answer
-	// rather than a gap left for later.
+	// `init`'s two flags (#183, #214), curated onto one function (#228). This is
+	// the move this table was kept for: they were recorded against Run while the
+	// module expressed a scaffolding run through the escape hatch alone, and
+	// they came off it in the commit that added the function.
 	//
-	// A curated function would have to be `Scaffold(copybooks []*dagger.File,
-	// out string) *dagger.File`, and every part of that is wrong here. `init`
-	// writes what a copybook decides and deliberately leaves the adopter's half
-	// blank, so its output is a file somebody edits once and commits — not an
-	// artifact a pipeline rebuilds, which is what every other function on this
-	// module returns. Its destination may be standard output, which a
-	// File-returning function cannot express any more than it can express
-	// --emit-ir's. And a scaffold is generated once per project against
-	// copybooks that are already in the caller's tree; a Dagger function is
-	// worth having for what a pipeline runs on every commit, and this is not
-	// that.
+	// The name is the CLI's verb rather than the `Scaffold` this comment used to
+	// name in prose. #62 is *map cpybkc commands to dagger functions*, there are
+	// two commands, and mapping the second one's name straight through is what
+	// lets somebody who read docs/cli/SPEC.md find it here — a second name for
+	// one command would be this module's own vocabulary, which is exactly what
+	// the curation is trying not to grow.
 	//
-	// So `dagger call run --args=init,--copybook,posting.cpy,--out,-` is how it
-	// is reached, and the entrypoint takes the vector exactly as a person would
-	// type it. If a scaffolding function is ever curated, these two entries move
-	// to it in the same commit that adds it, which is what this table is for.
-	"--copybook": "Run",
-	"--out":      "Run",
+	// Init takes copybook *paths* into --source rather than files, because
+	// docs/cli/SPEC.md has the scaffold record each path as it was typed and a
+	// layout's paths are relative to the layout; and it supplies --out itself, at
+	// a path outside the mounted project, so *nothing at <dest> is ever replaced*
+	// holds without the module reasoning about the caller's tree. The one
+	// spelling it does not offer is `--out -`, which a File-returning function
+	// cannot express — that stays Run's, as --emit-ir's is:
+	//
+	//	dagger call run --source . --args=init,--copybook,posting.cpy,--out,-
+	"--copybook": "Init",
+	"--out":      "Init",
 }
 
 // CliSurface checks that every flag the CLI accepts is one the companion module
@@ -466,7 +467,42 @@ const (
 	// for the same reason, and overriding it would only add a second unused
 	// value to read.
 	neverPulledRepository = "cpybkc.invalid/never-pulled"
+
+	// scaffoldName is what the two scaffolds are called while they are being
+	// compared. It is a name for the diff and nothing else: the curated call
+	// hands back a File the caller names at export, and the hand-typed one hands
+	// back bytes on standard output, so neither side has a name of its own here.
+	scaffoldName = "scaffold.sexpr"
 )
+
+// exampleCopybooks are the copybooks in [companionExampleDir], as the paths a
+// person would type them, and they are all three of them.
+//
+// All three because the check that would pass on one is not the check worth
+// having: `init` derives a record per 01-level across every copybook it was
+// given, in the order it was given them, so a single input says nothing about
+// whether the module preserved that order or dropped a repetition of the flag.
+//
+// They are written down rather than globbed out of the example for the reason
+// the composed generators are: a fourth copybook added to that directory is a
+// decision about what this check covers, and it should fail here loudly rather
+// than widen silently.
+var exampleCopybooks = []string{"header.cpy", "posting.cpy", "trailer.cpy"}
+
+// exampleInitVector is the hand-typed escape-hatch spelling of the same
+// scaffolding run, `--out -` and all.
+//
+// It is written out here rather than assembled from the module's internal/argv,
+// which is the whole point of the comparison below: two statements of one run
+// that were arrived at independently, so that a vector this module got wrong
+// disagrees with itself instead of agreeing with its own mistake.
+var exampleInitVector = []string{
+	"init",
+	"--copybook", "header.cpy",
+	"--copybook", "posting.cpy",
+	"--copybook", "trailer.cpy",
+	"--out", "-",
+}
 
 // CompanionModule drives the companion module's functions over the image this
 // pipeline just built, and requires what comes out to be the committed worked
@@ -517,11 +553,13 @@ const (
 // ships no image for with-generator to take one out of — see [graphGenerator].
 // The pair being compared is still the `go` half, which is what varies.
 //
-// Then the two functions that are not part of that pair, because a check that
+// Then the functions that are not part of that pair, because a check that
 // exercised only what it needed would leave the rest of the module's surface
 // covered by nothing: image, whose plugin directory has to hold the generator
-// the CLI resolves on PATH, and run, the escape hatch, asked the one question
-// docs/cli/SPEC.md requires to succeed against nothing at all.
+// the CLI resolves on PATH; run, the escape hatch, asked the one question
+// docs/cli/SPEC.md requires to succeed against nothing at all; and init, the
+// curated scaffolding run (#228), required to hand back the same scaffold the
+// escape hatch writes over the same copybooks — see [Cpybkc.checkInit].
 //
 // Both compositions start from the base image this pipeline built, which carries
 // the CLI and no generator — so a generation that succeeded did so with the
@@ -609,6 +647,10 @@ func (m *Cpybkc) CompanionModule(ctx context.Context) error {
 				"generators in: %w", err))
 	}
 
+	if err := m.checkInit(ctx, platform); err != nil {
+		errs = append(errs, err)
+	}
+
 	// --version through the escape hatch, with no project: it is the one
 	// invocation docs/cli/SPEC.md requires to succeed touching nothing, so a
 	// failure here is run failing to reach the CLI rather than anything about a
@@ -623,6 +665,60 @@ func (m *Cpybkc) CompanionModule(ctx context.Context) error {
 	}
 
 	return errors.Join(errs...)
+}
+
+// checkInit requires the curated scaffolding function and the hand-typed escape
+// hatch to be the same run, over [companionExampleDir]'s copybooks.
+//
+// # What is asserted, and why it is not what a scaffold should contain
+//
+// The scaffold `init --source . --copybook …` hands back has to be byte-identical
+// to what `run --args=init,--copybook,…,--out,-` writes on standard output over
+// the same copybooks. That is cheap, it needs no second reading of
+// docs/cli/SPEC.md's `init` section — what a record is derived from, which forms
+// are commented, what a note says — and it is exactly the property the escape
+// hatch entry in [companionCoverage] used to stand in for: a caller who reached
+// for `run` before this function existed should get the same file from the
+// function that replaced it.
+//
+// What the scaffold *contains* is checked where it is decided:
+// internal/scaffold's tests and cmd/cpybkc's. A second expectation here would be
+// this pipeline's own reading of that document, and the two would drift.
+//
+// # No generator, deliberately
+//
+// This drives the base image with nothing composed into it, where the
+// compositions above install two. `init` resolves no layout and runs no
+// generator (docs/cli/SPEC.md, "`init` reads no manifest"), and the state it
+// runs in is the one an adopter is actually in: before there is a manifest, let
+// alone a generator to name in one. A check that reached for a composed image
+// would be asserting less while costing more.
+//
+// The two sides are compared as trees rather than as strings so that a
+// disagreement arrives as a diff naming the line, through the same helper the
+// tree comparisons above use.
+func (m *Cpybkc) checkInit(ctx context.Context, platform dagger.Platform) error {
+	bare := m.companion(platform)
+	example := m.Source.Directory(companionExampleDir)
+
+	handTyped, err := bare.Run(exampleInitVector, dagger.CompanionRunOpts{Source: example}).Stdout(ctx)
+	if err != nil {
+		return fmt.Errorf("run --args=init,… over %s/'s copybooks did not reach the CLI: %w",
+			companionExampleDir, err)
+	}
+
+	curated := dag.Directory().WithFile(scaffoldName, bare.Init(example, exampleCopybooks))
+	typed := dag.Directory().WithNewFile(scaffoldName, handTyped)
+
+	if err := m.diffTrees(ctx, typed, curated, "/companion-module/init"); err != nil {
+		return fmt.Errorf(
+			"init over %s/'s copybooks did not hand back the scaffold `run --args=init,…` writes over the same "+
+				"copybooks (or did not get that far — the wrapped error says which): the curated function and the "+
+				"escape hatch are the same run spelled two ways, so a difference is one of them being wrong: %w",
+			companionExampleDir, err)
+	}
+
+	return nil
 }
 
 // companion is the module bound to the image this pipeline built, and it is the

--- a/.dagger/companion.go
+++ b/.dagger/companion.go
@@ -190,6 +190,12 @@ const cliPackageDir = "cmd/cpybkc"
 // flag moving from Run to a curated argument is an edit here in the same commit
 // that adds the argument, which is what happened to `init`'s two below.
 //
+// That five is counted off the map rather than carried forward. It read "six"
+// while the map held seven, which is the kind of thing a number in prose does if
+// nobody re-derives it — and it is worth saying rather than quietly fixing,
+// because this comment is the drift record and a count nobody checked is exactly
+// what it warns about everywhere else.
+//
 // This is a table in the pipeline rather than a list in the module because it is
 // this repository's opinion about the module, in the file that already holds the
 // other two (#61). The module states the same split in prose, in its package
@@ -696,14 +702,21 @@ func (m *Cpybkc) CompanionModule(ctx context.Context) error {
 //
 // The two sides are compared as trees rather than as strings so that a
 // disagreement arrives as a diff naming the line, through the same helper the
-// tree comparisons above use.
+// tree comparisons above use. [Cpybkc.diffTrees] runs diff(1), which compares
+// contents and nothing else, so the two sides may be built differently — one
+// from the file cpybkc wrote and one from bytes — without a mode or an owner
+// deciding the outcome.
 func (m *Cpybkc) checkInit(ctx context.Context, platform dagger.Platform) error {
 	bare := m.companion(platform)
 	example := m.Source.Directory(companionExampleDir)
 
+	// "did not succeed" rather than "did not reach the CLI", because both are
+	// reachable from here: run may fail to reach the CLI at all, and the CLI may
+	// be reached and exit non-zero — which is what a typo in the hand-maintained
+	// [exampleInitVector] looks like. The wrapped error says which.
 	handTyped, err := bare.Run(exampleInitVector, dagger.CompanionRunOpts{Source: example}).Stdout(ctx)
 	if err != nil {
-		return fmt.Errorf("run --args=init,… over %s/'s copybooks did not reach the CLI: %w",
+		return fmt.Errorf("run --args=init,… over %s/'s copybooks did not succeed: %w",
 			companionExampleDir, err)
 	}
 

--- a/.dagger/dagger.gen.go
+++ b/.dagger/dagger.gen.go
@@ -436,14 +436,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg notes", err))
 				}
 			}
-			var repository string
-			if inputArgs["repository"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["repository"]), &repository)
+			var reference string
+			if inputArgs["reference"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["reference"]), &reference)
 				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg repository", err))
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg reference", err))
 				}
 			}
-			return (*Cpybkc).ReleaseNotes(&parent, ctx, tag, notes, repository)
+			return (*Cpybkc).ReleaseNotes(&parent, ctx, tag, notes, reference)
 		case "ReleaseNotesContract":
 			var parent Cpybkc
 			err = json.Unmarshal(parentJSON, &parent)

--- a/.dagger/internal/dagger/companion.gen.go
+++ b/.dagger/internal/dagger/companion.gen.go
@@ -192,11 +192,21 @@ func (r *Companion) Image() *Container { // companion (../../../daggerverse/cpyb
 // deliberately does not.
 //
 // Nothing is written to the host, exactly as with Generate: the File that comes
-// back is a value, and exporting it is the caller's separate step. Where it goes
-// is theirs — this module writes the scaffold to a path of its own inside the
-// container ([scaffoldPath]) that nothing was mounted into, so the run cannot
+// back is a value, and exporting it is the caller's separate step. What it is
+// called is theirs — this module writes the scaffold to a path of its own inside
+// the container ([scaffoldPath]) that nothing was mounted into, so the run cannot
 // land on something the caller already has, and the name it takes in their tree
 // is the one they give `export`.
+//
+// *Where* it goes is theirs within one constraint, and it is the one thing here
+// a caller cannot infer from the signature. The scaffold names each copybook by
+// the path it was given, which is relative to the root of source, and a layout's
+// own paths are relative to the layout — so the file belongs at that root, beside
+// the copybooks it names. Exported into a subdirectory it is a layout whose
+// copybook paths resolve nowhere, and nothing at export time will say so. A
+// project that keeps its layout somewhere else moves the paths as it moves the
+// file; they are the adopter's to edit, like the rest of what `init` leaves
+// blank.
 //
 // The destination this module supplies is a file rather than a stream, so
 // `--out -` is not offered here. A caller who wants the scaffold on standard
@@ -204,7 +214,7 @@ func (r *Companion) Image() *Container { // companion (../../../daggerverse/cpyb
 //
 //	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
 //	  run --source . --args=init,--copybook,posting.cpy,--out,- stdout
-func (r *Companion) Init(source *Directory, copybook []string) *File { // companion (../../../daggerverse/cpybkc/main.go:669:1)
+func (r *Companion) Init(source *Directory, copybook []string) *File { // companion (../../../daggerverse/cpybkc/main.go:679:1)
 	assertNotNil("source", source)
 	q := r.query.Select("init")
 	q = q.Arg("source", source)
@@ -225,7 +235,7 @@ type CompanionRunOpts struct {
 	// contact nothing. With no source the container is the image as it was
 	// resolved, and cpybkc runs in whatever directory the image left it in.
 	//
-	Source *Directory // companion (../../../daggerverse/cpybkc/main.go:769:2)
+	Source *Directory // companion (../../../daggerverse/cpybkc/main.go:795:2)
 }
 
 // Run is the escape hatch: cpybkc invoked with an argument vector this module
@@ -262,7 +272,7 @@ type CompanionRunOpts struct {
 // unrecognised flag is, whether a flag may repeat and what a usage error exits
 // with are all docs/cli/SPEC.md's, and the exec's failure carries them back
 // verbatim.
-func (r *Companion) Run(args []string, opts ...CompanionRunOpts) *Container { // companion (../../../daggerverse/cpybkc/main.go:756:1)
+func (r *Companion) Run(args []string, opts ...CompanionRunOpts) *Container { // companion (../../../daggerverse/cpybkc/main.go:782:1)
 	q := r.query.Select("run")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `source` optional argument

--- a/.dagger/internal/dagger/companion.gen.go
+++ b/.dagger/internal/dagger/companion.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Companion
-func (r *Binding) AsCompanion() *Companion { // companion (../../../daggerverse/cpybkc/main.go:221:6)
+func (r *Binding) AsCompanion() *Companion { // companion (../../../daggerverse/cpybkc/main.go:259:6)
 	q := r.query.Select("asCompanion")
 
 	return &Companion{
@@ -24,7 +24,7 @@ func (r *Binding) AsCompanion() *Companion { // companion (../../../daggerverse/
 // A function on it is a builder returning a new Cpybkc, a terminal that runs
 // something, or an accessor handing back what was resolved, so a call chain
 // reads as the image being assembled and then used; nothing here mutates.
-type Companion struct { // companion (../../../daggerverse/cpybkc/main.go:221:6)
+type Companion struct { // companion (../../../daggerverse/cpybkc/main.go:259:6)
 	query *querybuilder.Selection
 
 	id *ID
@@ -60,7 +60,7 @@ type CompanionGenerateOpts struct {
 	// cannot be "-": a manifest's own paths are relative to the directory holding
 	// it, and a manifest arriving on a stream is in no directory.
 	//
-	Manifest string // companion (../../../daggerverse/cpybkc/main.go:584:2)
+	Manifest string // companion (../../../daggerverse/cpybkc/main.go:622:2)
 }
 
 // Generate runs cpybkc over a project and hands back the project as it should
@@ -83,7 +83,7 @@ type CompanionGenerateOpts struct {
 // express half of what a run did. `generate --source . export --path .` is
 // therefore the ordinary use, and it is a full statement of the run rather than
 // an overlay that leaves deletions behind.
-func (r *Companion) Generate(source *Directory, opts ...CompanionGenerateOpts) *Directory { // companion (../../../daggerverse/cpybkc/main.go:561:1)
+func (r *Companion) Generate(source *Directory, opts ...CompanionGenerateOpts) *Directory { // companion (../../../daggerverse/cpybkc/main.go:599:1)
 	assertNotNil("source", source)
 	q := r.query.Select("generate")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -166,10 +166,51 @@ func (r *Companion) UnmarshalJSON(bs []byte) error {
 // none of the signatures or attestations one does (docs/container/SPEC.md, "What
 // a tag carries besides the image"), because those are attached to the digest
 // this project published and not to the bytes.
-func (r *Companion) Image() *Container { // companion (../../../daggerverse/cpybkc/main.go:537:1)
+func (r *Companion) Image() *Container { // companion (../../../daggerverse/cpybkc/main.go:575:1)
 	q := r.query.Select("image")
 
 	return &Container{
+		query: q,
+	}
+}
+
+// Init scaffolds a layout from copybooks and hands back the file to edit:
+//
+//	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+//	  init --source . --copybook posting.cpy export --path ledger.sexpr
+//
+// It is the first thing an adopter runs, before there is a manifest, a layout or
+// a generator to speak of, and it is curated for that reason: the one invocation
+// somebody has nothing to copy from is a poor place to make them assemble an
+// argument vector by hand.
+//
+// What comes back is **not a valid layout** and is not meant to be. `init`
+// writes what the copybooks decide — a record per 01-level, an alternative per
+// REDEFINES — and leaves the half no copybook holds as commented forms for a
+// person to answer: which field discriminates, and in what order the records
+// come. docs/cli/SPEC.md's `init` section is what that file says and what it
+// deliberately does not.
+//
+// Nothing is written to the host, exactly as with Generate: the File that comes
+// back is a value, and exporting it is the caller's separate step. Where it goes
+// is theirs — this module writes the scaffold to a path of its own inside the
+// container ([scaffoldPath]) that nothing was mounted into, so the run cannot
+// land on something the caller already has, and the name it takes in their tree
+// is the one they give `export`.
+//
+// The destination this module supplies is a file rather than a stream, so
+// `--out -` is not offered here. A caller who wants the scaffold on standard
+// output still has Run, which is the same arrangement --emit-ir has:
+//
+//	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+//	  run --source . --args=init,--copybook,posting.cpy,--out,- stdout
+func (r *Companion) Init(source *Directory, copybook []string) *File { // companion (../../../daggerverse/cpybkc/main.go:669:1)
+	assertNotNil("source", source)
+	q := r.query.Select("init")
+	q = q.Arg("source", source)
+	q = q.Arg("copybook", copybook)
+
+	return &File{
 		query: q,
 	}
 }
@@ -184,7 +225,7 @@ type CompanionRunOpts struct {
 	// contact nothing. With no source the container is the image as it was
 	// resolved, and cpybkc runs in whatever directory the image left it in.
 	//
-	Source *Directory // companion (../../../daggerverse/cpybkc/main.go:648:2)
+	Source *Directory // companion (../../../daggerverse/cpybkc/main.go:769:2)
 }
 
 // Run is the escape hatch: cpybkc invoked with an argument vector this module
@@ -221,7 +262,7 @@ type CompanionRunOpts struct {
 // unrecognised flag is, whether a flag may repeat and what a usage error exits
 // with are all docs/cli/SPEC.md's, and the exec's failure carries them back
 // verbatim.
-func (r *Companion) Run(args []string, opts ...CompanionRunOpts) *Container { // companion (../../../daggerverse/cpybkc/main.go:635:1)
+func (r *Companion) Run(args []string, opts ...CompanionRunOpts) *Container { // companion (../../../daggerverse/cpybkc/main.go:756:1)
 	q := r.query.Select("run")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `source` optional argument
@@ -247,7 +288,7 @@ type CompanionWithGeneratorOpts struct {
 	// image being composed into, which is checked, because a mismatch here is
 	// checkable and its exec-time failure is not legible.
 	//
-	Image *Container // companion (../../../daggerverse/cpybkc/main.go:419:2)
+	Image *Container // companion (../../../daggerverse/cpybkc/main.go:457:2)
 }
 
 // WithGenerator adds one generator to the image by copying its executable out of
@@ -275,7 +316,7 @@ type CompanionWithGeneratorOpts struct {
 // about multi-platform: composing an amd64 generator into an arm64 image produces
 // an image that builds and pushes and then fails at exec with the kernel's
 // message rather than cpybkc's, which is a long way from the call that caused it.
-func (r *Companion) WithGenerator(name string, opts ...CompanionWithGeneratorOpts) *Companion { // companion (../../../daggerverse/cpybkc/main.go:406:1)
+func (r *Companion) WithGenerator(name string, opts ...CompanionWithGeneratorOpts) *Companion { // companion (../../../daggerverse/cpybkc/main.go:444:1)
 	q := r.query.Select("withGenerator")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `image` optional argument
@@ -312,7 +353,7 @@ func (r *Companion) WithGenerator(name string, opts ...CompanionWithGeneratorOpt
 // or foreign-architecture generator fails at exec time with the kernel's message
 // rather than cpybkc's. WithGenerator can check the platform half of that because
 // a container states one; here there is nothing to read.
-func (r *Companion) WithGeneratorExecutable(name string, executable *File) *Companion { // companion (../../../daggerverse/cpybkc/main.go:491:1)
+func (r *Companion) WithGeneratorExecutable(name string, executable *File) *Companion { // companion (../../../daggerverse/cpybkc/main.go:529:1)
 	assertNotNil("executable", executable)
 	q := r.query.Select("withGeneratorExecutable")
 	q = q.Arg("name", name)
@@ -332,7 +373,7 @@ func (r *Companion) AsNode() Node {
 }
 
 // Create or update a binding of type Companion in the environment
-func (r *Env) WithCompanionInput(name string, value *Companion, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:221:6)
+func (r *Env) WithCompanionInput(name string, value *Companion, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:259:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withCompanionInput")
 	q = q.Arg("name", name)
@@ -345,7 +386,7 @@ func (r *Env) WithCompanionInput(name string, value *Companion, description stri
 }
 
 // Declare a desired Companion output to be assigned in the environment
-func (r *Env) WithCompanionOutput(name string, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:221:6)
+func (r *Env) WithCompanionOutput(name string, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:259:6)
 	q := r.query.Select("withCompanionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -369,7 +410,7 @@ type CompanionOpts struct {
 	//
 	//
 	// Default: "v0"
-	Version string // companion (../../../daggerverse/cpybkc/main.go:292:2)
+	Version string // companion (../../../daggerverse/cpybkc/main.go:330:2)
 	//
 	// The registry repository the image is pulled from, as `<host>/<path>` with no
 	// tag.
@@ -384,7 +425,7 @@ type CompanionOpts struct {
 	//
 	//
 	// Default: "ghcr.io/zaba505/cpybkc"
-	Repository string // companion (../../../daggerverse/cpybkc/main.go:305:2)
+	Repository string // companion (../../../daggerverse/cpybkc/main.go:343:2)
 	//
 	// Run in this container instead of pulling one, replacing it entirely.
 	//
@@ -404,7 +445,7 @@ type CompanionOpts struct {
 	// does not track whatever was pinned here, so a build that pins the CLI by
 	// digest and wants the pairing to hold still passes --version beside it.
 	//
-	Image *Container // companion (../../../daggerverse/cpybkc/main.go:324:2)
+	Image *Container // companion (../../../daggerverse/cpybkc/main.go:362:2)
 	//
 	// Pull the image for this platform, as `GOOS/GOARCH`, instead of for the
 	// engine's own.
@@ -423,7 +464,7 @@ type CompanionOpts struct {
 	// Empty is the engine's own platform, which is what makes an ordinary
 	// `dagger call` from a checkout do the obvious thing.
 	//
-	Platform string // companion (../../../daggerverse/cpybkc/main.go:342:2)
+	Platform string // companion (../../../daggerverse/cpybkc/main.go:380:2)
 }
 
 // New selects the cpybkc release to run:
@@ -444,7 +485,7 @@ type CompanionOpts struct {
 // resolves companion images against, which is why an air-gapped caller passing a
 // container from their own registry should pass --repository beside it rather
 // than instead of it.
-func (r *Query) Companion(opts ...CompanionOpts) *Companion { // companion (../../../daggerverse/cpybkc/main.go:281:1)
+func (r *Query) Companion(opts ...CompanionOpts) *Companion { // companion (../../../daggerverse/cpybkc/main.go:319:1)
 	q := r.query.Select("companion")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `version` optional argument

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -731,9 +731,22 @@ companion exactly as it does to the root.
 ### The curated surface, and the check that keeps it honest
 
 `Generate` takes a source directory and a manifest and hands back a
-`Directory`; `Run` takes an argument vector verbatim and hands back a
-`Container`. Those two are the whole surface, and the split between them is a
-decision rather than a stopping point (#62).
+`Directory`; `Init` takes a source directory and copybook paths and hands back
+the layout scaffold as a `File`; `Run` takes an argument vector verbatim and
+hands back a `Container`. Those three are the whole surface, and the split
+between them is a decision rather than a stopping point (#62).
+
+The two curated ones are the two commands cpybkc has. `Init` is `cpybkc init`
+(#228), and it is curated for a reason the default action does not need: it is
+the run an adopter reaches **first**, before there is a manifest or a layout for
+anything else to read, so it is the one invocation they have nothing to copy
+from. It takes copybook *paths* into `--source` rather than files, because
+[`docs/cli/SPEC.md`](docs/cli/SPEC.md) has the scaffold record each path as it
+was typed and a layout's own paths are relative to the layout; and it supplies
+`--out` itself, at a path outside the mounted project, so *nothing at `<dest>`
+is ever replaced* holds without the module reasoning about the caller's tree at
+all. Where the file goes in that tree is what they name at `export`, which is
+the one thing the adopter knows and cpybkc does not.
 
 The module **does not** grow an argument per entry in
 [`docs/cli/SPEC.md`](docs/cli/SPEC.md)'s flag table. A module argument is public
@@ -751,6 +764,13 @@ invocations are exactly the ones whose answer is not a tree — `--emit-ir` may
 write to standard output, and `--version` and `--help` write nothing else at
 all.
 
+It is also what lets a curated function decline one *spelling* of a flag
+without declining the flag. `Init` does not offer `--out -`, which a
+`File`-returning function cannot express any more than it can express
+`--emit-ir`'s stream; the scaffold on standard output is
+`run --source . --args=init,--copybook,posting.cpy,--out,-`, exactly as it was
+before there was an `Init`.
+
 What a curated surface risks is the CLI quietly growing a flag the module can
 no longer express, which reads from out here exactly like a module that chose
 not to express it. `dagger call cli-surface` is the difference, and it is in
@@ -766,7 +786,7 @@ and fails when one of them is not recorded in `companionCoverage` in
 function `daggerverse/cpybkc` does not declare, or when an entry names a flag
 the CLI has stopped accepting. **So adding a flag to cpybkc fails CI until
 somebody says which side of the curation it falls on** — a curated argument on
-`Generate`, or `Run`.
+`Generate` or `Init`, or `Run`.
 
 Be exact about what an entry in that table claims, because it is less than it
 looks. It is a person's assertion that they thought about the flag and decided
@@ -786,10 +806,15 @@ can be written — package scope or a function body, one hyphen or two, a litera
 or one flag's spelling built from another's — because each of those was a hole
 found in review, and each is now a row in
 [`.dagger/internal/surface/`](.dagger/internal/surface/)'s tests rather than a
-sentence in a comment. And it is a **flag**-level check because
-`docs/cli/SPEC.md` fixes cpybkc as one command with no subcommands — there is no
-verb list for a module function to correspond to, so the surface that can drift
-is the flag table.
+sentence in a comment. And it is a **flag**-level check even though the CLI now
+has a verb (#183, #214): the set of subcommand names is closed at `init` by
+`docs/cli/SPEC.md`, so a second one is a change to that document rather than a
+constant somebody adds on the way past, and the reading would be unsound anyway
+— `internal/surface` keeps the constants shaped like a flag, and a verb is not
+one, so picking `init` out of them means knowing its spelling in advance. What
+the verb adds is two flags, `--copybook` and `--out`, and those reach the table
+through the same constants as everything else. The surface that can drift is the
+flag table.
 
 Two things stop it degrading quietly, which matters more here than for an
 ordinary check: a drift guard's failure mode is *staying green*. A read that
@@ -944,8 +969,20 @@ which is what makes the two
 rather than merely both present (#63). Both start from the base image, which
 carries the CLI and **no** generator — so a generation that succeeded did so with
 the generators these calls installed and not with something lying around in the
-image. `image` and `run` are checked too, since a check that exercised only what
-it needed would leave the rest of the module's surface covered by nothing.
+image. `image`, `run` and `init` are checked too, since a check that exercised
+only what it needed would leave the rest of the module's surface covered by
+nothing.
+
+**`init` is checked against the escape hatch, not against a second expectation.**
+The curated scaffolding function has to hand back the scaffold
+`run --args=init,…,--out,-` writes over the same three copybooks in
+[`example/`](example/), byte for byte (#228). That is cheap, it needs no second
+reading of what a scaffold should contain — `internal/scaffold`'s tests own that
+— and it is the property the escape-hatch entry in `companionCoverage` stood in
+for while there was no function: a caller who reached for `run` before it existed
+gets the same file from the function that replaced it. It runs against the base
+image with nothing composed into it, because `init` resolves no layout and runs
+no generator, which is also the state an adopter is in when they run it.
 
 **Two generators, because the example runs two.** Since #191 the committed
 example names `go` *and* `graph`, so each composition installs both and the

--- a/daggerverse/cpybkc/dagger.gen.go
+++ b/daggerverse/cpybkc/dagger.gen.go
@@ -234,6 +234,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return (*Cpybkc).Image(&parent), nil
+		case "Init":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var source *dagger.Directory
+			if inputArgs["source"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["source"]), &source)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg source", err))
+				}
+			}
+			var copybook []string
+			if inputArgs["copybook"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["copybook"]), &copybook)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg copybook", err))
+				}
+			}
+			return (*Cpybkc).Init(&parent, ctx, source, copybook)
 		case "Run":
 			var parent Cpybkc
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/cpybkc/internal/argv/argv.go
+++ b/daggerverse/cpybkc/internal/argv/argv.go
@@ -21,6 +21,23 @@ import "fmt"
 // document's synopsis writes.
 const manifestFlag = "--manifest"
 
+// initSubcommand is the verb a scaffolding run is asked for by, and it is the
+// first argument of the vector rather than a flag: docs/cli/SPEC.md reads a
+// subcommand name at the first argument and nowhere else, so it cannot follow
+// anything.
+const initSubcommand = "init"
+
+// copybookFlag names one copybook a scaffolding run reads. It is the one flag
+// that repeats — once per file, in the order the scaffold then holds them in —
+// and the repetition is what a list argument on the module becomes here.
+const copybookFlag = "--copybook"
+
+// outFlag names where the scaffold goes. It has no default in the CLI and none
+// here: the caller of [Init] supplies the destination, because where the file
+// lands inside the container is a property of how this module mounts things and
+// not of the vector.
+const outFlag = "--out"
+
 // standardOutput is the dash cpybkc reads as "a stream" wherever it accepts
 // one. --manifest is the one flag that refuses it.
 const standardOutput = "-"
@@ -57,4 +74,66 @@ func Generate(manifest string) ([]string, error) {
 	}
 
 	return []string{manifestFlag, manifest}, nil
+}
+
+// Init is the vector for a scaffolding run over copybooks in a project mounted
+// at the container's working directory, with the scaffold written to out.
+//
+// The subcommand leads and every copybook is a flag of its own, which is the
+// whole shape of `cpybkc init --copybook <path> … --out <dest>`. The order the
+// copybooks were given is kept, because it is not decoration: the scaffold holds
+// one record per 01-level in the order the copybooks were read, so reordering
+// the vector would reorder somebody's layout.
+//
+// A copybook is a path the CLI resolves against its working directory — the
+// mounted project's root — and writes into the scaffold as it was typed. That is
+// why they arrive here as strings rather than as files: the paths are what the
+// adopter has to find again in their own tree.
+//
+// out is the caller's rather than a constant here, and it is the only argument
+// of the two that this package does not get from a user. Where a scaffold lands
+// inside the container is a property of how the module mounts things, so it is
+// stated there and passed in; what belongs here is that the destination is one
+// flag and that the flag is not optional.
+//
+// Two things are refused before the vector leaves, on the grounds
+// [Generate] already states for a manifest on a stream: a vector with no
+// copybook in it names nothing to read, and a copybook named "-" names an input
+// whose path the scaffold has to record and a stream has none. Neither describes
+// a run the CLI could perform for any state of any filesystem, so paying for a
+// pull and an exec to be told so buys nothing.
+//
+// Everything else stays the CLI's, including the rules that are decidable from a
+// line. A byte-equal duplicate is a usage error whose diagnostic names the value
+// (docs/cli/SPEC.md, "A flag appears at most once"), and leaving it there is what
+// keeps this package from holding a second copy of a rule that document is
+// entitled to revise. A value naming a directory, or one that cannot be opened,
+// is a status 1 that needs a look at the filesystem — a better diagnostic than
+// anything guessable from out here.
+func Init(copybooks []string, out string) ([]string, error) {
+	if len(copybooks) == 0 {
+		return nil, fmt.Errorf(
+			"%s reads the copybooks it is given and this run names none: a scaffold is derived from the 01-levels "+
+				"in them, so there is nothing to derive one from", initSubcommand)
+	}
+
+	// The position is named because a list argument has no flag of its own to
+	// point at: the caller wrote one --copybook holding several values, and
+	// which of them the message is about is otherwise theirs to guess at.
+	for i, copybook := range copybooks {
+		if copybook == standardOutput {
+			return nil, fmt.Errorf(
+				"copybook %d cannot be %q: the scaffold states a path for each record's copybook, and a copybook "+
+					"on a stream has none to state", i+1, standardOutput)
+		}
+	}
+
+	args := make([]string, 0, 2*len(copybooks)+3)
+	args = append(args, initSubcommand)
+
+	for _, copybook := range copybooks {
+		args = append(args, copybookFlag, copybook)
+	}
+
+	return append(args, outFlag, out), nil
 }

--- a/daggerverse/cpybkc/internal/argv/argv_test.go
+++ b/daggerverse/cpybkc/internal/argv/argv_test.go
@@ -1,9 +1,12 @@
-// These tests cover the vector Generate hands the CLI, which is public API in
-// the same way imageref's default reference is: a caller who passes no manifest
-// gets an invocation of no arguments, and what that means — the mounted
-// project's own cpybkc.json, read from the working directory — is a promise
-// docs/cli/SPEC.md makes and this module relies on rather than restates. Pinning
-// the vector here turns a later accidental flag into a red build.
+// These tests cover the vectors the curated functions hand the CLI, which are
+// public API in the same way imageref's default reference is: a caller who
+// passes no manifest gets an invocation of no arguments, and what that means —
+// the mounted project's own cpybkc.json, read from the working directory — is a
+// promise docs/cli/SPEC.md makes and this module relies on rather than restates.
+// A scaffolding run's vector carries two more of them: that the subcommand
+// leads, and that the copybooks reach cpybkc in the order they were given, which
+// is the order the scaffold then holds their records in. Pinning the vectors here
+// turns a later accidental flag, or a quietly reordered list, into a red build.
 //
 // What is not tested here is anything needing an engine: whether the exec
 // succeeds, whether the project mounted at the working directory has a manifest
@@ -63,6 +66,123 @@ func TestGenerateWithAManifest(t *testing.T) {
 			}
 			if !slices.Equal(got, tc.want) {
 				t.Errorf("Generate(%q) = %q, want %q", tc.manifest, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInitAssemblesTheVector(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		copybooks []string
+		out       string
+		want      []string
+	}{
+		{
+			// The subcommand leads, because docs/cli/SPEC.md reads a subcommand
+			// name at the first argument and nowhere else.
+			name:      "one copybook",
+			copybooks: []string{"posting.cpy"},
+			out:       "/scaffold/layout.sexpr",
+			want:      []string{"init", "--copybook", "posting.cpy", "--out", "/scaffold/layout.sexpr"},
+		},
+		{
+			// The order is pinned rather than incidental: the scaffold holds one
+			// record per 01-level in the order the copybooks were read, so a
+			// vector that reordered them would reorder somebody's layout.
+			name:      "three copybooks, in the order they were given",
+			copybooks: []string{"header.cpy", "posting.cpy", "trailer.cpy"},
+			out:       "/scaffold/layout.sexpr",
+			want: []string{
+				"init",
+				"--copybook", "header.cpy",
+				"--copybook", "posting.cpy",
+				"--copybook", "trailer.cpy",
+				"--out", "/scaffold/layout.sexpr",
+			},
+		},
+		{
+			// A path below the project root, resolved by the CLI against the
+			// mounted project because that is its working directory, and written
+			// into the scaffold as it was typed.
+			name:      "a path below the project root",
+			copybooks: []string{"copybooks/posting.cpy"},
+			out:       "/scaffold/layout.sexpr",
+			want: []string{
+				"init", "--copybook", "copybooks/posting.cpy", "--out", "/scaffold/layout.sexpr",
+			},
+		},
+		{
+			// Separated rather than joined, so a value carrying an equals sign
+			// needs no thought about which one cpybkc cuts on.
+			name:      "a path carrying an equals sign",
+			copybooks: []string{"odd=name/posting.cpy"},
+			out:       "/scaffold/layout.sexpr",
+			want: []string{
+				"init", "--copybook", "odd=name/posting.cpy", "--out", "/scaffold/layout.sexpr",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Init(tc.copybooks, tc.out)
+			if err != nil {
+				t.Fatalf("Init(%q, %q): unexpected error: %v", tc.copybooks, tc.out, err)
+			}
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("Init(%q, %q) = %q, want %q", tc.copybooks, tc.out, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInitRefusesNoCopybooksAtAll(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		copybooks []string
+	}{
+		{name: "nil", copybooks: nil},
+		{name: "empty", copybooks: []string{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Init(tc.copybooks, "/scaffold/layout.sexpr")
+			if err == nil {
+				t.Fatalf("Init(%q, …) = %q, want an error", tc.copybooks, got)
+			}
+			if got != nil {
+				t.Errorf("Init(%q, …) returned %q beside its error, want no vector", tc.copybooks, got)
+			}
+			// Checked for saying what a scaffold is derived from rather than
+			// merely for being non-nil: the caller has to learn that the
+			// copybooks are the input and not an optional narrowing of one.
+			if !strings.Contains(err.Error(), "01-levels") {
+				t.Errorf("Init(%q, …) error = %q, want it to say what a scaffold is derived from", tc.copybooks, err)
+			}
+		})
+	}
+}
+
+func TestInitRefusesTheDashAmongTheCopybooks(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		copybooks []string
+	}{
+		{name: "alone", copybooks: []string{"-"}},
+		{name: "beside real paths", copybooks: []string{"header.cpy", "-", "trailer.cpy"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Init(tc.copybooks, "/scaffold/layout.sexpr")
+			if err == nil {
+				t.Fatalf("Init(%q, …) = %q, want an error", tc.copybooks, got)
+			}
+			if got != nil {
+				t.Errorf("Init(%q, …) returned %q beside its error, want no vector", tc.copybooks, got)
+			}
+			// The reason, for [TestGenerateRefusesTheDash]'s reason: a caller who
+			// reached for the dash was thinking of a stream, and why a copybook
+			// cannot arrive on one is the whole of what the message has to teach.
+			if !strings.Contains(err.Error(), "has none to state") {
+				t.Errorf("Init(%q, …) error = %q, want it to say why a copybook cannot arrive on a stream",
+					tc.copybooks, err)
 			}
 		})
 	}

--- a/daggerverse/cpybkc/main.go
+++ b/daggerverse/cpybkc/main.go
@@ -146,14 +146,28 @@
 //
 // # The curated surface, and why it is not the flag table
 //
-// Generate takes a source directory and a manifest, and that is the whole of
-// what this module maps by name. It deliberately does not grow an argument per
-// entry in docs/cli/SPEC.md's flag table: a module argument is public API for as
-// long as the directory this module is published under exists, so a table
-// mapped one-to-one would make every change to that table a change to this
-// module's surface, and would have to express in Dagger arguments things a
-// command line says better — a flag that replaces the action rather than
-// configuring it, and a flag that may not appear beside another.
+// Two functions map a cpybkc command by name, and they are the two commands
+// there are. Generate takes a source directory and a manifest, and is the
+// default action — what cpybkc does when nothing else is asked of it. Init takes
+// a source directory and copybook paths and hands back the layout scaffold, which
+// is `cpybkc init`; it is curated because it is the run an adopter reaches first,
+// before there is a manifest or a layout for anything else to read, and so the one
+// invocation they have nothing to copy from.
+//
+// That is the whole of what this module maps by name. It deliberately does not
+// grow an argument per entry in docs/cli/SPEC.md's flag table: a module argument
+// is public API for as long as the directory this module is published under
+// exists, so a table mapped one-to-one would make every change to that table a
+// change to this module's surface, and would have to express in Dagger arguments
+// things a command line says better — a flag that replaces the action rather
+// than configuring it, and a flag that may not appear beside another.
+//
+// A curated function is also allowed to decline one spelling of a flag without
+// declining the flag. Init supplies --out itself, at a path inside the container
+// the caller never types, and hands back the File; `--out -` is not offered,
+// because a File-returning function cannot express a stream any more than it can
+// express --emit-ir's. That is not the command being out of reach — it is Run's,
+// below, exactly as --emit-ir is.
 //
 // Run is the other half of that decision, and the reason the first half can stay
 // small. It takes the argument vector verbatim and hands back the container, so
@@ -202,6 +216,30 @@ const executableMode = 0o755
 // this path, so it is written into that function's documentation rather than
 // left to be discovered.
 const projectDir = "/src"
+
+// scaffoldDir is where Init has cpybkc write the scaffold, and scaffoldPath is
+// the file inside it.
+//
+// It is deliberately **outside** [projectDir]. `cpybkc init` replaces nothing:
+// a destination that is occupied fails the run, whatever is in it
+// (docs/cli/SPEC.md, "Nothing at <dest> is ever replaced"), and that rule is the
+// one unrecoverable act this command could otherwise perform — the `discriminate`
+// forms and the `sequence` in an edited layout are the part no copybook holds.
+// Writing into a directory of this module's own, which nothing was mounted into,
+// is what makes the rule hold here without the module reasoning about the
+// caller's tree at all: there is nothing at the path, ever, whatever is in
+// theirs.
+//
+// The caller never types either constant. The file comes back as a
+// *dagger.File, and where it lands is what they name at export — which keeps
+// *where the file goes is the one thing the adopter knows and cpybkc does not*
+// true of this module as well as of the CLI. The name below is only what the
+// file is called on the way out; the manifest's `layout` field names the
+// adopter's copy, and this module has no business choosing that.
+const (
+	scaffoldDir  = "/scaffold"
+	scaffoldPath = scaffoldDir + "/layout.sexpr"
+)
 
 // contractUser is the UID:GID docs/container/SPEC.md pins the image to, used to
 // own the mounted project when the container cannot say who it runs as.
@@ -598,6 +636,89 @@ func (m *Cpybkc) Generate(
 		Directory(projectDir), nil
 }
 
+// Init scaffolds a layout from copybooks and hands back the file to edit:
+//
+//	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+//	  init --source . --copybook posting.cpy export --path ledger.sexpr
+//
+// It is the first thing an adopter runs, before there is a manifest, a layout or
+// a generator to speak of, and it is curated for that reason: the one invocation
+// somebody has nothing to copy from is a poor place to make them assemble an
+// argument vector by hand.
+//
+// What comes back is **not a valid layout** and is not meant to be. `init`
+// writes what the copybooks decide — a record per 01-level, an alternative per
+// REDEFINES — and leaves the half no copybook holds as commented forms for a
+// person to answer: which field discriminates, and in what order the records
+// come. docs/cli/SPEC.md's `init` section is what that file says and what it
+// deliberately does not.
+//
+// Nothing is written to the host, exactly as with Generate: the File that comes
+// back is a value, and exporting it is the caller's separate step. Where it goes
+// is theirs — this module writes the scaffold to a path of its own inside the
+// container ([scaffoldPath]) that nothing was mounted into, so the run cannot
+// land on something the caller already has, and the name it takes in their tree
+// is the one they give `export`.
+//
+// The destination this module supplies is a file rather than a stream, so
+// `--out -` is not offered here. A caller who wants the scaffold on standard
+// output still has Run, which is the same arrangement --emit-ir has:
+//
+//	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+//	  run --source . --args=init,--copybook,posting.cpy,--out,- stdout
+func (m *Cpybkc) Init(
+	ctx context.Context,
+	// The project the copybooks are in: the directory their paths are relative
+	// to, mounted at /src and made the working directory.
+	//
+	// It is required, unlike Run's, because a scaffolding run reads files by
+	// definition. The whole directory is mounted rather than the named copybooks
+	// alone, because that is what makes the paths below resolve as the adopter
+	// typed them: --source is already how every other function on this module
+	// takes the caller's tree, and a mount holding only the named files would be
+	// a second, weaker answer to where a relative path points.
+	source *dagger.Directory,
+	// A copybook to read, as a path relative to the root of source. Repeat it
+	// once per copybook, in the order the scaffold should hold their records in.
+	//
+	// Paths rather than files, because the path is data: docs/cli/SPEC.md has
+	// the scaffold record each copybook's path *as it was typed*, and a layout's
+	// own paths are relative to the layout. A file handed over on its own would
+	// have cpybkc write a container path the adopter cannot find anywhere in
+	// their tree.
+	//
+	// At least one is required, and none may be "-": a copybook on a stream has
+	// no path for the scaffold to state. Everything else is the CLI's to refuse —
+	// a value naming a directory is a run that failed rather than a line that
+	// was wrong, and it says so with a diagnostic naming the path.
+	copybook []string,
+) (*dagger.File, error) {
+	args, err := argv.Init(copybook, scaffoldPath)
+	if err != nil {
+		return nil, err
+	}
+
+	user, err := m.user(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	project, err := m.project(ctx, source)
+	if err != nil {
+		return nil, err
+	}
+
+	// An empty directory owned by whoever the container runs as, because the
+	// scaffold is written through a temporary file created beside its
+	// destination and linked into place — the write is atomic or it does not
+	// happen — so the process needs a directory it can create in, not merely a
+	// path nothing occupies.
+	return project.
+		WithDirectory(scaffoldDir, dag.Directory(), dagger.ContainerWithDirectoryOpts{Owner: user}).
+		WithExec(args, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
+		File(scaffoldPath), nil
+}
+
 // Run is the escape hatch: cpybkc invoked with an argument vector this module
 // has no opinion about, in a container handed back whole.
 //
@@ -662,25 +783,42 @@ func (m *Cpybkc) Run(
 
 // project mounts a caller's project at [projectDir] and stands in it.
 //
-// The mount is owned by whoever the container runs as, asked of the container
-// rather than assumed, so that a caller who passed --image built on a derived
-// image with its own user still gets a project their process can write into. A
-// container that reports no user at all falls back to [contractUser], which is
-// what the base-image contract pins and what an image satisfying it runs as; the
-// alternative, leaving the mount root-owned, is a run that fails on the first
-// file a generator writes.
+// The mount is owned by [Cpybkc.user], which is what keeps a run from failing on
+// the first file a generator writes.
 func (m *Cpybkc) project(ctx context.Context, source *dagger.Directory) (*dagger.Container, error) {
-	user, err := m.Container.User(ctx)
+	user, err := m.user(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("reading the user the cpybkc image runs as, which the mounted project has to be "+
-			"writable by: %w", err)
-	}
-
-	if user == "" {
-		user = contractUser
+		return nil, err
 	}
 
 	return m.Container.
 		WithDirectory(projectDir, source, dagger.ContainerWithDirectoryOpts{Owner: user}).
 		WithWorkdir(projectDir), nil
+}
+
+// user is who the container runs as, and it is the owner every directory this
+// module mounts or creates is given.
+//
+// It is asked of the container rather than assumed, so that a caller who passed
+// --image built on a derived image with its own user still gets directories
+// their process can write into. A container that reports no user at all falls
+// back to [contractUser], which is what the base-image contract pins and what an
+// image satisfying it runs as; the alternative, leaving a mount root-owned, is a
+// run that fails on the first file it writes.
+//
+// It is a function of its own because two things need it now: the project mount,
+// and the directory Init has the scaffold written into. A second copy of the
+// fallback would be a second answer to who this image is.
+func (m *Cpybkc) user(ctx context.Context) (string, error) {
+	user, err := m.Container.User(ctx)
+	if err != nil {
+		return "", fmt.Errorf("reading the user the cpybkc image runs as, which the directories this module "+
+			"mounts have to be writable by: %w", err)
+	}
+
+	if user == "" {
+		return contractUser, nil
+	}
+
+	return user, nil
 }

--- a/daggerverse/cpybkc/main.go
+++ b/daggerverse/cpybkc/main.go
@@ -654,11 +654,21 @@ func (m *Cpybkc) Generate(
 // deliberately does not.
 //
 // Nothing is written to the host, exactly as with Generate: the File that comes
-// back is a value, and exporting it is the caller's separate step. Where it goes
-// is theirs — this module writes the scaffold to a path of its own inside the
-// container ([scaffoldPath]) that nothing was mounted into, so the run cannot
+// back is a value, and exporting it is the caller's separate step. What it is
+// called is theirs — this module writes the scaffold to a path of its own inside
+// the container ([scaffoldPath]) that nothing was mounted into, so the run cannot
 // land on something the caller already has, and the name it takes in their tree
 // is the one they give `export`.
+//
+// *Where* it goes is theirs within one constraint, and it is the one thing here
+// a caller cannot infer from the signature. The scaffold names each copybook by
+// the path it was given, which is relative to the root of source, and a layout's
+// own paths are relative to the layout — so the file belongs at that root, beside
+// the copybooks it names. Exported into a subdirectory it is a layout whose
+// copybook paths resolve nowhere, and nothing at export time will say so. A
+// project that keeps its layout somewhere else moves the paths as it moves the
+// file; they are the adopter's to edit, like the rest of what `init` leaves
+// blank.
 //
 // The destination this module supplies is a file rather than a stream, so
 // `--out -` is not offered here. A caller who wants the scaffold on standard
@@ -691,6 +701,12 @@ func (m *Cpybkc) Init(
 	// no path for the scaffold to state. Everything else is the CLI's to refuse —
 	// a value naming a directory is a run that failed rather than a line that
 	// was wrong, and it says so with a diagnostic naming the path.
+	//
+	// One boundary belongs to the command line rather than to cpybkc: `dagger
+	// call` renders a list argument as `--copybook a.cpy --copybook b.cpy` or as
+	// one comma-separated `--copybook a.cpy,b.cpy`, so a copybook whose path
+	// contains a comma cannot be spelled here. That one is Run's, where the
+	// vector is passed through as written.
 	copybook []string,
 ) (*dagger.File, error) {
 	args, err := argv.Init(copybook, scaffoldPath)
@@ -698,22 +714,32 @@ func (m *Cpybkc) Init(
 		return nil, err
 	}
 
+	// Resolved once and used for both the project mount and the scaffold
+	// directory below, which is the whole reason [Cpybkc.user] is a function:
+	// two answers to who this image is would be two answers.
 	user, err := m.user(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	project, err := m.project(ctx, source)
-	if err != nil {
-		return nil, err
-	}
+	project := m.mount(user, source)
 
-	// An empty directory owned by whoever the container runs as, because the
-	// scaffold is written through a temporary file created beside its
-	// destination and linked into place — the write is atomic or it does not
-	// happen — so the process needs a directory it can create in, not merely a
-	// path nothing occupies.
+	// Emptied first, then an empty directory owned by whoever the container runs
+	// as.
+	//
+	// Emptied because WithDirectory *merges*: whatever the image already had
+	// here would survive it, and a caller may have passed --image, which this
+	// module is not entitled to have an opinion about the contents of. Without
+	// the removal, such a container carrying anything at [scaffoldPath] would
+	// fail the run on a destination its caller never named and cannot see in the
+	// call — which is the one failure this path is arranged to make impossible.
+	//
+	// Owned, because the scaffold is written through a temporary file created
+	// beside its destination and linked into place — the write is atomic or it
+	// does not happen — so the process needs a directory it can create in, not
+	// merely a path nothing occupies.
 	return project.
+		WithoutDirectory(scaffoldDir).
 		WithDirectory(scaffoldDir, dag.Directory(), dagger.ContainerWithDirectoryOpts{Owner: user}).
 		WithExec(args, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
 		File(scaffoldPath), nil
@@ -791,9 +817,15 @@ func (m *Cpybkc) project(ctx context.Context, source *dagger.Directory) (*dagger
 		return nil, err
 	}
 
+	return m.mount(user, source), nil
+}
+
+// mount is [Cpybkc.project] with the user already in hand, for a caller that
+// needs it for something else as well and should not ask twice.
+func (m *Cpybkc) mount(user string, source *dagger.Directory) *dagger.Container {
 	return m.Container.
 		WithDirectory(projectDir, source, dagger.ContainerWithDirectoryOpts{Owner: user}).
-		WithWorkdir(projectDir), nil
+		WithWorkdir(projectDir)
 }
 
 // user is who the container runs as, and it is the owner every directory this


### PR DESCRIPTION
Closes #228

`cpybkc init` was reachable from the companion module only through the escape hatch:

```
dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
  run --source . --args=init,--copybook,posting.cpy,--out,- stdout
```

This curates the function `companionCoverage` already anticipated, and moves the two entries onto it in the same commit — which is what that table is for.

```
dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
  init --source . --copybook posting.cpy export --path ledger.sexpr
```

## Acceptance criteria

- [x] `daggerverse/cpybkc` declares a curated scaffolding function taking the project directory and one or more copybook paths relative to it, and returning `*dagger.File` — `Init(source *dagger.Directory, copybook []string) (*dagger.File, error)`.
- [x] Its name is decided rather than assumed. **`Init`**, the CLI's verb, over the `Scaffold` `companionCoverage` named in prose: #62 is *map cpybkc commands to dagger functions*, there are two commands now, and a second name for one of them would be vocabulary this module invented — a caller who read `docs/cli/SPEC.md` finds the same word here. It is one line in the module and one in the table.
- [x] Copybooks are paths into the mounted source, not `[]*dagger.File`, so cpybkc writes into the scaffold the paths the adopter can find again in their own tree.
- [x] `--out` names a destination outside the mounted project — `/scaffold/layout.sexpr`, a directory of the module's own that nothing is mounted into — so *nothing at `<dest>` is ever replaced* holds without the module reasoning about the caller's tree. The caller names the file on their own side at `export`.
- [x] The vector is assembled in `internal/argv` beside `Generate` (`argv.Init`) and pinned by tests there, including the order of the copybooks — which is the order the scaffold holds their records in.
- [x] The refusals decidable from the vector alone are made before the pull: no copybook at all, and a `-` among them. A byte-equal duplicate and a `--copybook` naming a directory stay the CLI's, with reasons in the doc comment.
- [x] `companionCoverage` moves `--copybook` and `--out` off `Run` onto `Init` in this commit, and the comment that reasoned them onto `Run` is rewritten to what is now true. `CliSurface` passes, which is what says the named function exists.
- [x] The module's package comment states the curation split as it now stands — two curated functions for the two commands, `Run` for everything else, and a curated function declining one *spelling* of a flag without declining the flag.
- [x] `CompanionModule` calls the new function against `example/`'s three copybooks.
- [x] What it asserts is that the curated call and the hand-typed one are the same run: the scaffold `init` hands back is byte-identical to what `run --args=init,--copybook,…,--out,-` writes over the same copybooks.

## Judgment calls that shaped the public API

- **`Init`, not `Scaffold`** — reasoned above and recorded in `companionCoverage`.
- **The argument is `--copybook`, singular and repeated**, mirroring the flag a person already types.
- **`--out -` is not offered.** A `File`-returning function cannot express a stream any more than it can express `--emit-ir`'s; the stream spelling stays `Run`'s, which is the same arrangement `--emit-ir` has.
- **The scaffold's container path is the module's, not the caller's.** `/scaffold/layout.sexpr` is never typed by anybody; it exists so the write cannot land on something the caller already has.
- **`checkInit` drives the base image with no generator composed in**, because `init` resolves no layout and runs no generator — which is also the state an adopter is in when they run it.
- The user lookup `project` did inline is now `Cpybkc.user`, because the scaffold directory needs the same owner and a second copy of the `contractUser` fallback would be a second answer to who this image is.

## How it was verified

`dagger call ci` — the configured verify command — cannot run from a git worktree (CONTRIBUTING.md, *The pipeline does not run from a git worktree*), so it was run from an ordinary clone holding this exact tree, after `dagger develop` in both modules. **Green**, all fifteen stages.

The new assertion was checked for being live rather than merely present: dropping `trailer.cpy` from the hand-typed vector in a scratch copy made `companion-module` fail with a real diff, whose `+` lines were that copybook's record, `discriminate` form and `sequence` entry coming out of the curated call. Restored, and green again.

One aside for anyone reproducing this: a `dagger call ci` after that deliberate failure kept reporting `missing shared result` for a stale engine result. That is the engine's cache, not the tree — restarting the engine container cleared it and the run was green.

## One pre-existing fix riding along, named rather than silent

`.dagger/dagger.gen.go` carries a hunk this branch's source changes do not produce: `ReleaseNotes`' fifth argument goes from `repository` to `reference`. That file was **stale on `main`** — `.dagger/release.go` has declared `reference string` since 0fb8a83, while the committed dispatch still unmarshalled `inputArgs["repository"]` into it, so the name the schema published and the name the source declared had drifted apart. Adding `Init` obliges a `dagger develop` in both modules, and a generated file cannot be regenerated halfway, so the whole file came into step with its source. Nothing in this branch renames anything.

## Review round

Reviewed on the `local` rung (Copilot is not enabled for this organisation). Eight findings, all answered on their threads; six changed the code, in 61938d7:

- **`/scaffold` is not guaranteed empty.** `WithDirectory` merges, so a caller-supplied `--image` already carrying something at `/scaffold/layout.sexpr` would have failed the run on a destination its caller never named. `WithoutDirectory(scaffoldDir)` now precedes the mount — the comment claimed more than the code did, and the claim was the better half.
- **Where the file may be exported is a real constraint** and is now stated: the scaffold names copybooks by paths relative to `--source`'s root, and a layout resolves its own paths against the directory holding it, so it belongs at that root.
- **A copybook path containing a comma cannot be spelled** as a Dagger list argument (`--copybook strings` is a comma-splitting slice, confirmed against `dagger call init --help`). Documented, and pointed at `Run`.
- **The container user was resolved twice.** It is now resolved once and passed to a `mount` helper, which is what `Cpybkc.user`'s own comment claimed.
- **The `Run` count in `companionCoverage`** is counted off the map. Five is right; the `six` it replaced was already wrong, the map having held seven — recorded rather than quietly swapped, since that paragraph is the drift record.
- **`diffTrees` is content-only** (`diff --recursive --unified --text`), so the two sides of `checkInit` may be built differently; the comment now says so. And the run error no longer says *did not reach the CLI* for a case that includes the CLI being reached and exiting non-zero.

`dagger call ci` re-run green on the amended tree, from an ordinary clone.
