### PR TITLE
story(container): publish cpybkc-gen-graph as a generator image

### DIFF
--- a/.dagger/companion.go
+++ b/.dagger/companion.go
@@ -431,24 +431,6 @@ const (
 	// for byte, and this repository already has that tree.
 	companionExampleDir = "example"
 
-	// graphGenerator is the diagram generator, by the name example/cpybkc.json
-	// asks for it by, and graphGeneratorExecutable and graphGeneratorPackage are
-	// what the CLI's PATH discovery looks for and what builds it.
-	//
-	// They are here rather than beside [generatorExecutable] in image.go because
-	// that name goes into a *published* image and this one does not: a release
-	// publishes the CLI image and one generator image, and cpybkc-gen-graph is
-	// neither. It reaches this check by being built and handed over as a file,
-	// which is the path a generator that ships no image takes.
-	//
-	// The check has to install it because the committed example runs two
-	// generators (#191). That is not an accident of this check: with one
-	// generator, "every generator in a run is handed the same descriptor" is
-	// vacuous, and the example carries the second one so it stops being.
-	graphGenerator           = "graph"
-	graphGeneratorExecutable = generatorPrefix + graphGenerator
-	graphGeneratorPackage    = "./cmd/" + graphGeneratorExecutable
-
 	// neverPulledRepository is the registry repository this check hands the
 	// module, and it is deliberately one that cannot exist: `.invalid` is
 	// reserved by RFC 2606 and resolves nowhere, ever.
@@ -554,10 +536,12 @@ var exampleInitVector = []string{
 // Requiring both to produce the committed example is what makes them
 // interchangeable rather than merely both present.
 //
-// The example runs two generators since #191, so each composition installs two.
-// The `graph` one goes in through with-generator-executable in both, because it
-// ships no image for with-generator to take one out of — see [graphGenerator].
-// The pair being compared is still the `go` half, which is what varies.
+// The example runs two generators since #191, so each composition installs two —
+// and since #230 both of them go in the same way on each side, because both are
+// published as images. `graph` used to be a with-generator-executable in both
+// compositions for want of an image to take it out of, which left the documented
+// adopter path uncovered for one of this project's two generators; the check for
+// it is now the same check `go` gets.
 //
 // Then the functions that are not part of that pair, because a check that
 // exercised only what it needed would leave the rest of the module's surface
@@ -593,18 +577,27 @@ func (m *Cpybkc) CompanionModule(ctx context.Context) error {
 
 	committed := m.Source.Directory(companionExampleDir)
 
-	// Two generators in each composition, because the committed example runs two.
-	// The `go` half is what differs between them and is the pair being checked;
-	// the `graph` half is added the same way to both, since it ships no image for
-	// with-generator to take one out of.
+	// Two generators in each composition, because the committed example runs two,
+	// and each composition installs both of them its own way: every generator
+	// through with-generator on one side and through with-generator-executable on
+	// the other. That is what makes the two routes interchangeable *for each
+	// generator* rather than for whichever one happened to have an image.
+	//
+	// Each is written out rather than looped over [publishedGenerators], because
+	// what this check covers is the committed example's manifest and not the set
+	// of images a release publishes. The two agree today; a generator published
+	// without being added to the example, or the reverse, is a decision that
+	// should be made here rather than followed silently.
 	fromImage := m.companion(platform).
 		WithGenerator(ownGenerator, dagger.CompanionWithGeneratorOpts{
-			Image: m.generatorImage(platform),
+			Image: m.generatorImage(platform, ownGeneratorSpec()),
 		}).
-		WithGeneratorExecutable(graphGenerator, m.graphGeneratorBinary(platform))
+		WithGenerator(graphGenerator, dagger.CompanionWithGeneratorOpts{
+			Image: m.generatorImage(platform, graphGeneratorSpec()),
+		})
 	fromExecutable := m.companion(platform).
-		WithGeneratorExecutable(ownGenerator, m.generatorBinary(devVersion, platform)).
-		WithGeneratorExecutable(graphGenerator, m.graphGeneratorBinary(platform))
+		WithGeneratorExecutable(ownGenerator, m.generatorBinary(devVersion, platform, ownGeneratorSpec())).
+		WithGeneratorExecutable(graphGenerator, m.generatorBinary(devVersion, platform, graphGeneratorSpec()))
 
 	var errs []error
 
@@ -634,12 +627,11 @@ func (m *Cpybkc) CompanionModule(ctx context.Context) error {
 	// installed a second copy under another name would pass every assertion
 	// above.
 	//
-	// The pair is written down rather than read out of example/cpybkc.json,
-	// because the manifest does not carry the thing this needs: *how* a generator
-	// is installed. `go` has a published image and goes in through with-generator;
-	// `graph` has none and goes in as a file. A third entry in that manifest has
-	// to be added here too, and fails this check loudly rather than going
-	// uncovered if it is not.
+	// The pair is written down rather than read out of example/cpybkc.json or out
+	// of [publishedGenerators], because an expectation derived from what the
+	// compositions above were built from would agree with them however wrong they
+	// were. A third entry in that manifest has to be added here too, and fails
+	// this check loudly rather than going uncovered if it is not.
 	composed := []string{generatorExecutable, graphGeneratorExecutable}
 
 	if err := m.checkComposedImage(ctx, fromImage.Image(), composed); err != nil {
@@ -748,34 +740,6 @@ func (m *Cpybkc) companion(platform dagger.Platform) *dagger.Companion {
 		Image:      m.baseImage(platform),
 		Repository: neverPulledRepository,
 	})
-}
-
-// graphGeneratorBinary builds the diagram generator for one platform, as a file
-// to hand to with-generator-executable.
-//
-// It is [Cpybkc.generatorBinary] pointed at the other command, and it carries the
-// same CGO and -trimpath switches for the same reason: what goes into the
-// composed image has to start in a scratch one. The two are not folded into a
-// single parameterised helper because they are not the same thing — that one
-// builds what a release publishes as an image, and this one builds an executable
-// for a check, so a change to how a published artifact is stamped or documented
-// has no business reaching this.
-//
-// The version stamp is passed by hand for [Cpybkc.generatorBinary]'s reason:
-// nothing upstream stamps a binary built through the generic Go build, and a
-// generator refusing an IR version it does not implement names its own version in
-// the diagnostic.
-func (m *Cpybkc) graphGeneratorBinary(platform dagger.Platform) *dagger.File {
-	return dag.Go().
-		Build(m.appSource(), dagger.GoBuildOpts{
-			Pkg:          graphGeneratorPackage,
-			ArtifactName: graphGeneratorExecutable,
-			Trimpath:     true,
-			DisableCgo:   true,
-			Platform:     string(platform),
-			Stamps:       []string{"main.version=" + devVersion},
-		}).
-		File(graphGeneratorExecutable)
 }
 
 // checkComposedImage requires an image's plugin directory to hold the generators

--- a/.dagger/companion.go
+++ b/.dagger/companion.go
@@ -627,11 +627,17 @@ func (m *Cpybkc) CompanionModule(ctx context.Context) error {
 	// installed a second copy under another name would pass every assertion
 	// above.
 	//
-	// The pair is written down rather than read out of example/cpybkc.json or out
-	// of [publishedGenerators], because an expectation derived from what the
-	// compositions above were built from would agree with them however wrong they
-	// were. A third entry in that manifest has to be added here too, and fails
-	// this check loudly rather than going uncovered if it is not.
+	// What the pair being written down buys is the **set**, and not the spelling.
+	// The two entries are the same constants the compositions above were built
+	// from, so a constant changed to a wrong spelling moves both together and this
+	// would not notice; what it does notice is a generator arriving or leaving. A
+	// third entry in example/cpybkc.json, or a third generator in
+	// [publishedGenerators], has to be added here too, and fails this check loudly
+	// rather than going uncovered if it is not.
+	//
+	// The spelling is pinned where it is a promise instead:
+	// daggerverse/cpybkc/internal/generator's TestExecutable, against the same
+	// discovery rule and in a module that cannot import this one.
 	composed := []string{generatorExecutable, graphGeneratorExecutable}
 
 	if err := m.checkComposedImage(ctx, fromImage.Image(), composed); err != nil {

--- a/.dagger/image.go
+++ b/.dagger/image.go
@@ -216,6 +216,26 @@ const (
 	generatorExecutable = generatorPrefix + ownGenerator
 	generatorPackage    = "./cmd/" + generatorExecutable
 
+	// graphGenerator is the diagram generator, by the name example/cpybkc.json
+	// asks for it by, and graphGeneratorExecutable and graphGeneratorPackage are
+	// what the CLI's PATH discovery looks for and what builds it.
+	//
+	// They are here rather than beside the companion checks for the reason the
+	// three above are, and they arrived here by that reason inverting (#230).
+	// They sat in companion.go under "that name goes into a *published* image and
+	// this one does not", which was true for exactly as long as a release
+	// published one generator image; it publishes two, so this name goes into one
+	// as well and its build is a release's business rather than a check's.
+	//
+	// The companion check still installs it, and still has to, because the
+	// committed example runs two generators (#191). That is not an accident of
+	// the check: with one generator, "every generator in a run is handed the same
+	// descriptor" is vacuous, and the example carries the second one so it stops
+	// being. What changed is only how it gets in — an image now, like the first.
+	graphGenerator           = "graph"
+	graphGeneratorExecutable = generatorPrefix + graphGenerator
+	graphGeneratorPackage    = "./cmd/" + graphGeneratorExecutable
+
 	// generatorRepositorySuffix is what turns the CLI image's repository into the
 	// repository the generator image for one name is published to.
 	//
@@ -255,7 +275,7 @@ const (
 	contractVersion = "v0.0.0-contract"
 
 	// generatorVersionProbePackage is the Go package name checkGeneratorVersion
-	// hands the generator, and it names nothing that is ever written.
+	// hands cpybkc-gen-go, and it names nothing that is ever written.
 	//
 	// docs/plugin/SPEC.md has this generator require a package name before it
 	// will accept a vector at all, and the vector has to parse before the
@@ -368,8 +388,91 @@ func (m *Cpybkc) baseImage(platform dagger.Platform) *dagger.Container {
 	return m.baseApp(devVersion).Container(platform)
 }
 
-// generatorApp is the published generator image as the archetype's application:
-// the base image, wearing cpybkc's own generator in the plugin directory.
+// publishedGenerator is one of the generators this repository publishes an image
+// for: what the image carries, what builds it, and what it takes to make it
+// answer with its own version.
+//
+// It is a type because there are two of them since #230 and every place that
+// deals with one deals with both — the App, the per-platform binary, the
+// contract check, the release's push list, the release notes. Written out as
+// parallel pairs of functions instead, the way the first generator's were while
+// it was the only one, a check added for one is a check the other silently does
+// without; passing the generator makes "a check added here is a check the
+// release gate acquires" hold across the family rather than for whichever member
+// somebody had in mind.
+//
+// What is deliberately not a field is the repository. Where a generator image is
+// published is derived from the base image's repository by [generatorRepository]
+// and is a property of the release rather than of the generator — a generator
+// that carried its own would be the constant that rule exists not to be.
+type publishedGenerator struct {
+	// name is what a manifest asks for this generator by, what the CLI's PATH
+	// discovery makes an executable name out of, and what generatorRepository
+	// appends to the base image's repository.
+	name string
+
+	// executable is what that discovery looks for, and pkg is the command
+	// directory that builds it.
+	executable string
+	pkg        string
+
+	// versionProbeOptions are the `k=v` pairs checkGeneratorVersion has to pass
+	// this generator — without the `--opt` flags — before it will parse the
+	// vector at all.
+	//
+	// They belong to the generator rather than to the check because an option
+	// vocabulary is a plugin's own (docs/plugin/SPEC.md): cpybkc passes options
+	// through without checking one against a declared list, and each of these
+	// generators refuses an option it does not recognise rather than ignoring it.
+	// The two disagree, so there is no single vector — cpybkc-gen-go requires
+	// package_name, and cpybkc-gen-graph refuses that option outright because
+	// both of the options it does take have defaults. Passing one generator's
+	// vector to the other fails in argument parsing, which is before the refusal
+	// the check reads, and the check would then be reporting the wrong failure.
+	versionProbeOptions []string
+}
+
+// ownGeneratorSpec is cpybkc's own Go generator, and graphGeneratorSpec the
+// diagram generator, as the images a release publishes them as.
+//
+// Functions rather than variables for [imagePlatforms]'s reason: a package-level
+// slice is one an accident could append to, and there is no state here worth
+// keeping.
+func ownGeneratorSpec() publishedGenerator {
+	return publishedGenerator{
+		name:                ownGenerator,
+		executable:          generatorExecutable,
+		pkg:                 generatorPackage,
+		versionProbeOptions: []string{"package_name=" + generatorVersionProbePackage},
+	}
+}
+
+func graphGeneratorSpec() publishedGenerator {
+	return publishedGenerator{
+		name:       graphGenerator,
+		executable: graphGeneratorExecutable,
+		pkg:        graphGeneratorPackage,
+	}
+}
+
+// publishedGenerators is every generator this repository publishes an image for,
+// and the single definition of that set in this module.
+//
+// Two since #230, and the order is the order a release pushes them in — see
+// Release, where it is a mitigation rather than a detail.
+//
+// docs/container/SPEC.md deliberately does not cover *which* generators this
+// project publishes, only where one is published: another arriving beside these
+// is not a breaking change. This is the list that decides, and a generator added
+// to it acquires the contract check, the version stamp check, the release push
+// and the release notes at once.
+func publishedGenerators() []publishedGenerator {
+	return []publishedGenerator{ownGeneratorSpec(), graphGeneratorSpec()}
+}
+
+// generatorApp is one published generator image as the archetype's application:
+// the base image, wearing one of cpybkc's own generators in the plugin
+// directory.
 //
 // This is the one construction of it, for baseApp's reason. CompanionModule
 // drives it, ImageContract checks it and Release publishes it, so the image a
@@ -393,12 +496,12 @@ func (m *Cpybkc) baseImage(platform dagger.Platform) *dagger.Container {
 // base does, under the base's version, which is the whole of how #180's "the
 // same signature and attestations the base image carries" is satisfied: by being
 // published the same way rather than by a second arrangement here.
-func (m *Cpybkc) generatorApp(version string) *dagger.Z5LabsApp {
-	return m.baseApp(version).WithApp(m.ownGeneratorApp(version))
+func (m *Cpybkc) generatorApp(version string, g publishedGenerator) *dagger.Z5LabsApp {
+	return m.baseApp(version).WithApp(m.ownGeneratorApp(version, g))
 }
 
-// ownGeneratorApp is cpybkc's own generator as an application of its own, before
-// it is composed onto anything.
+// ownGeneratorApp is one of cpybkc's own generators as an application of its
+// own, before it is composed onto anything.
 //
 // # Why the generic constructor and not the Go chain
 //
@@ -429,20 +532,20 @@ func (m *Cpybkc) generatorApp(version string) *dagger.Z5LabsApp {
 // than asserted about it — the publish checks that the document names the
 // SHA-256 of the executable it accompanies, and a derived document cannot
 // disagree with what it describes.
-func (m *Cpybkc) ownGeneratorApp(version string) *dagger.Z5LabsApp {
+func (m *Cpybkc) ownGeneratorApp(version string, g publishedGenerator) *dagger.Z5LabsApp {
 	app := dag.Z5Labs().App(version)
 
 	for _, platform := range imagePlatforms() {
-		binary := m.generatorBinary(version, platform)
+		binary := m.generatorBinary(version, platform, g)
 
 		app = app.WithVariant(platform, binary, dag.Go().Spdx(binary, m.appSource()),
-			dagger.Z5LabsAppBuilderWithVariantOpts{Name: generatorExecutable})
+			dagger.Z5LabsAppBuilderWithVariantOpts{Name: g.executable})
 	}
 
 	return app.Build()
 }
 
-// generatorBinary builds cpybkc's own generator for one platform.
+// generatorBinary builds one of cpybkc's own generators for one platform.
 //
 // It is [Cpybkc.binary] with a different package and name, and it carries the
 // same CGO and -trimpath switches for the same reasons: what a generator image
@@ -472,26 +575,26 @@ func (m *Cpybkc) ownGeneratorApp(version string) *dagger.Z5LabsApp {
 // stamp naming a variable that does not exist is silently dropped, so passing
 // one would be a line in this recipe that does nothing and reads as though it
 // did.
-func (m *Cpybkc) generatorBinary(version string, platform dagger.Platform) *dagger.File {
+func (m *Cpybkc) generatorBinary(version string, platform dagger.Platform, g publishedGenerator) *dagger.File {
 	return dag.Go().
 		Build(m.appSource(), dagger.GoBuildOpts{
-			Pkg:          generatorPackage,
-			ArtifactName: generatorExecutable,
+			Pkg:          g.pkg,
+			ArtifactName: g.executable,
 			Trimpath:     true,
 			DisableCgo:   true,
 			Platform:     string(platform),
 			Stamps:       []string{"main.version=" + version},
 		}).
-		File(generatorExecutable)
+		File(g.executable)
 }
 
-// generatorImage is one platform's generator image, for the checks and for the
-// stages that drive it rather than publish it.
+// generatorImage is one platform's image for one generator, for the checks and
+// for the stages that drive it rather than publish it.
 //
 // It is an accessor onto the App, exactly as baseImage is, so a check reads the
 // container a publish would push.
-func (m *Cpybkc) generatorImage(platform dagger.Platform) *dagger.Container {
-	return m.generatorApp(devVersion).Container(platform)
+func (m *Cpybkc) generatorImage(platform dagger.Platform, g publishedGenerator) *dagger.Container {
+	return m.generatorApp(devVersion, g).Container(platform)
 }
 
 // generatorRepository is where the generator image for name is published:
@@ -575,10 +678,11 @@ func (m *Cpybkc) irProtoTree() *dagger.Directory {
 //   - The entrypoint being the CLI, by running it — twice, as the image's own
 //     user and as an arbitrary other one.
 //
-// The generator image a release publishes beside the base is checked here too
-// (#180), on the same platforms and by the same reading of the same document:
-// it is the base's exhaustive listing plus exactly one file, at the name the
-// plugin contract resolves. See checkGeneratorImage.
+// Every generator image a release publishes beside the base is checked here too
+// — `go` since #180 and `graph` since #230 — on the same platforms and by the
+// same reading of the same document: each is the base's exhaustive listing plus
+// exactly one file, at the name the plugin contract resolves for that generator.
+// See checkGeneratorImage.
 //
 // platform restricts the check to one of the published platforms; empty runs
 // every one of them, and every failure is reported rather than the first,
@@ -604,11 +708,13 @@ func (m *Cpybkc) ImageContract(
 
 	var errs []error
 	for _, p := range platforms {
-		// Both branches name which image they are about. The base's used to be
-		// the only one and went unqualified; with two images in the loop, a
-		// reader would have had to know that a bare platform prefix meant the
-		// base — which stops being obvious the moment a third image arrives.
-		// devVersion twice over, because that is what baseImage and
+		// Every branch names which image it is about. The base's used to be the
+		// only one and went unqualified; the third image arrived (#230), which is
+		// the moment the comment here predicted, and a generator's message names
+		// the generator as well as the platform because "it holds for `go` and
+		// not for `graph`" is as much the finding as "it holds on amd64 and not
+		// on arm64".
+		// devVersion throughout, because that is what baseImage and
 		// generatorImage build under and the check is "what the image reports is
 		// what it was built for". A release asks the same two functions the same
 		// question with its own version — see release.go's gate — so the version
@@ -618,8 +724,14 @@ func (m *Cpybkc) ImageContract(
 			errs = append(errs, fmt.Errorf("%s: the base image: %w", p, err))
 		}
 
-		if err := errors.Join(m.checkGeneratorImage(ctx, m.generatorImage(p), p, devVersion)...); err != nil {
-			errs = append(errs, fmt.Errorf("%s: the generator image: %w", p, err))
+		// Every generator a release publishes, from the one list of them, so a
+		// generator added to publishedGenerators is checked here without anybody
+		// remembering to add it — which is the failure that would otherwise ship
+		// an unchecked image on the release that first published it.
+		for _, g := range publishedGenerators() {
+			if err := errors.Join(m.checkGeneratorImage(ctx, m.generatorImage(p, g), p, devVersion, g)...); err != nil {
+				errs = append(errs, fmt.Errorf("%s: the %s generator image: %w", p, g.name, err))
+			}
 		}
 	}
 
@@ -664,11 +776,18 @@ func (m *Cpybkc) ImageContract(
 // does not vary by architecture. checkImageBuild is where per-platform claims
 // about these binaries are made.
 //
-// Both apps rather than one, because the two are stamped by different parties.
-// The CLI's comes from the shared archetype, with the flag and the symbol fixed
-// upstream; the generator's is passed by hand in generatorBinary, since it is
-// built through the generic constructor and has nobody upstream to stamp it. A
-// check of one says nothing about the other.
+// Every app rather than one, because the CLI and the generators are stamped by
+// different parties. The CLI's comes from the shared archetype, with the flag
+// and the symbol fixed upstream; a generator's is passed by hand in
+// generatorBinary, since it is built through the generic constructor and has
+// nobody upstream to stamp it. A check of one says nothing about the other.
+//
+// Every generator and not only the first, for the same reason one step down. The
+// stamp is passed per generator, each command declares its own `var version` in
+// a package that deliberately imports nothing shared, and each is therefore its
+// own chance for a stamp to be dropped or to name a symbol that is not there.
+// A `graph` generator whose stamp stopped landing would report `0.0.0-dev` out
+// of a released image exactly as #181's did.
 func (m *Cpybkc) checkVersionIsStamped(ctx context.Context) []error {
 	platform, err := dag.DefaultPlatform(ctx)
 	if err != nil {
@@ -679,9 +798,13 @@ func (m *Cpybkc) checkVersionIsStamped(ctx context.Context) []error {
 
 	errs := m.checkImageIsTheCLI(ctx, base, contractVersion)
 
-	generator := m.generatorApp(contractVersion).Container(platform)
+	for _, g := range publishedGenerators() {
+		generator := m.generatorApp(contractVersion, g).Container(platform)
 
-	return append(errs, m.checkGeneratorVersion(ctx, generator, contractVersion)...)
+		errs = append(errs, m.checkGeneratorVersion(ctx, generator, contractVersion, g)...)
+	}
+
+	return errs
 }
 
 // checkBaseImage holds one platform's base image to docs/container/SPEC.md.
@@ -766,6 +889,7 @@ func (m *Cpybkc) checkGeneratorImage(
 	image *dagger.Container,
 	platform dagger.Platform,
 	version string,
+	g publishedGenerator,
 ) []error {
 	protos, err := m.shippedProtos(ctx)
 	if err != nil {
@@ -773,14 +897,15 @@ func (m *Cpybkc) checkGeneratorImage(
 	}
 
 	errs := m.checkImageConfig(ctx, image)
-	errs = append(errs, m.checkImageContents(ctx, image, generatorImageContents(baseImageContents(protos)))...)
-	errs = append(errs, m.checkImageBuild(ctx, image, platform, pluginDir+"/"+generatorExecutable)...)
-	errs = append(errs, m.checkGeneratorVersion(ctx, image, version)...)
+	errs = append(errs, m.checkImageContents(ctx, image, generatorImageContents(baseImageContents(protos), g))...)
+	errs = append(errs, m.checkImageBuild(ctx, image, platform, pluginDir+"/"+g.executable)...)
+	errs = append(errs, m.checkGeneratorVersion(ctx, image, version, g)...)
 
-	// The one generator a release publishes an image for, and nothing else. The
-	// committed example runs a second one, but it ships no image of its own, so
-	// what belongs in this image's plugin directory is unchanged by that.
-	if err := m.checkComposedImage(ctx, image, []string{generatorExecutable}); err != nil {
+	// This generator and nothing else. One image per generator is what
+	// [publishedGenerators] means: two generators in one plugin directory would
+	// be an image an adopter cannot take one of them out of without the other,
+	// and a `COPY --from` naming the wrong one would still find something.
+	if err := m.checkComposedImage(ctx, image, []string{g.executable}); err != nil {
 		errs = append(errs, err)
 	}
 
@@ -810,8 +935,8 @@ func (m *Cpybkc) checkGeneratorImage(
 // repository's own generator carrying a surface no other plugin has, which is
 // the arrangement its package comment exists to refuse.
 //
-// The descriptor is empty, so it states no IR version — the case
-// cmd/cpybkc-gen-go's own tests pin — and an empty file is the one descriptor
+// The descriptor is empty, so it states no IR version — the case each
+// generator's own tests pin — and an empty file is the one descriptor
 // whose bytes need no encoding: it goes in as the empty string rather than as a
 // protobuf message this module would have to hand-assemble to make a version
 // number out of. --out names a directory that does not exist and never will,
@@ -820,11 +945,36 @@ func (m *Cpybkc) checkGeneratorImage(
 // all. Both are properties of that program rather than accidents, and the
 // assertion below fails loudly if either stops holding, because what it requires
 // is *this* refusal and not merely a non-zero exit.
-func (m *Cpybkc) checkGeneratorVersion(ctx context.Context, image *dagger.Container, version string) []error {
+//
+// # The option vector is the generator's own
+//
+// The `--opt` pairs come from the generator rather than being written here,
+// because the two published generators agree on none of them: cpybkc-gen-go
+// requires a package name before it will parse a vector at all, and
+// cpybkc-gen-graph refuses that option outright. A single vector would fail one
+// of them in argument parsing — which is *before* the refusal this check reads,
+// so it would report a version check that had never run as one that had failed.
+// See [publishedGenerator.versionProbeOptions].
+func (m *Cpybkc) checkGeneratorVersion(
+	ctx context.Context,
+	image *dagger.Container,
+	version string,
+	g publishedGenerator,
+) []error {
 	const (
 		descriptor = "/no-version.binpb"
 		out        = "/nowhere"
 	)
+
+	args := []string{
+		pluginDir + "/" + g.executable,
+		"--descriptor", descriptor,
+		"--out", out,
+	}
+
+	for _, option := range g.versionProbeOptions {
+		args = append(args, "--opt", option)
+	}
 
 	// Expect a failure, because a refusal is one: the generator exits non-zero
 	// and writes the diagnostic to standard error. A run that *succeeded* is the
@@ -833,16 +983,11 @@ func (m *Cpybkc) checkGeneratorVersion(ctx context.Context, image *dagger.Contai
 	// it arrives here as an error from Stderr rather than as a passing check.
 	refusal, err := image.
 		WithNewFile(descriptor, "").
-		WithExec([]string{
-			pluginDir + "/" + generatorExecutable,
-			"--descriptor", descriptor,
-			"--out", out,
-			"--opt", "package_name=" + generatorVersionProbePackage,
-		}, dagger.ContainerWithExecOpts{Expect: dagger.ReturnTypeFailure}).
+		WithExec(args, dagger.ContainerWithExecOpts{Expect: dagger.ReturnTypeFailure}).
 		Stderr(ctx)
 	if err != nil {
 		return []error{fmt.Errorf("running %s in the image on a descriptor stating no IR version: %w",
-			generatorExecutable, err)}
+			g.executable, err)}
 	}
 
 	var errs []error
@@ -854,15 +999,15 @@ func (m *Cpybkc) checkGeneratorVersion(ctx context.Context, image *dagger.Contai
 	if !strings.Contains(refusal, "implements IR version") {
 		errs = append(errs, fmt.Errorf("%s in the image answered a descriptor stating no IR version with %q, "+
 			"and docs/plugin/SPEC.md has it refuse one naming the descriptor's version, the highest it "+
-			"implements and its own", generatorExecutable, strings.TrimSpace(refusal)))
+			"implements and its own", g.executable, strings.TrimSpace(refusal)))
 
 		return errs
 	}
 
-	if want := generatorExecutable + " " + reportedVersion(version) + " "; !strings.Contains(refusal, want) {
+	if want := g.executable + " " + reportedVersion(version) + " "; !strings.Contains(refusal, want) {
 		errs = append(errs, fmt.Errorf("%s in the image refused with %q, and an image built under %s carries a "+
 			"generator naming itself %q: a released generator reporting the development version gives its "+
-			"refusal a number nobody can map to a release", generatorExecutable, strings.TrimSpace(refusal),
+			"refusal a number nobody can map to a release", g.executable, strings.TrimSpace(refusal),
 			version, strings.TrimSpace(want)))
 	}
 
@@ -871,6 +1016,10 @@ func (m *Cpybkc) checkGeneratorVersion(ctx context.Context, image *dagger.Contai
 
 // generatorImageContents is the base image's listing plus the one executable a
 // generator image adds, which is the whole of what a generator image is.
+//
+// One executable however many generators this project publishes: each gets an
+// image of its own, so the entry this adds is the caller's generator and never
+// the set of them.
 //
 // It is separate from derivedImageContents, which describes what a *stranger's*
 // Dockerfile produces, and the difference between the two is the point rather
@@ -905,11 +1054,11 @@ func (m *Cpybkc) checkGeneratorVersion(ctx context.Context, image *dagger.Contai
 // depend on that. docs/container/SPEC.md holds the ownership and mode of this
 // directory out of the contract in as many words; the row is here because the
 // listing is exhaustive or it is nothing.
-func generatorImageContents(base map[string]imageEntry) map[string]imageEntry {
+func generatorImageContents(base map[string]imageEntry, g publishedGenerator) map[string]imageEntry {
 	contents := maps.Clone(base)
 
 	contents[pluginDir] = imageEntry{kindDir, 0, 0, dirMode}
-	contents[pluginDir+"/"+generatorExecutable] = imageEntry{kindFile, 65532, 65532, 0o555}
+	contents[pluginDir+"/"+g.executable] = imageEntry{kindFile, 65532, 65532, 0o555}
 
 	return contents
 }

--- a/.dagger/release.go
+++ b/.dagger/release.go
@@ -123,15 +123,32 @@ const (
 	notesClose = "<!-- /cpybkc:image -->"
 )
 
-// Release publishes the images for the release at HEAD (#59, #185, #180).
+// releaseImage is one image a release publishes: the App it is built from, the
+// repository it goes to, and the contract check it is gated by.
 //
-// Two of them, over the same platforms and under the same release's tags: the
-// base image, and the generator image carrying cpybkc's own generator. The
-// second is not an extra artifact bolted on beside the first — it is the base
-// App with one more application composed into it, so it is signed, attested and
-// tagged by having been published the same way rather than by a second
-// arrangement here. Where it goes is derived from where the base went; see
-// generatorRepository.
+// A named type rather than the anonymous struct this used to be a slice of,
+// because the generator entries are now assembled in a loop over
+// [publishedGenerators] and an anonymous type cannot be appended to from one.
+//
+// The check is the same shape for every image — see checkBaseImage and
+// checkGeneratorImage — so the gate below asks all of them the same question and
+// no entry can be gated by less than the others.
+type releaseImage struct {
+	app        *dagger.Z5LabsApp
+	repository string
+	check      func(context.Context, *dagger.Container, dagger.Platform, string) []error
+}
+
+// Release publishes the images for the release at HEAD (#59, #185, #180, #230).
+//
+// Three of them, over the same platforms and under the same release's tags: the
+// base image, the generator image carrying cpybkc's own Go generator, and the
+// generator image carrying the diagram generator the worked example's second
+// half runs. Neither generator is an extra artifact bolted on beside the base —
+// each is the base App with one more application composed into it, so each is
+// signed, attested and tagged by having been published the same way rather than
+// by a second arrangement here. Where each goes is derived from where the base
+// went; see generatorRepository.
 //
 // Whether there is a release at all is decided here, from the release's own tag
 // and the refs at HEAD: a canonical version tag pointing at HEAD is a release,
@@ -235,42 +252,54 @@ func (m *Cpybkc) Release(
 			releaseName(tag), strings.Join(refs, ", ")), nil
 	}
 
-	// The two images this release publishes, and the repository each goes to. The
+	// The images this release publishes, and the repository each goes to. Each
 	// generator's is derived rather than an argument for the reason
 	// generatorRepository gives: a mirror redirects the whole family by moving
-	// the CLI image, and a caller who could name the two independently could
-	// publish a generator the companion module's default would never look for.
+	// the CLI image, and a caller who could name them independently could publish
+	// a generator the companion module's default would never look for.
 	//
-	// # The generator is first, and the order is the mitigation
+	// Assembled from [publishedGenerators] rather than written out, so a
+	// generator added to that list is one this release publishes. The alternative
+	// is a generator that ImageContract checks on every pull request and that no
+	// release ever pushes — which is the gap #230 closed for `graph` and would
+	// reopen for the next one.
+	//
+	// # The generators are first, and the order is the mitigation
 	//
 	// This slice is iterated for the gate and again for the push, so its order is
-	// the push order. The generator leads because its repository is the one that
-	// might not be writable: the first release under #180 *creates*
+	// the push order. The generators lead because their repositories are the ones
+	// that might not be writable: the first release under #180 *creates*
 	// `<repository>-gen-<name>`, and a registry that will accept a push to an
 	// existing package does not necessarily accept the creation of a new one. So
-	// the question that has never been answered is asked first, while the answer
-	// still costs nothing.
+	// the questions that have never been answered are asked first, while the
+	// answers still cost nothing.
 	//
 	// Ordering is a mitigation and not a fix, because there is no fix available
 	// here — see the push loop below.
-	images := []struct {
-		app        *dagger.Z5LabsApp
-		repository string
-		check      func(context.Context, *dagger.Container, dagger.Platform, string) []error
-	}{
-		{
-			app:        m.generatorApp(version),
-			repository: generatorRepository(repository, ownGenerator),
-			check:      m.checkGeneratorImage,
-		},
-		{
-			app:        m.baseApp(version),
-			repository: repository,
-			check:      m.checkBaseImage,
-		},
+	images := make([]releaseImage, 0, len(publishedGenerators())+1)
+
+	for _, g := range publishedGenerators() {
+		images = append(images, releaseImage{
+			app:        m.generatorApp(version, g),
+			repository: generatorRepository(repository, g.name),
+			check: func(
+				ctx context.Context,
+				image *dagger.Container,
+				platform dagger.Platform,
+				version string,
+			) []error {
+				return m.checkGeneratorImage(ctx, image, platform, version, g)
+			},
+		})
 	}
 
-	// The gate. Nothing is pushed until **both** images have been checked against
+	images = append(images, releaseImage{
+		app:        m.baseApp(version),
+		repository: repository,
+		check:      m.checkBaseImage,
+	})
+
+	// The gate. Nothing is pushed until **every** image has been checked against
 	// docs/container/SPEC.md on every platform they are published for, and each is
 	// checked on the containers its own App carries — see this file's comment for
 	// why that is not the same as having run `dagger call image-contract` a moment
@@ -279,28 +308,28 @@ func (m *Cpybkc) Release(
 	// checkBaseImage and checkGeneratorImage rather than sequences assembled here,
 	// so that a check added to ImageContract is a check this gate acquires.
 	//
-	// Both are gated before either is pushed, rather than each image being checked
-	// and then published in turn, so that an image failing its contract cannot be
-	// discovered after the other one is already out.
+	// All of them are gated before any is pushed, rather than each image being
+	// checked and then published in turn, so that an image failing its contract
+	// cannot be discovered after another one is already out.
 	//
 	// That rules out one cause of a half-published release and **not** the
 	// general case, which is worth saying plainly because the arrangement looks
-	// stronger than it is. The pushes below are sequential across two
+	// stronger than it is. The pushes below are sequential across three
 	// repositories and a registry has no transaction spanning them, so anything
 	// that fails at push time — a credential, a rate limit, a repository that
-	// cannot be created — still leaves the earlier image published under tags
+	// cannot be created — still leaves the earlier images published under tags
 	// this project's contract says are never repointed.
 	//
 	// # This is also where a version that disagrees with the tag is refused
 	//
 	// Each check is handed the version, and each holds the binaries in its image
-	// to it: the CLI's --version line and the version the generator's refusal
-	// names, both against the tag this release was cut from (#181). Here rather
+	// to it: the CLI's --version line and the version each generator's refusal
+	// names, all against the tag this release was cut from (#181). Here rather
 	// than in a check of its own, because there is exactly one moment at which
 	// the version a binary reports and the version a release is being cut under
 	// are both in hand, and it is this one — before anything is pushed, over the
 	// very containers that would be. A check of its own would have to rebuild
-	// both images to ask, and would be a second place a release can be refused
+	// every image to ask, and would be a second place a release can be refused
 	// from.
 	//
 	// It costs nothing at a release to say so, and it is worth saying: the same
@@ -324,18 +353,19 @@ func (m *Cpybkc) Release(
 
 	fmt.Fprintf(&report, "%s\n  version:    %s\n", registry, version)
 
-	// Two publishes, in the order the slice above fixes, and the failure of the
-	// second leaves the first published. What makes that survivable is that this
-	// whole function is safe to run again: each image is a function of the source,
-	// so a re-run pushes the same bytes and every tag lands back on the digest it
-	// already named. So the recovery from a half-published release is to fix
-	// whatever refused the push and re-run the job — not to hand-push the missing
-	// image, and never to repoint a tag.
+	// One publish per image, in the order the slice above fixes, and the failure
+	// of one leaves the ones before it published. What makes that survivable is
+	// that this whole function is safe to run again: each image is a function of
+	// the source, so a re-run pushes the same bytes and every tag lands back on
+	// the digest it already named. So the recovery from a half-published release
+	// is to fix whatever refused the push and re-run the job — not to hand-push
+	// the missing image, and never to repoint a tag.
 	//
 	// The report is written as it goes rather than at the end, and it is returned
 	// beside the error rather than discarded, precisely so a half-published
-	// release says which half. An error alone would leave whoever is holding it
-	// unable to tell a release that pushed nothing from one that pushed one image.
+	// release says how far it got. An error alone would leave whoever is holding
+	// it unable to tell a release that pushed nothing from one that pushed two of
+	// its three images.
 	for _, image := range images {
 		published, err := image.app.
 			WithRegistry(registry, username, password).
@@ -649,27 +679,54 @@ func (m *Cpybkc) TagScheme() error {
 		}
 	}
 
-	// Where the generator image goes, which is the other half of the release
+	// Where the generator images go, which is the other half of the release
 	// decision since #180: a release states a version *and* the repositories that
 	// version is published to, and only one of the two is an argument.
 	//
 	// The literals matter more here than anywhere else in this function, because
 	// this rule is written down twice — daggerverse/cpybkc/internal/generator's
 	// Repository is the other spelling, in a Go module this one cannot import.
-	// Its TestRepository pins the same two answers. So the pair below is not a
-	// tautology over one line of code: it is one end of a drift guard whose other
-	// end is a test in another module, and the failure it rules out is a release
-	// publishing where the companion module's default never looks.
+	// Its TestRepository pins the same answers. So the rows below are not a
+	// tautology over one line of code: they are one end of a drift guard whose
+	// other end is a test in another module, and the failure they rule out is a
+	// release publishing where the companion module's default never looks.
 	for _, c := range []struct{ repository, name, want string }{
 		{"zaba505/cpybkc", "go", "zaba505/cpybkc-gen-go"},
+		// The second generator this repository publishes (#230), spelled out for
+		// the same reason and against the same other end: `with-generator graph`
+		// with no --image resolves that module's answer, and this is the one a
+		// release pushes to.
+		{"zaba505/cpybkc", "graph", "zaba505/cpybkc-gen-graph"},
 		// A mirror redirects the whole family by moving the CLI image alone,
 		// which is the property that makes the rule derived rather than constant.
+		// One generator is enough to pin it: what varies here is the repository
+		// and not the name, and the rows above are what pin the names.
 		{"mirrors/cpybkc", "go", "mirrors/cpybkc-gen-go"},
 	} {
 		if got := generatorRepository(c.repository, c.name); got != c.want {
 			errs = append(errs, fmt.Errorf("the generator image for %q beside %q publishes to %q, want %q",
 				c.name, c.repository, got, c.want))
 		}
+	}
+
+	// And which generators those rows are supposed to cover, pinned as a literal
+	// against [publishedGenerators].
+	//
+	// Without it the rows above are a check on a rule and not on this release: a
+	// third generator added to that list would be published to a repository no
+	// literal here has ever been compared against, and the drift guard whose other
+	// end is another module's test would silently stop covering the family. Which
+	// generators exist is deliberately outside docs/container/SPEC.md's contract,
+	// so nothing else fails when the set changes — this is what makes the change
+	// arrive as a decision rather than as a release.
+	var names []string
+	for _, g := range publishedGenerators() {
+		names = append(names, g.name)
+	}
+
+	if want := []string{"go", "graph"}; !slices.Equal(names, want) {
+		errs = append(errs, fmt.Errorf("a release publishes a generator image for %v, want %v: add the new one to "+
+			"the rows above, to the release notes block and to docs/container/SPEC.md's table", names, want))
 	}
 
 	// What the binaries a release publishes say their version is, which is the
@@ -738,11 +795,13 @@ func (m *Cpybkc) ReleaseNotesContract() error {
 		"IR version 7",
 		"`v0.2.0`",
 		"ghcr.io/zaba505/cpybkc:v0.2.0",
-		// The generator image, named beside the base it is published with (#180).
-		// A literal rather than generatorRepository's answer, like every other
-		// expectation here: a check that derived it the way the block does would
-		// go green on a block that had stopped naming the generator at all.
+		// The generator images, named beside the base they are published with
+		// (#180, #230). Literals rather than generatorRepository's answers, like
+		// every other expectation here: a check that derived them the way the
+		// block does would go green on a block that had stopped naming a
+		// generator at all.
 		"ghcr.io/zaba505/cpybkc-gen-go:v0.2.0",
+		"ghcr.io/zaba505/cpybkc-gen-graph:v0.2.0",
 		notesOpen, notesClose,
 	} {
 		if !strings.Contains(block, want) {
@@ -1056,12 +1115,19 @@ func (m *Cpybkc) irVersion(ctx context.Context) (int, error) {
 // published, so ReleaseNotesContract can read it back without a registry, a git
 // checkout or a release.
 //
-// It names **both** images a release publishes (#180), and the generator's
-// reference is derived from the base's rather than passed in — one argument for
-// two images, so a mirror's release notes cannot name the mirror for one and
-// ghcr.io for the other. That the generator exists at all is the fact this half
-// of the block is for: `v0.0.0` published the base alone, and the one documented
-// way to get the generator was a reference that answered NAME_UNKNOWN.
+// It names **every** image a release publishes (#180, #230), and each
+// generator's reference is derived from the base's rather than passed in — one
+// argument for the whole family, so a mirror's release notes cannot name the
+// mirror for one and ghcr.io for another. That the generators exist at all is
+// the fact this half of the block is for: `v0.0.0` published the base alone, and
+// the one documented way to get a generator was a reference that answered
+// NAME_UNKNOWN.
+//
+// The pull lines come from [publishedGenerators] so a generator added there is
+// one this block names. The prose beside them does not, and that is deliberate:
+// it says how many images there are and what they are for, which is a sentence
+// somebody has to rewrite rather than a list to extend — and TagScheme is what
+// fails when the set changes without anybody having done so.
 //
 // It names the version and no other tag. Which tags a version implies is the
 // shared pipeline's rule since #185, and a block enumerating them would be this
@@ -1086,14 +1152,20 @@ func releaseNotesBlock(version string, irVersion int, reference string) string {
 	b.WriteString("\n## The images this release publishes\n\n")
 
 	if reference != "" {
-		fmt.Fprintf(&b, "```console\n$ docker pull %s:%s\n$ docker pull %s:%s\n```\n\n",
-			reference, version, generatorRepository(reference, ownGenerator), version)
+		b.WriteString("```console\n")
+		fmt.Fprintf(&b, "$ docker pull %s:%s\n", reference, version)
+
+		for _, g := range publishedGenerators() {
+			fmt.Fprintf(&b, "$ docker pull %s:%s\n", generatorRepository(reference, g.name), version)
+		}
+
+		b.WriteString("```\n\n")
 	}
 
-	fmt.Fprintf(&b, "Two images: the cpybkc CLI, and `cpybkc-gen-%s`, this project's own generator. The generator\n"+
-		"reaches you the way a stranger's does — an image to `COPY --from`, never something the base image\n"+
-		"carries — and it is published from this same release, over the same platforms and under the same\n"+
-		"tags.\n\n", ownGenerator)
+	fmt.Fprintf(&b, "Three images: the cpybkc CLI, and `%s` and `%s`, this project's own generators. A\n"+
+		"generator reaches you the way a stranger's does — an image to `COPY --from`, never something the\n"+
+		"base image carries — and both are published from this same release, over the same platforms and\n"+
+		"under the same tags.\n\n", generatorExecutable, graphGeneratorExecutable)
 
 	fmt.Fprintf(&b, "**This image speaks IR version %d.** Every descriptor the `cpybkc` in it writes carries that\n"+
 		"version, and a generator that implements a lower one refuses the descriptor rather than guessing — so a\n"+

--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ beneath it — which is how you check that a layout describes the records you
 meant, in the order you meant, told apart on the bytes you meant, at the offsets
 you meant.
 
+Both are published as images of their own from every release, beside the CLI
+image and under the same tags:
+
+```console
+$ docker pull ghcr.io/zaba505/cpybkc-gen-go:v0
+$ docker pull ghcr.io/zaba505/cpybkc-gen-graph:v0
+```
+
+So neither needs a Go toolchain to run: a generator is copied out of its image
+into one built `FROM` the CLI's, which is the same route a stranger's generator
+takes. [Where this project's own generators are
+published](docs/container/SPEC.md#where-this-projects-own-generators-are-published)
+is the rule those addresses follow — derived from the CLI image's repository, so
+a mirror moves the whole family by moving one.
+
 A plugin written in anything else takes one of the two IR artifacts attached to
 every release: `ir.binpb`, the protobuf `FileDescriptorSet` that lets any
 runtime decode a descriptor with no code generation in the build, or

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ published](docs/container/SPEC.md#where-this-projects-own-generators-are-publish
 is the rule those addresses follow — derived from the CLI image's repository, so
 a mirror moves the whole family by moving one.
 
+**Until the first release under that rule is cut, those two references resolve
+to nothing.** They are written here ahead of it deliberately, because the rule
+they follow is what the release is built against; a reader arriving before it
+should build from source, as [the worked example](example/README.md#regenerating)
+does.
+
 A plugin written in anything else takes one of the two IR artifacts attached to
 every release: `ir.binpb`, the protobuf `FileDescriptorSet` that lets any
 runtime decode a descriptor with no code generation in the build, or

--- a/daggerverse/cpybkc/internal/generator/generator_test.go
+++ b/daggerverse/cpybkc/internal/generator/generator_test.go
@@ -80,6 +80,18 @@ func TestRepository(t *testing.T) {
 			want:       "ghcr.io/zaba505/cpybkc-gen-go",
 		},
 		{
+			// The other published generator, spelled out for the same reason: a
+			// caller who passed neither --repository nor --image for `graph`
+			// reaches this reference, and a release publishes to it. The root
+			// pipeline's TagScheme pins the same answer from the other side of the
+			// module boundary, which is what makes the pair a drift guard rather
+			// than one spelling checked twice.
+			testName:   "the other published default",
+			repository: "ghcr.io/zaba505/cpybkc",
+			name:       "graph",
+			want:       "ghcr.io/zaba505/cpybkc-gen-graph",
+		},
+		{
 			// The air-gap case, and the whole reason the derivation reads the
 			// caller's repository rather than a constant: redirecting the CLI image
 			// has to redirect its generators too.

--- a/daggerverse/cpybkc/internal/generator/generator_test.go
+++ b/daggerverse/cpybkc/internal/generator/generator_test.go
@@ -28,6 +28,12 @@ func TestExecutable(t *testing.T) {
 		// rebuilt the name the way Executable does would agree with it however
 		// wrong both were.
 		{name: "go", want: "cpybkc-gen-go"},
+		// The other name this project publishes an image for. Both are spelled
+		// out because both are what the root pipeline installs into a published
+		// image and what cpybkc then resolves on PATH; a name that only this
+		// module got right would produce an image that builds and pushes and
+		// then reports the generator missing.
+		{name: "graph", want: "cpybkc-gen-graph"},
 		{name: "hello", want: "cpybkc-gen-hello"},
 		// docs/plugin/SPEC.md's SHOULD is lowercase ASCII, digits and hyphens; a
 		// name using all three has to survive unchanged, prefix and nothing else.

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -121,12 +121,14 @@ have taught every adopter one more thing.
 ### Why cpybkc's own generator is not in the base image
 
 The base image holds **no** executable in the plugin directory (#55, #185).
-`cpybkc-gen-go` (#48–#53) is this project's own generator and reaches a user the
-way a stranger's does: as an image built `FROM` the base, adding one executable at
-the path this section names and changing nothing else.
+`cpybkc-gen-go` (#48–#53) and `cpybkc-gen-graph` are this project's own
+generators, and each reaches a user the way a stranger's does: as an image built
+`FROM` the base, adding one executable at the path this section names and
+changing nothing else.
 
-**Every release from the next one on publishes it**, at the repository
-[named below](#where-this-projects-own-generators-are-published) (#180).
+**Every release from the next one on publishes them**, one image each, at the
+repositories [named below](#where-this-projects-own-generators-are-published)
+(#180, #230).
 
 That is a change of state and not just of wording. The sentence above described
 an intention for as long as it stood alone: `v0.0.0` published the base image
@@ -137,6 +139,14 @@ to everybody outside this repository, while three places in the tree said it
 existed. What closes the gap is the generator image being cut from the same
 release as the base, over the same platforms, under the same tags, signed and
 attested the same way.
+
+The same argument is what added the second generator to that release (#230).
+`cpybkc-gen-graph` stood exactly where `cpybkc-gen-go` had: a peer in this
+project's own README, one of the two generators the [worked
+example](../../example/README.md) runs, and reachable only through a Go toolchain
+and a source checkout — while `with-generator graph` derived a reference nothing
+was ever pushed to. A rule that publishes one of two generators is a rule with an
+exception nobody documented.
 
 Until that release is cut, the references below resolve to nothing. They are
 written here ahead of it deliberately — the rule they follow is what the release
@@ -163,13 +173,14 @@ reference in a consumer's Dockerfile.
 
 A generator this project publishes for `<name>` is at the **base image's own
 repository with `-gen-<name>` appended**, in the same registry, under the same
-release's tags (#180). One generator is published under that rule, from the first
-release to carry it onwards:
+release's tags (#180). Two generators are published under that rule, from the
+first release to carry each onwards:
 
 | Image | Repository | Tags |
 | --- | --- | --- |
 | The cpybkc CLI | `<repository>` | [the family a release publishes](#tags-and-what-pinning-one-buys) |
 | The `go` generator | `<repository>-gen-go` | the same family, from the same release |
+| The `graph` generator | `<repository>-gen-graph` | the same family, from the same release |
 
 So with `ghcr.io/zaba505/cpybkc` as the repository, a release published under
 this rule is pulled as:
@@ -177,13 +188,14 @@ this rule is pulled as:
 ```console
 $ docker pull ghcr.io/zaba505/cpybkc:v0
 $ docker pull ghcr.io/zaba505/cpybkc-gen-go:v0
+$ docker pull ghcr.io/zaba505/cpybkc-gen-graph:v0
 ```
 
 The rule is **derived from the CLI image's repository and not from a constant**,
 which is what makes a mirror, an internal registry or an air-gapped copy redirect
-the whole family at once. Copy `<repository>` and `<repository>-gen-go` into
-`registry.internal/mirrors/`, point a build at
-`registry.internal/mirrors/cpybkc`, and the generator is where that rule says it
+the whole family at once. Copy `<repository>` and every `<repository>-gen-<name>`
+into `registry.internal/mirrors/`, point a build at
+`registry.internal/mirrors/cpybkc`, and each generator is where that rule says it
 is. A rule anchored to `ghcr.io` would instead send a build inside a network that
 cannot see it reaching back out on the second pull rather than the first.
 
@@ -204,9 +216,9 @@ change](#how-a-covered-thing-would-change) applies to it.
 
 What is **not** covered is which registry any of it is in, exactly as for the
 base image: a mirror serving the same digests satisfies this identically. Nor is
-the *set* of generators this project publishes — `go` is the only one today, and
-another arriving beside it is not a breaking change, while moving or withdrawing
-one is.
+the *set* of generators this project publishes — `go` and `graph` are the two
+today, and another arriving beside them is not a breaking change, while moving or
+withdrawing one is.
 
 None of this makes a published generator a privileged kind of plugin. It is
 built, named and discovered by the same rules as a stranger's, which is the whole
@@ -1289,11 +1301,12 @@ depending on something that may change in a patch release, with no notice:
 - Anything else appearing under `/usr/local/share/cpybkc/`. The two paths named
   above are the contract; a third file arriving beside them is not one to depend
   on until this document names it.
-- **Which** generators this project publishes, beyond `go`. The [naming
-  rule](#where-this-projects-own-generators-are-published) is covered and the set
-  it is applied to is not: another generator appearing beside `cpybkc-gen-go` is
-  not a breaking change, and neither is one never appearing. Nothing here
-  promises a generator for any particular language will exist.
+- **Which** generators this project publishes, beyond `go` and `graph`. The
+  [naming rule](#where-this-projects-own-generators-are-published) is covered and
+  the set it is applied to is not: another generator appearing beside
+  `cpybkc-gen-go` is not a breaking change — `cpybkc-gen-graph` is that having
+  happened — and neither is one never appearing. Nothing here promises a
+  generator for any particular language will exist.
 
 ### Why the platform set is the two it is
 
@@ -1391,8 +1404,8 @@ Go install with no document that applies to them.
 | Section | Implemented by |
 |---|---|
 | [The plugin directory](#the-plugin-directory) | #54, #55 `container`; #185 `container` withdraws the promise that the directory exists in the base image |
-| [Why cpybkc's own generator is not in the base image](#why-cpybkcs-own-generator-is-not-in-the-base-image) | #55 `container` for the base holding none, #48–#53 `gen-go` for the generator that goes through the front door, #180 `container` for the release that publishes it |
-| [Where this project's own generators are published](#where-this-projects-own-generators-are-published) | #180 `container` decides the rule is covered rather than internal, and publishes the first image under it |
+| [Why cpybkc's own generator is not in the base image](#why-cpybkcs-own-generator-is-not-in-the-base-image) | #55 `container` for the base holding none, #48–#53 `gen-go` for the generator that goes through the front door, #180 `container` for the release that publishes it, #230 `container` for the second generator joining it |
+| [Where this project's own generators are published](#where-this-projects-own-generators-are-published) | #180 `container` decides the rule is covered rather than internal, and publishes the first image under it; #230 `container` publishes the second, which is what makes the rule a family rather than an exception |
 | [The CLI's own path is not part of the contract](#the-clis-own-path-is-not-part-of-the-contract) | #55 `container`; #185 `container` is where it was spent |
 | [The entrypoint](#the-entrypoint) | #55 `container` |
 | [The arrangement survives a subcommand](#the-arrangement-survives-a-subcommand) | #183 `cli` adds the subcommand and restates the promise here; #213 `container` decides what a breaking CLI change does to this image's major tag |

--- a/example/README.md
+++ b/example/README.md
@@ -285,6 +285,24 @@ Each generator is found on `PATH` by name, which is the whole of how a generator
 is identified — the manifest names `go` and `graph`, and cpybkc looks for
 `cpybkc-gen-go` and `cpybkc-gen-graph`.
 
+The two `go build` lines are what a contributor to *this* repository runs, since
+they are working from the source anyway. Working from a release instead, both
+generators are published as images and neither needs a Go toolchain:
+
+```console
+$ docker pull ghcr.io/zaba505/cpybkc-gen-go:v0
+$ docker pull ghcr.io/zaba505/cpybkc-gen-graph:v0
+```
+
+Either is copied into an image built `FROM ghcr.io/zaba505/cpybkc`, or composed
+by the [companion Dagger module](../daggerverse/cpybkc/)'s `with-generator`,
+which resolves those references for `go` and `graph` on its own. [Where this
+project's own generators are
+published](../docs/container/SPEC.md#where-this-projects-own-generators-are-published)
+is the rule they follow, and [adding a
+generator](../docs/container/SPEC.md#worked-example-adding-a-generator) is the
+`COPY --from` it takes.
+
 Then commit what changed. `go test ./example/...` is what fails if you do not:
 it makes the same run into a temporary directory and holds the result against
 what is checked in, naming the file the two disagree on.

--- a/example/README.md
+++ b/example/README.md
@@ -285,8 +285,8 @@ Each generator is found on `PATH` by name, which is the whole of how a generator
 is identified — the manifest names `go` and `graph`, and cpybkc looks for
 `cpybkc-gen-go` and `cpybkc-gen-graph`.
 
-The two `go build` lines are what a contributor to *this* repository runs, since
-they are working from the source anyway. Working from a release instead, both
+The two `go build` lines are what a contributor to *this* repository runs, and
+they are the route that works today. Working from a release instead, both
 generators are published as images and neither needs a Go toolchain:
 
 ```console
@@ -302,6 +302,12 @@ published](../docs/container/SPEC.md#where-this-projects-own-generators-are-publ
 is the rule they follow, and [adding a
 generator](../docs/container/SPEC.md#worked-example-adding-a-generator) is the
 `COPY --from` it takes.
+
+**Until the first release under that rule is cut, those references resolve to
+nothing**, exactly as [the container contract
+says](../docs/container/SPEC.md#where-this-projects-own-generators-are-published).
+Before it, the two `go build` lines above are the way to regenerate this
+example; they stay the way a contributor does it afterwards.
 
 Then commit what changed. `go test ./example/...` is what fails if you do not:
 it makes the same run into a temporary directory and holds the result against


### PR DESCRIPTION
Closes #230

`Release` published the base image and one generator image. This repository has
two generators, so `cpybkc-gen-graph` was in no release output at all — no
image, no asset, no tag — and two things already reached for it and found
nothing: the companion module's `WithGenerator("graph")`, which derives
`<repository>-gen-graph` and pulls it, and the worked example, whose only
documented path to its second half was a Go toolchain and a source checkout.

## What changed

`Release` publishes a third image at `generatorRepository(repository, "graph")`.
It is the base App with the graph generator composed onto it through the same
`WithApp` shape `generatorApp` already used, so it publishes, signs and attests
exactly as the other two do rather than by a second arrangement.

The per-generator facts — the name, the executable, the command directory, and
the `--opt` pairs its version probe needs — move into a `publishedGenerator`
value, and `publishedGenerators()` is the one definition of the set. The App,
the binary build, the contract check, the release's push list and the release
notes all read it, so a generator added to that list acquires every one of them
at once instead of acquiring whichever a later change remembered.

`graphGenerator`, `graphGeneratorExecutable` and `graphGeneratorPackage` move
from `.dagger/companion.go` to `image.go`, and the comment that placed them —
_"that name goes into a **published** image and this one does not"_ — inverts
with them.

## Acceptance criteria

- [x] `Release` publishes a third image at `generatorRepository(repository, "graph")`, derived from the CLI image's repository like the other two.
- [x] It is the base App with the graph generator composed onto it through the same `WithApp` shape `generatorApp` uses.
- [x] The variant names the binary `cpybkc-gen-graph` explicitly through the generic constructor's `WithVariant`, for the reason `ownGeneratorApp` documents.
- [x] Each variant carries a `dag.Go().Spdx` document derived from the compiled artifact — `ownGeneratorApp` builds both generators' variants the same way.
- [x] The version stamp is passed by hand as `main.version=<version>`; `generatorBinary` now builds either generator and stamps both.
- [x] `ImageContract` covers it on every published platform — contents, build facts and version stamp — by looping `publishedGenerators()` through `checkGeneratorImage`, which is the same function the `go` image goes through. `checkVersionIsStamped` covers both generators too, since each command declares its own `var version` and each is its own chance for a stamp to be dropped (#181).
- [x] `TagScheme` pins `zaba505/cpybkc-gen-graph` with a literal, beside the first generator's, and additionally pins the **set** of published generator names — without which a third generator would be published to a repository no literal here had ever been compared against.
- [x] The release notes block names the third image beside the other two, and `ReleaseNotesContract` pins `ghcr.io/zaba505/cpybkc-gen-graph:v0.2.0` as a literal.
- [x] `CompanionModule` composes `graph` through `WithGenerator` against this run's image, as it does `go`; `WithGeneratorExecutable` is now the *other* route for both rather than the only route for one, and the `neverPulledRepository` guard still fails a call that forgot its `--image`.
- [x] `graphGenerator`, `graphGeneratorExecutable` and `graphGeneratorPackage` move to `image.go`, and the comment that placed them inverts.
- [x] `Release`'s doc comment says three images and names what the third carries.
- [x] docs/container/SPEC.md's generator table gains a row and _"One generator is published under that rule"_ becomes two. The naming rule stands unchanged, and so does the note that **which** generators exist is not covered — its `go` is the only one today` clause is the only part corrected.
- [x] `example/README.md` and `README.md` say where the graph generator is published.

## Judgment calls

- **`publishedGenerator` as a type rather than a second pair of parallel
  functions.** The single generator's facts were four constants and three
  methods; a second copy of that shape is how one of them acquires a check the
  other silently does without. The struct is what makes "a check added here is a
  check the release gate acquires" hold across the family.
- **`versionProbeOptions` belongs to the generator, not to the check.**
  `checkGeneratorVersion` used a hard-coded `--opt package_name=…`, which
  `cpybkc-gen-graph` refuses outright — both of its own options have defaults, and
  it rejects an option it does not recognise. That refusal happens in argument
  parsing, *before* the version refusal the check reads, so a shared vector would
  have reported a version check that never ran as one that failed.
- **`checkVersionIsStamped` covers both generators.** Not named in the
  acceptance criteria, but it is the only place a dropped stamp is observable —
  everything else builds under `devVersion`, which is the string the tree already
  carries — and the graph generator's stamp is passed by hand by the same code
  that #181 was about.
- **`CompanionModule`'s two compositions are still written out** rather than
  looped over `publishedGenerators()`: what that check covers is the committed
  example's manifest, not the set of images a release publishes. The two agree
  today, and a divergence should be a decision made there rather than followed
  silently.
- **`TagScheme` pins the generator set.** The repository rows are a check on the
  naming *rule*; without a literal naming which generators it is applied to, a
  third one would publish to an address neither end of the cross-module drift
  guard had ever seen.
- **`docs/container/SPEC.md` keeps the set of generators out of the contract.**
  The out-of-scope note is unchanged in substance; only its factual "`go` is the
  only one today" is corrected, and `cpybkc-gen-graph` is cited there as the
  "another generator appearing beside it is not a breaking change" case actually
  happening.

## Verification

`dagger call ci` — green. Run from an ordinary clone with this tree copied over,
since the root module binds `--git-dir` with `+defaultPath="/.git"` and a
worktree's `.git` is a file (CONTRIBUTING.md, "The pipeline does not run from a
git worktree"). `dagger call release` is not run outside the release workflow;
the stages that cover this work are `ci`'s `ImageContract`, `TagScheme`,
`ReleaseNotesContract` and `CompanionModule`.

`go test ./internal/...` in `daggerverse/cpybkc` for the other end of the
repository-derivation drift guard, which gains a `graph` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019UM47HrC2iHccR1opzwUmm