### PR TITLE
story(conformance): a descriptive generator declares its kind and is not a conformance subject

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1260,6 +1260,30 @@ sentence in `cmd/cpybkc-gen-go`'s README about the order they are emitted in: a
 promise that was load-bearing, unenforced, and would have compared each record
 against the wrong node without anything saying so.
 
+### The generator that is not a conformance subject
+
+The corpus tests **codecs**: an entry is bytes and the values those bytes decode
+to, so asking about one means handing a file to something that reads files.
+`cpybkc-gen-graph` emits a diagram. It never opens `input.bin`, there is no
+reader to hand one to, and `gen-docs`, `gen-sql`, `gen-avro`, `gen-json-schema`
+and `gen-copybook` would all be in the same category.
+
+[`internal/conformance/descriptive`](internal/conformance/descriptive) is the
+adapter for that category, and a conversation with it is four frames long: it
+declares `kind: "descriptive"` at the handshake, and an engine that hears that
+sends it nothing but `bye` and reports the run as **not applicable**. One
+command serves the whole category, because a descriptive adapter is asked
+nothing that could differ between its members — and it invokes no generator at
+all, since there is nothing it could be asked that one could answer.
+
+The two shapes that reporting has to avoid are a descriptive generator scored
+`0/n` of the corpus and one declining every entry in turn. Neither is true and
+both read as failures, so the truthful answer is reachable in one member of the
+first frame. What such a generator should be held to *instead* — whether a
+descriptive track is worth having, and what would grade it — is an open question
+in discussion #193, and nothing here answers it: this is only the framework
+being able to decline a subject it cannot test.
+
 ## Specs
 
 Seven of this project's interfaces are built against from outside it — the

--- a/internal/conformance/descriptive/adapter.go
+++ b/internal/conformance/descriptive/adapter.go
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package descriptive
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// Adapter is one descriptive generator, as the conformance engine meets it.
+//
+// Both members are for the report and neither is compared or parsed by
+// anything: what a reader of a result wants to know is which generator, at
+// which version, declined to be a conformance subject, and nothing else in the
+// conversation carries it.
+type Adapter struct {
+	// Name is the generator's name, as a report should spell it — the `<name>`
+	// of a cpybkc-gen-<name> executable.
+	Name string
+
+	// Version is which version of it. It is optional, which the contract makes
+	// it exactly for the run against a working tree that has no version string
+	// to give.
+	Version string
+}
+
+// Serve holds one conversation: it reads request frames from in, writes response
+// frames to out, and returns when the engine says goodbye or closes its end.
+//
+// A nil error is the one exit an adapter may make zero from, which is bye
+// answered or end of input seen. Every other return is this adapter reporting
+// that it broke, which is what a non-zero exit means and the only thing it
+// means.
+//
+// Nothing is written to out but frames. That is the caller's to arrange as well
+// — see the recipe in cmd/adapter — because a library that greets the world on
+// standard output turns every subsequent frame into a parse error, and the
+// failure surfaces as an adapter that appears to have answered gibberish.
+//
+// There is no context to cancel it with, unlike
+// [github.com/Zaba505/cpybkc/internal/conformance/goadapter.Adapter.Serve]:
+// this adapter starts no process, builds nothing and reads no file, so the only
+// thing it ever blocks on is the engine's own input. An engine that gives up
+// closes that input, which is end of input and an exit of zero, and one that
+// gives up harder kills the process — which an adapter is under no obligation
+// to survive gracefully.
+func (a *Adapter) Serve(in io.Reader, out io.Writer) error {
+	// ReadString rather than a Scanner: a receiver MUST accept a frame of any
+	// length. Nothing a descriptive conversation is sent is long, but a frame
+	// this adapter refuses is a frame it was sent anyway, and refusing a
+	// too-long generate as a broken stream rather than as an operation would
+	// report the wrong thing about the engine.
+	reader := bufio.NewReader(in)
+
+	for {
+		line, err := reader.ReadString('\n')
+		if errors.Is(err, io.EOF) && line == "" {
+			// End of input is a bye already answered: the adapter exits zero
+			// without writing anything further. A run that ended in a fault has
+			// no useful frame left to send, and an adapter that waited for a
+			// polite goodbye that was never coming would hang at the end of
+			// every such run.
+			return nil
+		}
+
+		if err != nil && !errors.Is(err, io.EOF) {
+			return fmt.Errorf("failed to read a request frame: %w", err)
+		}
+
+		req, err := parse(line)
+		if err != nil {
+			return err
+		}
+
+		answer, done := a.serve(req)
+
+		if err := write(out, answer); err != nil {
+			return err
+		}
+
+		if done {
+			return nil
+		}
+	}
+}
+
+// serve answers one request, and says whether the conversation is over.
+func (a *Adapter) serve(req *request) (*response, bool) {
+	id := *req.ID
+
+	switch req.Op {
+	case opHello:
+		return a.hello(id, req), false
+	case opGenerate, opDecode, opRoundtrip, opRebuild:
+		// An engine MUST NOT send one of these to an adapter that declared
+		// itself descriptive, so a correct one never arrives. It is refused
+		// rather than attempted because there is nothing to attempt: the
+		// generator behind this adapter emits a description and never opens a
+		// data file, so an answer would be an answer about a file nothing read.
+		return refuse(id, "this adapter's generator is %s: it emits something other than code that reads a file, "+
+			"so there is nothing to serve %s with", kindDescriptive, req.Op), false
+	case opBye:
+		return &response{ID: id, OK: true}, true
+	default:
+		// An unrecognised member is an extension a receiver can safely do
+		// nothing about; an unrecognised operation is work it cannot do, and an
+		// adapter that reported success for work it did not do is an adapter
+		// whose whole report is worthless.
+		return refuse(id, "this adapter does not know the operation %q", req.Op), false
+	}
+}
+
+// hello is the handshake, and the only frame of this conversation that says
+// anything.
+//
+// kind is declared here, before the adapter has been asked anything, because
+// the alternative is discovering it from a failure that looks like a wrong
+// answer: a descriptive generator scored zero out of the whole corpus, or one
+// declining every entry in turn. Neither is true, both read as failures, and the
+// truthful answer is reachable in one member of this frame.
+func (a *Adapter) hello(id int, req *request) *response {
+	spoken := Protocol
+
+	if req.Protocol == nil || *req.Protocol != Protocol {
+		// An adapter that does not speak the requested version states its own
+		// anyway, so that a report can say which two versions failed to meet
+		// instead of only that the handshake failed. A refused handshake
+		// carries nothing else: an adapter that could not agree the version has
+		// no basis for declaring a kind or a capability set.
+		asked := 0
+		if req.Protocol != nil {
+			asked = *req.Protocol
+		}
+
+		answer := refuse(id, "this adapter speaks protocol %d and the engine asked for %d", Protocol, asked)
+		answer.Protocol = &spoken
+
+		return answer
+	}
+
+	// Empty, and present. Reading is not a capability and this adapter does not
+	// read; writing and rebuilding are, and it does neither. An author who has
+	// to write `{}` has been asked which optional operations they serve, where
+	// one who may omit it has not.
+	capabilities := map[string]bool{}
+
+	return &response{
+		ID:           id,
+		OK:           true,
+		Protocol:     &spoken,
+		Name:         a.name(),
+		Version:      a.Version,
+		Kind:         kindDescriptive,
+		Capabilities: &capabilities,
+	}
+}
+
+// name is what a report calls this adapter.
+func (a *Adapter) name() string {
+	name := a.Name
+	if name == "" {
+		return "an unnamed descriptive generator's adapter"
+	}
+
+	return fmt.Sprintf("cpybkc-gen-%s adapter", name)
+}
+
+// write puts one response frame on the stream, terminated by the line feed that
+// delimits it.
+//
+// One call, because the conversation is strictly alternating and a peer waiting
+// on a frame this side has half-written is a deadlock neither side can leave.
+// The frame is marshalled first for the same reason: a marshal that failed
+// halfway through a write would leave the stream unresynchronisable.
+func write(out io.Writer, answer *response) error {
+	b, err := json.Marshal(answer)
+	if err != nil {
+		// Not reachable: every member of a response is a string, an integer, a
+		// boolean or a map of them. What is left is this adapter breaking, and a
+		// frame that cannot be written is not something there is a frame to say.
+		return fmt.Errorf("failed to write a response frame: %w", err)
+	}
+
+	if _, err := out.Write(append(b, '\n')); err != nil {
+		return fmt.Errorf("failed to write a response frame: %w", err)
+	}
+
+	return nil
+}

