### PR TITLE
story(conformance): the engine drives an adapter through the specified contract

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1203,6 +1203,39 @@ the code cannot drift apart. A change to what a value is written as is a change
 to `docs/conformance/SPEC.md` first, then to that table, and the test is what
 says the code followed.
 
+### The engine, and the adapter it drives
+
+The corpus above is half of what a third party needs; the other half is a
+program that asks a generator in another language the same question.
+[`internal/conformance/engine`](internal/conformance/engine) is that program.
+It starts a process, speaks the JSON frames
+[`docs/adapter/SPEC.md`](docs/adapter/SPEC.md) specifies over that process's
+standard input and standard output, and holds what came back against what each
+entry states. The program on the other end is an **adapter**, and a container
+image is one door onto it rather than the contract itself.
+
+What lives in the engine rather than in the adapter is not an organisational
+choice. The comparison is here because an adapter holding the expected answers
+is self-grading; the per-operation deadline is here because an adapter that gave
+up on a slow entry would turn one slow entry into a broken adapter and cost
+everything after it; and the fault isolation is here because a crashed adapter's
+stream cannot be resynchronised, so the run needs a fresh process on the entries
+that were left. No frame the engine writes carries any part of an entry's
+`values.json`, and `TestTheAdapterIsNeverGivenTheExpectedValues` asserts exactly
+that against every frame of a real run.
+
+A mismatch is followed by where the descriptor puts the item that disagreed —
+its offset within the record, its width, its usage and its charset — and by the
+bytes of `input.bin` it was read from, where the framing lets a record be
+placed. That is the position sum `docs/ir/SPEC.md` says every consumer runs, and
+the engine is the only thing in the system that can say it: the adapter was
+never told what was expected.
+
+`go test ./internal/conformance/engine/...` re-executes the test binary as a
+fake adapter — one process per case, over real pipes — so the crash, the hang,
+the greeting on standard output and the carriage return a receiver must refuse
+are each exercised against a real process rather than against a stub.
+
 ## Specs
 
 Seven of this project's interfaces are built against from outside it — the

--- a/internal/conformance/engine/adapter_test.go
+++ b/internal/conformance/engine/adapter_test.go
@@ -1,0 +1,464 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package engine_test
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Zaba505/cpybkc/internal/conformance"
+	"github.com/Zaba505/cpybkc/internal/conformance/engine"
+)
+
+// adapterEnv is the variable that turns this test binary into an adapter.
+//
+// The tests need a process on the other end of two pipes, because that is what
+// the contract is: a conversation this package holds over a real standard input
+// and a real standard output, with a real exit status and a process that can
+// really be killed. Re-executing the test binary is how that is had without a
+// build step — the alternative is compiling a helper program per run, which
+// costs a go build on every `go test` of this package and gives nothing back.
+const adapterEnv = "CPYBKC_CONFORMANCE_FAKE_ADAPTER"
+
+// TestMain is the fork in the road: with the variable set this process is an
+// adapter, and without it, it is the test binary.
+func TestMain(m *testing.M) {
+	if path := os.Getenv(adapterEnv); path != "" {
+		os.Exit(adapt(path))
+	}
+
+	os.Exit(m.Run())
+}
+
+// script is what a fake adapter has been told to do, which the test writes to a
+// file and the adapter reads.
+//
+// It reaches the adapter through a file of the test's own and never through the
+// engine, which is the point: the engine's frames are what the transcript
+// records, and an assertion that they carry no expected value is an assertion
+// about the engine rather than about how the fake was arranged.
+type script struct {
+	// Transcript is where every request frame the adapter received is written,
+	// one per line, as it arrives.
+	Transcript string
+
+	// The handshake. Protocol, Kind, Name and Capabilities each default to
+	// something conformant, so that a test states only what it is about.
+	Protocol         *int
+	Kind             string
+	Name             string
+	Capabilities     map[string]bool
+	OmitCapabilities bool
+	RefuseHello      string
+
+	// GenerateRefuse is a generate the adapter does not serve at all, and
+	// GenerateFail is a generate that failed for particular entries.
+	GenerateRefuse string
+	GenerateFail   map[string]string
+
+	// Entries is what the adapter answers about each entry.
+	Entries map[string]entryScript
+
+	// Break is how the adapter stops being an adapter, keyed by the entry it
+	// does so on. Its values are the constants below.
+	Break map[string]string
+}
+
+// entryScript is one entry's answers.
+type entryScript struct {
+	Decoded       json.RawMessage
+	Written       json.RawMessage
+	DecodeRefuse  string
+	OmitRoundtrip bool
+}
+
+// The ways a fake adapter stops being one. Each is a hazard the contract names:
+// a process that exits mid-conversation, one that never answers, a library that
+// greeted the world on standard output, a blank line, a carriage return the
+// engine must not trim, and a frame paired with a request nobody sent.
+const (
+	breakCrash   = "crash"
+	breakHang    = "hang"
+	breakGarbage = "garbage"
+	breakBlank   = "blank"
+	breakCR      = "carriage-return"
+	breakWrongID = "wrong-id"
+)
+
+// adapt is the fake adapter: it reads frames, writes frames, and misbehaves in
+// whichever one way its script names.
+func adapt(path string) int {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "the fake adapter could not read its script: %v\n", err)
+
+		return 2
+	}
+
+	var told script
+	if err := json.Unmarshal(b, &told); err != nil {
+		fmt.Fprintf(os.Stderr, "the fake adapter could not read its script: %v\n", err)
+
+		return 2
+	}
+
+	fake := &fakeAdapter{script: told}
+
+	return fake.run()
+}
+
+type fakeAdapter struct {
+	script script
+}
+
+// run reads one frame at a time and answers it, which is the whole of the
+// conversation from the other side.
+func (f *fakeAdapter) run() int {
+	in := bufio.NewReader(os.Stdin)
+
+	for {
+		line, err := in.ReadString('\n')
+		if err != nil {
+			// End of input is a bye already answered: exit zero without
+			// writing anything further.
+			return 0
+		}
+
+		f.record(line)
+
+		var got struct {
+			ID      int    `json:"id"`
+			Op      string `json:"op"`
+			Entry   string `json:"entry"`
+			Entries []struct {
+				Entry string `json:"entry"`
+			} `json:"entries"`
+		}
+
+		if err := json.Unmarshal([]byte(line), &got); err != nil {
+			fmt.Fprintf(os.Stderr, "the fake adapter was sent something that is not a frame: %q\n", line)
+
+			return 3
+		}
+
+		if broke := f.script.Break[got.Entry]; broke != "" && (got.Op == "decode" || got.Op == "roundtrip") {
+			if code, done := f.misbehave(broke, got.ID); done {
+				return code
+			}
+
+			continue
+		}
+
+		switch got.Op {
+		case "hello":
+			f.hello(got.ID)
+		case "generate":
+			names := make([]string, 0, len(got.Entries))
+			for _, one := range got.Entries {
+				names = append(names, one.Entry)
+			}
+
+			f.generate(got.ID, names)
+		case "decode":
+			f.decode(got.ID, got.Entry)
+		case "roundtrip":
+			f.roundtrip(got.ID, got.Entry)
+		case "bye":
+			f.write(map[string]any{"id": got.ID, "ok": true})
+
+			return 0
+		default:
+			f.write(map[string]any{"id": got.ID, "ok": false, "error": "this adapter does not know that operation"})
+		}
+	}
+}
+
+// misbehave is the one way this adapter stops being one, and whether that ends
+// the process.
+func (f *fakeAdapter) misbehave(how string, id int) (int, bool) {
+	switch how {
+	case breakCrash:
+		fmt.Fprintln(os.Stderr, "the fake adapter is about to crash")
+
+		return 3, true
+	case breakHang:
+		// Never answers. What ends this is the engine's deadline and the kill
+		// behind it — a sleep rather than a blocked channel, because the Go
+		// runtime turns a process whose every goroutine is parked into a
+		// deadlock panic, which is a crash and not the hang being tested.
+		time.Sleep(time.Hour)
+	case breakGarbage:
+		_, _ = fmt.Fprintln(os.Stdout, "a library in this adapter printed a greeting on standard output")
+	case breakBlank:
+		_, _ = fmt.Fprintln(os.Stdout, "")
+	case breakCR:
+		_, _ = fmt.Fprintf(os.Stdout, "{\"id\":%d,\"ok\":true}\r\n", id)
+	case breakWrongID:
+		f.write(map[string]any{"id": id + 1000, "ok": true})
+	}
+
+	return 0, false
+}
+
+func (f *fakeAdapter) hello(id int) {
+	protocol := engine.Protocol
+	if f.script.Protocol != nil {
+		protocol = *f.script.Protocol
+	}
+
+	if f.script.RefuseHello != "" {
+		f.write(map[string]any{"id": id, "ok": false, "error": f.script.RefuseHello, "protocol": protocol})
+
+		return
+	}
+
+	name := f.script.Name
+	if name == "" {
+		name = "the fake adapter"
+	}
+
+	kind := f.script.Kind
+	if kind == "" {
+		kind = "codec"
+	}
+
+	said := map[string]any{
+		"id": id, "ok": true, "protocol": protocol,
+		"name": name, "version": "0.0.1", "kind": kind,
+	}
+
+	if !f.script.OmitCapabilities {
+		capabilities := f.script.Capabilities
+		if capabilities == nil {
+			capabilities = map[string]bool{"write": true}
+		}
+
+		said["capabilities"] = capabilities
+	}
+
+	f.write(said)
+}
+
+func (f *fakeAdapter) generate(id int, entries []string) {
+	if f.script.GenerateRefuse != "" {
+		f.write(map[string]any{"id": id, "ok": false, "error": f.script.GenerateRefuse})
+
+		return
+	}
+
+	results := make([]map[string]any, 0, len(entries))
+
+	for _, entry := range entries {
+		result := map[string]any{"entry": entry, "ok": true}
+
+		if failed, ok := f.script.GenerateFail[entry]; ok {
+			result["ok"] = false
+			result["error"] = failed
+		}
+
+		results = append(results, result)
+	}
+
+	f.write(map[string]any{"id": id, "ok": true, "entries": results})
+}
+
+func (f *fakeAdapter) decode(id int, entry string) {
+	told, ok := f.script.Entries[entry]
+
+	switch {
+	case !ok:
+		f.write(map[string]any{"id": id, "ok": false, "error": "this adapter was told nothing about " + entry})
+	case told.DecodeRefuse != "":
+		f.write(map[string]any{"id": id, "ok": false, "error": told.DecodeRefuse})
+	default:
+		f.write(map[string]any{"id": id, "ok": true, "entry": entry, "decoded": told.Decoded})
+	}
+}
+
+func (f *fakeAdapter) roundtrip(id int, entry string) {
+	told := f.script.Entries[entry]
+
+	if told.OmitRoundtrip {
+		f.write(map[string]any{"id": id, "ok": true, "entry": entry})
+
+		return
+	}
+
+	f.write(map[string]any{"id": id, "ok": true, "entry": entry, "written": told.Written})
+}
+
+// write puts one frame on standard output, on one line and flushed, which is
+// what the framing requires of every writer.
+func (f *fakeAdapter) write(frame map[string]any) {
+	b, err := json.Marshal(frame)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "the fake adapter could not write a frame: %v\n", err)
+		os.Exit(4)
+	}
+
+	_, _ = fmt.Fprintf(os.Stdout, "%s\n", b)
+}
+
+// record appends a request frame to the transcript, so that a test can assert
+// what the engine sent as well as what it made of the answers.
+func (f *fakeAdapter) record(line string) {
+	if f.script.Transcript == "" {
+		return
+	}
+
+	file, err := os.OpenFile(f.script.Transcript, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return
+	}
+
+	defer func() { _ = file.Close() }()
+
+	_, _ = file.WriteString(line)
+}
+
+// door is a door onto the fake adapter running the given script.
+//
+// The transcript is written beside the script, and both are the test's
+// temporary directory's, so that a run leaves nothing behind.
+func door(t *testing.T, told script) (*engine.Command, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	transcript := filepath.Join(dir, "transcript.jsonl")
+	told.Transcript = transcript
+
+	b, err := json.Marshal(told)
+	if err != nil {
+		t.Fatalf("failed to write the fake adapter's script: %v", err)
+	}
+
+	path := filepath.Join(dir, "script.json")
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		t.Fatalf("failed to write the fake adapter's script: %v", err)
+	}
+
+	return &engine.Command{
+		Path: os.Args[0],
+		Env:  append(os.Environ(), adapterEnv+"="+path),
+	}, transcript
+}
+
+// transcript is every request frame the adapter received, as text.
+func transcript(t *testing.T, path string) string {
+	t.Helper()
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+
+		t.Fatalf("failed to read what the engine sent: %v", err)
+	}
+
+	return string(b)
+}
+
+// corpus is the entries the tests are written against, by name.
+//
+// Real entries and not invented ones: what makes a mismatch explainable is the
+// descriptor, and a hand-written descriptor in a test is a second author's
+// reading of the IR rather than the corpus's own.
+func corpus(t *testing.T, names ...string) []*conformance.Entry {
+	t.Helper()
+
+	entries, err := conformance.Load(conformance.CorpusPath(repoRoot(t)))
+	if err != nil {
+		t.Fatalf("the conformance corpus: %v", err)
+	}
+
+	held := make([]*conformance.Entry, 0, len(names))
+
+	for _, name := range names {
+		found := false
+
+		for _, entry := range entries {
+			if entry.Name == name {
+				held = append(held, entry)
+				found = true
+
+				break
+			}
+		}
+
+		if !found {
+			t.Fatalf("the corpus holds no entry called %s", name)
+		}
+	}
+
+	return held
+}
+
+// answers is a script that answers every entry with exactly what the entry
+// states, in both directions: the run that passes.
+func answers(t *testing.T, entries []*conformance.Entry) map[string]entryScript {
+	t.Helper()
+
+	told := make(map[string]entryScript, len(entries))
+
+	for _, entry := range entries {
+		values := marshalled(t, entry.Values)
+
+		written := values
+		if entry.Values.Failure != "" {
+			// Nothing is written back from a read that stopped, and the engine
+			// does not ask.
+			written = nil
+		}
+
+		told[entry.Name] = entryScript{Decoded: values, Written: written}
+	}
+
+	return told
+}
+
+// marshalled is a values document as a frame carries it.
+func marshalled(t *testing.T, values *conformance.Values) json.RawMessage {
+	t.Helper()
+
+	b, err := json.Marshal(values)
+	if err != nil {
+		t.Fatalf("failed to write a values document: %v", err)
+	}
+
+	return b
+}
+
+// repoRoot walks up from the test's working directory to the directory holding
+// go.mod, which for this module is the repository root and so the directory the
+// corpus sits in.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("working directory: %v", err)
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("no go.mod found above %q", dir)
+		}
+
+		dir = parent
+	}
+}

--- a/internal/conformance/engine/adapter_test.go
+++ b/internal/conformance/engine/adapter_test.go
@@ -70,6 +70,13 @@ type script struct {
 	// Break is how the adapter stops being an adapter, keyed by the entry it
 	// does so on. Its values are the constants below.
 	Break map[string]string
+
+	// DeafAfterHello is an adapter that answers the handshake and then stops
+	// attending to its standard input altogether — a generator that deadlocked
+	// in its own startup, seen from the engine's side. It never reads and never
+	// answers, so what it costs the engine is a write that cannot complete
+	// rather than an answer that does not come.
+	DeafAfterHello bool
 }
 
 // entryScript is one entry's answers.