--- a/internal/conformance/descriptive/adapter_test.go
+++ b/internal/conformance/descriptive/adapter_test.go
@@ -1,0 +1,276 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package descriptive_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/conformance/descriptive"
+)
+
+// answer is a response frame as a test reads one. It is written out here rather
+// than shared with the adapter's own type on purpose: what these tests assert is
+// what goes on the wire, and a test that unmarshalled into the same struct the
+// adapter marshalled from would agree with it about a member neither of them
+// spells the way the contract does.
+type answer struct {
+	ID           int              `json:"id"`
+	OK           bool             `json:"ok"`
+	Error        string           `json:"error"`
+	Protocol     *int             `json:"protocol"`
+	Name         string           `json:"name"`
+	Version      string           `json:"version"`
+	Kind         string           `json:"kind"`
+	Capabilities *map[string]bool `json:"capabilities"`
+}
+
+// converse holds one conversation against a named descriptive adapter and reads
+// back every frame it wrote.
+func converse(t *testing.T, frames ...string) ([]answer, string, error) {
+	t.Helper()
+
+	return hold(t, &descriptive.Adapter{Name: "graph", Version: "0.0.0-test"}, frames...)
+}
+
+// hold is one conversation against the adapter it is given, and hands back the
+// frames it wrote, the raw stream it wrote them on, and how it ended.
+//
+// The raw stream is kept because two of the things the contract requires are
+// properties of the bytes rather than of the values they decode to: that a frame
+// is one line, and that an empty capabilities object is written as `{}` rather
+// than left out or written as null.
+func hold(t *testing.T, adapter *descriptive.Adapter, frames ...string) ([]answer, string, error) {
+	t.Helper()
+
+	var out strings.Builder
+
+	err := adapter.Serve(strings.NewReader(strings.Join(frames, "")), &out)
+
+	var read []answer
+
+	for line := range strings.Lines(out.String()) {
+		var frame answer
+		if err := json.Unmarshal([]byte(line), &frame); err != nil {
+			t.Fatalf("the adapter wrote a line that is not a frame: %q: %v", line, err)
+		}
+
+		read = append(read, frame)
+	}
+
+	return read, out.String(), err
+}
+
+// frame is one request, as the engine writes one: one JSON object on one line.
+func frame(text string) string { return text + "\n" }
+
+// TestTheHandshakeDeclaresADescriptiveGenerator is the whole of this story: the
+// kind is declared in the first frame, before the adapter has been asked
+// anything, which is what lets an engine report a generator it cannot test as
+// not applicable instead of discovering it from a failure.
+func TestTheHandshakeDeclaresADescriptiveGenerator(t *testing.T) {
+	read, raw, err := converse(t, frame(`{"id":1,"op":"hello","protocol":1}`))
+	if err != nil {
+		t.Fatalf("the adapter broke: %v", err)
+	}
+
+	if len(read) != 1 {
+		t.Fatalf("one request was made and the adapter wrote %d frames", len(read))
+	}
+
+	got := read[0]
+
+	switch {
+	case got.ID != 1:
+		t.Errorf("the adapter answered id %d and it was asked id 1", got.ID)
+	case !got.OK:
+		t.Errorf("the adapter refused the handshake: %s", got.Error)
+	case got.Protocol == nil || *got.Protocol != descriptive.Protocol:
+		t.Errorf("the adapter stated protocol %v and it speaks %d", got.Protocol, descriptive.Protocol)
+	case got.Kind != "descriptive":
+		t.Errorf("the adapter declared kind %q, and it drives a generator that never opens a data file", got.Kind)
+	case got.Name != "cpybkc-gen-graph adapter":
+		t.Errorf("the adapter calls itself %q, and a report should be able to say which generator declined", got.Name)
+	case got.Version != "0.0.0-test":
+		t.Errorf("the adapter states version %q, and it was given 0.0.0-test", got.Version)
+	case got.Capabilities == nil:
+		t.Fatalf("the adapter declared no capabilities, and the member is required even when it is empty")
+	case len(*got.Capabilities) != 0:
+		t.Errorf("the adapter declared the capabilities %v, and it serves no optional operation", *got.Capabilities)
+	}
+
+	// The member is required of a successful handshake even when it is empty, so
+	// what the engine reads has to be an empty object and not a null and not an
+	// absence. Asserted against the bytes because that distinction is one
+	// encoding/json will happily erase on the way back in.
+	if !strings.Contains(raw, `"capabilities":{}`) {
+		t.Errorf("the handshake frame is %s, and an adapter with no capabilities says so with an empty object", raw)
+	}
+}
+
+// TestAHandshakeWithoutANameIsStillReadable is the adapter that was given no
+// name: a report has to have something to call it, and the engine refuses a
+// handshake that declared nothing.
+func TestAHandshakeWithoutANameIsStillReadable(t *testing.T) {
+	read, _, err := hold(t, &descriptive.Adapter{}, frame(`{"id":1,"op":"hello","protocol":1}`))
+	if err != nil {
+		t.Fatalf("the adapter broke: %v", err)
+	}
+
+	if got := read[0]; got.Name == "" {
+		t.Errorf("the adapter declared no name, and a report has nothing to call it")
+	}
+}
+
+// TestARefusedHandshakeStatesItsOwnProtocol is the version that did not meet.
+//
+// A refused handshake carries the four members the contract allows it and
+// nothing else: an adapter that could not agree the version has no basis for
+// declaring a kind or a capability set, and a frame that declared them anyway
+// would be one a report could quote.
+func TestARefusedHandshakeStatesItsOwnProtocol(t *testing.T) {
+	for _, asked := range []string{`{"id":1,"op":"hello","protocol":2}`, `{"id":1,"op":"hello"}`} {
+		t.Run(asked, func(t *testing.T) {
+			read, _, err := converse(t, frame(asked))
+			if err != nil {
+				t.Fatalf("the adapter broke: %v", err)
+			}
+
+			got := read[0]
+
+			switch {
+			case got.OK:
+				t.Errorf("the adapter agreed a handshake for a protocol it does not speak")
+			case got.Protocol == nil || *got.Protocol != descriptive.Protocol:
+				t.Errorf("the adapter stated protocol %v, and a report should say which two versions failed to meet",
+					got.Protocol)
+			case got.Kind != "":
+				t.Errorf("the refused handshake declared kind %q, and it agreed no version to declare one under", got.Kind)
+			case got.Capabilities != nil:
+				t.Errorf("the refused handshake declared capabilities, and it agreed no version to declare them under")
+			}
+		})
+	}
+}
+
+// TestEveryCodecOperationIsRefused is what happens when an engine asks a
+// question this generator cannot be asked.
+//
+// A correct engine never sends one — it MUST NOT, once the handshake said
+// descriptive — so this is about the two shapes that must not happen when one
+// does. Attempting the work would mean answering about a file nothing read, and
+// exiting would report a broken adapter where nothing is broken. The refusal
+// costs the entry and says why.
+func TestEveryCodecOperationIsRefused(t *testing.T) {
+	asked := []string{
+		`{"id":2,"op":"generate","entries":[{"entry":"packed-ebcdic","descriptor":"AAAA"}]}`,
+		`{"id":3,"op":"decode","entry":"packed-ebcdic","input":"AAAA"}`,
+		`{"id":4,"op":"roundtrip","entry":"packed-ebcdic"}`,
+		`{"id":5,"op":"rebuild","entry":"packed-ebcdic","descriptor":"AAAA"}`,
+		`{"id":6,"op":"transmogrify"}`,
+	}
+
+	var conversation []string
+	for _, one := range asked {
+		conversation = append(conversation, frame(one))
+	}
+
+	read, _, err := converse(t, conversation...)
+	if err != nil {
+		t.Fatalf("the adapter broke, and a request it had no business being sent is not a broken adapter: %v", err)
+	}
+
+	if len(read) != len(asked) {
+		t.Fatalf("%d requests were made and the adapter wrote %d frames", len(asked), len(read))
+	}
+
+	for i, got := range read {
+		if got.ID != i+2 {
+			t.Errorf("the adapter answered id %d and it was asked id %d", got.ID, i+2)
+		}
+
+		if got.OK {
+			t.Errorf("the adapter served %s, and it drives a generator that never opens a data file", asked[i])
+		}
+
+		if got.Error == "" {
+			t.Errorf("the adapter refused %s and said nothing about why", asked[i])
+		}
+	}
+}
+
+// TestByeEndsTheConversation is the last frame, and the one exit an adapter may
+// make zero from.
+func TestByeEndsTheConversation(t *testing.T) {
+	read, _, err := converse(t,
+		frame(`{"id":1,"op":"hello","protocol":1}`),
+		frame(`{"id":2,"op":"bye"}`),
+		frame(`{"id":3,"op":"hello","protocol":1}`))
+	if err != nil {
+		t.Fatalf("the adapter broke: %v", err)
+	}
+
+	if len(read) != 2 {
+		t.Fatalf("the adapter wrote %d frames, and it was asked two questions before it was told goodbye", len(read))
+	}
+
+	if got := read[1]; got.ID != 2 || !got.OK {
+		t.Errorf("the adapter answered bye with %+v: bye takes no argument it could object to", got)
+	}
+}
+
+// TestEndOfInputIsAByeAlreadyAnswered is the run that ended in a fault: there is
+// no useful frame left to send, and an adapter that waited for a polite goodbye
+// that was never coming would hang at the end of every such run.
+func TestEndOfInputIsAByeAlreadyAnswered(t *testing.T) {
+	read, raw, err := converse(t)
+	if err != nil {
+		t.Fatalf("the adapter broke on an input that simply ended: %v", err)
+	}
+
+	if len(read) != 0 {
+		t.Errorf("the adapter wrote %q after end of input, and it exits zero without writing anything further", raw)
+	}
+}
+
+// TestAStreamThatIsNotFramedStopsTheConversation is every line the framing does
+// not admit.
+//
+// Each one is a broken engine rather than a request, and the adapter stops
+// rather than answering: a stream whose framing is in doubt cannot be
+// resynchronised by anything the receiver can see, so an adapter that skipped a
+// bad line and read on would be answering questions it cannot know it was asked.
+func TestAStreamThatIsNotFramedStopsTheConversation(t *testing.T) {
+	tests := map[string]struct {
+		line string
+		says string
+	}{
+		"a blank line":          {line: "\n", says: "blank line"},
+		"a carriage return":     {line: "{\"id\":1,\"op\":\"hello\"}\r\n", says: "carriage return"},
+		"not one object":        {line: frame(`not json at all`), says: "one JSON object"},
+		"no id":                 {line: frame(`{"op":"hello"}`), says: "no id"},
+		"no op":                 {line: frame(`{"id":1}`), says: "no op"},
+		"an unterminated frame": {line: `{"id":1,"op":"hello","protocol":1}`, says: "in the middle of a frame"},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			read, _, err := converse(t, test.line)
+			if err == nil {
+				t.Fatalf("the adapter read %q as a frame and answered %+v", test.line, read)
+			}
+
+			if !strings.Contains(err.Error(), test.says) {
+				t.Errorf("the adapter broke with %q, and it does not say %q", err, test.says)
+			}
+
+			if len(read) != 0 {
+				t.Errorf("the adapter answered %+v a line that is not a frame", read)
+			}
+		})
+	}
+}