@@ -160,6 +167,10 @@ func (f *fakeAdapter) run() int {
 		switch got.Op {
 		case "hello":
 			f.hello(got.ID)
+
+			if f.script.DeafAfterHello {
+				time.Sleep(time.Hour)
+			}
 		case "generate":
 			names := make([]string, 0, len(got.Entries))
 			for _, one := range got.Entries {
@@ -368,7 +379,8 @@ func transcript(t *testing.T, path string) string {
 	return string(b)
 }
 
-// corpus is the entries the tests are written against, by name.
+// corpus is the entries the tests are written against, by name, or the whole
+// corpus where a test names none.
 //
 // Real entries and not invented ones: what makes a mismatch explainable is the
 // descriptor, and a hand-written descriptor in a test is a second author's
@@ -379,6 +391,10 @@ func corpus(t *testing.T, names ...string) []*conformance.Entry {
 	entries, err := conformance.Load(conformance.CorpusPath(repoRoot(t)))
 	if err != nil {
 		t.Fatalf("the conformance corpus: %v", err)
+	}
+
+	if len(names) == 0 {
+		return entries
 	}
 
 	held := make([]*conformance.Entry, 0, len(names))

--- a/internal/conformance/engine/conn.go
+++ b/internal/conformance/engine/conn.go
@@ -1,0 +1,240 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package engine
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+)
+
+// brokenError is the adapter having stopped being an adapter: it exited, it
+// wrote something that is not a frame, it answered a request nobody sent, or it
+// did not answer inside the deadline.
+//
+// It is a type rather than a sentinel because what the engine does about it is
+// not what it does about a fault. A fault costs one entry and the conversation
+// goes on; this ends the conversation, and the remaining entries are carried to
+// a fresh process — so the two have to be told apart at the point they are
+// caught rather than by reading the message.
+type brokenError struct {
+	// Err is what stopped the conversation.
+	Err error
+
+	// Diagnostics is what the adapter had written to standard error, quoted
+	// beside the fault because a broken adapter's own words are usually the
+	// only explanation there is. It is filled in when the process is stopped,
+	// so that a stream that stopped parsing and the panic trace that explains it
+	// arrive together.
+	Diagnostics string
+}
+
+func (e *brokenError) Error() string {
+	if e.Diagnostics == "" {
+		return e.Err.Error()
+	}
+
+	return fmt.Sprintf("%v\nthe adapter's standard error:\n%s", e.Err, e.Diagnostics)
+}
+
+func (e *brokenError) Unwrap() error { return e.Err }
+
+// broke reports whether an error ended the conversation.
+func broke(err error) bool {
+	var broken *brokenError
+
+	return errors.As(err, &broken)
+}
+
+// conn is one conversation with one adapter process.
+//
+// It holds the identifier the next request carries, which is strictly
+// increasing over the conversation and starts at 1. Under a strictly
+// alternating conversation that identifier is redundant, which is exactly why
+// it is cheap and worth carrying: it is the only thing that turns a stream that
+// has silently desynchronised — one extra frame, one frame swallowed — into an
+// error at the frame where it happened rather than a wrong answer several
+// entries later.
+type conn struct {
+	process Process
+	out     *bufio.Reader
+	next    int
+}
+
+// newConn begins a conversation over a started process.
+func newConn(process Process) *conn {
+	return &conn{
+		process: process,
+
+		// A bufio.Reader rather than a fixed buffer, because a receiver MUST
+		// accept a frame of any length: a values document for an entry with a
+		// large table is long, and ReadString grows for it rather than
+		// truncating at whatever the buffer happened to be.
+		out:  bufio.NewReader(process.Stdout()),
+		next: 1,
+	}
+}
+
+// exchange sends one request and waits for the response that answers it,
+// bounded by the deadline.
+//
+// The conversation is strictly alternating — the engine MUST NOT send a request
+// before the previous one's response has arrived — so this is the only way a
+// frame is written, and there is at most one read outstanding at a time.
+func (c *conn) exchange(ctx context.Context, deadline time.Duration, req *request) (*response, error) {
+	req.ID = c.next
+	c.next++
+
+	frame, err := marshal(req)
+	if err != nil {
+		// A request this engine could not write is this engine's fault and not
+		// the adapter's, but the conversation is over either way: nothing was
+		// sent, and the adapter is waiting for something.
+		return nil, &brokenError{Err: err}
+	}
+
+	// One Write of the whole line, which is the flush the contract requires
+	// after every frame: the conversation is strictly alternating, so a side
+	// that buffered a frame would deadlock against a peer waiting for it, and
+	// the peer has no way out — an adapter blocked on a request the engine
+	// never flushed is forbidden to time out, to exit, and to answer.
+	if _, err := c.process.Stdin().Write(frame); err != nil {
+		return nil, &brokenError{Err: fmt.Errorf("the adapter stopped reading its input during %s: %w", req.Op, err)}
+	}
+
+	got, err := c.read(ctx, deadline, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// An engine MUST refuse a response whose id is not the one it is waiting
+	// for, and refusing means treating the peer as broken rather than
+	// resynchronising by skipping the frame and reading on. A stream whose
+	// framing is in doubt cannot be resynchronised by anything the receiver can
+	// see, so an engine that skipped and an engine that killed would report
+	// different things about the same adapter.
+	if *got.ID != req.ID {
+		return nil, &brokenError{Err: fmt.Errorf("the adapter answered request %d while %s was request %d",
+			*got.ID, req.Op, req.ID)}
+	}
+
+	return got, nil
+}
+
+// read waits for one frame, or for the deadline.
+//
+// The read runs in a goroutine of its own because there is no way to interrupt
+// a blocking read of a pipe: what ends it is the process being killed, which
+// closes the pipe under it. The channel is buffered so that a read which lands
+// after the deadline has already been given up on is discarded rather than
+// leaking the goroutine holding it.
+func (c *conn) read(ctx context.Context, deadline time.Duration, req *request) (*response, error) {
+	type frame struct {
+		line string
+		err  error
+	}
+
+	lines := make(chan frame, 1)
+
+	go func() {
+		line, err := c.out.ReadString('\n')
+		lines <- frame{line: line, err: err}
+	}()
+
+	timer := time.NewTimer(deadline)
+	defer timer.Stop()
+
+	select {
+	case got := <-lines:
+		if got.err != nil && got.line == "" {
+			if errors.Is(got.err, io.EOF) {
+				return nil, &brokenError{Err: fmt.Errorf("the adapter closed its output without answering %s", req.Op)}
+			}
+
+			return nil, &brokenError{Err: fmt.Errorf("failed to read the adapter's answer to %s: %w", req.Op, got.err)}
+		}
+
+		// A line that arrived without its terminator because the stream ended
+		// is still a line to report, and [unmarshal] is what says so: a frame
+		// cut off halfway is the most useful thing there is to quote.
+		frame, err := unmarshal(got.line)
+		if err != nil {
+			return nil, &brokenError{Err: fmt.Errorf("the adapter's answer to %s is not a frame: %w", req.Op, err)}
+		}
+
+		return frame, nil
+	case <-timer.C:
+		return nil, &brokenError{Err: fmt.Errorf("the adapter did not answer %s within %s", req.Op, deadline)}
+	case <-ctx.Done():
+		return nil, &brokenError{Err: fmt.Errorf("the run was cancelled while %s was outstanding: %w", req.Op, ctx.Err())}
+	}
+}
+
+// end closes the conversation and reports how the adapter exited.
+//
+// An engine that stops early — a refused handshake, a broken adapter, a run it
+// abandons — MUST close the adapter's standard input, and MAY then kill the
+// process. Without the close the adapter is left waiting on a conversation that
+// is over and forbidden to leave it, which is a hang neither side is at fault
+// for; that obligation is the other half of the prohibition on an adapter
+// exiting quietly mid-conversation.
+//
+// The kill after it is what bounds this: an adapter that ignores end of input
+// would otherwise hold the run open for as long as it liked, and the contract
+// gives it no right to. An adapter killed here is not in violation of anything.
+func (c *conn) end(grace time.Duration) error {
+	// The close is the message. Its error is not reported, because the only one
+	// it has to report is a pipe the adapter has already closed by exiting,
+	// which is the state being asked for.
+	_ = c.process.Stdin().Close()
+
+	exited := make(chan error, 1)
+
+	go func() {
+		exited <- c.process.Wait()
+	}()
+
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+
+	select {
+	case err := <-exited:
+		return err
+	case <-timer.C:
+		c.process.Kill()
+
+		// Waited for after the kill so that the process is reaped and its
+		// standard error has been copied in full. What comes back is the signal
+		// that killed it, which is not the adapter's verdict on anything and is
+		// dropped for that reason: the fault being reported is that it did not
+		// leave when the conversation ended.
+		<-exited
+
+		return fmt.Errorf("the adapter did not exit within %s of its input being closed, and was killed", grace)
+	}
+}
+
+// abandon ends a conversation that is already over, and hands back what the
+// adapter said as it went.
+//
+// The process is killed rather than waited for. Its input is closed first all
+// the same, because the contract obliges an engine that stops early to close
+// it, and an adapter that is merely slow rather than broken deserves the chance
+// to exit of its own accord — but nothing here waits to find out whether it
+// took it.
+func (c *conn) abandon() string {
+	_ = c.process.Stdin().Close()
+	c.process.Kill()
+
+	// Reaped so that the pipe copying finishes and the diagnostics are whole.
+	// How it exited says nothing that is not already known: it was killed.
+	_ = c.process.Wait()
+
+	return c.process.Diagnostics()
+}

--- a/internal/conformance/engine/conn.go
+++ b/internal/conformance/engine/conn.go
@@ -99,13 +99,8 @@ func (c *conn) exchange(ctx context.Context, deadline time.Duration, req *reques
 		return nil, &brokenError{Err: err}
 	}
 
-	// One Write of the whole line, which is the flush the contract requires
-	// after every frame: the conversation is strictly alternating, so a side
-	// that buffered a frame would deadlock against a peer waiting for it, and
-	// the peer has no way out — an adapter blocked on a request the engine
-	// never flushed is forbidden to time out, to exit, and to answer.
-	if _, err := c.process.Stdin().Write(frame); err != nil {
-		return nil, &brokenError{Err: fmt.Errorf("the adapter stopped reading its input during %s: %w", req.Op, err)}
+	if err := c.write(ctx, deadline, req, frame); err != nil {
+		return nil, err
 	}
 
 	got, err := c.read(ctx, deadline, req)
@@ -125,6 +120,53 @@ func (c *conn) exchange(ctx context.Context, deadline time.Duration, req *reques
 	}
 
 	return got, nil
+}
+
+// write puts one frame on the adapter's standard input, bounded by the same
+// deadline as the answer to it.
+//
+// One Write of the whole line, which is the flush the contract requires after
+// every frame: the conversation is strictly alternating, so a side that
+// buffered a frame would deadlock against a peer waiting for it, and the peer
+// has no way out — an adapter blocked on a request the engine never flushed is
+// forbidden to time out, to exit, and to answer.
+//
+// The bound is the half that is easy to leave out, and leaving it out is a hang
+// with no way out either. An adapter that stops *reading* — one that deadlocked
+// in its own startup, or that answered the handshake and then stopped attending
+// to its input — parks this write forever once the pipe's buffer is full, and
+// the generate frame carries every entry's descriptor at once, so it is
+// comfortably the frame that fills one. A deadline on the read alone would
+// never be reached, because the request it was waiting to have answered was
+// never sent.
+func (c *conn) write(ctx context.Context, deadline time.Duration, req *request, frame []byte) error {
+	// Written in a goroutine for the reason the read is: there is no way to
+	// interrupt a blocking write to a pipe, and what ends it is the process
+	// being killed. The channel is buffered so that a write which completes
+	// after the deadline was given up on is discarded rather than leaking the
+	// goroutine holding it.
+	written := make(chan error, 1)
+
+	go func() {
+		_, err := c.process.Stdin().Write(frame)
+		written <- err
+	}()
+
+	timer := time.NewTimer(deadline)
+	defer timer.Stop()
+
+	select {
+	case err := <-written:
+		if err != nil {
+			return &brokenError{Err: fmt.Errorf("the adapter stopped reading its input during %s: %w", req.Op, err)}
+		}
+
+		return nil
+	case <-timer.C:
+		return &brokenError{Err: fmt.Errorf("the adapter did not read the %s request within %s", req.Op, deadline)}
+	case <-ctx.Done():
+		return &brokenError{Err: fmt.Errorf("the run was cancelled while %s was being sent: %w", req.Op, ctx.Err())}
+	}
 }
 
 // read waits for one frame, or for the deadline.

--- a/internal/conformance/engine/doc.go
+++ b/internal/conformance/engine/doc.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Package engine drives an adapter through the contract docs/adapter/SPEC.md
+// specifies: it starts a process, speaks JSON frames to it over standard input
+// and standard output, holds what came back against what each corpus entry
+// states, and reports (#198, #199).
+//
+// [github.com/Zaba505/cpybkc/internal/conformance] is the language-neutral half
+// — the entry, the value language and the comparison — and this package is the
+// process boundary and the front door onto it. Nothing here knows what a value
+// means or how one is spelled; what it knows is how the question is put, and
+// that the answers are compared here rather than by whoever answered them.
+//
+// # What the engine owns
+//
+// Everything except compiling and running generated code. Loading and
+// validating entries is the corpus package's; spawning the adapter, the
+// per-operation deadline, the fault isolation, the comparison and the report
+// are this one's. The split is not organisational: the comparison stays on this
+// side of the process boundary because an adapter holding the expected answers
+// is self-grading, which is not a weaker check than an independent one but a
+// different one — it measures whether the adapter's author could reproduce a
+// document they were handed (docs/adapter/SPEC.md, "The adapter is never given
+// the expected values"). The engine therefore sends an entry's descriptor and
+// its bytes and nothing else, and no frame this package writes carries any part
+// of values.json or anything derived from it.
+//
+// # Three outcomes, kept apart
+//
+// docs/adapter/SPEC.md's "Refusal is an answer, a fault is not, and an exit
+// code is neither" is the whole of what [Engine.Run] is careful about, because
+// an engine that conflates any two of them reports a wrong thing about a
+// working generator or a working thing about a broken one:
+//
+//   - An answer is `ok: true` and a values document, which may carry a failure.
+//     A file the generated reader refused is one of these, and a large part of
+//     the corpus expects exactly that, so it is compared like any other answer
+//     and never reported as a fault.
+//   - A fault is `ok: false`: the adapter could not serve that request. The
+//     entry is lost and the run is not, and it is reported as a
+//     [github.com/Zaba505/cpybkc/internal/conformance.RunError] — never as a
+//     mismatch, which would send a generator author to a specification section
+//     about a claim that was never tested.
+//   - A broken adapter is a non-zero exit, a stream that stopped parsing, or a
+//     deadline that expired. That conversation is over; this package kills the
+//     process and starts a fresh one on the entries that were left, so that one
+//     entry's crash costs that entry rather than the run.
+//
+// # Deadlines, and why they are here rather than in the adapter
+//
+// docs/adapter/SPEC.md, "Deadlines and lifetime belong to the engine": an
+// adapter that gave up on a slow entry would turn one slow entry into a broken
+// adapter and cost the run everything after it, where the engine's own deadline
+// costs that entry alone. So every request this package sends is bounded, and
+// an expiry kills the process rather than reading on — an adapter killed
+// mid-frame may have written half a line, and a stream whose next byte is the
+// middle of an abandoned frame cannot be resynchronised by anything the
+// receiver can see.
+//
+// # A door is how a process gets started, and the contract begins after that
+//
+// The argument vector, the working directory, the environment and whether the
+// process is local at all are not the contract's, which is why they are not
+// this package's either: [Door] is the seam, [Command] is the door that runs a
+// command, and a door that starts a container is a sibling of it rather than a
+// change here (#203). What a door adds — a run with no network, a read-only
+// root, a wall-clock cap — is reportable and is the door's own to describe, and
+// [Report] quotes that description rather than claiming a guarantee of its own.
+//
+// # Failure reporting is the point
+//
+// An engine that says `packed-comp6: mismatch` has done the minimum. This one
+// holds the descriptor, so a disagreement is followed by where the descriptor
+// puts the field that disagreed — its offset within the record, its width, its
+// usage and its charset — and by the bytes of input.bin it was read from, where
+// the framing lets those bytes be found. That is available to the engine and to
+// nothing else in the system: the adapter was never told what was expected, and
+// the corpus package compares documents rather than bytes.
+package engine

--- a/internal/conformance/engine/door.go
+++ b/internal/conformance/engine/door.go
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package engine
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+// Door is how an adapter process is started.
+//
+// docs/adapter/SPEC.md leaves the argument vector, the working directory, the
+// environment and whether the process is local at all out of the contract, on
+// the grounds that they are the door's rather than the contract's: one engine
+// runs a command and another spawns a container, and both drive one
+// implementation of the conversation precisely because the contract begins
+// after the process exists. This interface is that seam. [Command] is the door
+// this package ships, and the image door is a sibling of it (#203).
+type Door interface {
+	// Open starts one adapter process. A door that cannot start one at all is
+	// an error, and it costs the run: there is no conversation to have.
+	Open(ctx context.Context) (Process, error)
+
+	// Describe is what this door adds, for the report to quote.
+	//
+	// It is the door's own words and not the engine's, because an engine MUST
+	// NOT report a result as though it carried a guarantee its door did not
+	// provide — network isolation, a read-only root and a wall-clock cap are
+	// properties of a door and never of the contract, and a run through a door
+	// that provided none of them is the author's own working result rather than
+	// one they can hand to somebody else.
+	Describe() string
+}
+
+// Process is one started adapter: the two streams the conversation runs over,
+// what it wrote to standard error, and the two ways it ends.
+type Process interface {
+	// Stdin is where request frames are written. Closing it is end of input,
+	// which an adapter treats as a bye it has already answered.
+	Stdin() io.WriteCloser
+
+	// Stdout is where response frames are read.
+	Stdout() io.Reader
+
+	// Diagnostics is whatever the door captured of the adapter's standard
+	// error, which an engine SHOULD quote beside a fault and MUST NOT parse. It
+	// is read after the process has ended.
+	Diagnostics() string
+
+	// Wait waits for the process to exit and reports a non-zero exit as an
+	// error. It is called once.
+	Wait() error
+
+	// Kill ends the process without waiting for it to be polite. An adapter
+	// killed by the engine is not in violation of the contract and is under no
+	// obligation to catch a signal, unwind, or write anything on its way out.
+	Kill()
+}
+
+// Command is the door that runs a command.
+//
+// It is the low bar docs/adapter/SPEC.md sets deliberately: the first adapter
+// somebody writes can be a shell script that pipes lines through a program they
+// already have, and a contract whose smallest conforming implementation needed
+// a Dockerfile and a registry would be one most people evaluate by reading
+// about it. What it does not add is isolation of any kind, and [Command.Describe]
+// says so, because a result is only as believable as the door that produced it.
+type Command struct {
+	// Path is the executable to run. It is a path rather than a name to look up,
+	// for the reason
+	// [github.com/Zaba505/cpybkc/internal/conformance/gorunner.Runner] takes
+	// one: a run is usually against something just built from the tree under
+	// test, and resolving a name would find whichever one the author happened to
+	// have installed.
+	Path string
+
+	// Args are the arguments after the executable, which are the door's and not
+	// the contract's.
+	Args []string
+
+	// Dir is the working directory, and an empty one is the engine's own.
+	Dir string
+
+	// Env is the environment, in [os/exec.Cmd.Env]'s form. Nil is this
+	// process's environment.
+	Env []string
+}
+
+// Open starts the command.
+func (c *Command) Open(ctx context.Context) (Process, error) {
+	if c.Path == "" {
+		return nil, fmt.Errorf("the door has no executable to run")
+	}
+
+	// CommandContext rather than Command so that a cancelled run kills the
+	// adapter: the conversation's own deadlines bound each operation, and this
+	// bounds the whole run against a caller that gave up on it.
+	cmd := exec.CommandContext(ctx, c.Path, c.Args...)
+	cmd.Dir = c.Dir
+	cmd.Env = c.Env
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open the adapter's standard input: %w", err)
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open the adapter's standard output: %w", err)
+	}
+
+	// Standard error is free-form and this engine never parses it. It is
+	// captured because a fault is much easier to read beside whatever the
+	// adapter said as it happened — which, for an adapter that redirected its
+	// own standard output the way the contract recommends, is where every stray
+	// print in its dependencies ends up too.
+	diagnostics := &diagnostics{}
+	cmd.Stderr = diagnostics
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start the adapter %s: %w", c.Path, err)
+	}
+
+	return &process{cmd: cmd, stdin: stdin, stdout: stdout, diagnostics: diagnostics}, nil
+}
+
+// Describe says what this door provides, which is nothing beyond a process.
+func (c *Command) Describe() string {
+	return fmt.Sprintf("the command %s, run directly: no network isolation, no read-only root and no resource cap",
+		strings.Join(append([]string{c.Path}, c.Args...), " "))
+}
+
+// process is a running command, as the conversation sees it.
+type process struct {
+	cmd         *exec.Cmd
+	stdin       io.WriteCloser
+	stdout      io.Reader
+	diagnostics *diagnostics
+}
+
+func (p *process) Stdin() io.WriteCloser { return p.stdin }
+func (p *process) Stdout() io.Reader     { return p.stdout }
+func (p *process) Diagnostics() string   { return p.diagnostics.String() }
+func (p *process) Wait() error           { return p.cmd.Wait() }
+
+// Kill ends the process. The error is not reported: the only one it has is that
+// the process has already exited, which is the outcome being asked for.
+func (p *process) Kill() {
+	if p.cmd.Process != nil {
+		_ = p.cmd.Process.Kill()
+	}
+}
+
+// diagnosticsLimit is how much of an adapter's standard error is kept.
+//
+// It is bounded because an adapter that has gone wrong is exactly the one that
+// prints without stopping, and the report it would otherwise fill is the thing
+// somebody has to read to find out what it did. The first bytes are kept rather
+// than the last: what a broken adapter says first is usually what broke it, and
+// what it says afterwards is usually the same line again.
+const diagnosticsLimit = 64 << 10
+
+// diagnostics is the bounded capture of one adapter's standard error.
+//
+// It is written by the goroutine os/exec runs for the stream and read by the
+// engine after the process has ended, which are different goroutines with no
+// happens-before between them but the mutex.
+type diagnostics struct {
+	mu   sync.Mutex
+	held bytes.Buffer
+	over bool
+}
+
+func (d *diagnostics) Write(b []byte) (int, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if room := diagnosticsLimit - d.held.Len(); room > 0 {
+		d.held.Write(b[:min(room, len(b))])
+	}
+
+	if d.held.Len() >= diagnosticsLimit {
+		d.over = true
+	}
+
+	// Every byte is reported as written whether or not it was kept. A short
+	// write would stop os/exec copying the stream, which would block the
+	// adapter on its own standard error — a hang caused by this engine having
+	// decided it had read enough.
+	return len(b), nil
+}
+
+func (d *diagnostics) String() string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	held := d.held.String()
+	if d.over {
+		held += "\n(the rest of the adapter's standard error was not kept)"
+	}
+
+	return held
+}

--- a/internal/conformance/engine/engine.go
+++ b/internal/conformance/engine/engine.go
@@ -1,0 +1,536 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Zaba505/cpybkc/internal/conformance"
+	"github.com/Zaba505/cpybkc/internal/emit"
+)
+
+// The bounds a run is held to when the caller states none.
+//
+// They are deliberately generous. A deadline is not a performance budget — it is
+// what stops one hung entry costing the run — so the number that matters is the
+// one an adapter doing honest work never reaches, and every entry of the corpus
+// is a handful of bytes.
+const (
+	// DefaultDeadline bounds an ordinary operation: a handshake, one entry read,
+	// one file written and read back, a goodbye.
+	DefaultDeadline = time.Minute
+
+	// DefaultBuildDeadline bounds generate, which is the one operation that may
+	// run a compiler over the whole corpus. It has a bound of its own because
+	// the alternative is one number that has to be generous enough for a
+	// toolchain and tight enough for a read, which is a number that is wrong for
+	// both.
+	DefaultBuildDeadline = 10 * time.Minute
+
+	// DefaultGrace is how long an adapter is given to exit after its input has
+	// been closed, before it is killed. An adapter that has answered bye has
+	// nothing left to do, so this bounds a process that ignored end of input
+	// rather than one that is still working.
+	DefaultGrace = 10 * time.Second
+)
+
+// Engine drives an adapter through the contract and reports what came back.
+//
+// The zero value is not runnable: a [Door] is how a process gets started, and
+// there is no default one — a door decides what a result is worth, and an engine
+// that picked one would be an engine deciding that on a caller's behalf.
+type Engine struct {
+	// Door starts adapter processes, and is required.
+	Door Door
+
+	// Deadline bounds every operation but generate. Zero is [DefaultDeadline].
+	Deadline time.Duration
+
+	// BuildDeadline bounds generate. Zero is [DefaultBuildDeadline].
+	BuildDeadline time.Duration
+
+	// Grace is how long an adapter is given to exit once the conversation is
+	// over. Zero is [DefaultGrace].
+	Grace time.Duration
+}
+
+// Run asks one adapter about every entry, in order, and reports.
+//
+// What comes back is a [Report] whether the run went well or badly: an adapter
+// that refused the handshake, one that broke halfway and one that disagreed
+// about every entry are all runs that happened, and each is reported as itself.
+// The error is for a run that could not be attempted at all — no door, no
+// entries — because those are the caller's mistake rather than the adapter's
+// behaviour.
+//
+// The conversation is the contract's: hello, then generate carrying every
+// entry's descriptor at once, then decode for each entry and roundtrip after it
+// where the adapter declared a writer, then bye. Nothing sent carries any part
+// of an entry's values.json, and the comparison happens here.
+//
+// # Fault isolation
+//
+// An adapter that crashes, hangs or stops making sense costs the entry it was
+// asked about and nothing else. That conversation is over — a stream whose
+// framing is in doubt cannot be resynchronised — so the process is killed and a
+// fresh one is started on the entries that were left, which is the latitude
+// docs/adapter/SPEC.md, "Deadlines and lifetime belong to the engine", grants
+// in as many words. The one exception is an adapter that breaks during the
+// handshake or during generate: neither is about an entry, both would break the
+// same way again, and a run that restarted on them would restart forever.
+func (e *Engine) Run(ctx context.Context, entries []*conformance.Entry) (*Report, error) {
+	if e.Door == nil {
+		return nil, fmt.Errorf("the engine has no door to start an adapter through")
+	}
+
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("there is no entry to ask an adapter about")
+	}
+
+	report := &Report{Door: e.Door.Describe()}
+
+	for remaining := entries; len(remaining) > 0; {
+		session, err := e.hello(ctx, report)
+		if err != nil {
+			// A fault at the handshake is the one fault that costs the whole
+			// run rather than one entry: there is no conversation left to have.
+			report.faultAll(remaining, err)
+
+			return report, nil
+		}
+
+		if session.adapter.Kind == kindDescriptive {
+			// A descriptive generator emits a diagram, a schema or a copybook.
+			// It never opens a data file, so the engine MUST NOT send it
+			// generate, decode or roundtrip: it says goodbye and reports the run
+			// as not applicable. What such a generator should be held to instead
+			// is an open question (#193, #201) and is deliberately not answered
+			// by asking it the wrong one.
+			report.NotApplicable = true
+			report.Results = nil
+
+			report.note(session.bye(ctx, e.grace()))
+
+			return report, nil
+		}
+
+		remaining = e.pass(ctx, session, remaining, report)
+
+		if len(remaining) > 0 {
+			report.Restarts++
+		}
+	}
+
+	return report, nil
+}
+
+// pass asks one adapter process about entries, and hands back the ones a broken
+// conversation never reached.
+func (e *Engine) pass(ctx context.Context, session *session, entries []*conformance.Entry, report *Report) []*conformance.Entry {
+	faults, err := session.generate(ctx, entries, e.buildDeadline())
+	if err != nil {
+		// Every entry is lost, whether the adapter refused the operation or
+		// stopped being an adapter during it. Neither is attributable to an
+		// entry, so neither is retried: an adapter that could not generate the
+		// corpus would fail to generate it again.
+		if broke(err) {
+			session.abandon(err)
+		} else {
+			report.note(session.bye(ctx, e.grace()))
+		}
+
+		report.faultAll(entries, err)
+
+		return nil
+	}
+
+	for i, entry := range entries {
+		if fault := faults[entry.Name]; fault != nil {
+			// An entry whose descriptor the generator would not accept, or
+			// whose generated code would not compile. It is an adapter fault
+			// against that entry, never a mismatch and never a refusal, and the
+			// adapter stays alive and serves the rest.
+			report.fault(entry, fault)
+
+			continue
+		}
+
+		answer, err := session.ask(ctx, entry, e.deadline())
+		if err == nil {
+			e.compare(entry, answer, session.adapter.Writes(), report)
+
+			continue
+		}
+
+		if !broke(err) {
+			report.fault(entry, err)
+
+			continue
+		}
+
+		// The conversation is over. The entries behind this one are carried to
+		// a fresh process, which is what keeps one crash from costing the run.
+		session.abandon(err)
+		report.fault(entry, err)
+
+		return entries[i+1:]
+	}
+
+	report.note(session.bye(ctx, e.grace()))
+
+	return nil
+}
+
+// compare holds one answer against what the entry states, and says where the
+// descriptor puts whatever disagreed.
+func (e *Engine) compare(entry *conformance.Entry, answer *conformance.Answer, writes bool, report *Report) {
+	var err error
+
+	if writes {
+		err = conformance.CompareAnswer(entry.Values, answer)
+	} else {
+		// A read-only adapter is asked only the reading direction, and an engine
+		// MUST NOT report an entry as failing because written is absent from an
+		// adapter that declared write: false. The claim the run makes is smaller
+		// and the report says so; it is not a lesser result.
+		err = conformance.Compare(entry.Values, answer.Decoded)
+	}
+
+	if err == nil {
+		report.pass(entry)
+
+		return
+	}
+
+	report.mismatch(entry, explain(err, positions(entry), entry.Input))
+}
+
+// hello starts an adapter and shakes hands with it.
+func (e *Engine) hello(ctx context.Context, report *Report) (*session, error) {
+	process, err := e.Door.Open(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	session := &session{conn: newConn(process)}
+
+	if err := session.handshake(ctx, e.deadline()); err != nil {
+		session.abandon(err)
+
+		return nil, err
+	}
+
+	// The first adapter's declaration is the run's. A restarted process that
+	// declared something different is a different adapter answering the same
+	// corpus, which is worth saying and is not worth silently averaging.
+	if report.Adapter == nil {
+		adapter := session.adapter
+		report.Adapter = &adapter
+	} else if session.adapter.String() != report.Adapter.String() {
+		report.note(fmt.Errorf("a restarted adapter declared itself %s, and the first declared itself %s",
+			&session.adapter, report.Adapter))
+	}
+
+	return session, nil
+}
+
+func (e *Engine) deadline() time.Duration {
+	if e.Deadline > 0 {
+		return e.Deadline
+	}
+
+	return DefaultDeadline
+}
+
+func (e *Engine) buildDeadline() time.Duration {
+	if e.BuildDeadline > 0 {
+		return e.BuildDeadline
+	}
+
+	return DefaultBuildDeadline
+}
+
+func (e *Engine) grace() time.Duration {
+	if e.Grace > 0 {
+		return e.Grace
+	}
+
+	return DefaultGrace
+}
+
+// session is one adapter process, from its handshake to its goodbye.
+type session struct {
+	conn    *conn
+	adapter Adapter
+}
+
+// handshake is the first frame of every conversation, and the only one whose
+// failure costs the run.
+func (s *session) handshake(ctx context.Context, deadline time.Duration) error {
+	got, err := s.conn.exchange(ctx, deadline, &request{Op: opHello, Protocol: Protocol})
+	if err != nil {
+		return err
+	}
+
+	spoken := 0
+	if got.Protocol != nil {
+		spoken = *got.Protocol
+	}
+
+	if !got.served() {
+		// An adapter that does not speak this version answers ok: false and
+		// states its own anyway, so that a report can say which two versions
+		// failed to meet instead of only that the handshake failed.
+		return fmt.Errorf("the adapter refused the handshake: %s (this engine speaks protocol %d and it speaks %d)",
+			got.Error, Protocol, spoken)
+	}
+
+	if spoken != Protocol {
+		return fmt.Errorf("the adapter agreed the handshake while stating protocol %d, and this engine speaks %d",
+			spoken, Protocol)
+	}
+
+	if got.Kind != kindCodec && got.Kind != kindDescriptive {
+		// An engine MUST refuse a kind it does not recognise rather than
+		// falling back to one it does: a value added later means something, and
+		// treating it as the nearest thing that already existed is how a run
+		// reports a result about a thing it did not understand.
+		return fmt.Errorf("the adapter declared kind %q, and this engine knows %q and %q",
+			got.Kind, kindCodec, kindDescriptive)
+	}
+
+	if got.Name == "" {
+		return fmt.Errorf("the adapter declared no name, and a report has nothing to call it")
+	}
+
+	if got.Capabilities == nil {
+		// Required even when it is empty: an author who has to write `{}` has
+		// been asked which optional operations they serve, where an author who
+		// may omit it has not.
+		return fmt.Errorf("the adapter declared no capabilities, and an adapter with none says so with an empty object")
+	}
+
+	s.adapter = Adapter{
+		Name:         got.Name,
+		Version:      got.Version,
+		Kind:         got.Kind,
+		Protocol:     spoken,
+		Capabilities: got.capabilities(),
+	}
+
+	return nil
+}
+
+// generate hands the adapter every entry's descriptor at once, and reports
+// which entries it has code for.
+//
+// All of them at once because an adapter for a compiled language compiles what
+// its generator produced, and compiling is usually the most expensive thing in
+// the run by a wide margin: handed the corpus one entry at a time it pays that
+// cost once per entry, and handed all of them at once it builds the lot in one
+// invocation of its toolchain.
+//
+// What comes back is one error per entry the adapter could not generate, keyed
+// by name — a fault against that entry, which the run then skips while carrying
+// on with the rest.
+func (s *session) generate(ctx context.Context, entries []*conformance.Entry, deadline time.Duration) (map[string]error, error) {
+	req := &request{Op: opGenerate}
+
+	for _, entry := range entries {
+		// The binary encoding docs/plugin/SPEC.md calls canonical and the form a
+		// generator is handed, so the bytes an adapter passes to its own
+		// generator are the bytes cpybkc would have passed it — base64 because a
+		// frame is JSON.
+		descriptor, err := emit.Marshal(entry.Descriptor)
+		if err != nil {
+			return nil, fmt.Errorf("conformance entry %s: %w", entry.Name, err)
+		}
+
+		req.Entries = append(req.Entries, requestEntry{Entry: entry.Name, Descriptor: descriptor})
+	}
+
+	got, err := s.conn.exchange(ctx, deadline, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if !got.served() {
+		// A generate the adapter did not serve at all — a malformed request, an
+		// argument it could not read. Every entry is lost and the engine MUST
+		// NOT send decode or roundtrip for any of them.
+		return nil, fmt.Errorf("the adapter could not generate for the corpus at all: %s", got.Error)
+	}
+
+	asked := make(map[string]bool, len(entries))
+	for _, entry := range entries {
+		asked[entry.Name] = true
+	}
+
+	faults := make(map[string]error, len(entries))
+	answered := make(map[string]bool, len(entries))
+
+	for _, result := range got.Entries {
+		if !asked[result.Entry] {
+			return nil, fmt.Errorf("the adapter answered generate about %q, which it was not asked about", result.Entry)
+		}
+
+		if answered[result.Entry] {
+			return nil, fmt.Errorf("the adapter answered generate about %q twice", result.Entry)
+		}
+
+		answered[result.Entry] = true
+
+		if result.OK == nil {
+			return nil, fmt.Errorf("the adapter's generate result for %q says nothing about whether it succeeded",
+				result.Entry)
+		}
+
+		if !*result.OK {
+			faults[result.Entry] = fmt.Errorf("the adapter has no code to read this entry with: %s", result.Error)
+		}
+	}
+
+	// Exactly one result per entry the request named. A missing one is not an
+	// entry to skip quietly: the adapter has said nothing about whether it can
+	// read it, and reading on would be the engine deciding for it.
+	for _, entry := range entries {
+		if !answered[entry.Name] {
+			return nil, fmt.Errorf("the adapter's generate response says nothing about %q, which it was asked about",
+				entry.Name)
+		}
+	}
+
+	return faults, nil
+}
+
+// ask puts one entry to the adapter: read these bytes, and — where it declared a
+// writer and the read reached the end of the file — write those records back out
+// and read them again.
+func (s *session) ask(ctx context.Context, entry *conformance.Entry, deadline time.Duration) (*conformance.Answer, error) {
+	// An empty file is a file: the pointer is what keeps the member present
+	// rather than omitted, so that an entry of no bytes is asked about as an
+	// entry of no bytes rather than as a request carrying no input at all.
+	input := entry.Input
+	if input == nil {
+		input = []byte{}
+	}
+
+	decoded, err := s.values(ctx, deadline, &request{Op: opDecode, Entry: entry.Name, Input: &input},
+		entry.Name, func(got *response) json.RawMessage { return got.Decoded }, "decoded")
+	if err != nil {
+		return nil, err
+	}
+
+	answer := &conformance.Answer{Decoded: decoded}
+
+	// The preconditions on roundtrip, both of them checked here because an
+	// engine MUST NOT send a request whose precondition is not met: the adapter
+	// declared the write capability, and the read did not stop at a failure — a
+	// read that stopped holds no complete set of records to write back.
+	if !s.adapter.Writes() || decoded.Failure != "" {
+		return answer, nil
+	}
+
+	written, err := s.values(ctx, deadline, &request{Op: opRoundtrip, Entry: entry.Name},
+		entry.Name, func(got *response) json.RawMessage { return got.Written }, "written")
+	if err != nil {
+		return nil, err
+	}
+
+	answer.Written = written
+
+	return answer, nil
+}
+
+// values sends one request that answers with a values document, and reads that
+// document with the corpus format's own reader.
+//
+// A refusal here is a fault against the entry and never a mismatch, and the
+// document itself is not: a file the generated reader refused comes back
+// ok: true carrying a failure, which is an answer an entry is allowed to expect
+// and is compared like any other.
+func (s *session) values(ctx context.Context, deadline time.Duration, req *request, entry string,
+	held func(*response) json.RawMessage, member string,
+) (*conformance.Values, error) {
+	got, err := s.conn.exchange(ctx, deadline, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if !got.served() {
+		return nil, fmt.Errorf("the adapter could not serve %s for this entry: %s", req.Op, got.Error)
+	}
+
+	// The adapter MUST echo the entry. It is checked rather than trusted
+	// because the alternative is comparing one entry's answer against another
+	// entry's values, which is a mismatch nobody could explain.
+	if got.Entry != entry {
+		return nil, fmt.Errorf("the adapter answered %s about %q, and it was asked about %q", req.Op, got.Entry, entry)
+	}
+
+	document := held(got)
+	if len(document) == 0 {
+		return nil, fmt.Errorf("the adapter served %s and its answer carries no %s document", req.Op, member)
+	}
+
+	values, err := conformance.ParseValues(document)
+	if err != nil {
+		return nil, fmt.Errorf("the adapter's %s document cannot be read: %w", member, err)
+	}
+
+	return values, nil
+}
+
+// bye ends a conversation that is still working, and reports an adapter that
+// ended badly.
+//
+// An adapter MUST exit zero when it has answered bye or seen end of input, and
+// non-zero when it stopped for any other reason — so a non-zero exit here is
+// the adapter saying it broke on its way out. It is a note on the run rather
+// than a fault against an entry: every entry has already been answered, and
+// reporting it against the last one would blame an entry for something that
+// happened after it.
+func (s *session) bye(ctx context.Context, grace time.Duration) error {
+	got, err := s.conn.exchange(ctx, grace, &request{Op: opBye})
+	if err != nil {
+		_ = s.conn.abandon()
+
+		return fmt.Errorf("the adapter did not say goodbye: %w", err)
+	}
+
+	exited := s.conn.end(grace)
+
+	switch {
+	case !got.served():
+		// Nothing is lost by it, and it is still a thing the contract does not
+		// admit: bye takes no argument an adapter could object to.
+		return fmt.Errorf("the adapter refused bye: %s", got.Error)
+	case exited != nil:
+		return fmt.Errorf("the adapter answered bye and then exited badly: %w", exited)
+	}
+
+	return nil
+}
+
+// abandon ends a conversation that is already over, and folds what the adapter
+// wrote to standard error into the fault that ended it — which an engine SHOULD
+// capture and quote beside a fault, and which is usually the only explanation
+// there is for a stream that stopped parsing.
+//
+// It is called before the fault is reported, so that the report carries the
+// diagnostics rather than acquiring them afterwards.
+func (s *session) abandon(err error) {
+	diagnostics := s.conn.abandon()
+
+	var broken *brokenError
+	if diagnostics != "" && errors.As(err, &broken) {
+		broken.Diagnostics = diagnostics
+	}
+}

--- a/internal/conformance/engine/engine.go
+++ b/internal/conformance/engine/engine.go
@@ -141,7 +141,7 @@ func (e *Engine) pass(ctx context.Context, session *session, entries []*conforma
 		// entry, so neither is retried: an adapter that could not generate the
 		// corpus would fail to generate it again.
 		if broke(err) {
-			session.abandon(err)
+			err = session.abandon(err)
 		} else {
 			report.note(session.bye(ctx, e.grace()))
 		}
@@ -177,8 +177,7 @@ func (e *Engine) pass(ctx context.Context, session *session, entries []*conforma
 
 		// The conversation is over. The entries behind this one are carried to
 		// a fresh process, which is what keeps one crash from costing the run.
-		session.abandon(err)
-		report.fault(entry, err)
+		report.fault(entry, session.abandon(err))
 
 		return entries[i+1:]
 	}
@@ -222,9 +221,7 @@ func (e *Engine) hello(ctx context.Context, report *Report) (*session, error) {
 	session := &session{conn: newConn(process)}
 
 	if err := session.handshake(ctx, e.deadline()); err != nil {
-		session.abandon(err)
-
-		return nil, err
+		return nil, session.abandon(err)
 	}
 
 	// The first adapter's declaration is the run's. A restarted process that
@@ -519,18 +516,30 @@ func (s *session) bye(ctx context.Context, grace time.Duration) error {
 	return nil
 }
 
-// abandon ends a conversation that is already over, and folds what the adapter
-// wrote to standard error into the fault that ended it — which an engine SHOULD
-// capture and quote beside a fault, and which is usually the only explanation
-// there is for a stream that stopped parsing.
+// abandon ends a conversation that is already over, and hands back the fault
+// that ended it with what the adapter wrote to standard error folded in — which
+// an engine SHOULD capture and quote beside a fault, and which is usually the
+// only explanation there is.
 //
-// It is called before the fault is reported, so that the report carries the
-// diagnostics rather than acquiring them afterwards.
-func (s *session) abandon(err error) {
+// Every fault gets it and not only a broken one. A refused handshake is the
+// case where it matters most: the run failed before a single entry was asked,
+// so the adapter's own words are the only evidence of why, and an engine that
+// captured them and then dropped them because the failure was orderly would
+// throw away the whole explanation.
+func (s *session) abandon(err error) error {
 	diagnostics := s.conn.abandon()
-
-	var broken *brokenError
-	if diagnostics != "" && errors.As(err, &broken) {
-		broken.Diagnostics = diagnostics
+	if diagnostics == "" || err == nil {
+		return err
 	}
+
+	// A broken conversation already renders its diagnostics, so it takes them
+	// rather than being wrapped again.
+	var broken *brokenError
+	if errors.As(err, &broken) {
+		broken.Diagnostics = diagnostics
+
+		return err
+	}
+
+	return fmt.Errorf("%w\nthe adapter's standard error:\n%s", err, diagnostics)
 }

--- a/internal/conformance/engine/engine_test.go
+++ b/internal/conformance/engine/engine_test.go
@@ -1,0 +1,634 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package engine_test
+
+import (
+	"encoding/json"
+	"maps"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Zaba505/cpybkc/internal/conformance"
+	"github.com/Zaba505/cpybkc/internal/conformance/engine"
+)
+
+// TestTheEngineDrivesAnAdapterThroughTheContract is the conversation
+// docs/adapter/SPEC.md specifies, held with a real process over real pipes.
+//
+// The entries are chosen for the two shapes an answer takes: a file read to its
+// end, which is asked in both directions, and a file the reader refused, which
+// is an answer and not a fault — a large fraction of the corpus expects
+// precisely that, and an engine that reported one as a fault would fail those
+// entries by being right about them.
+func TestTheEngineDrivesAnAdapterThroughTheContract(t *testing.T) {
+	entries := corpus(t, "packed-ebcdic", "packed-invalid-sign", "zoned-ebcdic")
+
+	open, sent := door(t, script{Entries: answers(t, entries)})
+
+	report, err := (&engine.Engine{Door: open}).Run(t.Context(), entries)
+	if err != nil {
+		t.Fatalf("the run could not be made: %v", err)
+	}
+
+	if report.Failed() {
+		t.Fatalf("the adapter answered what every entry states and the run failed:\n%v", report)
+	}
+
+	if report.Adapter == nil || report.Adapter.Name != "the fake adapter" {
+		t.Fatalf("the report does not say what answered it: %v", report.Adapter)
+	}
+
+	if report.Restarts != 0 {
+		t.Errorf("the run started %d fresh adapters, and nothing broke", report.Restarts)
+	}
+
+	// The conversation, in the order the contract fixes it: the handshake
+	// first, every descriptor at once next, then one entry at a time, and the
+	// writing direction only where the read reached the end of the file.
+	ops := operations(t, sent)
+
+	want := []string{
+		"hello", "generate",
+		"decode", "roundtrip", // packed-ebcdic
+		"decode",              // packed-invalid-sign, whose read stops at a failure
+		"decode", "roundtrip", // zoned-ebcdic
+		"bye",
+	}
+
+	if strings.Join(ops, ",") != strings.Join(want, ",") {
+		t.Errorf("the engine sent %v, and the contract's conversation is %v", ops, want)
+	}
+}
+
+// TestTheIdentifierIsStrictlyIncreasingFromOne pins the one thing that turns a
+// stream which has silently desynchronised into an error at the frame where it
+// happened rather than a wrong answer several entries later.
+func TestTheIdentifierIsStrictlyIncreasingFromOne(t *testing.T) {
+	entries := corpus(t, "packed-ebcdic", "zoned-ebcdic")
+
+	open, sent := door(t, script{Entries: answers(t, entries)})
+
+	if _, err := (&engine.Engine{Door: open}).Run(t.Context(), entries); err != nil {
+		t.Fatalf("the run could not be made: %v", err)
+	}
+
+	for i, frame := range frames(t, sent) {
+		var got struct {
+			ID int `json:"id"`
+		}
+
+		if err := json.Unmarshal([]byte(frame), &got); err != nil {
+			t.Fatalf("the engine sent something that is not a frame: %q", frame)
+		}
+
+		if got.ID != i+1 {
+			t.Fatalf("request %d carries id %d, and identifiers start at 1 and increase by one", i+1, got.ID)
+		}
+	}
+}
+
+// TestTheAdapterIsNeverGivenTheExpectedValues is the rule the whole corpus
+// rests on: an adapter holding the expected answers is self-grading, which is
+// not a weaker check than an independent one but a different one — it measures
+// whether the adapter's author could reproduce a document they were handed, and
+// nothing in a passing result would distinguish that from a decoder.
+//
+// What is asserted is every frame the engine sent, against every scalar the
+// entry states. The descriptor and the input bytes are asserted to be there
+// too, because a run that sent nothing at all would pass the first assertion.
+func TestTheAdapterIsNeverGivenTheExpectedValues(t *testing.T) {
+	entries := corpus(t, "packed-ebcdic")
+
+	open, sent := door(t, script{Entries: answers(t, entries)})
+
+	if _, err := (&engine.Engine{Door: open}).Run(t.Context(), entries); err != nil {
+		t.Fatalf("the run could not be made: %v", err)
+	}
+
+	said := transcript(t, sent)
+
+	held, ok := entries[0].Values.Records[0].Value.(map[string]any)
+	if !ok {
+		t.Fatalf("%s: the first record is not a group", entries[0].Name)
+	}
+
+	for name, value := range held {
+		spelled, ok := value.(string)
+		if !ok {
+			continue
+		}
+
+		if strings.Contains(said, spelled) {
+			t.Errorf("the engine sent %s, which is what the entry says %s holds", spelled, name)
+		}
+	}
+
+	if !strings.Contains(said, `"descriptor"`) || !strings.Contains(said, `"input"`) {
+		t.Error("the engine sent neither a descriptor nor any input, so it asked the adapter nothing")
+	}
+}
+
+// TestAnAdapterThatCrashesOnOneEntryDoesNotCostTheRest is the fault isolation
+// the corpus is unusable without.
+//
+// The conversation with a crashed adapter is over — a stream whose framing is in
+// doubt cannot be resynchronised by anything the receiver can see — so what the
+// engine owes the run is a fresh process on the entries that were left, not a
+// report that stops at the crash.
+func TestAnAdapterThatCrashesOnOneEntryDoesNotCostTheRest(t *testing.T) {
+	entries := corpus(t, "packed-ebcdic", "zoned-ebcdic", "packed-invalid-sign")
+
+	open, _ := door(t, script{
+		Entries: answers(t, entries),
+		Break:   map[string]string{"zoned-ebcdic": breakCrash},
+	})
+
+	report, err := (&engine.Engine{Door: open}).Run(t.Context(), entries)
+	if err != nil {
+		t.Fatalf("the run could not be made: %v", err)
+	}
+
+	outcomes := outcomes(report)
+
+	if outcomes["packed-ebcdic"] != engine.Passed || outcomes["packed-invalid-sign"] != engine.Passed {
+		t.Errorf("the entries either side of the crash did not pass:\n%v", report)
+	}
+
+	if outcomes["zoned-ebcdic"] != engine.Faulted {
+		t.Errorf("the entry the adapter crashed on is %v, and nothing was learned about it", outcomes["zoned-ebcdic"])
+	}
+
+	if report.Restarts != 1 {
+		t.Errorf("the run started %d fresh adapters, and one crash needs one", report.Restarts)
+	}
+
+	// An engine SHOULD capture the adapter's standard error and quote it beside
+	// a fault, because a broken adapter's own words are usually the only
+	// explanation there is.
+	if said := reported(report, "zoned-ebcdic"); !strings.Contains(said, "about to crash") {
+		t.Errorf("the fault is %q, and it does not quote what the adapter said as it died", said)
+	}
+}
+
+// TestThePerCaseDeadlineIsTheEngines asserts that an adapter which hangs on one
+// entry costs that entry and not the run.
+//
+// The deadline is the engine's because an adapter that gave up on a slow entry
+// would turn one slow entry into a broken adapter and cost everything after it.
+// The fake adapter here never answers and never exits, so what ends it is the
+// deadline and the kill behind it — and the run finishing at all is the
+// assertion.
+func TestThePerCaseDeadlineIsTheEngines(t *testing.T) {
+	entries := corpus(t, "packed-ebcdic", "zoned-ebcdic", "packed-invalid-sign")
+
+	open, _ := door(t, script{
+		Entries: answers(t, entries),
+		Break:   map[string]string{"zoned-ebcdic": breakHang},
+	})
+
+	report, err := (&engine.Engine{Door: open, Deadline: 200 * time.Millisecond}).Run(t.Context(), entries)
+	if err != nil {
+		t.Fatalf("the run could not be made: %v", err)
+	}
+
+	outcomes := outcomes(report)
+
+	if outcomes["zoned-ebcdic"] != engine.Faulted {
+		t.Errorf("the entry the adapter hung on is %v", outcomes["zoned-ebcdic"])
+	}
+
+	if said := reported(report, "zoned-ebcdic"); !strings.Contains(said, "did not answer") {
+		t.Errorf("the fault is %q, and it does not say the adapter ran out of time", said)
+	}
+
+	if outcomes["packed-invalid-sign"] != engine.Passed {
+		t.Errorf("the entry behind the hang did not pass:\n%v", report)
+	}
+}
+
+// TestAMismatchNamesTheFieldAndItsPosition is the difference between a
+// framework somebody uses twice and one they use fifty times.
+//
+// The engine holds the descriptor and the bytes, so it can say which item
+// disagreed, where the position sum puts it, how wide it is and what encoding
+// it was read under — and quote the bytes it was read from. Nothing else in the
+// system can: the adapter was never told what was expected, and the corpus
+// package compares documents rather than bytes.
+func TestAMismatchNamesTheFieldAndItsPosition(t *testing.T) {
+	entries := corpus(t, "packed-ebcdic")
+	entry := entries[0]
+
+	const item = "P-SIGNED-POS"
+
+	held, ok := entry.Values.Records[0].Value.(map[string]any)
+	if !ok {
+		t.Fatalf("%s: the first record is not a group", entry.Name)
+	}
+
+	wrong := maps.Clone(held)
+	wrong[item] = "99999"
+
+	decoded := marshalled(t, &conformance.Values{
+		Records: []conformance.Record{{Name: entry.Values.Records[0].Name, Value: wrong}},
+	})
+
+	open, _ := door(t, script{Entries: map[string]entryScript{
+		entry.Name: {Decoded: decoded, Written: decoded},
+	}})
+
+	report, err := (&engine.Engine{Door: open}).Run(t.Context(), entries)
+	if err != nil {
+		t.Fatalf("the run could not be made: %v", err)
+	}
+
+	if outcomes(report)[entry.Name] != engine.Mismatched {
+		t.Fatalf("the adapter answered a value the file does not hold and the run did not report a mismatch:\n%v", report)
+	}
+
+	said := reported(report, entry.Name)
+
+	for _, says := range []string{
+		item,                      // which item disagreed
+		"at offset 0 of record 1", // where the descriptor puts it
+		"3 bytes",                 // and how wide it is
+		"usage PACKED_DECIMAL",    // under which encoding it was read
+		"charset ",
+		"input.bin 0x0000..0x0002: 12 34 5c", // and the bytes themselves
+	} {
+		if !strings.Contains(said, says) {
+			t.Errorf("the report is\n%s\nand it does not say %q", said, says)
+		}
+	}
+}
+
+// TestAReadOnlyAdapterIsNotFailedForOmittingTheWriteDirection holds the engine
+// to the rule that keeps a legal generator from failing every positive entry.
+//
+// docs/ir/SPEC.md's "Writing a file" leaves emitting a writer to the generator,
+// so a generator that emits a reader and no writer is conformant — and an
+// engine that demanded the writing direction of every adapter would report,
+// once per entry, a missing answer to a question the specification never
+// obliged anybody to answer.
+func TestAReadOnlyAdapterIsNotFailedForOmittingTheWriteDirection(t *testing.T) {
+	entries := corpus(t, "packed-ebcdic", "zoned-ebcdic")
+
+	open, sent := door(t, script{
+		Capabilities: map[string]bool{},
+		Entries:      answers(t, entries),
+	})
+
+	report, err := (&engine.Engine{Door: open}).Run(t.Context(), entries)
+	if err != nil {
+		t.Fatalf("the run could not be made: %v", err)
+	}
+
+	if report.Failed() {
+		t.Fatalf("a read-only adapter answered every entry's reading direction and the run failed:\n%v", report)
+	}
+
+	// The engine MUST NOT send roundtrip to an adapter that did not declare the
+	// capability, which is a stronger statement than not failing it for the
+	// answer being absent.
+	for _, op := range operations(t, sent) {
+		if op == "roundtrip" {
+			t.Fatal("the engine asked a read-only adapter to write a file back")
+		}
+	}
+
+	// A run by a read-only adapter is a smaller claim than a run by a full one,
+	// and an engine SHOULD say which it was.
+	if said := report.String(); !strings.Contains(said, "read-only") {
+		t.Errorf("the report is\n%s\nand it does not say the claim is a smaller one", said)
+	}
+}
+
+// TestAnAdapterThatBreaksTheFramingCostsOneEntry walks the ways a stream stops
+// being a conversation.
+//
+// Every one of them is a hazard docs/adapter/SPEC.md names: a library that
+// greeted the world on standard output, a blank line, a carriage return a
+// receiver MUST refuse rather than trim, and a frame answering a request nobody
+// sent. Each costs the entry it happened on and the run carries on, which is
+// the same isolation a crash gets.
+func TestAnAdapterThatBreaksTheFramingCostsOneEntry(t *testing.T) {
+	tests := map[string]struct {
+		broke string
+		says  string
+	}{
+		"a greeting on standard output": {broke: breakGarbage, says: "not a frame"},
+		"a blank line":                  {broke: breakBlank, says: "blank line"},
+		"a carriage return":             {broke: breakCR, says: "carriage return"},
+		"an answer to nothing":          {broke: breakWrongID, says: "answered request"},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			entries := corpus(t, "packed-ebcdic", "zoned-ebcdic", "packed-invalid-sign")
+
+			open, _ := door(t, script{
+				Entries: answers(t, entries),
+				Break:   map[string]string{"zoned-ebcdic": test.broke},
+			})
+
+			report, err := (&engine.Engine{Door: open, Deadline: 5 * time.Second}).Run(t.Context(), entries)
+			if err != nil {
+				t.Fatalf("the run could not be made: %v", err)
+			}
+
+			outcomes := outcomes(report)
+
+			if outcomes["zoned-ebcdic"] != engine.Faulted {
+				t.Errorf("the entry the framing broke on is %v", outcomes["zoned-ebcdic"])
+			}
+
+			if said := reported(report, "zoned-ebcdic"); !strings.Contains(said, test.says) {
+				t.Errorf("the fault is %q, and it does not say %q", said, test.says)
+			}
+
+			if outcomes["packed-ebcdic"] != engine.Passed || outcomes["packed-invalid-sign"] != engine.Passed {
+				t.Errorf("the entries either side of it did not pass:\n%v", report)
+			}
+		})
+	}
+}
+
+// TestTheHandshakeCostsTheWholeRun walks what an engine refuses before it has
+// asked anything.
+//
+// A fault at the handshake is the one fault that costs the whole run rather
+// than one entry: there is no conversation left to have. Every entry is
+// reported as a fault, because an entry nobody asked about is not an entry that
+// passed.
+func TestTheHandshakeCostsTheWholeRun(t *testing.T) {
+	two := 2
+
+	tests := map[string]struct {
+		told script
+		says string
+	}{
+		"a version the adapter does not speak": {
+			told: script{RefuseHello: "this adapter speaks protocol 2", Protocol: &two},
+			says: "refused the handshake",
+		},
+		"a version it agreed to and does not speak": {
+			told: script{Protocol: &two},
+			says: "stating protocol 2",
+		},
+		"a kind this engine has never heard of": {
+			told: script{Kind: "oracular"},
+			says: `declared kind "oracular"`,
+		},
+		"no capabilities at all": {
+			told: script{OmitCapabilities: true},
+			says: "declared no capabilities",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			entries := corpus(t, "packed-ebcdic", "zoned-ebcdic")
+
+			told := test.told
+			told.Entries = answers(t, entries)
+
+			open, sent := door(t, told)
+
+			report, err := (&engine.Engine{Door: open}).Run(t.Context(), entries)
+			if err != nil {
+				t.Fatalf("the run could not be made: %v", err)
+			}
+
+			for _, entry := range entries {
+				if outcomes(report)[entry.Name] != engine.Faulted {
+					t.Errorf("%s was not reported as a fault, and the handshake never completed:\n%v", entry.Name, report)
+				}
+
+				if said := reported(report, entry.Name); !strings.Contains(said, test.says) {
+					t.Errorf("the fault is %q, and it does not say %q", said, test.says)
+				}
+			}
+
+			for _, op := range operations(t, sent) {
+				if op != "hello" {
+					t.Errorf("the engine sent %s after a handshake that failed", op)
+				}
+			}
+		})
+	}
+}
+
+// TestADescriptiveAdapterIsNotAConformanceSubject asserts the one thing an
+// engine owes a generator that emits a diagram rather than a codec: it is asked
+// nothing and reported as not applicable.
+//
+// The two shapes that must not happen are a descriptive generator scored zero
+// out of the whole corpus, and one declining every entry in turn. Neither is
+// true, both read as failures, and what such a generator should be held to
+// instead is an open question (#193, #201) that asking it the wrong one would
+// not answer.
+func TestADescriptiveAdapterIsNotAConformanceSubject(t *testing.T) {
+	entries := corpus(t, "packed-ebcdic", "zoned-ebcdic")
+
+	open, sent := door(t, script{Kind: "descriptive", Capabilities: map[string]bool{}})
+
+	report, err := (&engine.Engine{Door: open}).Run(t.Context(), entries)
+	if err != nil {
+		t.Fatalf("the run could not be made: %v", err)
+	}
+
+	if !report.NotApplicable {
+		t.Fatalf("the run is not reported as not applicable:\n%v", report)
+	}
+
+	if report.Failed() || len(report.Results) != 0 {
+		t.Errorf("a descriptive generator was scored against the corpus:\n%v", report)
+	}
+
+	want := []string{"hello", "bye"}
+	if got := operations(t, sent); strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("the engine sent %v to a descriptive adapter, and it may send %v", got, want)
+	}
+}
+
+// TestGenerate walks the two halves of the operation that costs the most.
+//
+// An entry the generator would not accept, or whose generated code would not
+// compile, is a fault against that entry and the adapter stays alive to serve
+// the rest. A generate the adapter did not serve at all is every entry lost —
+// and the engine MUST NOT send decode for any of them, which is what the
+// transcript is asserted for.
+func TestGenerate(t *testing.T) {
+	t.Run("an entry the adapter has no code for costs that entry", func(t *testing.T) {
+		entries := corpus(t, "packed-ebcdic", "zoned-ebcdic")
+
+		open, sent := door(t, script{
+			Entries:      answers(t, entries),
+			GenerateFail: map[string]string{"zoned-ebcdic": "OCCURS DEPENDING ON is not supported"},
+		})
+
+		report, err := (&engine.Engine{Door: open}).Run(t.Context(), entries)
+		if err != nil {
+			t.Fatalf("the run could not be made: %v", err)
+		}
+
+		if outcomes(report)["zoned-ebcdic"] != engine.Faulted {
+			t.Errorf("an entry the adapter cannot generate for is not a fault:\n%v", report)
+		}
+
+		if outcomes(report)["packed-ebcdic"] != engine.Passed {
+			t.Errorf("the entry it can generate for did not pass:\n%v", report)
+		}
+
+		if said := transcript(t, sent); strings.Contains(said, `"op":"decode","entry":"zoned-ebcdic"`) {
+			t.Error("the engine asked about an entry the adapter said it had no code for")
+		}
+	})
+
+	t.Run("a generate the adapter did not serve costs the run", func(t *testing.T) {
+		entries := corpus(t, "packed-ebcdic", "zoned-ebcdic")
+
+		open, sent := door(t, script{
+			Entries:        answers(t, entries),
+			GenerateRefuse: "this adapter could not read the request",
+		})
+
+		report, err := (&engine.Engine{Door: open}).Run(t.Context(), entries)
+		if err != nil {
+			t.Fatalf("the run could not be made: %v", err)
+		}
+
+		for _, entry := range entries {
+			if outcomes(report)[entry.Name] != engine.Faulted {
+				t.Errorf("%s survived a generate nobody served:\n%v", entry.Name, report)
+			}
+		}
+
+		for _, op := range operations(t, sent) {
+			if op == "decode" || op == "roundtrip" {
+				t.Errorf("the engine sent %s after a generate the adapter did not serve", op)
+			}
+		}
+
+		if report.Restarts != 0 {
+			t.Errorf("the run started %d fresh adapters over a generate that would fail again", report.Restarts)
+		}
+	})
+}
+
+// TestAnEntryTheAdapterRefusedIsAFaultAndNotAMismatch keeps the two apart.
+//
+// A mismatch is a disagreement about bytes, and whoever reads it decides
+// whether the generator or the entry is wrong. A refusal is the corpus failing
+// to ask the question, so nothing has been learned about either — and a run
+// reporting it as a disagreement would send a generator author to a
+// specification section about a claim that was never tested.
+func TestAnEntryTheAdapterRefusedIsAFaultAndNotAMismatch(t *testing.T) {
+	entries := corpus(t, "packed-ebcdic", "zoned-ebcdic")
+
+	told := answers(t, entries)
+	told["packed-ebcdic"] = entryScript{DecodeRefuse: "the generated reader panicked"}
+
+	open, _ := door(t, script{Entries: told})
+
+	report, err := (&engine.Engine{Door: open}).Run(t.Context(), entries)
+	if err != nil {
+		t.Fatalf("the run could not be made: %v", err)
+	}
+
+	if outcomes(report)["packed-ebcdic"] != engine.Faulted {
+		t.Errorf("an entry the adapter refused is not a fault:\n%v", report)
+	}
+
+	if said := reported(report, "packed-ebcdic"); !strings.Contains(said, "could not be run") {
+		t.Errorf("the fault is %q, and it does not read as one", said)
+	}
+
+	if outcomes(report)["zoned-ebcdic"] != engine.Passed {
+		t.Errorf("the entry behind the refusal did not pass:\n%v", report)
+	}
+
+	if report.Restarts != 0 {
+		t.Errorf("a refusal restarted the adapter %d times, and a refusal leaves it working", report.Restarts)
+	}
+}
+
+// TestARunThatCannotBeAttempted asserts that the caller's own mistakes are
+// errors rather than reports: a report saying nothing failed is a report about
+// a run that happened.
+func TestARunThatCannotBeAttempted(t *testing.T) {
+	entries := corpus(t, "packed-ebcdic")
+
+	if _, err := (&engine.Engine{}).Run(t.Context(), entries); err == nil {
+		t.Error("an engine with no door ran")
+	}
+
+	open, _ := door(t, script{})
+
+	if _, err := (&engine.Engine{Door: open}).Run(t.Context(), nil); err == nil {
+		t.Error("an engine with nothing to ask about ran")
+	}
+}
+
+// outcomes is what became of each entry, by name.
+func outcomes(report *engine.Report) map[string]engine.Outcome {
+	held := make(map[string]engine.Outcome, len(report.Results))
+
+	for _, result := range report.Results {
+		held[result.Entry] = result.Outcome
+	}
+
+	return held
+}
+
+// reported is what the report says about one entry.
+func reported(report *engine.Report, entry string) string {
+	for _, result := range report.Results {
+		if result.Entry != entry || result.Err == nil {
+			continue
+		}
+
+		return result.Err.Error()
+	}
+
+	return ""
+}
+
+// frames is every request frame the engine sent, in order.
+func frames(t *testing.T, path string) []string {
+	t.Helper()
+
+	var sent []string
+
+	for _, line := range strings.Split(transcript(t, path), "\n") {
+		if line != "" {
+			sent = append(sent, line)
+		}
+	}
+
+	return sent
+}
+
+// operations is the op of every request frame the engine sent, in order.
+func operations(t *testing.T, path string) []string {
+	t.Helper()
+
+	var ops []string
+
+	for _, frame := range frames(t, path) {
+		var got struct {
+			Op string `json:"op"`
+		}
+
+		if err := json.Unmarshal([]byte(frame), &got); err != nil {
+			t.Fatalf("the engine sent something that is not a frame: %q", frame)
+		}
+
+		ops = append(ops, got.Op)
+	}
+
+	return ops
+}

--- a/internal/conformance/engine/engine_test.go
+++ b/internal/conformance/engine/engine_test.go
@@ -97,11 +97,13 @@ func TestTheIdentifierIsStrictlyIncreasingFromOne(t *testing.T) {
 // whether the adapter's author could reproduce a document they were handed, and
 // nothing in a passing result would distinguish that from a decoder.
 //
-// What is asserted is every frame the engine sent, against every scalar the
-// entry states. The descriptor and the input bytes are asserted to be there
-// too, because a run that sent nothing at all would pass the first assertion.
+// What is asserted is every frame the engine sent, against every scalar every
+// entry states — at every depth, in every record, and including the text of a
+// failure, since a leak one group down is the same leak. The descriptor and the
+// input bytes are asserted to be there too, because a run that sent nothing at
+// all would pass the first assertion.
 func TestTheAdapterIsNeverGivenTheExpectedValues(t *testing.T) {
-	entries := corpus(t, "packed-ebcdic")
+	entries := corpus(t, "packed-ebcdic", "zoned-ebcdic", "packed-invalid-sign", "batch-rdw")
 
 	open, sent := door(t, script{Entries: answers(t, entries)})
 
@@ -111,25 +113,67 @@ func TestTheAdapterIsNeverGivenTheExpectedValues(t *testing.T) {
 
 	said := transcript(t, sent)
 
-	held, ok := entries[0].Values.Records[0].Value.(map[string]any)
-	if !ok {
-		t.Fatalf("%s: the first record is not a group", entries[0].Name)
+	looked := 0
+
+	for _, entry := range entries {
+		for _, spelled := range scalars(entry.Values) {
+			// A short value is passed over rather than searched for. The frames
+			// carry the descriptor and the input as base64, so a one or two
+			// character value occurs in them by coincidence — and a test that
+			// failed on a coincidence is a test somebody deletes.
+			if len(spelled) < 3 {
+				continue
+			}
+
+			looked++
+
+			if strings.Contains(said, spelled) {
+				t.Errorf("the engine sent %q, which is part of what %s states", spelled, entry.Name)
+			}
+		}
 	}
 
-	for name, value := range held {
-		spelled, ok := value.(string)
-		if !ok {
-			continue
-		}
-
-		if strings.Contains(said, spelled) {
-			t.Errorf("the engine sent %s, which is what the entry says %s holds", spelled, name)
-		}
+	if looked == 0 {
+		t.Fatal("no expected value was long enough to look for, so this test asserted nothing")
 	}
 
 	if !strings.Contains(said, `"descriptor"`) || !strings.Contains(said, `"input"`) {
 		t.Error("the engine sent neither a descriptor nor any input, so it asked the adapter nothing")
 	}
+}
+
+// scalars is every value a values document states, at every depth, and the text
+// of its failure.
+func scalars(values *conformance.Values) []string {
+	var (
+		found []string
+		walk  func(value any)
+	)
+
+	walk = func(value any) {
+		switch held := value.(type) {
+		case map[string]any:
+			for _, one := range held {
+				walk(one)
+			}
+		case []any:
+			for _, one := range held {
+				walk(one)
+			}
+		case string:
+			found = append(found, held)
+		}
+	}
+
+	for _, record := range values.Records {
+		walk(record.Value)
+	}
+
+	if values.Failure != "" {
+		found = append(found, values.Failure)
+	}
+
+	return found
 }
 
 // TestAnAdapterThatCrashesOnOneEntryDoesNotCostTheRest is the fault isolation
@@ -150,6 +194,13 @@ func TestAnAdapterThatCrashesOnOneEntryDoesNotCostTheRest(t *testing.T) {
 	report, err := (&engine.Engine{Door: open}).Run(t.Context(), entries)
 	if err != nil {
 		t.Fatalf("the run could not be made: %v", err)
+	}
+
+	// Every entry is reported, which is the assertion the outcomes below rest
+	// on: an entry the run dropped altogether is the failure this test is about,
+	// and a lookup of a name that is not there says nothing on its own.
+	if len(report.Results) != len(entries) {
+		t.Fatalf("the run reported %d of %d entries:\n%v", len(report.Results), len(entries), report)
 	}
 
 	outcomes := outcomes(report)
@@ -190,7 +241,14 @@ func TestThePerCaseDeadlineIsTheEngines(t *testing.T) {
 		Break:   map[string]string{"zoned-ebcdic": breakHang},
 	})
 
-	report, err := (&engine.Engine{Door: open, Deadline: 200 * time.Millisecond}).Run(t.Context(), entries)
+	// Two seconds rather than something tighter because this deadline bounds
+	// the handshake too, and a handshake here is a process spawn: a fork, a Go
+	// runtime starting up and a script being read, twice over, since the hang
+	// costs a restart. What the test needs is only that the hang resolves in a
+	// fraction of the suite's own wall clock, and a budget that also has to
+	// cover an exec on a loaded machine is a budget that fails for a reason
+	// this test is not about.
+	report, err := (&engine.Engine{Door: open, Deadline: 2 * time.Second}).Run(t.Context(), entries)
 	if err != nil {
 		t.Fatalf("the run could not be made: %v", err)
 	}
@@ -207,6 +265,49 @@ func TestThePerCaseDeadlineIsTheEngines(t *testing.T) {
 
 	if outcomes["packed-invalid-sign"] != engine.Passed {
 		t.Errorf("the entry behind the hang did not pass:\n%v", report)
+	}
+}
+
+// TestAnAdapterThatStopsReadingIsNotAHangTheEngineWaitsOut bounds the half of
+// an operation that is easy to leave unbounded.
+//
+// An adapter that answers the handshake and then stops attending to its
+// standard input — one that deadlocked in its own startup — is not an adapter
+// that fails to answer. It is one the engine cannot finish writing to, and the
+// generate frame carries every entry's descriptor at once, so it is comfortably
+// the frame that fills a pipe. A deadline on the answer alone would never be
+// reached, because the request it was waiting to have answered was never sent.
+//
+// The corpus is doubled until the frame cannot fit in any pipe buffer a system
+// might have — a megabyte or so, against Linux's default of 64 KiB — because a
+// write that happens to fit succeeds and tests the read deadline instead.
+func TestAnAdapterThatStopsReadingIsNotAHangTheEngineWaitsOut(t *testing.T) {
+	entries := corpus(t)
+
+	for len(entries) < 1024 {
+		entries = append(entries, entries...)
+	}
+
+	open, _ := door(t, script{DeafAfterHello: true})
+
+	report, err := (&engine.Engine{
+		Door: open, Deadline: 2 * time.Second, BuildDeadline: 2 * time.Second,
+	}).Run(t.Context(), entries)
+	if err != nil {
+		t.Fatalf("the run could not be made: %v", err)
+	}
+
+	if len(report.Results) != len(entries) {
+		t.Fatalf("the run reported %d of %d entries", len(report.Results), len(entries))
+	}
+
+	if !strings.Contains(reported(report, entries[0].Name), "did not read") {
+		t.Errorf("the fault is %q, and the adapter stopped reading rather than stopped answering",
+			reported(report, entries[0].Name))
+	}
+
+	if report.Restarts != 0 {
+		t.Errorf("the run started %d fresh adapters over a generate that would block again", report.Restarts)
 	}
 }
 

--- a/internal/conformance/engine/frame.go
+++ b/internal/conformance/engine/frame.go
@@ -1,0 +1,242 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Protocol is the version of docs/adapter/SPEC.md this engine speaks, which the
+// handshake states and an adapter either matches or does not. There is no range
+// and no fallback: an adapter speaks one version, and either it is this one or
+// the run does not happen.
+const Protocol = 1
+
+// The operations, spelled once. They are constants because each is written by
+// the code that builds a request and read by the tests that pin the
+// conversation, and an operation the tests agree with and an adapter does not is
+// the one thing this contract cannot afford.
+const (
+	opHello     = "hello"
+	opGenerate  = "generate"
+	opDecode    = "decode"
+	opRoundtrip = "roundtrip"
+	opBye       = "bye"
+)
+
+// The capabilities an adapter may declare. `rebuild` is deliberately absent
+// from this engine's vocabulary rather than declared and unused: a corpus run
+// generates once and asks each entry once, so it has nothing to rebuild, and an
+// engine that read a capability it never exercised would be claiming a
+// conversation it does not have.
+const capabilityWrite = "write"
+
+// The two kinds an adapter may declare. An engine MUST refuse a kind it does
+// not recognise rather than falling back to one it does: a value added later
+// means something, and treating it as the nearest thing that already existed is
+// how a run reports a result about a thing it did not understand.
+const (
+	kindCodec       = "codec"
+	kindDescriptive = "descriptive"
+)
+
+// request is a frame the engine writes.
+//
+// Every optional member is omitted when empty, so that each operation's frame
+// carries the members that operation defines and nothing else. A receiver is
+// required to ignore a member it does not recognise, so an engine that sent
+// them all would be conforming and unreadable.
+type request struct {
+	ID int    `json:"id"`
+	Op string `json:"op"`
+
+	// Protocol is the handshake's, and is the version this engine speaks.
+	Protocol int `json:"protocol,omitempty"`
+
+	// Entries is generate's: every entry at once, which is what lets an adapter
+	// for a compiled language build the corpus in one invocation of its
+	// toolchain rather than once per entry.
+	Entries []requestEntry `json:"entries,omitempty"`
+
+	// Entry is decode's and roundtrip's: which entry the request is about.
+	Entry string `json:"entry,omitempty"`
+
+	// Input is decode's: the entry's bytes, which encoding/json writes as
+	// base64 in RFC 4648 section 4's alphabet — the alphabet the contract names
+	// and the one a values document already spells a run of bytes in.
+	//
+	// The bytes travel in the frame rather than as a path because the door that
+	// produces a believable result runs the adapter with no access to the corpus
+	// directory at all, and because an adapter that could open input.bin could
+	// open values.json beside it.
+	//
+	// A pointer, so that an entry whose file holds no bytes is asked about with
+	// an empty input rather than with no input member at all. An empty file is a
+	// file — a layout whose sequencing expression accepts nothing is exactly
+	// what one entry ought to be about — and the two are different questions.
+	Input *[]byte `json:"input,omitempty"`
+}
+
+// requestEntry is one entry of a generate request: its name, and its descriptor
+// in the binary encoding docs/plugin/SPEC.md hands a generator.
+type requestEntry struct {
+	Entry      string `json:"entry"`
+	Descriptor []byte `json:"descriptor"`
+}
+
+// response is a frame the adapter writes.
+//
+// Every member an adapter may omit is a pointer or a nil-able type, because
+// absent and zero are different answers here: an `ok` nobody wrote is a
+// malformed frame, where an `ok` written false is a fault, and a protocol
+// version of 0 is a version an adapter stated rather than one it left out.
+//
+// Unknown members are not refused. That is the opposite of the rule the corpus
+// format applies to an entry, and the difference is who writes the document: an
+// entry is written by a person, where an unrecognised member is a typo, and a
+// frame is written by a program against a version it announced at the
+// handshake, where an unrecognised member is one a later version of the
+// contract added. A receiver that refused it would make every future addition a
+// breaking change.
+type response struct {
+	ID    *int   `json:"id"`
+	OK    *bool  `json:"ok"`
+	Error string `json:"error"`
+
+	// Protocol is the version the adapter speaks — stated, not echoed, so that
+	// a refused handshake can say which two versions failed to meet.
+	Protocol *int `json:"protocol"`
+
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Kind    string `json:"kind"`
+
+	// Capabilities is a pointer because the member is required of a successful
+	// handshake even when it is empty: an author who has to write `{}` has been
+	// asked the question, where an author who may omit it has not.
+	Capabilities *map[string]bool `json:"capabilities"`
+
+	// Entries is a generate response's per-entry results.
+	Entries []entryResult `json:"entries"`
+
+	// Entry is echoed by decode and roundtrip.
+	Entry string `json:"entry"`
+
+	// Decoded and Written are values documents, held back as raw JSON so that
+	// they are read by the corpus format's own reader rather than by this one.
+	// The relaxation above is the envelope's and stops at the envelope: an
+	// unknown member inside one of these is refused exactly as the corpus format
+	// requires.
+	Decoded json.RawMessage `json:"decoded"`
+	Written json.RawMessage `json:"written"`
+}
+
+// entryResult is what a generate or rebuild response says about one entry.
+type entryResult struct {
+	Entry string `json:"entry"`
+	OK    *bool  `json:"ok"`
+	Error string `json:"error"`
+}
+
+// served is whether the adapter served the request at all, which is `ok` and
+// never the presence of an answer beside it.
+func (r *response) served() bool { return r.OK != nil && *r.OK }
+
+// capabilities is what the adapter declared, with an absent object read as no
+// capabilities rather than as an error — the handshake is where a missing one
+// is refused, so that every caller of this does not have to.
+func (r *response) capabilities() map[string]bool {
+	if r.Capabilities == nil {
+		return nil
+	}
+
+	return *r.Capabilities
+}
+
+// marshal writes a request as the one line it goes out as.
+//
+// encoding/json escapes every control character inside a string, so the line
+// feed appended here is the only one in the frame — which is what makes a line
+// feed a frame delimiter at all.
+func marshal(req *request) ([]byte, error) {
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to write the %s request: %w", req.Op, err)
+	}
+
+	return append(b, '\n'), nil
+}
+
+// unmarshal reads one line of the adapter's standard output as a response
+// frame, and refuses everything the framing does not admit.
+//
+// The line arrives with its terminator, or without one at end of input. What is
+// refused here is what docs/adapter/SPEC.md, "A frame is one line of UTF-8
+// JSON", requires be refused rather than tolerated:
+//
+//   - a blank line, because a skipped one is a corrupted stream reported one
+//     frame later, at whichever frame first fails to parse;
+//   - a carriage return before the line feed, because a stream that tolerates
+//     both is one where a text-mode file handle silently changes what was sent;
+//   - anything that is not one JSON object, which is the greeting a library
+//     printed the first time it was used, arriving where a frame was expected.
+//
+// A line that is not a well-formed frame is an adapter fault, and it is quoted
+// back, because that line is usually the diagnostic that explains it.
+func unmarshal(line string) (*response, error) {
+	body, ok := strings.CutSuffix(line, "\n")
+	if !ok {
+		return nil, fmt.Errorf("the adapter's output ended in the middle of a frame: %s", quoted(line))
+	}
+
+	if strings.HasSuffix(body, "\r") {
+		return nil, fmt.Errorf("a frame is terminated by a line feed and this one carries a carriage return before it: %s",
+			quoted(body))
+	}
+
+	if body == "" {
+		return nil, fmt.Errorf("a blank line is not a frame")
+	}
+
+	var frame response
+	if err := json.Unmarshal([]byte(body), &frame); err != nil {
+		return nil, fmt.Errorf("a frame is one JSON object on one line, and this is not: %s", quoted(body))
+	}
+
+	if frame.ID == nil {
+		return nil, fmt.Errorf("the frame carries no id, and an id is what pairs it with a request: %s", quoted(body))
+	}
+
+	if frame.OK == nil {
+		return nil, fmt.Errorf("the frame carries no ok, so it says nothing about whether the request was served: %s",
+			quoted(body))
+	}
+
+	if !frame.served() && frame.Error == "" {
+		return nil, fmt.Errorf("the frame refused the request and says nothing about why: %s", quoted(body))
+	}
+
+	return &frame, nil
+}
+
+// quotedLimit is how much of an unreadable line is quoted back.
+//
+// A line that is not a frame is usually a diagnostic and occasionally a
+// megabyte of a runtime's stack trace, and a report is read in a terminal.
+const quotedLimit = 240
+
+// quoted is a line as a diagnostic should carry it: as a Go quoted string, so
+// that a stray carriage return or a control character is visible rather than
+// something that moved the cursor, and shortened to something a report can hold.
+func quoted(line string) string {
+	if len(line) > quotedLimit {
+		return fmt.Sprintf("%q (and %d more bytes)", line[:quotedLimit], len(line)-quotedLimit)
+	}
+
+	return fmt.Sprintf("%q", line)
+}

--- a/internal/conformance/engine/frame_test.go
+++ b/internal/conformance/engine/frame_test.go
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package engine
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestAFrameIsOneLineOfJSON walks what the framing does not admit.
+//
+// Every row is a hazard docs/adapter/SPEC.md names rather than an invented
+// malformation: a receiver that skipped a blank line would report a corrupted
+// stream one frame later, at whichever frame first failed to parse; one that
+// trimmed a carriage return would let a text-mode file handle silently change
+// what was sent; and one that read a frame with no ok would call an answer out
+// of a line that says nothing about whether the request was served.
+func TestAFrameIsOneLineOfJSON(t *testing.T) {
+	tests := map[string]struct {
+		line string
+		says string
+	}{
+		"a blank line": {
+			line: "\n",
+			says: "blank line",
+		},
+		"a carriage return before the terminator": {
+			line: "{\"id\":1,\"ok\":true}\r\n",
+			says: "carriage return",
+		},
+		"a line the stream cut off": {
+			line: `{"id":1,"ok":true}`,
+			says: "ended in the middle of a frame",
+		},
+		"a greeting a library printed": {
+			line: "loading tables, please wait\n",
+			says: "one JSON object on one line",
+		},
+		"two documents on one line": {
+			line: "{\"id\":1,\"ok\":true} {\"id\":2,\"ok\":true}\n",
+			says: "one JSON object on one line",
+		},
+		"a frame with no id": {
+			line: "{\"ok\":true}\n",
+			says: "carries no id",
+		},
+		"a frame with no ok": {
+			line: "{\"id\":1}\n",
+			says: "carries no ok",
+		},
+		"a refusal that says nothing": {
+			line: "{\"id\":1,\"ok\":false}\n",
+			says: "says nothing about why",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := unmarshal(test.line)
+			if err == nil {
+				t.Fatal("the line was read as a frame, and the framing does not admit it")
+			}
+
+			if !strings.Contains(err.Error(), test.says) {
+				t.Errorf("the fault is %q, and it does not say %q", err, test.says)
+			}
+		})
+	}
+}
+
+// TestAnUnknownMemberIsIgnored is the opposite of the rule the corpus format
+// applies to an entry, and the difference is who writes the document.
+//
+// An entry is written by a person, where an unrecognised member is a typo and
+// refusing it is a kindness. A frame is written by a program against a version
+// it announced at the handshake, where an unrecognised member is one a later
+// version of the contract added — and a receiver that refused it would make
+// every future addition a breaking change, which is how a protocol acquires a
+// version number it never gets to increment.
+func TestAnUnknownMemberIsIgnored(t *testing.T) {
+	got, err := unmarshal("{\"id\":1,\"ok\":true,\"protocol\":1,\"name\":\"x\",\"kind\":\"codec\"," +
+		"\"capabilities\":{},\"telemetry\":{\"entries\":7}}\n")
+	if err != nil {
+		t.Fatalf("a frame carrying a member this version does not know was refused: %v", err)
+	}
+
+	if !got.served() || got.Name != "x" {
+		t.Errorf("the frame was read as %+v", got)
+	}
+}
+
+// TestAnEmptyInputIsAskedAboutAsAnEmptyInput asserts that an entry whose file
+// holds no bytes reaches the adapter as one.
+//
+// An empty file is a file — a layout whose sequencing expression accepts
+// nothing is exactly what one entry ought to be about — and a request that
+// dropped the member would be asking a different question, which the adapter
+// would have to guess the answer to.
+func TestAnEmptyInputIsAskedAboutAsAnEmptyInput(t *testing.T) {
+	empty := []byte{}
+
+	frame, err := marshal(&request{ID: 3, Op: opDecode, Entry: "empty", Input: &empty})
+	if err != nil {
+		t.Fatalf("the request could not be written: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(frame, &got); err != nil {
+		t.Fatalf("the request is not a JSON object: %v", err)
+	}
+
+	if input, ok := got["input"]; !ok || input != "" {
+		t.Errorf("the request carries input %v, and an entry of no bytes is asked about with an empty one", input)
+	}
+
+	if _, ok := got["entries"]; ok {
+		t.Error("a decode request carries generate's entries")
+	}
+}
+
+// TestAFrameIsOneLine asserts that nothing this engine writes carries a line
+// feed of its own, which is the whole of what makes a line feed a delimiter.
+func TestAFrameIsOneLine(t *testing.T) {
+	descriptor := []byte{0x00, 0x0a, 0xff}
+
+	frame, err := marshal(&request{
+		ID: 2, Op: opGenerate,
+		Entries: []requestEntry{{Entry: "an entry\nwith a line feed in its name", Descriptor: descriptor}},
+	})
+	if err != nil {
+		t.Fatalf("the request could not be written: %v", err)
+	}
+
+	if got := strings.Count(string(frame), "\n"); got != 1 {
+		t.Errorf("the frame carries %d line feeds, and a frame is one line", got)
+	}
+
+	if !strings.HasSuffix(string(frame), "\n") {
+		t.Error("the frame is not terminated by a line feed")
+	}
+}
+
+// TestQuotedShortensWhatItQuotes asserts that a report quoting a line which is
+// not a frame stays something a person can read.
+//
+// A line that is not a frame is usually a diagnostic and occasionally a
+// megabyte of a runtime's stack trace, and the quote is the thing somebody has
+// to read to find out what the adapter did.
+func TestQuotedShortensWhatItQuotes(t *testing.T) {
+	said := quoted(strings.Repeat("x", quotedLimit*2))
+
+	if len(said) > quotedLimit+64 {
+		t.Errorf("a quoted line is %d bytes long", len(said))
+	}
+
+	if !strings.Contains(said, "more bytes") {
+		t.Errorf("the quote is %q, and it does not say it is short of the whole line", said)
+	}
+}

--- a/internal/conformance/engine/position.go
+++ b/internal/conformance/engine/position.go
@@ -1,0 +1,472 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package engine
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Zaba505/cpybkc/internal/conformance"
+	"github.com/Zaba505/cpybkc/irpb"
+)
+
+// position is where the descriptor puts one value of a values document.
+//
+// An engine that says `packed-comp6: mismatch` has done the minimum. This is
+// the rest of it: the engine holds the descriptor and the bytes, so it can say
+// which item disagreed, where it sits, how wide it is and what encoding it was
+// read under — which is available to the engine and to nothing else in the
+// system, since the adapter was never told what was expected and the corpus
+// package compares documents rather than bytes.
+type position struct {
+	// Path is the values-document path [conformance.Compare] names, and is what
+	// a fault is looked up by.
+	Path string
+
+	// Name is what the copybook calls the item.
+	Name string
+
+	// Record is which record of the file it is in, counted from one as every
+	// other report of a record counts.
+	Record int
+
+	// Offset is where the item begins inside its record, and Width is how many
+	// bytes it takes. Both come from the position sum over the record's member
+	// lists — the sum docs/ir/SPEC.md names as the thing every consumer runs and
+	// every consumer may get wrong on its own, which is why the corpus exists.
+	Offset int
+	Width  int
+
+	// Group is whether the item holds other items, in which case the encoding
+	// axes below are its members' and not its own.
+	Group bool
+
+	// Usage, Charset and Sign are the axes an elementary item was read under.
+	// They are named because a disagreement about a number is nearly always a
+	// disagreement about one of them, and the entry that reports it is the one
+	// that knows which of the four the item carried.
+	Usage   string
+	Charset string
+	Sign    string
+
+	// FileOffset is where the item's bytes are in input.bin, and Located says
+	// whether that could be worked out at all: a record's start in the file is
+	// determinate only where the framing lets records abut, and an item behind a
+	// table whose count is read at run time slides with it.
+	FileOffset int
+	Located    bool
+}
+
+// String is the sentence a report carries beneath the disagreement.
+func (p position) String() string {
+	held := "bytes"
+	if p.Width == 1 {
+		held = "byte"
+	}
+
+	said := fmt.Sprintf("%s is %d %s at offset %d of record %d", p.Name, p.Width, held, p.Offset, p.Record)
+
+	if p.Group {
+		return said + ", and is a group"
+	}
+
+	return fmt.Sprintf("%s, usage %s, charset %s, sign convention %s", said, p.Usage, p.Charset, p.Sign)
+}
+
+// bytesLimit is how many of an item's bytes a report quotes.
+//
+// An item is usually a handful of bytes and occasionally a table thousands of
+// bytes wide, and what makes the quote useful is that it fits on the line under
+// the disagreement.
+const bytesLimit = 16
+
+// bytes is the item's own bytes, quoted from the entry's input where the
+// framing let them be found.
+//
+// It is the item's run and not a window around it on purpose: a window has to
+// choose a width and mark a position inside it, and every reader then has to
+// count characters to check the marking. The offsets are written out instead, so
+// what is quoted is unambiguous by construction.
+func (p position) bytes(input []byte) (string, bool) {
+	if !p.Located || p.Width == 0 {
+		return "", false
+	}
+
+	end := p.FileOffset + p.Width
+	if p.FileOffset < 0 || end > len(input) {
+		// The item runs past the end of the file. That is a fact about the
+		// entry rather than about the answer — and quoting whatever bytes there
+		// happen to be would be quoting an item the file does not carry.
+		return "", false
+	}
+
+	run := input[p.FileOffset:end]
+	said := fmt.Sprintf("%s 0x%04x..0x%04x:", conformance.InputName, p.FileOffset, end-1)
+
+	for _, b := range run[:min(len(run), bytesLimit)] {
+		said += fmt.Sprintf(" %02x", b)
+	}
+
+	if len(run) > bytesLimit {
+		said += fmt.Sprintf(" (and %d more)", len(run)-bytesLimit)
+	}
+
+	return said, true
+}
+
+// positions is where the descriptor puts every value the entry states, keyed by
+// the path [conformance.Compare] names it by.
+//
+// The walk is guided by the entry's own values document rather than by the
+// descriptor alone, because the descriptor does not say how many occurrences a
+// table holds when its count is read at run time, nor which arm of a variant an
+// occurrence took. The entry states both, and it is the oracle here as
+// everywhere else in the corpus.
+//
+// Nothing in it can fail. A descriptor and a values document that disagree about
+// shape produce fewer positions rather than an error: this is what a report
+// adds beneath a disagreement, and a report that refused to be written because
+// the disagreement was structural would withhold the explanation exactly when it
+// is most wanted.
+func positions(entry *conformance.Entry) map[string]position {
+	found := map[string]position{}
+
+	if entry.Descriptor == nil || entry.Values == nil {
+		return found
+	}
+
+	nodes := index(entry.Descriptor)
+
+	walk := &walker{nodes: nodes, found: found}
+
+	// Where one record's bytes end and the next record's begin is the file
+	// node's, and only one of the four framings lets a reader place a record
+	// without reading it: under unframed, a record begins at the byte after the
+	// record before it. Under the other three there are framing bytes that
+	// belong to the dataset and to no record, and this package deliberately does
+	// not model them — an offset into input.bin that was wrong would be worse
+	// than none at all, so the offsets within the record are still reported and
+	// the bytes are not quoted.
+	located := unframed(entry.Descriptor)
+	file := 0
+
+	for i, record := range entry.Values.Records {
+		root := recordRoot(entry.Descriptor, nodes, record.Name)
+		if root == nil {
+			// A record the descriptor does not carry, which the loader already
+			// refuses in an entry: nothing after it can be placed either, since
+			// its width is unknown.
+			return found
+		}
+
+		walk.record = i + 1
+		walk.file = file
+		walk.located = located
+
+		width, ok := walk.node(root, record.Value, fmt.Sprintf("record %d %s", i+1, record.Name), 0)
+		if !ok {
+			// The shape of this record could not be followed, so where the next
+			// one starts is not known either. What was placed before it stands.
+			return found
+		}
+
+		file += width
+	}
+
+	return found
+}
+
+// index is every node of the descriptor by identifier, which is how every
+// reference in it is resolved: a consumer MUST resolve a reference by
+// identifier and MUST NOT look a node up by name, because duplicate data names
+// are legal COBOL.
+func index(descriptor *irpb.Descriptor) map[uint64]*irpb.Node {
+	nodes := make(map[uint64]*irpb.Node, len(descriptor.GetNodes()))
+
+	for _, node := range descriptor.GetNodes() {
+		nodes[node.GetId()] = node
+	}
+
+	return nodes
+}
+
+// unframed is whether the descriptor's file node says records abut.
+func unframed(descriptor *irpb.Descriptor) bool {
+	for _, node := range descriptor.GetNodes() {
+		if file := node.GetFile(); file != nil {
+			return file.GetUnframed() != nil
+		}
+	}
+
+	return false
+}
+
+// recordRoot is the top-level group of the record type the copybook calls name.
+//
+// The first record node of that name wins. Two record types cannot be told
+// apart by a values document either — a record is named there and nowhere
+// identified — so a descriptor carrying two of one name is a descriptor this
+// explanation is approximate about, and the comparison it explains is not.
+func recordRoot(descriptor *irpb.Descriptor, nodes map[uint64]*irpb.Node, name string) *irpb.Node {
+	for _, node := range descriptor.GetNodes() {
+		record := node.GetRecord()
+		if record == nil || record.GetNames().GetOriginal() != name {
+			continue
+		}
+
+		return nodes[record.GetRootId()]
+	}
+
+	return nil
+}
+
+// walker is one record's walk: the descriptor beside the values the entry
+// states, accumulating positions as it goes.
+type walker struct {
+	nodes  map[uint64]*irpb.Node
+	found  map[string]position
+	record int
+
+	// file is where this record begins in input.bin, and located is whether
+	// that number means anything.
+	file    int
+	located bool
+}
+
+// node places one node of a record, and reports how many bytes it takes.
+//
+// The boolean is whether the width is known. A width that is not is not a
+// failure — it is the point past which nothing else in the record can be
+// placed, because every offset behind it would be a guess.
+func (w *walker) node(node *irpb.Node, value any, path string, offset int) (int, bool) {
+	switch kind := node.GetKind().(type) {
+	case *irpb.Node_Slack:
+		// Bytes that are part of the record and belong to no item: they take
+		// their width and contribute no value and no path.
+		return int(kind.Slack.GetWidth()), true
+	case *irpb.Node_Group:
+		return w.occurrences(kind.Group.GetRepetition(), value, path, offset,
+			func(one any, path string, offset int) (int, bool) {
+				width, ok := w.group(kind.Group, one, path, offset)
+
+				w.place(path, kind.Group.GetNames().GetOriginal(), offset, width, ok, position{Group: true})
+
+				return width, ok
+			})
+	case *irpb.Node_Field:
+		return w.occurrences(kind.Field.GetRepetition(), value, path, offset,
+			func(_ any, path string, offset int) (int, bool) {
+				width := int(kind.Field.GetWidth())
+
+				w.place(path, kind.Field.GetNames().GetOriginal(), offset, width, true, position{
+					Usage:   trimmed("USAGE_", kind.Field.GetUsage().String()),
+					Charset: trimmed("CHARSET_", kind.Field.GetEncoding().GetCharset().String()),
+					Sign:    trimmed("SIGN_CONVENTION_", kind.Field.GetEncoding().GetSignConvention().String()),
+				})
+
+				return width, true
+			})
+	default:
+		// A predicate, a state, a transition or anything else that is not an
+		// item of a record. Nothing points at one from a member list, so
+		// reaching here is a descriptor this walk does not understand rather
+		// than a shape it can carry on through.
+		return 0, false
+	}
+}
+
+// occurrences places a node that may repeat, once per occurrence.
+//
+// How many there are comes from the descriptor where the count is a constant,
+// and from the entry's own document where it is read at run time — the entry
+// states what the file holds, which is exactly the question a variable count
+// asks. A repetition whose count is neither is the end of the walk.
+func (w *walker) occurrences(repetition *irpb.Repetition, value any, path string, offset int,
+	one func(value any, path string, offset int) (int, bool),
+) (int, bool) {
+	if repetition == nil {
+		return one(value, path, offset)
+	}
+
+	held, _ := value.([]any)
+
+	count, ok := 0, false
+
+	switch counted := repetition.GetCount().(type) {
+	case *irpb.Repetition_Constant:
+		count, ok = int(counted.Constant), true
+	case *irpb.Repetition_Variable:
+		// The count is read at run time, so the descriptor does not carry it and
+		// the entry does: what the file holds is what values.json states.
+		if held != nil {
+			count, ok = len(held), true
+		}
+	}
+
+	if !ok {
+		return 0, false
+	}
+
+	total := 0
+
+	for i := range count {
+		var occurrence any
+		if i < len(held) {
+			occurrence = held[i]
+		}
+
+		width, ok := one(occurrence, fmt.Sprintf("%s[%d]", path, i), offset+total)
+		if !ok {
+			return 0, false
+		}
+
+		total += width
+	}
+
+	return total, true
+}
+
+// group places every member of a group in record order.
+func (w *walker) group(group *irpb.Group, value any, path string, offset int) (int, bool) {
+	// A value that is not an object is a shape the answer disagrees about, and
+	// the members are still placed: their widths come from the descriptor, and
+	// what the walk loses is only the arm a variant took and the length of a
+	// table whose count is read at run time.
+	held, _ := value.(map[string]any)
+
+	total := 0
+
+	for _, id := range group.GetMemberIds() {
+		member, ok := w.nodes[id]
+		if !ok {
+			return 0, false
+		}
+
+		if variant := member.GetVariant(); variant != nil {
+			width, ok := w.variant(variant, held, path, offset+total)
+			if !ok {
+				return 0, false
+			}
+
+			total += width
+
+			continue
+		}
+
+		name := member.GetGroup().GetNames().GetOriginal()
+		if field := member.GetField(); field != nil {
+			name = field.GetNames().GetOriginal()
+		}
+
+		var value any
+		if held != nil && name != "" {
+			value = held[name]
+		}
+
+		memberPath := path
+		if name != "" {
+			memberPath = path + "." + name
+		}
+
+		width, ok := w.node(member, value, memberPath, offset+total)
+		if !ok {
+			return 0, false
+		}
+
+		total += width
+	}
+
+	return total, true
+}
+
+// variant places the arm an occurrence took.
+//
+// Every arm's extent equals every other arm's, which is what keeps a variant's
+// contribution to the position sum constant — so the arm that was taken is
+// needed for the paths beneath it and never for the width. Which arm that was
+// is not in the descriptor: an arm the occurrence did not take contributes no
+// key at all to the document, so the key that is there is the answer.
+func (w *walker) variant(variant *irpb.Variant, held map[string]any, path string, offset int) (int, bool) {
+	for _, arm := range variant.GetArms() {
+		body, name, ok := w.arm(arm)
+		if !ok {
+			return 0, false
+		}
+
+		if value, taken := held[name]; taken {
+			return w.node(body, value, path+"."+name, offset)
+		}
+	}
+
+	// No arm's name is a key of the document. Either the entry states a shape
+	// this walk did not follow, or the answer is about to be reported as
+	// holding an arm the entry does not expect — and the first arm's extent is
+	// the alternation's whichever it was, so the walk goes on. Placing that
+	// arm's items is deliberate: a mismatch naming one of them is exactly the
+	// answer that took the wrong arm, and it is the one worth explaining.
+	arms := variant.GetArms()
+	if len(arms) == 0 {
+		return 0, false
+	}
+
+	body, name, ok := w.arm(arms[0])
+	if !ok {
+		return 0, false
+	}
+
+	return w.node(body, nil, path+"."+name, offset)
+}
+
+// arm resolves an arm to the node that is its body and the name that body
+// carries, which is the key an occurrence writes when it took that arm.
+func (w *walker) arm(arm *irpb.Arm) (*irpb.Node, string, bool) {
+	var id uint64
+
+	switch body := arm.GetBody().(type) {
+	case *irpb.Arm_GroupId:
+		id = body.GroupId
+	case *irpb.Arm_FieldId:
+		id = body.FieldId
+	default:
+		return nil, "", false
+	}
+
+	body, ok := w.nodes[id]
+	if !ok {
+		return nil, "", false
+	}
+
+	name := body.GetGroup().GetNames().GetOriginal()
+	if field := body.GetField(); field != nil {
+		name = field.GetNames().GetOriginal()
+	}
+
+	return body, name, true
+}
+
+// place records where an item sits, unless its width could not be worked out.
+func (w *walker) place(path, name string, offset, width int, known bool, held position) {
+	if !known || name == "" {
+		return
+	}
+
+	held.Path = path
+	held.Name = name
+	held.Record = w.record
+	held.Offset = offset
+	held.Width = width
+	held.FileOffset = w.file + offset
+	held.Located = w.located
+
+	w.found[path] = held
+}
+
+// trimmed is an enumerator's name without the prefix every one of its values
+// carries, because a report reads better saying PACKED_DECIMAL than
+// USAGE_PACKED_DECIMAL and the prefix is already in the word before it.
+func trimmed(prefix, value string) string {
+	return strings.TrimPrefix(value, prefix)
+}

--- a/internal/conformance/engine/position_test.go
+++ b/internal/conformance/engine/position_test.go
@@ -1,0 +1,243 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/conformance"
+	"github.com/Zaba505/cpybkc/irpb"
+)
+
+// TestThePositionSumIsRunOverTheDescriptor pins the arithmetic a mismatch is
+// explained with.
+//
+// docs/ir/SPEC.md carries no offset on any node — position is stated once, as
+// ordering and width — so an offset is a sum a consumer runs, and this is the
+// engine's. The record here holds the three things that make the sum more than
+// an addition: bytes that belong to no item, an item that repeats, and an item
+// behind both of them.
+func TestThePositionSumIsRunOverTheDescriptor(t *testing.T) {
+	descriptor := &irpb.Descriptor{
+		Version: irpb.IrVersion_IR_VERSION_1,
+		Nodes: []*irpb.Node{
+			{Id: 1, Kind: &irpb.Node_File{File: &irpb.File{
+				Framing: &irpb.File_Unframed{Unframed: &irpb.Unframed{}}, StartStateId: 9,
+			}}},
+			{Id: 2, Kind: &irpb.Node_Record{Record: &irpb.Record{
+				RootId: 3, Names: &irpb.Names{Original: "REC"},
+			}}},
+			{Id: 3, Kind: &irpb.Node_Group{Group: &irpb.Group{
+				MemberIds: []uint64{4, 5, 6, 7}, Names: &irpb.Names{Original: "REC"},
+			}}},
+			{Id: 4, Kind: &irpb.Node_Field{Field: &irpb.Field{
+				Width: 4, Names: &irpb.Names{Original: "HEAD"},
+				Usage:    irpb.Usage_USAGE_DISPLAY,
+				Encoding: &irpb.Encoding{Charset: irpb.Charset_CHARSET_CP037},
+			}}},
+			{Id: 5, Kind: &irpb.Node_Slack{Slack: &irpb.Slack{Width: 2}}},
+			{Id: 6, Kind: &irpb.Node_Field{Field: &irpb.Field{
+				Width: 5, Names: &irpb.Names{Original: "TABLE"},
+				Usage:      irpb.Usage_USAGE_PACKED_DECIMAL,
+				Encoding:   &irpb.Encoding{Charset: irpb.Charset_CHARSET_ASCII},
+				Repetition: &irpb.Repetition{Count: &irpb.Repetition_Constant{Constant: 3}},
+			}}},
+			{Id: 7, Kind: &irpb.Node_Field{Field: &irpb.Field{
+				Width: 1, Names: &irpb.Names{Original: "TAIL"},
+				Usage:    irpb.Usage_USAGE_BINARY,
+				Encoding: &irpb.Encoding{Charset: irpb.Charset_CHARSET_ASCII},
+			}}},
+		},
+	}
+
+	values, err := conformance.ParseValues([]byte(
+		`{"records": [{"name": "REC", "value": {"HEAD": "abcd", "TABLE": ["1", "2", "3"], "TAIL": "7"}}]}`))
+	if err != nil {
+		t.Fatalf("the values the test is written against: %v", err)
+	}
+
+	found := positions(&conformance.Entry{Name: "made-up", Descriptor: descriptor, Values: values})
+
+	tests := map[string]struct {
+		offset int
+		width  int
+	}{
+		"record 1 REC.HEAD":     {offset: 0, width: 4},
+		"record 1 REC.TABLE[0]": {offset: 6, width: 5},
+		"record 1 REC.TABLE[1]": {offset: 11, width: 5},
+		"record 1 REC.TABLE[2]": {offset: 16, width: 5},
+		"record 1 REC.TAIL":     {offset: 21, width: 1},
+	}
+
+	for path, want := range tests {
+		got, ok := found[path]
+		if !ok {
+			t.Errorf("%s was not placed at all", path)
+
+			continue
+		}
+
+		if got.Offset != want.offset || got.Width != want.width {
+			t.Errorf("%s is %d bytes at offset %d, and the descriptor puts it %d bytes at offset %d",
+				path, got.Width, got.Offset, want.width, want.offset)
+		}
+
+		if got.FileOffset != want.offset || !got.Located {
+			t.Errorf("%s is at 0x%x of a file whose records abut, and it begins at %d",
+				path, got.FileOffset, want.offset)
+		}
+	}
+
+	if said := found["record 1 REC.TABLE[1]"].String(); !strings.Contains(said, "usage PACKED_DECIMAL") ||
+		!strings.Contains(said, "charset ASCII") {
+		t.Errorf("the item reads %q, and a disagreement about a number is nearly always about one of those axes", said)
+	}
+}
+
+// TestARecordAfterAnotherIsPlacedBehindIt asserts that a second record's bytes
+// are found where the first one's end, which is what makes the quoted bytes
+// beneath a mismatch the right bytes.
+//
+// It is asserted against a real entry rather than an invented one, because what
+// is being checked is that the sum agrees with a file somebody wrote down.
+func TestARecordAfterAnotherIsPlacedBehindIt(t *testing.T) {
+	entry := loadEntry(t, "zoned-ebcdic")
+
+	if len(entry.Values.Records) < 2 {
+		t.Fatalf("%s carries %d records, and this is about the second", entry.Name, len(entry.Values.Records))
+	}
+
+	found := positions(entry)
+
+	starts := map[int]int{}
+
+	for _, held := range found {
+		if !held.Located {
+			t.Fatalf("%s is not placed in a file whose records abut", held.Path)
+		}
+
+		// Every item of one record shares the record's own start, which is
+		// what the file offset is: the record's beginning plus the offset the
+		// position sum gives inside it.
+		start := held.FileOffset - held.Offset
+
+		if held, ok := starts[held.Record]; ok && held != start {
+			t.Fatalf("record %d begins at two different bytes", held)
+		}
+
+		starts[held.Record] = start
+	}
+
+	if starts[1] != 0 {
+		t.Errorf("the first record begins at byte %d of the file", starts[1])
+	}
+
+	if starts[2] <= starts[1] || starts[2] >= len(entry.Input) {
+		t.Errorf("the second record begins at byte %d of a file of %d bytes", starts[2], len(entry.Input))
+	}
+
+	// The two records are the same record type, so the second begins exactly
+	// one record's width behind the first.
+	if starts[2]*2 != len(entry.Input) {
+		t.Errorf("two records of one type do not divide a file of %d bytes at %d", len(entry.Input), starts[2])
+	}
+}
+
+// TestTheBytesQuotedAreTheItemsOwn asserts that what a report quotes beneath a
+// mismatch is the run of bytes the item was read from, and that an item nothing
+// can be said about is passed over rather than guessed at.
+func TestTheBytesQuotedAreTheItemsOwn(t *testing.T) {
+	entry := loadEntry(t, "packed-ebcdic")
+
+	held, ok := positions(entry)["record 1 PACKED-RECORD.P-SIGNED-POS"]
+	if !ok {
+		t.Fatal("the first item of the first record was not placed")
+	}
+
+	said, ok := held.bytes(entry.Input)
+	if !ok {
+		t.Fatal("the item's bytes were not quoted, and the file's records abut")
+	}
+
+	if !strings.Contains(said, "12 34 5c") {
+		t.Errorf("the quote is %q, and the file begins 12 34 5c", said)
+	}
+
+	// An item the framing could not place quotes nothing at all. An offset into
+	// input.bin that was wrong would be worse than none: it would send whoever
+	// reads it to the wrong bytes with no way to tell.
+	unplaced := held
+	unplaced.Located = false
+
+	if _, ok := unplaced.bytes(entry.Input); ok {
+		t.Error("an item that could not be placed quoted bytes anyway")
+	}
+
+	past := held
+	past.FileOffset = len(entry.Input)
+
+	if _, ok := past.bytes(entry.Input); ok {
+		t.Error("an item running past the end of the file quoted bytes anyway")
+	}
+}
+
+// TestPositionsSurvivesADescriptorItCannotWalk asserts that the explanation is
+// an addition to a report and never a condition of one.
+//
+// A report that refused to be written because the disagreement was structural
+// would withhold the explanation exactly when it is most wanted.
+func TestPositionsSurvivesADescriptorItCannotWalk(t *testing.T) {
+	values, err := conformance.ParseValues([]byte(`{"records": [{"name": "NOBODY", "value": {"X": "1"}}]}`))
+	if err != nil {
+		t.Fatalf("the values the test is written against: %v", err)
+	}
+
+	tests := map[string]*conformance.Entry{
+		"an entry with nothing in it":           {Name: "empty"},
+		"a record the descriptor does not hold": {Name: "unknown", Descriptor: &irpb.Descriptor{}, Values: values},
+	}
+
+	for name, entry := range tests {
+		t.Run(name, func(t *testing.T) {
+			if found := positions(entry); len(found) != 0 {
+				t.Errorf("%d items were placed against a descriptor that carries none", len(found))
+			}
+		})
+	}
+}
+
+// loadEntry reads one entry of the corpus by name.
+func loadEntry(t *testing.T, name string) *conformance.Entry {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("working directory: %v", err)
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			break
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("no go.mod found above %q", dir)
+		}
+
+		dir = parent
+	}
+
+	entry, err := conformance.LoadEntry(filepath.Join(conformance.CorpusPath(dir), name))
+	if err != nil {
+		t.Fatalf("the conformance corpus: %v", err)
+	}
+
+	return entry
+}

--- a/internal/conformance/engine/report.go
+++ b/internal/conformance/engine/report.go
@@ -1,0 +1,363 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package engine
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Zaba505/cpybkc/internal/conformance"
+)
+
+// Outcome is what became of one entry.
+//
+// Three, and keeping them apart is most of the value of the contract: an engine
+// that conflated any two of them would report a wrong thing about a working
+// generator or a working thing about a broken one.
+type Outcome int
+
+const (
+	// Passed is an entry the adapter answered and whose answer is what the
+	// entry states — in both directions, where the adapter declared a writer.
+	Passed Outcome = iota
+
+	// Mismatched is an entry the adapter answered and whose answer is not what
+	// the entry states. Something is wrong with the generator or with the entry,
+	// and whoever reads the report decides which.
+	Mismatched
+
+	// Faulted is an entry the adapter could not answer about at all: it refused
+	// the request, it broke, or it did not answer in time. Nothing has been
+	// learned about the generator, which is why it is not a mismatch.
+	Faulted
+)
+
+func (o Outcome) String() string {
+	switch o {
+	case Passed:
+		return "PASS"
+	case Mismatched:
+		return "FAIL"
+	case Faulted:
+		return "FAULT"
+	default:
+		return fmt.Sprintf("Outcome(%d)", int(o))
+	}
+}
+
+// Result is what became of one entry, and why.
+type Result struct {
+	// Entry is the entry's name, and Source is the section of a specification
+	// it cites as the origin of its expected answer — carried because whoever
+	// reads a failure has to decide whether the generator is wrong or the entry
+	// is, and that decision starts there.
+	Entry  string
+	Source string
+
+	Outcome Outcome
+
+	// Err is the disagreement or the fault, and is nil where the entry passed.
+	// It is a
+	// [github.com/Zaba505/cpybkc/internal/conformance.MismatchError] or a
+	// [github.com/Zaba505/cpybkc/internal/conformance.RunError], so that a
+	// result printed on its own says which of the two it is.
+	Err error
+}
+
+// Adapter is what the adapter said about itself at the handshake.
+//
+// Every member of it is for the report and none of it is compared or parsed: an
+// adapter that drives a particular generator at a particular version is the
+// useful thing to say, because that is what a reader of a result wants to know
+// and nothing else in the conversation carries it.
+type Adapter struct {
+	Name     string
+	Version  string
+	Kind     string
+	Protocol int
+
+	// Capabilities are the optional operations it declared. A capability absent
+	// is one it does not have.
+	Capabilities map[string]bool
+}
+
+// Writes is whether the adapter's generator emits a writer.
+//
+// A generator that emits a reader and no writer is conformant to
+// docs/ir/SPEC.md's "Writing a file", so an engine that demanded the writing
+// direction of every adapter would fail every positive entry for such a
+// generator — reporting, once per entry, a missing answer to a question the
+// specification never obliged it to answer.
+func (a *Adapter) Writes() bool { return a != nil && a.Capabilities[capabilityWrite] }
+
+// String is the adapter as a report names it.
+func (a *Adapter) String() string {
+	said := a.Name
+	if said == "" {
+		said = "an adapter that gave no name"
+	}
+
+	if a.Version != "" {
+		said += " " + a.Version
+	}
+
+	return fmt.Sprintf("%s (%s, protocol %d)", said, a.Kind, a.Protocol)
+}
+
+// Report is one run: which adapter, through which door, and what became of
+// every entry it was asked about.
+type Report struct {
+	// Door is what the door said it provides, quoted rather than summarised. An
+	// engine MUST NOT report a result as though it carried a guarantee its door
+	// did not provide, and quoting is how this one keeps that promise: the
+	// sentence in a report is the door's own.
+	Door string
+
+	// Adapter is what the adapter declared, and is nil where the handshake
+	// never completed.
+	Adapter *Adapter
+
+	// NotApplicable is a run by an adapter that declared itself descriptive: a
+	// generator that emits a diagram, a schema or a copybook never opens a data
+	// file, so there is nothing to hand input.bin to. It is not a failure and
+	// not a score of zero — the two shapes that must not happen are a
+	// descriptive generator scored zero out of the whole corpus, and one
+	// declining every entry one at a time.
+	NotApplicable bool
+
+	// Restarts is how many fresh adapter processes this run needed after one
+	// broke. It is reported because an adapter that had to be restarted is one
+	// whose results were produced by more than one process, and because a run
+	// that restarted repeatedly is a fact about the adapter that no single entry
+	// carries.
+	Restarts int
+
+	// Results are the entries, in the order they were asked about.
+	Results []*Result
+
+	// Notes are what happened to the run rather than to an entry: an adapter
+	// that exited badly, a door that could not start another process.
+	Notes []string
+}
+
+// Failed is whether anything went wrong: an entry that disagreed, or one that
+// could not be asked at all.
+//
+// A run that could not ask is a failed run and not an empty one. An entry lost
+// to a broken adapter has told nobody anything about the generator, and a
+// caller that read "nothing mismatched" as "everything passed" would report a
+// conformant generator on the strength of never having asked it.
+func (r *Report) Failed() bool {
+	for _, result := range r.Results {
+		if result.Outcome != Passed {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Counts is how many entries passed, disagreed and could not be asked.
+func (r *Report) Counts() (passed, mismatched, faulted int) {
+	for _, result := range r.Results {
+		switch result.Outcome {
+		case Passed:
+			passed++
+		case Mismatched:
+			mismatched++
+		case Faulted:
+			faulted++
+		}
+	}
+
+	return passed, mismatched, faulted
+}
+
+// String is the whole report, as something a person reads.
+//
+// The summary is first because the first question is whether it passed, and
+// every entry is listed rather than only the failures, because a corpus run
+// whose output shrinks as it goes wrong is one where a missing line and a
+// passing entry look the same.
+func (r *Report) String() string {
+	var said strings.Builder
+
+	if r.Adapter != nil {
+		fmt.Fprintf(&said, "adapter: %s\n", r.Adapter)
+	}
+
+	fmt.Fprintf(&said, "door: %s\n", r.Door)
+
+	if r.NotApplicable {
+		fmt.Fprintf(&said, "\nthis generator is descriptive: it emits something other than code that reads a file,\n"+
+			"so the corpus has nothing to ask it and this run is not applicable rather than failed.\n")
+
+		return said.String()
+	}
+
+	if r.Adapter != nil && !r.Adapter.Writes() {
+		fmt.Fprintf(&said, "this adapter declares no writer, so only the reading direction was asked:\n"+
+			"a run by a read-only adapter is a smaller claim than a run by a full one, and not a lesser result.\n")
+	}
+
+	passed, mismatched, faulted := r.Counts()
+
+	fmt.Fprintf(&said, "%d entries: %d passed, %d disagreed, %d could not be asked\n",
+		len(r.Results), passed, mismatched, faulted)
+
+	if r.Restarts == 1 {
+		said.WriteString("a fresh adapter was started after one broke\n")
+	} else if r.Restarts > 1 {
+		fmt.Fprintf(&said, "%d fresh adapters were started after one broke\n", r.Restarts)
+	}
+
+	for _, note := range r.Notes {
+		fmt.Fprintf(&said, "%s\n", note)
+	}
+
+	said.WriteString("\n")
+
+	for _, result := range r.Results {
+		if result.Err == nil {
+			fmt.Fprintf(&said, "%s %s\n", result.Outcome, result.Entry)
+
+			continue
+		}
+
+		fmt.Fprintf(&said, "%s %v\n", result.Outcome, result.Err)
+	}
+
+	return said.String()
+}
+
+// pass records an entry whose answer is what the entry states.
+func (r *Report) pass(entry *conformance.Entry) {
+	r.Results = append(r.Results, &Result{Entry: entry.Name, Source: entry.Source, Outcome: Passed})
+}
+
+// mismatch records an entry the adapter answered and disagreed about.
+func (r *Report) mismatch(entry *conformance.Entry, err error) {
+	r.Results = append(r.Results, &Result{
+		Entry:   entry.Name,
+		Source:  entry.Source,
+		Outcome: Mismatched,
+		Err:     &conformance.MismatchError{Entry: entry.Name, Source: entry.Source, Err: err},
+	})
+}
+
+// fault records an entry nothing was learned about.
+func (r *Report) fault(entry *conformance.Entry, err error) {
+	r.Results = append(r.Results, &Result{
+		Entry:   entry.Name,
+		Source:  entry.Source,
+		Outcome: Faulted,
+		Err:     &conformance.RunError{Entry: entry.Name, Source: entry.Source, Err: err},
+	})
+}
+
+// faultAll records every entry of a run that ended before they could be asked.
+func (r *Report) faultAll(entries []*conformance.Entry, err error) {
+	for _, entry := range entries {
+		r.fault(entry, err)
+	}
+}
+
+// note records something that happened to the run rather than to an entry.
+func (r *Report) note(err error) {
+	if err == nil {
+		return
+	}
+
+	r.Notes = append(r.Notes, err.Error())
+}
+
+// explained is a disagreement with where the descriptor puts the items it
+// named.
+//
+// The disagreement is unchanged and the explanation follows it, because the two
+// answer different questions: the first is what the adapter said, which is the
+// corpus's own comparison, and the second is where in the file that item lives,
+// which only the engine can say.
+type explained struct {
+	Err error
+
+	// Where is one line per item named, and the bytes it was read from where
+	// the framing let them be found.
+	Where []string
+}
+
+func (e *explained) Error() string {
+	return fmt.Sprintf("%v\nwhere the descriptor puts what disagreed:\n\t%s",
+		e.Err, strings.Join(e.Where, "\n\t"))
+}
+
+func (e *explained) Unwrap() error { return e.Err }
+
+// explain says where the descriptor puts every item a comparison named.
+//
+// A path the walk could not place is left out rather than guessed at, and a
+// comparison naming nothing placeable comes back untouched: the explanation is
+// an addition to a report and never a condition of one.
+func explain(err error, found map[string]position, input []byte) error {
+	if err == nil {
+		return nil
+	}
+
+	var (
+		where []string
+		seen  = map[string]bool{}
+	)
+
+	for _, path := range paths(err) {
+		held, ok := found[path]
+		if !ok || seen[path] {
+			continue
+		}
+
+		seen[path] = true
+
+		where = append(where, held.String())
+
+		if quoted, ok := held.bytes(input); ok {
+			where = append(where, quoted)
+		}
+	}
+
+	if len(where) == 0 {
+		return err
+	}
+
+	return &explained{Err: err, Where: where}
+}
+
+// paths is every place in the values document a comparison disagreed about, in
+// the order it reported them.
+//
+// The tree is walked rather than [errors.As]'d over, because a comparison
+// reports every disagreement rather than the first and errors.As stops at the
+// first match — which would explain one item of a record whose whole encoding is
+// wrong and leave the rest unexplained.
+func paths(err error) []string {
+	switch held := err.(type) {
+	case interface{ Unwrap() []error }:
+		var found []string
+
+		for _, one := range held.Unwrap() {
+			found = append(found, paths(one)...)
+		}
+
+		return found
+	case *conformance.PathError:
+		return []string{held.Path}
+	}
+
+	if unwrapped := errors.Unwrap(err); unwrapped != nil {
+		return paths(unwrapped)
+	}
+
+	return nil
+}

--- a/internal/conformance/engine/report.go
+++ b/internal/conformance/engine/report.go
@@ -21,9 +21,17 @@ import (
 type Outcome int
 
 const (
+	// Unknown is the zero value, and is never a verdict a run reaches. It is
+	// first so that nothing defaults to having passed: a [Result] nobody filled
+	// in, or an entry looked up in a map of outcomes it was never added to,
+	// reads as an entry nothing is known about rather than as one that
+	// succeeded. That is the one direction a conformance report must not
+	// default in — an entry lost to a broken adapter has told nobody anything.
+	Unknown Outcome = iota
+
 	// Passed is an entry the adapter answered and whose answer is what the
 	// entry states — in both directions, where the adapter declared a writer.
-	Passed Outcome = iota
+	Passed
 
 	// Mismatched is an entry the adapter answered and whose answer is not what
 	// the entry states. Something is wrong with the generator or with the entry,
@@ -38,6 +46,8 @@ const (
 
 func (o Outcome) String() string {
 	switch o {
+	case Unknown:
+		return "UNKNOWN"
 	case Passed:
 		return "PASS"
 	case Mismatched:
@@ -169,7 +179,10 @@ func (r *Report) Counts() (passed, mismatched, faulted int) {
 			passed++
 		case Mismatched:
 			mismatched++
-		case Faulted:
+		case Faulted, Unknown:
+			// An outcome nobody set is counted with the faults rather than
+			// dropped, so that the three numbers always sum to the entries and
+			// a result that was never filled in cannot go missing from a total.
 			faulted++
 		}
 	}

--- a/internal/conformance/errors.go
+++ b/internal/conformance/errors.go
@@ -55,6 +55,36 @@ func (e *MismatchError) Error() string {
 
 func (e *MismatchError) Unwrap() error { return e.Err }
 
+// PathError is one disagreement [Compare] found, carrying the path through the
+// record it is at as well as the sentence a reader sees.
+//
+// The message is the sentence and nothing else: the path is already in it,
+// spelled for whoever is reading a report, and a wrapper that said it twice
+// would be a wrapper every report had to be edited around. What the type adds
+// is the same path in a form a caller can key on, so that a caller holding the
+// descriptor can say where the descriptor puts the item that disagreed — its
+// offset, its width, its usage and its charset — beside the disagreement
+// (#199).
+//
+// That caller is the engine, and it is the only thing in the system that can do
+// it: the adapter was never told what was expected, and this package compares
+// documents rather than bytes. Recovering the path by parsing the sentence back
+// out of an error string would work exactly until somebody improved the
+// sentence, which is the kind of coupling a type costs nothing to replace.
+type PathError struct {
+	// Path is where in the values document the disagreement is, in the spelling
+	// [Compare] uses throughout: `record 1 ORDER-RECORD.ORDER-ID`, with an
+	// occurrence written `[0]` and counted from zero as the document writes it.
+	Path string
+
+	// Err is the disagreement, whose message already names Path.
+	Err error
+}
+
+func (e *PathError) Error() string { return e.Err.Error() }
+
+func (e *PathError) Unwrap() error { return e.Err }
+
 // RunError is an entry a runner could not answer about at all: the generator
 // would not run, what it produced would not compile, or the runner could not be
 // driven.

--- a/internal/conformance/values.go
+++ b/internal/conformance/values.go
@@ -204,8 +204,8 @@ func Compare(want, got *Values) error {
 		path := fmt.Sprintf("record %d", i+1)
 
 		if wantRecord.Name != gotRecord.Name {
-			faults = append(faults, fmt.Errorf("%s is a %s and the entry expects a %s",
-				path, gotRecord.Name, wantRecord.Name))
+			faults = append(faults, at(path, fmt.Errorf("%s is a %s and the entry expects a %s",
+				path, gotRecord.Name, wantRecord.Name)))
 
 			continue
 		}
@@ -223,14 +223,14 @@ func difference(path string, want, got any) []error {
 	case map[string]any:
 		gotObject, ok := got.(map[string]any)
 		if !ok {
-			return []error{fmt.Errorf("%s: %s, and the entry expects a group", path, described(got))}
+			return []error{at(path, fmt.Errorf("%s: %s, and the entry expects a group", path, described(got)))}
 		}
 
 		return objectDifference(path, want, gotObject)
 	case []any:
 		gotArray, ok := got.([]any)
 		if !ok {
-			return []error{fmt.Errorf("%s: %s, and the entry expects %d occurrences", path, described(got), len(want))}
+			return []error{at(path, fmt.Errorf("%s: %s, and the entry expects %d occurrences", path, described(got), len(want)))}
 		}
 
 		return arrayDifference(path, want, gotArray)
@@ -241,7 +241,7 @@ func difference(path string, want, got any) []error {
 		// the item repeats at all.
 		switch got.(type) {
 		case map[string]any, []any:
-			return []error{fmt.Errorf("%s: %s, and the entry expects %s", path, described(got), rendered(want))}
+			return []error{at(path, fmt.Errorf("%s: %s, and the entry expects %s", path, described(got), rendered(want)))}
 		}
 
 		// String equality over the written form, and deliberately not Go's !=
@@ -254,11 +254,18 @@ func difference(path string, want, got any) []error {
 		// over the written form" requires, and rendering both sides keeps that
 		// true of anything a document carries that is not one (#194, #195).
 		if rendered(want) != rendered(got) {
-			return []error{fmt.Errorf("%s is %s and the entry expects %s", path, rendered(got), rendered(want))}
+			return []error{at(path, fmt.Errorf("%s is %s and the entry expects %s", path, rendered(got), rendered(want)))}
 		}
 
 		return nil
 	}
+}
+
+// at says where in the values document a disagreement is, in a form a caller
+// holding the descriptor can act on. See [PathError], which is the whole of why
+// it exists; the message is untouched.
+func at(path string, err error) error {
+	return &PathError{Path: path, Err: err}
 }
 
 // objectDifference compares two groups, member by member.
@@ -273,8 +280,8 @@ func objectDifference(path string, want, got map[string]any) []error {
 	for _, name := range slices.Sorted(maps.Keys(want)) {
 		gotValue, ok := got[name]
 		if !ok {
-			faults = append(faults, fmt.Errorf("%s: %s is not there, and the entry expects %s",
-				path, name, rendered(want[name])))
+			faults = append(faults, at(path+"."+name, fmt.Errorf("%s: %s is not there, and the entry expects %s",
+				path, name, rendered(want[name]))))
 
 			continue
 		}
@@ -284,8 +291,8 @@ func objectDifference(path string, want, got map[string]any) []error {
 
 	for _, name := range slices.Sorted(maps.Keys(got)) {
 		if _, ok := want[name]; !ok {
-			faults = append(faults, fmt.Errorf("%s: %s is %s, and the entry does not expect it at all",
-				path, name, rendered(got[name])))
+			faults = append(faults, at(path+"."+name, fmt.Errorf("%s: %s is %s, and the entry does not expect it at all",
+				path, name, rendered(got[name]))))
 		}
 	}
 
@@ -297,8 +304,8 @@ func arrayDifference(path string, want, got []any) []error {
 	var faults []error
 
 	if len(want) != len(got) {
-		faults = append(faults, fmt.Errorf("%s holds %d occurrences and the entry expects %d",
-			path, len(got), len(want)))
+		faults = append(faults, at(path, fmt.Errorf("%s holds %d occurrences and the entry expects %d",
+			path, len(got), len(want))))
 	}
 
 	for i := range min(len(want), len(got)) {


### PR DESCRIPTION
Closes #199

Builds the half of the corpus that is not language-specific: `internal/conformance/engine`
starts an adapter process, speaks the JSON frames [`docs/adapter/SPEC.md`](docs/adapter/SPEC.md)
specifies over its standard input and standard output, compares what came back against what
each entry states, and reports. `internal/conformance` keeps the loader, the value language
and the comparison unchanged; this gives them a process boundary and a front door.

## Acceptance criteria

- [x] **The engine spawns an adapter and drives it through the contract in #198.** `Engine.Run`
  holds the conversation the contract fixes — `hello`, one `generate` carrying every
  descriptor, `decode` and `roundtrip` per entry, `bye` — with identifiers strictly
  increasing from 1, a response whose id is not the one awaited treated as a broken peer, one
  line of UTF-8 JSON per frame, a blank line and a trailing carriage return refused rather than
  skipped or trimmed, and an unknown member ignored. `Door` is the seam for how a process is
  started, since that is deliberately outside the contract; `Command` is the door that runs a
  command, and the image door (#203) is a sibling of it.
- [x] **The comparison happens in the engine; the adapter is never given `values.json`.**
  Only the descriptor and the input bytes go out.
  `TestTheAdapterIsNeverGivenTheExpectedValues` asserts every frame of a real run against every
  scalar the entry states.
- [x] **An adapter that crashes or hangs on one entry does not lose the rest of the run.** The
  process is killed and a fresh one carries the entries that were left. A crash, a hang, a
  greeting on standard output, a blank line, a carriage return and an answer to a request nobody
  sent are each exercised against a real process.
- [x] **A per-case deadline is enforced by the engine rather than by the adapter.** Every
  operation is bounded; `generate` has a bound of its own because it may run a compiler over the
  whole corpus. An expiry kills rather than reads on, since an adapter killed mid-frame may have
  written half a line.
- [x] **A mismatch names the field and its position, derived from the descriptor.** The position
  sum is run over the record's member lists, guided by the entry's own document for the things a
  descriptor does not carry — a table's run-time count, the arm a variant took. A disagreement is
  followed by the item's offset in its record, its width, its usage, charset and sign convention,
  and by the bytes of `input.bin` it was read from where the framing lets a record be placed.
- [x] **A declared read-only adapter is not failed for omitting the write direction.** It is
  never sent `roundtrip` at all, and the report says the claim is a smaller one.

## Judgment calls

- **`conformance.PathError`** is new: `Compare` now wraps each disagreement with the path it is
  at. The messages are byte-for-byte what they were; what the type adds is a key the engine can
  look a position up by, instead of parsing the sentence back out of an error string.
- **A descriptive adapter** is answered minimally — `bye`, and a run reported as not applicable —
  because the contract forbids the engine to send it `generate`. What such a generator should be
  measured against stays open (#193, #201).
- **`rebuild` is not spoken.** A corpus run generates once and asks each entry once, so there is
  nothing to keep warm; an engine that read a capability it never exercised would be claiming a
  conversation it does not have.
- **A broken `generate` or handshake ends the run** rather than restarting: neither is
  attributable to an entry, and both would break the same way again.

## Verified

- `dagger call ci` — green, run from an ordinary clone (a worktree cannot run it since #185).
- `go test -race ./internal/conformance/...` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VycsyoGntP12ghL9nAbbSF