--- a/internal/conformance/descriptive/adapter_test.go
+++ b/internal/conformance/descriptive/adapter_test.go
@@ -7,6 +7,7 @@ package descriptive_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -84,22 +85,39 @@ func TestTheHandshakeDeclaresADescriptiveGenerator(t *testing.T) {
 
 	got := read[0]
 
-	switch {
-	case got.ID != 1:
+	// Every member is asserted rather than the first one that disagrees, because
+	// these are independent claims about one frame: an adapter that answered the
+	// wrong id and declared kind codec has two things wrong with it, and a run
+	// that reported only the id would send somebody to fix the smaller one.
+	if got.ID != 1 {
 		t.Errorf("the adapter answered id %d and it was asked id 1", got.ID)
-	case !got.OK:
+	}
+
+	if !got.OK {
 		t.Errorf("the adapter refused the handshake: %s", got.Error)
-	case got.Protocol == nil || *got.Protocol != descriptive.Protocol:
+	}
+
+	if got.Protocol == nil || *got.Protocol != descriptive.Protocol {
 		t.Errorf("the adapter stated protocol %v and it speaks %d", got.Protocol, descriptive.Protocol)
-	case got.Kind != "descriptive":
+	}
+
+	if got.Kind != "descriptive" {
 		t.Errorf("the adapter declared kind %q, and it drives a generator that never opens a data file", got.Kind)
-	case got.Name != "cpybkc-gen-graph adapter":
+	}
+
+	if got.Name != "cpybkc-gen-graph adapter" {
 		t.Errorf("the adapter calls itself %q, and a report should be able to say which generator declined", got.Name)
-	case got.Version != "0.0.0-test":
+	}
+
+	if got.Version != "0.0.0-test" {
 		t.Errorf("the adapter states version %q, and it was given 0.0.0-test", got.Version)
-	case got.Capabilities == nil:
+	}
+
+	if got.Capabilities == nil {
 		t.Fatalf("the adapter declared no capabilities, and the member is required even when it is empty")
-	case len(*got.Capabilities) != 0:
+	}
+
+	if len(*got.Capabilities) != 0 {
 		t.Errorf("the adapter declared the capabilities %v, and it serves no optional operation", *got.Capabilities)
 	}
 
@@ -121,6 +139,10 @@ func TestAHandshakeWithoutANameIsStillReadable(t *testing.T) {
 		t.Fatalf("the adapter broke: %v", err)
 	}
 
+	if len(read) != 1 {
+		t.Fatalf("one request was made and the adapter wrote %d frames", len(read))
+	}
+
 	if got := read[0]; got.Name == "" {
 		t.Errorf("the adapter declared no name, and a report has nothing to call it")
 	}
@@ -140,17 +162,30 @@ func TestARefusedHandshakeStatesItsOwnProtocol(t *testing.T) {
 				t.Fatalf("the adapter broke: %v", err)
 			}
 
+			if len(read) != 1 {
+				t.Fatalf("one request was made and the adapter wrote %d frames", len(read))
+			}
+
 			got := read[0]
 
-			switch {
-			case got.OK:
+			if got.OK {
 				t.Errorf("the adapter agreed a handshake for a protocol it does not speak")
-			case got.Protocol == nil || *got.Protocol != descriptive.Protocol:
+			}
+
+			if got.Error == "" {
+				t.Errorf("the adapter refused the handshake and said nothing about why")
+			}
+
+			if got.Protocol == nil || *got.Protocol != descriptive.Protocol {
 				t.Errorf("the adapter stated protocol %v, and a report should say which two versions failed to meet",
 					got.Protocol)
-			case got.Kind != "":
+			}
+
+			if got.Kind != "" {
 				t.Errorf("the refused handshake declared kind %q, and it agreed no version to declare one under", got.Kind)
-			case got.Capabilities != nil:
+			}
+
+			if got.Capabilities != nil {
 				t.Errorf("the refused handshake declared capabilities, and it agreed no version to declare them under")
 			}
 		})
@@ -234,6 +269,32 @@ func TestEndOfInputIsAByeAlreadyAnswered(t *testing.T) {
 
 	if len(read) != 0 {
 		t.Errorf("the adapter wrote %q after end of input, and it exits zero without writing anything further", raw)
+	}
+}
+
+// TestAFrameOfAnyLengthIsRead is the receiver's MUST that reading into a fixed
+// buffer breaks.
+//
+// A bufio.Scanner stops at a line longer than the buffer it reads into, which is
+// why this adapter reads with ReadString instead, and a stated MUST resting on a
+// comment is one nothing would notice the loss of. The length is made of an
+// unknown member because that is what a later version of the contract adds: it
+// is ignored rather than refused, so what comes back is an ordinary handshake.
+func TestAFrameOfAnyLengthIsRead(t *testing.T) {
+	long := fmt.Sprintf(`{"id":1,"op":"hello","protocol":1,"a-member-a-later-version-added":%q}`,
+		strings.Repeat("x", 256<<10))
+
+	read, _, err := converse(t, frame(long))
+	if err != nil {
+		t.Fatalf("the adapter broke on a frame of %d bytes: %v", len(long), err)
+	}
+
+	if len(read) != 1 {
+		t.Fatalf("one request was made and the adapter wrote %d frames", len(read))
+	}
+
+	if got := read[0]; !got.OK || got.Kind != "descriptive" {
+		t.Errorf("the adapter answered a long frame with %+v", got)
 	}
 }
 

--- a/internal/conformance/descriptive/cmd/adapter/main.go
+++ b/internal/conformance/descriptive/cmd/adapter/main.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Command adapter is the conformance adapter for a descriptive generator: a
+// process the conformance engine starts and speaks docs/adapter/SPEC.md to,
+// which declares at the handshake that the generator behind it is not a
+// conformance subject and is asked nothing else (#201).
+//
+//	adapter --name graph
+//
+// It is one command for the whole category rather than one per generator.
+// cmd/cpybkc-gen-graph is the generator that motivated it, and gen-docs,
+// gen-sql, gen-avro, gen-json-schema and gen-copybook are all plausibly in it —
+// and every one of them holds the same four-frame conversation, because a
+// descriptive adapter is asked nothing that could differ between them.
+//
+// `--name` and `--version` are the two halves of what a report calls this
+// adapter, and they are the door's to supply: the argument vector, the working
+// directory and the environment are deliberately out of the specification's
+// scope, which is why they are flags here and why nothing in the conversation
+// carries them. A published image knows which release of the generator it
+// carries (#203), and a run against a working tree has no version string to
+// give — so the corpus's own runs leave it empty, which the contract makes
+// optional exactly for this case.
+//
+// No generator is invoked. A descriptive adapter is never asked anything a
+// generator could answer, so starting one would be starting it to throw its
+// output away — and the point is that the framework can decline a subject it
+// cannot test without pretending to have tested it.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/Zaba505/cpybkc/internal/conformance/descriptive"
+)
+
+func main() {
+	name := flag.String("name", "", "the generator's name, as a report should spell it: the <name> of a cpybkc-gen-<name>")
+	version := flag.String("version", "", "what to tell the engine this adapter's generator is, for the report")
+
+	flag.Parse()
+
+	// The frames go to the standard output this process started with, and
+	// nothing else does.
+	//
+	// docs/adapter/SPEC.md gives the recipe in POSIX's terms — dup the
+	// descriptor, then point standard output at standard error — and says
+	// plainly that it is a recipe rather than the requirement: what is required
+	// is the property that nothing but frames reaches the stream, which a
+	// platform without those calls meets by whatever means its runtime offers.
+	// Go's is os.Stdout, which every print in this process and in everything it
+	// imports resolves at the moment it writes. Moving it here, before anything
+	// else runs, is what makes a greeting from some dependency a diagnostic
+	// instead of a corrupted frame — and an adapter that instead resolved to be
+	// careful is one that is one dependency away from being wrong.
+	frames := os.Stdout
+	os.Stdout = os.Stderr
+
+	adapter := &descriptive.Adapter{Name: *name, Version: *version}
+
+	if err := adapter.Serve(os.Stdin, frames); err != nil {
+		// A non-zero exit means the adapter broke, and it means nothing else. A
+		// request this adapter had no business being sent is not that: it goes
+		// back refused, inside a frame, and the conversation carries on.
+		fmt.Fprintln(os.Stderr, err)
+
+		os.Exit(1)
+	}
+}

--- a/internal/conformance/descriptive/cmd/adapter/main.go
+++ b/internal/conformance/descriptive/cmd/adapter/main.go
@@ -45,19 +45,29 @@ func main() {
 
 	flag.Parse()
 
-	// The frames go to the standard output this process started with, and
-	// nothing else does.
+	// The frames go to the standard output this process started with, and this
+	// is the first statement of the program so that nothing has had the chance
+	// to print before it runs.
 	//
 	// docs/adapter/SPEC.md gives the recipe in POSIX's terms — dup the
 	// descriptor, then point standard output at standard error — and says
 	// plainly that it is a recipe rather than the requirement: what is required
-	// is the property that nothing but frames reaches the stream, which a
-	// platform without those calls meets by whatever means its runtime offers.
-	// Go's is os.Stdout, which every print in this process and in everything it
-	// imports resolves at the moment it writes. Moving it here, before anything
-	// else runs, is what makes a greeting from some dependency a diagnostic
-	// instead of a corrupted frame — and an adapter that instead resolved to be
-	// careful is one that is one dependency away from being wrong.
+	// is the property that nothing but frames reaches the stream.
+	//
+	// What this buys, exactly: every write that resolves os.Stdout at the moment
+	// it writes — fmt.Print and everything built on it — lands on standard
+	// error from here on, where it is a diagnostic instead of a corruption. What
+	// it does not buy is a writer captured during package initialisation, which
+	// runs before main (`var log = log.New(os.Stdout, …)`), or a write to file
+	// descriptor 1 that never goes through the variable at all. Those need the
+	// dup, which needs a syscall this repository does not otherwise depend on
+	// and a fallback for every platform without one.
+	//
+	// It is enough here because this program's whole import graph is the
+	// standard library and one package of this repository's, and neither does
+	// either of those things. An adapter that grew a dependency would be one
+	// this reasoning no longer covers, which is why it is written down rather
+	// than assumed.
 	frames := os.Stdout
 	os.Stdout = os.Stderr
 

--- a/internal/conformance/descriptive/corpus_test.go
+++ b/internal/conformance/descriptive/corpus_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package descriptive_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/conformance"
+	"github.com/Zaba505/cpybkc/internal/conformance/engine"
+)
+
+// TestADescriptiveGeneratorIsNotApplicableAndTheRunIsClean is the whole corpus,
+// put to a real descriptive adapter through a real process, and declined.
+//
+// The engine's own tests already assert this against a scripted adapter. What
+// this adds is the half nothing else covers: that a generator which is not a
+// conformance subject can actually be handed to the framework — built,
+// started, spoken to over two pipes — and comes back not applicable. Until
+// there was an adapter to say `kind: "descriptive"`, the only descriptive
+// generator this repository has, cmd/cpybkc-gen-graph, could not be run at all,
+// and "never reported as failing" was true of nothing.
+//
+// The two shapes asserted against are the ones the story exists to prevent: a
+// descriptive generator scored zero out of the whole corpus, and one declining
+// every entry in turn. Neither is true, and both read as failures.
+func TestADescriptiveGeneratorIsNotApplicableAndTheRunIsClean(t *testing.T) {
+	root := repoRoot(t)
+
+	entries, err := conformance.Load(conformance.CorpusPath(root))
+	if err != nil {
+		t.Fatalf("the conformance corpus: %v", err)
+	}
+
+	if len(entries) == 0 {
+		t.Fatalf("the conformance corpus holds no entries, and a run that asked about none proves nothing")
+	}
+
+	driving := &engine.Engine{
+		Door: &engine.Command{
+			Path: build(t, root, "./internal/conformance/descriptive/cmd/adapter"),
+			Args: []string{"--name", "graph"},
+		},
+	}
+
+	report, err := driving.Run(t.Context(), entries)
+	if err != nil {
+		// A run that could not be attempted at all, which is this test's mistake
+		// rather than the adapter's behaviour.
+		t.Fatalf("the run could not be made: %v", err)
+	}
+
+	t.Logf("%s", report)
+
+	if !report.NotApplicable {
+		t.Fatalf("the run is not reported as not applicable, and the generator behind it emits a diagram:\n%v", report)
+	}
+
+	if report.Failed() {
+		t.Errorf("a descriptive generator is reported as failing:\n%v", report)
+	}
+
+	if len(report.Results) != 0 {
+		t.Errorf("a descriptive generator was scored against %d of the corpus's entries:\n%v",
+			len(report.Results), report)
+	}
+
+	if passed, mismatched, faulted := report.Counts(); passed != 0 || mismatched != 0 || faulted != 0 {
+		t.Errorf("a descriptive generator scored %d passed, %d disagreed and %d could not be asked, out of a corpus "+
+			"it was never asked about", passed, mismatched, faulted)
+	}
+
+	for _, note := range report.Notes {
+		t.Errorf("the run: %s", note)
+	}
+
+	if report.Restarts > 0 {
+		t.Errorf("%d fresh adapters were started after one broke, and this adapter should not break", report.Restarts)
+	}
+
+	if report.Adapter == nil {
+		t.Fatalf("the report says nothing about the adapter, and the handshake is where a kind is declared")
+	}
+
+	if report.Adapter.Kind != "descriptive" {
+		t.Errorf("the report calls the adapter %s, and it declared itself descriptive", report.Adapter)
+	}
+}
+
+// build builds one program from the tree under test and says where it put it.
+func build(t *testing.T, root, pkg string) string {
+	t.Helper()
+
+	name := filepath.Base(pkg)
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+
+	path := filepath.Join(t.TempDir(), name)
+
+	built := exec.Command("go", "build", "-o", path, pkg)
+	built.Dir = root
+
+	if out, err := built.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build %s: %v\n%s", pkg, err, out)
+	}
+
+	return path
+}
+
+// repoRoot walks up from the test's working directory to the directory holding
+// go.mod, which for this module is the repository root and so the directory the
+// corpus sits in.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("working directory: %v", err)
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("no go.mod found above %q", dir)
+		}
+
+		dir = parent
+	}
+}

--- a/internal/conformance/descriptive/corpus_test.go
+++ b/internal/conformance/descriptive/corpus_test.go
@@ -6,10 +6,14 @@
 package descriptive_test
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/Zaba505/cpybkc/internal/conformance"
@@ -90,6 +94,80 @@ func TestADescriptiveGeneratorIsNotApplicableAndTheRunIsClean(t *testing.T) {
 
 	if report.Adapter.Kind != "descriptive" {
 		t.Errorf("the report calls the adapter %s, and it declared itself descriptive", report.Adapter)
+	}
+}
+
+// TestTheCommandExitsZeroOnlyWhenTheConversationEndedWell is the half of the
+// contract that is a property of the process rather than of a frame.
+//
+// An adapter MUST exit zero when it has answered bye or seen end of input, and
+// non-zero when it stopped for any other reason. Exiting quietly in the middle
+// of a conversation is the one failure that looks, from the engine's side,
+// exactly like a successful run that stopped early — so it is asserted against
+// the built binary's own status, which is the only place that distinction
+// exists.
+//
+// Every case also asserts that standard output carried frames and nothing else.
+// That is what the redirection at the top of main buys, and a diagnostic printed
+// on the frame stream would turn every frame after it into a parse error while
+// looking, in a report, like an adapter that answered gibberish.
+func TestTheCommandExitsZeroOnlyWhenTheConversationEndedWell(t *testing.T) {
+	adapter := build(t, repoRoot(t), "./internal/conformance/descriptive/cmd/adapter")
+
+	const hello = "{\"id\":1,\"op\":\"hello\",\"protocol\":1}\n"
+
+	tests := map[string]struct {
+		conversation string
+		zero         bool
+		frames       int
+	}{
+		"bye is answered":       {conversation: hello + "{\"id\":2,\"op\":\"bye\"}\n", zero: true, frames: 2},
+		"the input simply ends": {conversation: hello, zero: true, frames: 1},
+		"a blank line":          {conversation: hello + "\n", zero: false, frames: 1},
+		"a carriage return":     {conversation: "{\"id\":1,\"op\":\"hello\",\"protocol\":1}\r\n", zero: false, frames: 0},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cmd := exec.CommandContext(t.Context(), adapter, "--name", "graph")
+			cmd.Stdin = strings.NewReader(test.conversation)
+
+			var frames, diagnostics bytes.Buffer
+
+			cmd.Stdout = &frames
+			cmd.Stderr = &diagnostics
+
+			err := cmd.Run()
+
+			var exited *exec.ExitError
+			switch {
+			case test.zero && err != nil:
+				t.Errorf("the adapter exited non-zero on a conversation that ended well: %v\n%s", err, &diagnostics)
+			case !test.zero && err == nil:
+				t.Errorf("the adapter exited zero having neither answered bye nor seen end of input")
+			case !test.zero && !errors.As(err, &exited):
+				t.Fatalf("the adapter could not be run: %v", err)
+			}
+
+			if !test.zero && diagnostics.Len() == 0 {
+				t.Errorf("the adapter broke and said nothing on standard error, which is where a diagnostic goes")
+			}
+
+			var wrote int
+
+			for line := range strings.Lines(frames.String()) {
+				wrote++
+
+				var frame map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSuffix(line, "\n")), &frame); err != nil {
+					t.Errorf("the adapter wrote %q on the frame stream, and it carries frames and nothing else", line)
+				}
+			}
+
+			if wrote != test.frames {
+				t.Errorf("the adapter wrote %d frames and this conversation asked for %d", wrote, test.frames)
+			}
+		})
 	}
 }
 

--- a/internal/conformance/descriptive/doc.go
+++ b/internal/conformance/descriptive/doc.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Package descriptive is the conformance adapter for a generator that is not a
+// conformance subject: one that emits a diagram, a schema, a document or a
+// copybook rather than code that reads a file (#201).
+//
+// The corpus tests codecs. An entry is bytes and the values those bytes decode
+// to, so asking about one means handing a file to something that reads files,
+// and cmd/cpybkc-gen-graph has nothing to hand it to — it never opens
+// input.bin, and no amount of running it would produce a record. The same is
+// true of every generator that emits a description rather than a reader.
+//
+// docs/adapter/SPEC.md, "kind, because not every generator is a conformance
+// subject", is what lets such a generator say so: kind is declared at the
+// handshake, before the adapter has been asked anything, and an adapter that
+// declares descriptive is not applicable rather than failing. This package is
+// the adapter half of that. The engine's half — sending it nothing but bye, and
+// reporting the run as not applicable — is
+// [github.com/Zaba505/cpybkc/internal/conformance/engine]'s.
+//
+// # What a conversation is
+//
+// Four frames, which is the whole of it:
+//
+//	→ {"id":1,"op":"hello","protocol":1}
+//	← {"id":1,"ok":true,"protocol":1,"name":"cpybkc-gen-graph adapter",
+//	   "kind":"descriptive","capabilities":{}}
+//
+//	→ {"id":2,"op":"bye"}
+//	← {"id":2,"ok":true}
+//
+// Nothing here runs a generator, and that is not an omission. A descriptive
+// adapter is never asked anything a generator could answer, so an adapter that
+// started one would be starting it to throw its output away — and the point of
+// this package is that the framework can decline a subject it cannot test
+// without pretending to have tested it.
+//
+// # Why the codec operations are refused rather than attempted
+//
+// An engine MUST NOT send generate, decode, roundtrip or rebuild to an adapter
+// that declared itself descriptive, so a correct engine never reaches them.
+// They are refused anyway, with ok: false, because the alternative shapes are
+// both untrue: attempting one would mean inventing an answer about a file
+// nothing read, and exiting would report a broken adapter where nothing is
+// broken. A refusal costs the entry it was asked about and says why, which is
+// the one honest thing left to say to an engine that asked the wrong question.
+//
+// # What this package is deliberately not
+//
+// No oracle. What a descriptive generator should be held to instead — whether a
+// descriptive track is worth having at all, and what would grade it — is an
+// open question in discussion #193, and specifying one before deciding whether
+// to have one would specify it twice. This package settles only the cheap half:
+// such a generator can say what it is in one member of the first frame, and be
+// told the truth about itself.
+package descriptive

--- a/internal/conformance/descriptive/frame.go
+++ b/internal/conformance/descriptive/frame.go
@@ -60,9 +60,11 @@ type request struct {
 
 // response is a frame this adapter writes.
 //
-// Every member but the three the contract requires of every response is omitted
-// when empty, so that each operation's frame carries what that operation defines
-// and nothing else.
+// `id` and `ok` are written unconditionally, because the contract requires them
+// of every response and a zero one is an answer rather than an omission. Every
+// other member is omitted when empty, `error` included: it is present exactly
+// when `ok` is false, which is what omitting it from a successful frame
+// implements. So each frame carries what its operation defines and nothing else.
 type response struct {
 	ID    int    `json:"id"`
 	OK    bool   `json:"ok"`
@@ -121,7 +123,15 @@ func parse(line string) (*request, error) {
 
 	var frame request
 	if err := json.Unmarshal([]byte(body), &frame); err != nil {
-		return nil, fmt.Errorf("a frame is one JSON object on one line, and this is not: %s", quoted(body))
+		// Two different failures reach this branch: a line that is not one JSON
+		// object, and a line that is one but spells a member as something the
+		// contract does not give it — a protocol that is a float, an id that is
+		// a string. Both stop the conversation, because a frame whose members
+		// are not the types the contract fixes is a peer this adapter cannot
+		// read rather than a request it could refuse. Which of the two it was is
+		// the decoder's to say, so its words are carried rather than dropped.
+		return nil, fmt.Errorf("a frame is one JSON object on one line, written in the types the contract gives its "+
+			"members, and this is not: %w: %s", err, quoted(body))
 	}
 
 	if frame.ID == nil {

--- a/internal/conformance/descriptive/frame.go
+++ b/internal/conformance/descriptive/frame.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package descriptive
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Protocol is the version of docs/adapter/SPEC.md this adapter speaks. There is
+// no range and no fallback: an adapter speaks one version, and either it is the
+// engine's or the run does not happen.
+const Protocol = 1
+
+// The operations this adapter recognises. An op that is not one of these is
+// refused with ok: false rather than ignored — an unrecognised member is an
+// extension a receiver can safely do nothing about, and an unrecognised
+// operation is work it cannot do.
+//
+// The four between hello and bye are recognised in order to be refused. A
+// correct engine never sends one to an adapter that declared itself
+// descriptive, and an adapter that answered one anyway would be answering about
+// a file nothing read.
+const (
+	opHello     = "hello"
+	opGenerate  = "generate"
+	opDecode    = "decode"
+	opRoundtrip = "roundtrip"
+	opRebuild   = "rebuild"
+	opBye       = "bye"
+)
+
+// kindDescriptive is what this adapter declares, and the whole reason it
+// exists: the generator behind it emits something other than code that reads a
+// file, so the corpus has nothing to ask it and the run is not applicable
+// rather than failed.
+const kindDescriptive = "descriptive"
+
+// request is a frame the engine writes.
+//
+// It carries the three members a descriptive conversation turns on and no
+// others, because a member this adapter does not recognise is ignored rather
+// than refused: a frame is written by a program against a version announced at
+// the handshake, where an unrecognised member is one a later version of the
+// contract added, and a receiver that refused it would make every future
+// addition a breaking change. encoding/json ignores one by default, which is
+// what implements that here — and is why generate's entries and decode's input
+// need no field to be safely discarded.
+type request struct {
+	ID *int   `json:"id"`
+	Op string `json:"op"`
+
+	// Protocol is the handshake's: the version the engine speaks.
+	Protocol *int `json:"protocol"`
+}
+
+// response is a frame this adapter writes.
+//
+// Every member but the three the contract requires of every response is omitted
+// when empty, so that each operation's frame carries what that operation defines
+// and nothing else.
+type response struct {
+	ID    int    `json:"id"`
+	OK    bool   `json:"ok"`
+	Error string `json:"error,omitempty"`
+
+	// Protocol is the handshake's, and is stated rather than echoed: an adapter
+	// that does not speak the engine's version answers ok: false and states its
+	// own anyway, so that a report can say which two versions failed to meet.
+	Protocol *int `json:"protocol,omitempty"`
+
+	Name    string `json:"name,omitempty"`
+	Version string `json:"version,omitempty"`
+	Kind    string `json:"kind,omitempty"`
+
+	// Capabilities is a pointer because the member is required of a successful
+	// handshake even when it is empty — and here it is always empty, which is
+	// the case the pointer is for: an adapter that serves no optional operation
+	// says so with `{}`, and a member left out would be read as an adapter that
+	// was never asked which it serves.
+	Capabilities *map[string]bool `json:"capabilities,omitempty"`
+}
+
+// refuse is a response that did not serve the request. It is a fault and never a
+// wrong answer: the entry is lost, and the run is not.
+func refuse(id int, format string, args ...any) *response {
+	return &response{ID: id, OK: false, Error: fmt.Sprintf(format, args...)}
+}
+
+// parse reads one line of the engine's standard output as a request frame, and
+// refuses everything the framing does not admit.
+//
+// Refusing here means the conversation stops and the peer is treated as broken,
+// rather than as having asked something: a stream whose framing is in doubt
+// cannot be resynchronised by anything the receiver can see, so an adapter that
+// skipped a bad line and read on would be answering questions it cannot know it
+// was asked.
+//
+// The line arrives with its terminator. What is refused is what
+// docs/adapter/SPEC.md, "A frame is one line of UTF-8 JSON", requires be refused
+// rather than tolerated: a blank line, a carriage return before the line feed,
+// and anything that is not one JSON object carrying an id and an op.
+func parse(line string) (*request, error) {
+	body, ok := strings.CutSuffix(line, "\n")
+	if !ok {
+		return nil, fmt.Errorf("the engine's input ended in the middle of a frame: %s", quoted(line))
+	}
+
+	if strings.HasSuffix(body, "\r") {
+		return nil, fmt.Errorf("a frame is terminated by a line feed and this one carries a carriage return before it: %s",
+			quoted(body))
+	}
+
+	if body == "" {
+		return nil, fmt.Errorf("a blank line is not a frame")
+	}
+
+	var frame request
+	if err := json.Unmarshal([]byte(body), &frame); err != nil {
+		return nil, fmt.Errorf("a frame is one JSON object on one line, and this is not: %s", quoted(body))
+	}
+
+	if frame.ID == nil {
+		return nil, fmt.Errorf("the frame carries no id, and an id is what pairs it with a response: %s", quoted(body))
+	}
+
+	if frame.Op == "" {
+		return nil, fmt.Errorf("the frame carries no op, so it asks for nothing: %s", quoted(body))
+	}
+
+	return &frame, nil
+}
+
+// quotedLimit is how much of an unreadable line is quoted back. A line that is
+// not a frame is usually a diagnostic and occasionally a megabyte of a runtime's
+// stack trace, and a report is read in a terminal.
+const quotedLimit = 240
+
+// quoted is a line as a diagnostic should carry it: as a Go quoted string, so
+// that a stray carriage return is visible rather than something that moved the
+// cursor, and shortened to something a report can hold.
+func quoted(line string) string {
+	if len(line) > quotedLimit {
+		return fmt.Sprintf("%q (and %d more bytes)", line[:quotedLimit], len(line)-quotedLimit)
+	}
+
+	return fmt.Sprintf("%q", line)
+}


### PR DESCRIPTION
Closes #201

The corpus tests **codecs**. `values.json` structurally requires a generator whose
output can be handed bytes and produce records, and `cpybkc-gen-graph` is not one:
it emits a diagram, never opens `input.bin`, and there is no reader to hand a file
to. It is not a conformance subject, and the framework has to be able to say so.

`docs/adapter/SPEC.md` already settles how — `kind` is declared in the first
frame — and #235 landed the engine's half of it, which sends a descriptive
adapter nothing but `bye` and reports the run as not applicable. What was
missing is the other half: nothing could declare itself descriptive, so the
motivating generator could not be handed to the framework at all and "never
reported as failing" was true of no real generator.

`internal/conformance/descriptive` is that half. A conversation with it is four
frames long.

## Acceptance criteria

- [x] **An adapter declares its kind at handshake.** `descriptive.Adapter.Serve`
  answers `hello` with `kind: "descriptive"`, an empty-but-present
  `capabilities: {}`, the protocol it speaks and the name a report calls it —
  and a refused handshake states its own protocol and declares neither, which is
  the only shape the contract allows one.
- [x] **An adapter that declares itself descriptive is reported as not
  applicable and the run exits clean.** `TestADescriptiveGeneratorIsNotApplicableAndTheRunIsClean`
  builds `cmd/adapter`, drives it through the engine's `Command` door over the
  whole corpus as a real process, and asserts `NotApplicable`, `Failed() == false`,
  no notes and no restarts. The report it prints reads:

  ```
  adapter: cpybkc-gen-graph adapter (descriptive, protocol 1)
  this generator is descriptive: it emits something other than code that reads a file,
  so the corpus has nothing to ask it and this run is not applicable rather than failed.
  ```
- [x] **A descriptive generator is never reported as failing, and never as
  scoring zero.** The same test asserts zero results and `Counts()` of
  `0/0/0` — the two shapes to avoid are a descriptive generator scored `0/n` and
  one declining every entry one at a time, and neither is reachable: the engine
  stops after the handshake, so there is no entry to decline.
- [x] **No descriptive oracle is built.** Nothing here measures a diagram
  against anything, and no generator is invoked at all. The open questions stay
  in discussion #193, which the package doc and CONTRIBUTING both point at.

## Judgment calls

- **One command for the whole category, not one per generator.** `--name` and
  `--version` are flags, so `gen-docs`, `gen-sql`, `gen-avro`, `gen-json-schema`
  and `gen-copybook` need no new code. A descriptive adapter is asked nothing
  that could differ between them.
- **The adapter invokes no generator.** It is never asked anything a generator
  could answer, so starting one would be starting it to throw its output away.
  The name in the report is the door's to supply, exactly as the Go adapter's
  `--version` is.
- **The codec operations are refused rather than attempted or exited on.** A
  correct engine never sends one, but the two alternatives are both untrue:
  attempting one means answering about a file nothing read, and exiting reports
  a broken adapter where nothing is broken.
- **`Serve` takes no context**, unlike `goadapter.Adapter.Serve`. This adapter
  starts no process and reads no file, so the only thing it blocks on is the
  engine's own input — which the engine closes when it gives up.
- The frame plumbing mirrors `goadapter`'s rather than being shared with it. The
  two are peers on opposite ends of the same contract, and the engine already
  keeps its own copy for the same reason: a shared struct would make a test that
  unmarshals into it agree with the marshaller about a member neither spells the
  way the contract does.

## Verified

- `dagger call ci` — green, from an ordinary clone of this branch (it cannot run
  from a git worktree; CONTRIBUTING says why).
- `go test -race ./internal/conformance/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)