### PR TITLE
story(conformance): the engine and corpus ship as a release asset

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -28,12 +28,12 @@
 //   - The contract checks. ImageContract, WorkedExample, CompanionModule,
 //     CliSurface, EngineLock, IrArtifacts, LayoutArtifact, ConformanceArtifact,
 //     IrDescriptorSet, IrProtos, LayoutSchema, ConformanceBundle, ProtoLint,
-//     ProtoGen and Build are assertions about
-//     docs/container/SPEC.md, docs/plugin/SPEC.md and docs/cli/SPEC.md, and every
-//     one of them holds against a container whoever built it. They are also the
-//     evidence that adopting the archetype changed nothing a consumer can see
-//     that this change did not choose to change, which is the only thing that
-//     makes a change of this size reviewable.
+//     ProtoGen and Build are assertions about docs/container/SPEC.md,
+//     docs/plugin/SPEC.md, docs/cli/SPEC.md and docs/conformance/SPEC.md, and
+//     every one of them holds against a container whoever built it. They are
+//     also the evidence that adopting the archetype changed nothing a consumer
+//     can see that this change did not choose to change, which is the only
+//     thing that makes a change of this size reviewable.
 //   - Whether this commit is a release. The archetype takes a version from its
 //     caller and derives the tag family from it; reading the refs at HEAD to
 //     decide whether there is a release here at all, refusing two version tags
@@ -405,7 +405,7 @@ func (m *Cpybkc) appSource() *dagger.Directory {
 // ConformanceArtifact is the one that arrived, for the conformance archive a
 // release attaches (#202).
 //
-// ImageContract is one of the fifteen, and since #185 that stage builds an App —
+// ImageContract is one of the sixteen, and since #185 that stage builds an App —
 // so this call needs real git metadata and does not run from a git worktree. See
 // New.
 //

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -26,8 +26,9 @@
 // about how an image gets built:
 //
 //   - The contract checks. ImageContract, WorkedExample, CompanionModule,
-//     CliSurface, EngineLock, IrArtifacts, LayoutArtifact, IrDescriptorSet,
-//     IrProtos, LayoutSchema, ProtoLint, ProtoGen and Build are assertions about
+//     CliSurface, EngineLock, IrArtifacts, LayoutArtifact, ConformanceArtifact,
+//     IrDescriptorSet, IrProtos, LayoutSchema, ConformanceBundle, ProtoLint,
+//     ProtoGen and Build are assertions about
 //     docs/container/SPEC.md, docs/plugin/SPEC.md and docs/cli/SPEC.md, and every
 //     one of them holds against a container whoever built it. They are also the
 //     evidence that adopting the archetype changed nothing a consumer can see
@@ -145,16 +146,23 @@
 //
 // # Why the release artifacts are built here
 //
-// IrDescriptorSet and IrProtos produce two of the three files a release
-// attaches — the IR's FileDescriptorSet and the schema sources (#19) — and
+// IrDescriptorSet and IrProtos produce two of the four files a release
+// attaches — the IR's FileDescriptorSet and the schema sources (#19) —
 // LayoutSchema produces the third, the published layout schema a shop's layout
-// generator targets (#23). They are functions on this module for the same reason
-// ProtoLint is: a recipe that only ever ran inside
-// .github/workflows/release.yaml would be a build nobody can reproduce locally
-// and one that first runs on a tag, where a failure is a release that did not
-// happen. Here, `dagger call ir-descriptor-set` is a command a contributor runs,
-// and IrArtifacts and LayoutArtifact put all three builds inside Ci so the
-// recipes are exercised on every pull request rather than once per release.
+// generator targets (#23), and ConformanceBundle produces the fourth, the
+// conformance engine and corpus a generator author runs offline (#202). They are
+// functions on this module for the same reason ProtoLint is: a recipe that only
+// ever ran inside .github/workflows/release.yaml would be a build nobody can
+// reproduce locally and one that first runs on a tag, where a failure is a
+// release that did not happen. Here, `dagger call ir-descriptor-set` is a
+// command a contributor runs, and IrArtifacts, LayoutArtifact and
+// ConformanceArtifact put all four builds inside Ci so the recipes are exercised
+// on every pull request rather than once per release.
+//
+// The fourth is the one that is a program rather than a description of an
+// interface, and its check is correspondingly wider: which platforms the engine
+// is built for is decided here, so whether each of them compiled and landed in
+// the archive is a question only a run of the pipeline can answer.
 //
 // They are also the seam the container work builds on: #57 copies the same file
 // into the published image, from this function rather than from a second
@@ -216,6 +224,25 @@ const (
 	// The image has no PATH to find it on, which is the point of running it
 	// there at all.
 	cliBinaryPath = "/cpybkc"
+
+	// conformPackage is the main package the conformance engine is built from,
+	// and conformBinary is the stem every platform's executable is named after.
+	// It is the program cpybkc-conformance.tar.gz ships (#202), and the name is
+	// stated here for the reason cliBinary is: it is what a person types.
+	conformPackage = "./cmd/cpybkc-conform"
+	conformBinary  = "cpybkc-conform"
+
+	// conformanceBundle is the fourth asset a release attaches, and the first
+	// that is a program rather than a description of an interface.
+	conformanceBundle = "cpybkc-conformance.tar.gz"
+
+	// conformanceRoot is the one directory that archive unpacks into, as
+	// internal/tools/conformance-bundle writes it. This module is a Go module of
+	// its own and cannot import that package, so this is a second spelling of
+	// one name — pinned by ConformanceArtifact reading it back out of the
+	// artifact rather than by an import, which is the arrangement
+	// reportedVersion already lives under.
+	conformanceRoot = "cpybkc-conformance"
 )
 
 // Cpybkc is the root module type. Source and the lint configuration are bound
@@ -358,7 +385,7 @@ func (m *Cpybkc) appSource() *dagger.Directory {
 // Ci runs the whole pipeline: fmt, vet, golangci-lint and `go test -race`, as
 // the Z5Labs standard defines them, over each of this repository's four Go
 // modules, plus `buf lint` over the IR schema, a build of the CLI itself, a
-// build of the three artifacts a release publishes, the published base image on
+// build of the four artifacts a release publishes, the published base image on
 // every platform it ships for, the worked examples docs/container/SPEC.md hands
 // an adopter, the release decision and the release notes a release is published
 // under, the companion module's coverage of the CLI's flags, and that module's
@@ -366,15 +393,17 @@ func (m *Cpybkc) appSource() *dagger.Directory {
 // one `dagger call ci` and stays one, because a workflow step that reran any of
 // these stages would be a second definition of them.
 //
-// The fifteen parts run concurrently and all are reported, for the reason the
+// The sixteen parts run concurrently and all are reported, for the reason the
 // standard runs its own four that way: waiting on a Go stage to learn that the
 // schema is unlintable, or the reverse, is a second push to find out about the
 // second failure.
 //
-// It was sixteen until #185. Attestations checked the provenance predicate and
-// the SBOM set this module used to render, and both are the archetype's now, so
-// the stage went with sign.go rather than being kept as a check on somebody
-// else's output.
+// It was fifteen between #185 and #202, and sixteen before that for a different
+// reason. Attestations checked the provenance predicate and the SBOM set this
+// module used to render, and both are the archetype's now, so that stage went
+// with sign.go rather than being kept as a check on somebody else's output.
+// ConformanceArtifact is the one that arrived, for the conformance archive a
+// release attaches (#202).
 //
 // ImageContract is one of the fifteen, and since #185 that stage builds an App —
 // so this call needs real git metadata and does not run from a git worktree. See
@@ -385,9 +414,10 @@ func (m *Cpybkc) appSource() *dagger.Directory {
 func (m *Cpybkc) Ci(ctx context.Context) error {
 	var goErr, irErr, protoErr, buildErr, artifactErr, layoutErr, imageErr, exampleErr error
 	var tagErr, notesErr, companionErr, engineErr, surfaceErr, moduleErr, pipelineErr error
+	var conformanceErr error
 
 	var wg sync.WaitGroup
-	wg.Add(15)
+	wg.Add(16)
 
 	go func() {
 		defer wg.Done()
@@ -417,6 +447,11 @@ func (m *Cpybkc) Ci(ctx context.Context) error {
 	go func() {
 		defer wg.Done()
 		layoutErr = m.LayoutArtifact(ctx)
+	}()
+
+	go func() {
+		defer wg.Done()
+		conformanceErr = m.ConformanceArtifact(ctx)
 	}()
 
 	go func() {
@@ -469,8 +504,8 @@ func (m *Cpybkc) Ci(ctx context.Context) error {
 
 	wg.Wait()
 
-	return errors.Join(goErr, irErr, protoErr, buildErr, artifactErr, layoutErr, imageErr, exampleErr,
-		tagErr, notesErr, companionErr, engineErr, surfaceErr, moduleErr, pipelineErr)
+	return errors.Join(goErr, irErr, protoErr, buildErr, artifactErr, layoutErr, conformanceErr, imageErr,
+		exampleErr, tagErr, notesErr, companionErr, engineErr, surfaceErr, moduleErr, pipelineErr)
 }
 
 // IrCi runs the same standard pipeline over irpb/, the published IR module.
@@ -963,6 +998,212 @@ func (m *Cpybkc) LayoutArtifact(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// conformPlatforms is the set of platforms the conformance engine is built for
+// and shipped in cpybkc-conformance.tar.gz.
+//
+// It is wider than imagePlatforms, and the difference is not an oversight in
+// either. The image is a Linux container base, so its platforms are the ones a
+// registry serves; this archive is downloaded onto whatever machine somebody
+// writes a code generator on, and a great many of those are macOS laptops and
+// some are Windows. An author who has to compile the engine before they can run
+// it needs a Go toolchain in order to check a generator written in something
+// else, which is the whole cost this artifact exists to remove.
+//
+// Sorted, because the archive's listing is a function of the names in it and a
+// released artifact is compared across releases.
+//
+// Cross-compiled rather than built under emulation, for the reason binary gives:
+// nothing about a Go build needs the target's architecture to be executable, and
+// paying qemu to learn what `go build` already knows would be minutes per
+// platform per run.
+func conformPlatforms() []dagger.Platform {
+	return []dagger.Platform{
+		"darwin/amd64",
+		"darwin/arm64",
+		"linux/amd64",
+		"linux/arm64",
+		"windows/amd64",
+	}
+}
+
+// conformBinaryName is what one platform's engine is called inside the archive.
+//
+// The platform is in the name because all of them are in one archive: the point
+// of the artifact is that somebody with no egress can be handed a file, and one
+// file per platform would be a choice they have to make before they can
+// download anything. Windows keeps its .exe, because a Windows shell will not
+// run a file without one.
+func conformBinaryName(platform dagger.Platform) string {
+	name := conformBinary + "-" + strings.ReplaceAll(string(platform), "/", "-")
+
+	if strings.HasPrefix(string(platform), "windows/") {
+		name += ".exe"
+	}
+
+	return name
+}
+
+// conformEngines is the conformance engine built for every platform above, by
+// the name it carries inside the archive.
+//
+// One helper rather than a build at each site, so that ConformanceBundle and
+// ConformanceArtifact are about the same executables. They are the same Dagger
+// nodes, so the check is a check of what shipped rather than of a second build
+// that merely agrees with it — the same arrangement image copying in the file
+// IrDescriptorSet produces already lives under.
+func (m *Cpybkc) conformEngines() map[string]*dagger.File {
+	engines := map[string]*dagger.File{}
+
+	for _, platform := range conformPlatforms() {
+		name := conformBinaryName(platform)
+
+		engines[name] = dag.Go().
+			Build(m.Source, dagger.GoBuildOpts{
+				Pkg:          conformPackage,
+				ArtifactName: name,
+				// CGO-free and -trimpath for the reasons binary gives: a
+				// statically linked file is one that runs on a machine this
+				// project knows nothing about, and a binary carrying the path it
+				// was compiled under is a build that depends on where it ran —
+				// which a released artifact may not be.
+				Trimpath:   true,
+				DisableCgo: true,
+				Platform:   string(platform),
+			}).
+			File(name)
+	}
+
+	return engines
+}
+
+// ConformanceBundle builds the conformance archive — the published
+// cpybkc-conformance.tar.gz — carrying the corpus, a digest of it, and the
+// engine built for every platform above:
+//
+//	dagger call conformance-bundle export --path=cpybkc-conformance.tar.gz
+//
+// It is the fourth asset a release attaches and the one that is not a
+// description of an interface: a generator author downloads it, unpacks it, and
+// runs `cpybkc-conform check --exec ./their-adapter` with no registry, no
+// daemon and no image in front of them (#202).
+// internal/tools/conformance-bundle carries the argument for why that is worth
+// an artifact of its own, and for why the binaries are in it.
+//
+// It is a function on this module for the reason IrDescriptorSet is: a recipe
+// that only ever ran inside .github/workflows/release.yaml would be a build
+// nobody can reproduce locally and one that first runs on a tag, where a failure
+// is a release that did not happen.
+//
+// The archive's own bytes are a function of its contents — every tar field the
+// filesystem could have supplied is a constant and the entries are sorted — so
+// the same commit archives to the same wrapper. What is inside it is
+// reproducible on the toolchain's own terms, which is what CGO_ENABLED=0 and
+// -trimpath above are for.
+func (m *Cpybkc) ConformanceBundle() *dagger.File {
+	const (
+		out = "/out/" + conformanceBundle
+
+		// Not /bin, which the toolchain container already has and would be
+		// merged with rather than replaced — handing the archiver every
+		// executable in the image.
+		engineDir = "/engines"
+	)
+
+	engines := dag.Directory()
+	for name, engine := range m.conformEngines() {
+		engines = engines.WithFile(name, engine)
+	}
+
+	return dag.Go().
+		Container(m.Source).
+		WithDirectory(engineDir, engines).
+		WithExec([]string{"go", "run", "./internal/tools/conformance-bundle", "-bin", engineDir, "-o", out}).
+		File(out)
+}
+
+// ConformanceArtifact builds the conformance archive and checks that every
+// platform's engine is in it.
+//
+// It is IrArtifacts' counterpart for the conformance half of what a release
+// carries, and everything that comment says about why an artifact build belongs
+// in Ci applies here unchanged.
+//
+// What it asserts is more than the others do, and the reason is that this
+// artifact has a part the Go tests cannot reach. internal/tools/conformance-bundle
+// is tested against a stand-in for the engines, because building five of them in
+// a unit test would make it a cross-compilation; which platforms there are is
+// this file's, and whether each one compiled is a question only a run of the
+// pipeline can answer. A platform that silently produced nothing would otherwise
+// arrive as a downloader on a machine the archive has no engine for.
+//
+// The empty file is the same failure the other artifact checks name: it is what
+// a tool that created its parent directory and exited would leave behind, and it
+// uploads as happily as a good one.
+//
+// +check
+// +cache="session"
+func (m *Cpybkc) ConformanceArtifact(ctx context.Context) error {
+	var errs []error
+
+	engines := m.conformEngines()
+
+	names := make([]string, 0, len(engines))
+	for name := range engines {
+		names = append(names, name)
+	}
+
+	// Sorted, so that two runs failing on two different platforms report them in
+	// the same order rather than in whichever order the map produced.
+	slices.Sort(names)
+
+	for _, name := range names {
+		size, err := engines[name].Size(ctx)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to build %s: %w", name, err))
+
+			continue
+		}
+
+		if size == 0 {
+			errs = append(errs, fmt.Errorf("%s built to an empty file", name))
+		}
+	}
+
+	bundle := m.ConformanceBundle()
+
+	size, err := bundle.Size(ctx)
+	if err != nil {
+		return errors.Join(append(errs, fmt.Errorf("failed to build %s: %w", conformanceBundle, err))...)
+	}
+
+	if size == 0 {
+		return errors.Join(append(errs, fmt.Errorf("%s built to an empty file", conformanceBundle))...)
+	}
+
+	// Read out of the artifact rather than assumed from the build above. The
+	// two are the same Dagger nodes, so this is not a second opinion about
+	// whether they compiled — it is the claim that each of them was actually put
+	// in the archive, at the path the archive's own README tells somebody to run.
+	listing, err := dag.Go().
+		Container(m.Source).
+		WithFile("/tmp/"+conformanceBundle, bundle).
+		WithExec([]string{"tar", "-tzf", "/tmp/" + conformanceBundle}).
+		Stdout(ctx)
+	if err != nil {
+		return errors.Join(append(errs, fmt.Errorf("failed to read %s: %w", conformanceBundle, err))...)
+	}
+
+	archived := strings.Split(listing, "\n")
+
+	for _, name := range names {
+		if !slices.Contains(archived, conformanceRoot+"/bin/"+name) {
+			errs = append(errs, fmt.Errorf("%s does not carry bin/%s", conformanceBundle, name))
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 // stage returns the check builder the standard pipeline builds on, bound to

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ permissions:
   contents: read
 
 jobs:
-  # The three contract artifacts, attached to the release.
+  # The four contract artifacts, attached to the release.
   #
   # ir.binpb is the protobuf FileDescriptorSet describing cpybkc.ir.v1.Descriptor
   # (#19), so that a plugin author whose language has no protobuf code generation
@@ -50,6 +50,16 @@ jobs:
   # generator targets and cpybkc's own validator reads — and it carries its
   # version inside it rather than in its name, so that a file downloaded on its
   # own still says which version of the format it describes.
+  #
+  # cpybkc-conformance.tar.gz is the fourth, and the only one that is a program
+  # rather than a description of an interface: the conformance corpus, a digest
+  # of it, and cpybkc-conform built for every platform this project builds it for
+  # (#202). It is here because conformance is what an outsider runs once, on a
+  # whim, before they are invested — and the container image that would otherwise
+  # be the way to get it is a procurement ticket for anyone whose builders have
+  # no egress. A download and an `--exec` is the offline path, with no registry,
+  # no daemon and no image; the container door is #203's and is where the
+  # properties that make a result believable live.
   #
   # The same ir.binpb bytes ship inside the published image, at
   # /usr/local/share/cpybkc/ir.binpb, and the same sources ship unpacked beside
@@ -85,7 +95,7 @@ jobs:
               BIN_DIR="$HOME/.local/bin" sh
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      # The same three functions `dagger call ci` builds on every pull request
+      # The same four functions `dagger call ci` builds on every pull request
       # and a contributor runs locally, so the released assets are produced by a
       # recipe that has already been exercised rather than by one that only ever
       # runs at release time.
@@ -94,6 +104,7 @@ jobs:
           dagger call ir-descriptor-set export --path "$RUNNER_TEMP/ir.binpb"
           dagger call ir-protos export --path "$RUNNER_TEMP/ir-protos.tar.gz"
           dagger call layout-schema export --path "$RUNNER_TEMP/layout-schema.sexpr"
+          dagger call conformance-bundle export --path "$RUNNER_TEMP/cpybkc-conformance.tar.gz"
 
       # --clobber so that re-running a failed release job replaces the assets
       # instead of failing on a name that is already taken. Every artifact is a
@@ -106,6 +117,7 @@ jobs:
             "$RUNNER_TEMP/ir.binpb" \
             "$RUNNER_TEMP/ir-protos.tar.gz" \
             "$RUNNER_TEMP/layout-schema.sexpr" \
+            "$RUNNER_TEMP/cpybkc-conformance.tar.gz" \
             --clobber
 
   # The published base image (#55) — the one docs/container/SPEC.md describes and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## The pipeline
 
-fmt, vet, golangci-lint, `go test -race`, `buf lint`, the three artifacts a
+fmt, vet, golangci-lint, `go test -race`, `buf lint`, the four artifacts a
 release attaches, the published base image and the worked example in the
 base-image contract are defined once, in the root Dagger module under
 [`.dagger/`](.dagger/). CI calls that module and so do you, which is the point:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -345,14 +345,17 @@ kept in step by hand.
 
 ## The release artifacts
 
-Every published release carries three files. Two describe the IR, for the plugin
+Every published release carries four files. Two describe the IR, for the plugin
 authors who are not importing `irpb`; the third is the layout schema, for the
-shop generating layout files rather than writing them:
+shop generating layout files rather than writing them; the fourth is the
+conformance corpus and the engine that runs it, for the generator author
+checking their own work:
 
 ```sh
 dagger call ir-descriptor-set export --path=ir.binpb
 dagger call ir-protos export --path=ir-protos.tar.gz
 dagger call layout-schema export --path=layout-schema.sexpr
+dagger call conformance-bundle export --path=cpybkc-conformance.tar.gz
 ```
 
 `ir.binpb` is the protobuf `FileDescriptorSet` describing
@@ -371,7 +374,23 @@ text. [The published schema](docs/layout/SPEC.md#the-published-schema) is the
 document to change if what it declares changes — including the version it
 carries, which moves with the format and not with the document.
 
-Three properties are worth knowing before you touch any of them:
+`cpybkc-conformance.tar.gz` is the odd one out, and deliberately: it is a
+program rather than a description of an interface. It carries the conformance
+corpus, a SHA-256 over it, and `cpybkc-conform` cross-compiled for five
+platforms, all under one directory an adopter unpacks and works in. [The
+published corpus](docs/conformance/SPEC.md#the-published-corpus) is the contract
+— the layout, and the digest rule stated precisely enough for somebody to
+recompute it without running anything of ours.
+
+It exists because conformance is what an outsider runs once, on a whim, before
+they are invested, and the obvious alternative — a container image — is a
+procurement ticket for anybody whose builders have no egress and whose registry
+runs an allowlist (#202). A download and an `--exec` is the offline path. The
+container door is #203's, and it is where the properties that make a result
+believable live: `--exec` provides no isolation of any kind, and
+`cpybkc-conform` says so in every report it writes.
+
+Four properties are worth knowing before you touch any of them:
 
 - **Neither IR artifact is committed.** `ir.binpb` is computed from the
   descriptors `protoc-gen-go` compiled into `irpb`, so it cannot drift from the
@@ -380,17 +399,31 @@ Three properties are worth knowing before you touch any of them:
   schema is the other way round — it is a source file a person writes, so it is
   committed, and `layout-schema` publishes it unchanged after checking that it
   loads.
-- **All three are reproducible.** Two builds of one commit produce byte-identical
+  The conformance corpus is committed and its digest is not, for the first of
+  those reasons: the digest is a function of the corpus, so a checked-in copy
+  would be a second statement of it for the next entry to be added without.
+- **All four are reproducible.** Two builds of one commit produce byte-identical
   files — the encoding is deterministic, every tar field the filesystem could
   have supplied is a constant, and the schema is copied rather than reformatted —
   because an artifact that moved on a rebuild would make a rebuild
-  indistinguishable from a change to the contract.
-- **`dagger call ci` builds them.** `ir-artifacts` and `layout-artifact` are in
-  the pipeline so that the recipe a release runs is exercised on every pull
-  request, rather than for the first time on a tag. What is in them is asserted
-  by Go tests, in `irpb` and beside each tool under `internal/tools/`; the
-  pipeline stages only check that the commands run to completion and leave a file
-  behind.
+  indistinguishable from a change to the contract. The conformance archive's
+  *wrapper* is reproducible on the same terms; the executables inside it are the
+  Go toolchain's, and are CGO-free and `-trimpath` for that reason among others.
+- **`dagger call ci` builds them.** `ir-artifacts`, `layout-artifact` and
+  `conformance-artifact` are in the pipeline so that the recipe a release runs is
+  exercised on every pull request, rather than for the first time on a tag. What
+  is in them is asserted by Go tests, in `irpb` and beside each tool under
+  `internal/tools/`; the pipeline stages only check that the commands run to
+  completion and leave a file behind.
+
+  `conformance-artifact` asserts more than that, and the extra is the part the Go
+  tests cannot reach. Which platforms the engine is built for is decided in
+  `.dagger/main.go`, so `internal/tools/conformance-bundle`'s tests run against a
+  stand-in — building five executables in a unit test would make it a
+  cross-compilation. Whether each of them compiled, and landed in the archive at
+  the path the archive's own README tells somebody to run, is a question only a
+  run of the pipeline can answer, and a platform that silently produced nothing
+  would otherwise arrive as a downloader on a machine there is no engine for.
 - **Both IR artifacts also ship inside the image**, at
   `/usr/local/share/cpybkc/ir.binpb` and `/usr/local/share/cpybkc/proto/`, so
   that a plugin author building `FROM` the image needs no download at all. They
@@ -407,8 +440,8 @@ That is deliberate: the IR is one message and everything in `proto/` is reachabl
 from it, so a file that is not is a mistake in the schema rather than something
 to exclude.
 
-`.github/workflows/release.yaml` attaches all three to a release when one is
-published, building them with the same three calls above at the release's tag.
+`.github/workflows/release.yaml` attaches all four to a release when one is
+published, building them with the same four calls above at the release's tag.
 
 ## Signing a release
 
@@ -449,7 +482,7 @@ Three things are worth knowing:
 ## Making a release
 
 Publish a GitHub release whose tag is a canonical `vX.Y.Z`.
-`.github/workflows/release.yaml` does the rest: it attaches the three artifacts
+`.github/workflows/release.yaml` does the rest: it attaches the four artifacts
 above, pushes the image, signs the digest, and writes into the release's notes
 which IR version that image speaks.
 
@@ -1245,6 +1278,23 @@ through the public contract exactly as a stranger's would be, so every gap
 between what the engine needs and what an adapter can supply surfaces here, where
 the only people inconvenienced are us. A second generator, in any language, is a
 second executable behind `--exec` and no change to anything in this repository.
+
+[`cmd/cpybkc-conform`](cmd/cpybkc-conform) is where that `--exec` lives: the
+engine with a command line on it, and the program every release ships in
+`cpybkc-conformance.tar.gz`. It holds no rule of its own — the corpus is
+`internal/conformance`'s, the conversation is the engine's, and the comparison
+is the engine's too — so what is in it is the flags, the corpus digest check
+and an exit status. Running it against this repository's own tree needs the
+corpus named, because the default is where the archive unpacks one:
+
+```sh
+go run ./cmd/cpybkc-conform check \
+  --corpus testdata/conformance \
+  --exec ./bin/adapter -- --root "$PWD" --generator ./bin/cpybkc-gen-go
+```
+
+The bare `--` is not optional where an adapter takes flags of its own: without
+it they are read as `cpybkc-conform`'s and refused.
 
 Two of its decisions are load-bearing rather than incidental. The codec program
 it builds per entry **stays alive after the `decode` it answered**, holding the

--- a/README.md
+++ b/README.md
@@ -85,6 +85,23 @@ schema](docs/layout/SPEC.md#the-published-schema) is what it is and what it
 deliberately leaves to the reader; `schema/layout.sexpr` is the same file in
 this repository.
 
+Whoever wrote that plugin takes the fourth, `cpybkc-conformance.tar.gz`: the
+conformance corpus — small files with the right answer written down — a digest
+of it, and `cpybkc-conform` built for five platforms. Unpack it, write an
+[adapter](docs/adapter/SPEC.md) for your generator, and run
+
+```sh
+./bin/cpybkc-conform-linux-amd64 check --exec ../my-adapter
+```
+
+with no clone, no registry and no container runtime in front of you. [The
+published corpus](docs/conformance/SPEC.md#the-published-corpus) is the
+archive's layout and the digest rule; [the corpus
+format](docs/conformance/SPEC.md) is what an entry holds and the language a
+decoded record is written in. A run through `--exec` is your own working result
+rather than one to hand to somebody else — the door provides no isolation, and
+the report says so.
+
 ## The project manifest
 
 A project is driven by a `cpybkc.json` checked in beside the files it names, so

--- a/cmd/cpybkc-conform/check.go
+++ b/cmd/cpybkc-conform/check.go
@@ -7,10 +7,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/Zaba505/cpybkc/internal/conformance"
@@ -42,6 +45,17 @@ func check(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 	)
 
 	if err := flags.Parse(args); err != nil {
+		// Asking for help is an answer, not a failed run: flag reports -h and
+		// --help as ErrHelp, and left as an ordinary error they would be printed
+		// to standard error and exit 2, which this program's own contract
+		// reserves for a run that could not be attempted. The archive's README
+		// tells a first-time offline reader to type exactly this.
+		if errors.Is(err, flag.ErrHelp) {
+			_, _ = fmt.Fprint(stdout, usage)
+
+			return nil
+		}
+
 		return fmt.Errorf("%w\n\n%s", err, usage)
 	}
 
@@ -118,29 +132,58 @@ func readCorpus(dir string, stderr io.Writer) ([]*conformance.Entry, error) {
 	return entries, nil
 }
 
-// adapterPath is the executable --exec named, checked before a run starts.
+// adapterPath is the executable --exec named, checked before a run starts and
+// resolved to an absolute path.
 //
-// A name is refused rather than looked up on PATH, which is the rule
+// A bare name is refused rather than looked up on PATH, which is the rule
 // [engine.Command.Path] states and the reason it gives: a run is usually
 // against something just built from the tree under test, and resolving a name
-// would find whichever adapter the author happened to have installed. Refusing
-// is the honest half of that — silently reading it as a relative path would
-// make `--exec adapter` mean something different from what a shell means by it.
-func adapterPath(path string) (string, error) {
-	if path == "" {
+// would find whichever adapter the author happened to have installed.
+//
+// Refused rather than read as `./name`, which is the other thing it could have
+// done. Both of those are decisions about what somebody meant, and a shell
+// makes neither: `adapter` at a prompt runs the one on PATH and nothing runs
+// the one in this directory. Saying so costs one line and one sentence, and
+// leaves the caller to write which they meant.
+//
+// # Why it is made absolute
+//
+// os/exec resolves a relative Path against [os/exec.Cmd.Dir] rather than against
+// this process's working directory. With --dir set, `--exec ./adapter` would
+// therefore be checked here against the file the caller meant and started from
+// the adapter's own directory instead — a different program of the same name, or
+// none, and neither outcome says which file it ran. Resolving once, here, is
+// what makes --exec mean the same thing whether or not --dir was given.
+func adapterPath(name string) (string, error) {
+	if name == "" {
 		return "", fmt.Errorf("--exec is required: name the adapter executable to run\n\n%s", usage)
 	}
 
-	info, err := os.Stat(path)
+	// Checked before the file is looked for, so that the diagnostic is about the
+	// shape of what was written rather than about a file that may well exist.
+	// The forward slash is tested as well as the platform's separator because
+	// Windows accepts both, so `--exec ./adapter` is a path there too.
+	if !strings.ContainsRune(name, '/') && !strings.ContainsRune(name, filepath.Separator) {
+		return "", fmt.Errorf("--exec %s names no directory, and this is a path rather than a name to look up on "+
+			"PATH: write %c%c%s for the one here, or give the path to the one you mean",
+			name, '.', filepath.Separator, name)
+	}
+
+	info, err := os.Stat(name)
 	if err != nil {
-		return "", fmt.Errorf("failed to find the adapter %s: %w", path, err)
+		return "", fmt.Errorf("failed to find the adapter %s: %w", name, err)
 	}
 
 	if info.IsDir() {
-		return "", fmt.Errorf("%s is a directory: --exec names the adapter executable itself", path)
+		return "", fmt.Errorf("%s is a directory: --exec names the adapter executable itself", name)
 	}
 
-	return path, nil
+	absolute, err := filepath.Abs(name)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve the adapter %s: %w", name, err)
+	}
+
+	return absolute, nil
 }
 
 // positive refuses a bound that is not one. A zero duration is the engine's

--- a/cmd/cpybkc-conform/check.go
+++ b/cmd/cpybkc-conform/check.go
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/Zaba505/cpybkc/internal/conformance"
+	"github.com/Zaba505/cpybkc/internal/conformance/engine"
+)
+
+// check runs the corpus against one adapter.
+//
+// The order is deliberate and is what makes a failure attributable: the corpus
+// is checked against its digest first, then loaded, and only then is a process
+// started. A run against a corpus that was half unpacked would otherwise report
+// a generator disagreeing with entries nobody published.
+func check(ctx context.Context, args []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("check", flag.ContinueOnError)
+
+	// Discarded, because flag's own error output writes a synopsis of its own to
+	// standard error the moment a flag is wrong, and this program has one
+	// synopsis. What a caller gets is the parse error and the same usage every
+	// other mistake produces.
+	flags.SetOutput(io.Discard)
+
+	var (
+		corpus        = flags.String("corpus", defaultCorpus, "the unpacked corpus")
+		exec          = flags.String("exec", "", "the adapter executable, as a path")
+		dir           = flags.String("dir", "", "the adapter's working directory")
+		deadline      = flags.Duration("deadline", engine.DefaultDeadline, "bounds one operation")
+		buildDeadline = flags.Duration("build-deadline", engine.DefaultBuildDeadline, "bounds generate")
+		grace         = flags.Duration("grace", engine.DefaultGrace, "how long the adapter is given to exit")
+	)
+
+	if err := flags.Parse(args); err != nil {
+		return fmt.Errorf("%w\n\n%s", err, usage)
+	}
+
+	path, err := adapterPath(*exec)
+	if err != nil {
+		return err
+	}
+
+	if err := positive(*deadline, *buildDeadline, *grace); err != nil {
+		return err
+	}
+
+	entries, err := readCorpus(*corpus, stderr)
+	if err != nil {
+		return err
+	}
+
+	report, err := (&engine.Engine{
+		Door: &engine.Command{
+			Path: path,
+			// Everything the flags did not consume, which is the adapter's own
+			// argument vector: docs/adapter/SPEC.md leaves it to the door
+			// precisely so that an adapter can be a script taking arguments of
+			// its own without the contract growing a place to put them.
+			Args: flags.Args(),
+			Dir:  *dir,
+		},
+		Deadline:      *deadline,
+		BuildDeadline: *buildDeadline,
+		Grace:         *grace,
+	}).Run(ctx, entries)
+	if err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprint(stdout, report)
+
+	if report.Failed() {
+		return errFailed
+	}
+
+	return nil
+}
+
+// readCorpus checks the corpus at dir against the digest published beside it,
+// loads it, and says on stderr which corpus the run is about to be against.
+//
+// The digest line is on standard error rather than in the report because the
+// report is the engine's and describes a conversation. Which corpus was asked
+// is a fact about this program's inputs, and it belongs beside the report
+// rather than inside a structure that will one day be serialised as one.
+func readCorpus(dir string, stderr io.Writer) ([]*conformance.Entry, error) {
+	digest, checked, err := conformance.CheckDigest(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := conformance.Load(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	_, _ = fmt.Fprintf(stderr, "corpus: %s, %d entries, sha256 %s\n", dir, len(entries), digest)
+
+	if !checked {
+		// Said out loud rather than passed over. A corpus with no digest beside
+		// it is the ordinary case in a checkout and an unusual one in a
+		// download, and a run that silently accepted an edited corpus would
+		// report a conformance result about a question nobody asked.
+		_, _ = fmt.Fprintf(stderr, "there is no %s beside it, so nothing checked that this is the published corpus\n",
+			conformance.DigestPath(dir))
+	}
+
+	return entries, nil
+}
+
+// adapterPath is the executable --exec named, checked before a run starts.
+//
+// A name is refused rather than looked up on PATH, which is the rule
+// [engine.Command.Path] states and the reason it gives: a run is usually
+// against something just built from the tree under test, and resolving a name
+// would find whichever adapter the author happened to have installed. Refusing
+// is the honest half of that — silently reading it as a relative path would
+// make `--exec adapter` mean something different from what a shell means by it.
+func adapterPath(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("--exec is required: name the adapter executable to run\n\n%s", usage)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to find the adapter %s: %w", path, err)
+	}
+
+	if info.IsDir() {
+		return "", fmt.Errorf("%s is a directory: --exec names the adapter executable itself", path)
+	}
+
+	return path, nil
+}
+
+// positive refuses a bound that is not one. A zero duration is the engine's
+// "use the default", so a caller who wrote --deadline 0 meaning "no limit" would
+// silently get a minute; a negative one is a deadline already past, which turns
+// every operation into a timeout and reads as an adapter that answers nothing.
+func positive(bounds ...time.Duration) error {
+	for _, bound := range bounds {
+		if bound <= 0 {
+			return fmt.Errorf("a bound of %s is not one: every deadline must be positive, and the defaults are "+
+				"what a run with no flags uses", bound)
+		}
+	}
+
+	return nil
+}

--- a/cmd/cpybkc-conform/digest.go
+++ b/cmd/cpybkc-conform/digest.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/Zaba505/cpybkc/internal/conformance"
+)
+
+// digest writes the corpus's own SHA-256, and fails if a digest published
+// beside the corpus disagrees with it.
+//
+// Standard output carries the digest and a newline and nothing else, so that
+// the check somebody would write by hand is a comparison rather than a parse:
+//
+//	test "$(cpybkc-conform digest)" = "$(cat corpus.sha256)"
+//
+// Everything a reader wants beside it goes to standard error, for that reason.
+//
+// It exists as a command of its own so that the digest can be recomputed
+// without trusting this program's silence. `check` verifies it and says nothing
+// when it agrees, which is the right shape for a run and the wrong shape for
+// somebody deciding whether to trust a download at all.
+func digest(args []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("digest", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+
+	corpus := flags.String("corpus", defaultCorpus, "the unpacked corpus")
+
+	if err := flags.Parse(args); err != nil {
+		return fmt.Errorf("%w\n\n%s", err, usage)
+	}
+
+	if rest := flags.Args(); len(rest) > 0 {
+		return fmt.Errorf("unexpected arguments %v\n\n%s", rest, usage)
+	}
+
+	computed, checked, err := conformance.CheckDigest(*corpus)
+
+	// The digest is written before the error is reported, and that is the whole
+	// point of the command: somebody holding a corpus that does not match its
+	// published digest wants to see both numbers, and a program that failed
+	// without printing what it computed would have told them only that
+	// something is wrong.
+	if computed != "" {
+		_, _ = fmt.Fprintln(stdout, computed)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if checked {
+		_, _ = fmt.Fprintf(stderr, "%s agrees\n", conformance.DigestPath(*corpus))
+	} else {
+		_, _ = fmt.Fprintf(stderr, "there is no %s beside the corpus, so this digest was compared against nothing\n",
+			conformance.DigestPath(*corpus))
+	}
+
+	return nil
+}

--- a/cmd/cpybkc-conform/digest.go
+++ b/cmd/cpybkc-conform/digest.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -34,6 +35,13 @@ func digest(args []string, stdout, stderr io.Writer) error {
 	corpus := flags.String("corpus", defaultCorpus, "the unpacked corpus")
 
 	if err := flags.Parse(args); err != nil {
+		// An answer rather than a failed run, for the reason check gives.
+		if errors.Is(err, flag.ErrHelp) {
+			_, _ = fmt.Fprint(stdout, usage)
+
+			return nil
+		}
+
 		return fmt.Errorf("%w\n\n%s", err, usage)
 	}
 

--- a/cmd/cpybkc-conform/main.go
+++ b/cmd/cpybkc-conform/main.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Command cpybkc-conform runs the conformance corpus against a generator's
+// adapter and reports what came back.
+//
+//	cpybkc-conform check --exec <path> [--corpus <dir>] [-- args for the adapter...]
+//	cpybkc-conform digest [--corpus <dir>]
+//
+// It is [github.com/Zaba505/cpybkc/internal/conformance/engine] with a command
+// line on it, and it holds no rule of its own: what an entry is and what its
+// answer is written in are docs/conformance/SPEC.md's, how the adapter is asked
+// is docs/adapter/SPEC.md's, and the comparison is the engine's.
+//
+// # Why this is a command at all
+//
+// Until this existed the only way to run the corpus was to clone this
+// repository and run `go test ./internal/conformance/...`, which asks
+// cpybkc-gen-go and nothing else. A generator author in another language had a
+// corpus they could read and no program that would ask their generator about
+// it.
+//
+// The natural next thought is a container image, and it fails a specific and
+// common adopter: an engineer inside an organisation whose builders have no
+// egress and whose images come from an internal mirror with an allowlist, where
+// adding an external image is a ticket with a security review and a named
+// internal owner. Conformance is the thing an outsider runs once, on a whim,
+// before they are invested, which makes it the worst possible place to spend a
+// procurement ticket (#202). So this command is built for several platforms and
+// attached to every release beside the corpus, as cpybkc-conformance.tar.gz —
+// a download and an `--exec`, with no registry, no daemon and no image.
+//
+// A container door is the *other* door and is #203's. It is where the
+// properties that make a result believable live — no network, a read-only root,
+// a deadline — and this one has none of them: [engine.Command.Describe] says so
+// in as many words, and the report quotes it. A run through this door is the
+// author's own working result, and that is what it should be labelled.
+//
+// # The exit status
+//
+// docs/conformance/SPEC.md leaves what exit code a failing comparison produces
+// out of scope, deliberately, so this is the command's own contract rather than
+// the format's:
+//
+//   - 0 — the run happened and nothing failed. A descriptive generator's run,
+//     which the corpus has nothing to ask, is one of these.
+//   - 1 — the run happened and something failed: an entry disagreed, or one
+//     could not be asked at all.
+//   - 2 — the run could not be attempted: the arguments were wrong, the corpus
+//     could not be read, or it did not match the digest published beside it.
+//
+// One and two are separate because a script that treats them alike cannot tell
+// a generator that failed the corpus from a corpus that never ran, and only the
+// first is a fact about the generator.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+
+	"github.com/Zaba505/cpybkc/internal/conformance"
+)
+
+// defaultCorpus is where the corpus is looked for when nothing says otherwise.
+//
+// It is the directory cpybkc-conformance.tar.gz unpacks the corpus into, so
+// that the invocation in the archive's own README is `--exec` and nothing else.
+// Running against this repository's tree needs `--corpus testdata/conformance`,
+// which is the right way round: the default serves the artifact this command is
+// shipped in, and a checkout is the case where somebody already knows where
+// they are.
+const defaultCorpus = conformance.PublishedCorpusDir
+
+// errFailed is what a run that happened and went badly comes back as.
+//
+// It is a sentinel rather than a message because the report has already said
+// everything there is to say, on standard output, entry by entry. What is left
+// for main is the exit status, and a second summary on standard error would be
+// the same news in a place a reader is not looking.
+var errFailed = errors.New("the run reported a failure")
+
+func main() {
+	// Interrupt cancels the run, which kills the adapter: the conversation's own
+	// deadlines bound each operation, and this is what bounds the whole thing
+	// against somebody who has seen enough. An adapter killed by the engine is
+	// not in violation of anything (docs/adapter/SPEC.md, "Deadlines and
+	// lifetime belong to the engine").
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	err := run(ctx, os.Args[1:], os.Stdout, os.Stderr)
+
+	switch {
+	case err == nil:
+		return
+	case errors.Is(err, errFailed):
+		os.Exit(1)
+	default:
+		fmt.Fprintf(os.Stderr, "cpybkc-conform: %v\n", err)
+		os.Exit(2)
+	}
+}
+
+// run is the whole program with the exit path taken out, so that main owns the
+// exit status and nothing else, and so that a test can drive a whole run
+// without ending the test binary.
+//
+// Both streams are parameters for the same reason. stdout carries the answer —
+// the report, or the digest — and stderr carries what a reader wants beside it
+// but a script piping the answer does not, and a test that had to move this
+// process's own streams could not assert either.
+func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("no command given\n\n%s", usage)
+	}
+
+	switch command := args[0]; command {
+	case "check":
+		return check(ctx, args[1:], stdout, stderr)
+	case "digest":
+		return digest(args[1:], stdout, stderr)
+	case "help", "-h", "--help":
+		_, _ = fmt.Fprint(stdout, usage)
+
+		return nil
+	default:
+		return fmt.Errorf("%q is not a command of this program\n\n%s", command, usage)
+	}
+}

--- a/cmd/cpybkc-conform/main_test.go
+++ b/cmd/cpybkc-conform/main_test.go
@@ -1,0 +1,319 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/conformance"
+)
+
+// TestCheckRunsTheCorpusThroughAnAdapter is the whole program, over the corpus
+// this repository publishes, against a real process speaking the real contract.
+//
+// The descriptive adapter is the one to drive it with here. A conversation with
+// it is four frames long and invokes no generator and no compiler, so this test
+// exercises the command — the flags, the corpus, the door and the exit path —
+// rather than re-running the conformance suite, which
+// internal/conformance/goadapter already owns.
+func TestCheckRunsTheCorpusThroughAnAdapter(t *testing.T) {
+	root := repoRoot(t)
+	adapter := build(t, root, "./internal/conformance/descriptive/cmd/adapter")
+
+	stdout, stderr, err := drive(t, "check",
+		"--corpus", conformance.CorpusPath(root),
+		"--exec", adapter,
+		"--", "--name", "graph")
+	if err != nil {
+		t.Fatalf("check: %v\n%s", err, stderr)
+	}
+
+	// The door's own sentence, quoted rather than summarised: a report that did
+	// not carry it would be a result presented as though it had guarantees this
+	// door does not provide.
+	if !strings.Contains(stdout, "no network isolation") {
+		t.Errorf("the report does not say what the door provides:\n%s", stdout)
+	}
+
+	if !strings.Contains(stdout, "not applicable") {
+		t.Errorf("a descriptive generator's run is not reported as not applicable:\n%s", stdout)
+	}
+
+	if !strings.Contains(stderr, "sha256 ") {
+		t.Errorf("nothing said which corpus the run was against:\n%s", stderr)
+	}
+}
+
+// TestCheckFailsWhenTheRunDoes pins the exit path apart from the report. A run
+// that went badly has to come back as errFailed and not as an ordinary error,
+// because main turns the first into exit 1 — a fact about the generator — and
+// the second into exit 2, which says the run never happened.
+func TestCheckFailsWhenTheRunDoes(t *testing.T) {
+	root := repoRoot(t)
+	adapter := build(t, root, "./internal/conformance/descriptive/cmd/adapter")
+
+	// An argument the adapter refuses, so it exits before it says hello. That is
+	// a run that happened and failed rather than one that could not be started:
+	// the door opened.
+	_, _, err := drive(t, "check",
+		"--corpus", conformance.CorpusPath(root),
+		"--exec", adapter,
+		"--", "--not-a-flag-this-adapter-has")
+
+	if !errors.Is(err, errFailed) {
+		t.Fatalf("a failed run came back as %v, and not as errFailed", err)
+	}
+}
+
+// TestCheckRefusesACorpusThatIsNotThePublishedOne is the digest doing its job,
+// and the diagnostic matters as much as the refusal: somebody holding a corpus
+// that does not match wants both numbers, so they can tell a half-finished
+// download from an edit they made themselves.
+func TestCheckRefusesACorpusThatIsNotThePublishedOne(t *testing.T) {
+	dir := writeCorpus(t)
+
+	digest, err := conformance.Digest(dir)
+	if err != nil {
+		t.Fatalf("Digest: %v", err)
+	}
+
+	const wrong = "0000000000000000000000000000000000000000000000000000000000000000"
+	write(t, conformance.DigestPath(dir), conformance.FormatDigest(wrong))
+
+	_, _, err = drive(t, "check", "--corpus", dir, "--exec", os.Args[0])
+	if err == nil {
+		t.Fatal("check ran against a corpus that does not match its published digest")
+	}
+
+	if errors.Is(err, errFailed) {
+		t.Error("a corpus that does not match is reported as a failed run, and no run happened")
+	}
+
+	for _, want := range []string{digest, wrong} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal does not name %s:\n%v", want, err)
+		}
+	}
+}
+
+// TestCheckSaysWhenNothingCheckedTheCorpus covers the other half. A corpus with
+// no digest beside it is the ordinary case in a checkout and an unusual one in a
+// download, and a run that passed over it in silence would report a conformance
+// result about a corpus nobody vouched for.
+func TestCheckSaysWhenNothingCheckedTheCorpus(t *testing.T) {
+	root := repoRoot(t)
+	adapter := build(t, root, "./internal/conformance/descriptive/cmd/adapter")
+
+	_, stderr, err := drive(t, "check",
+		"--corpus", conformance.CorpusPath(root),
+		"--exec", adapter,
+		"--", "--name", "graph")
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+
+	if !strings.Contains(stderr, "nothing checked") {
+		t.Errorf("a run against a corpus with no digest beside it said nothing about it:\n%s", stderr)
+	}
+}
+
+// TestDigestWritesOnlyTheDigest is the command's contract with a shell. Anything
+// else on standard output turns a comparison into a parse, and the comparison is
+// the whole reason this is a command rather than a line of the report.
+func TestDigestWritesOnlyTheDigest(t *testing.T) {
+	dir := writeCorpus(t)
+
+	want, err := conformance.Digest(dir)
+	if err != nil {
+		t.Fatalf("Digest: %v", err)
+	}
+
+	stdout, stderr, err := drive(t, "digest", "--corpus", dir)
+	if err != nil {
+		t.Fatalf("digest: %v", err)
+	}
+
+	if stdout != want+"\n" {
+		t.Errorf("digest wrote %q, want %q", stdout, want+"\n")
+	}
+
+	if !strings.Contains(stderr, "compared against nothing") {
+		t.Errorf("digest did not say there was nothing to compare against:\n%s", stderr)
+	}
+}
+
+// TestDigestReportsTheNumberItComputedEvenWhenItDisagrees is why the write comes
+// before the error. Somebody whose download does not match wants to see what
+// they have as well as what they should have had, and a program that failed
+// without printing either has told them only that something is wrong.
+func TestDigestReportsTheNumberItComputedEvenWhenItDisagrees(t *testing.T) {
+	dir := writeCorpus(t)
+
+	computed, err := conformance.Digest(dir)
+	if err != nil {
+		t.Fatalf("Digest: %v", err)
+	}
+
+	write(t, conformance.DigestPath(dir),
+		conformance.FormatDigest("0000000000000000000000000000000000000000000000000000000000000000"))
+
+	stdout, _, err := drive(t, "digest", "--corpus", dir)
+	if err == nil {
+		t.Fatal("digest passed a corpus that does not match its published digest")
+	}
+
+	if stdout != computed+"\n" {
+		t.Errorf("digest wrote %q and not the number it computed, %q", stdout, computed+"\n")
+	}
+}
+
+// TestHelpIsAnAnswer keeps the synopsis on standard output and the exit status
+// at zero. A person who asked for it got what they asked for, and a program that
+// answered on standard error would be one whose help cannot be piped.
+func TestHelpIsAnAnswer(t *testing.T) {
+	for _, arg := range []string{"help", "-h", "--help"} {
+		t.Run(arg, func(t *testing.T) {
+			stdout, _, err := drive(t, arg)
+			if err != nil {
+				t.Fatalf("%s: %v", arg, err)
+			}
+
+			if !strings.Contains(stdout, "cpybkc-conform check") {
+				t.Errorf("%s did not write the synopsis:\n%s", arg, stdout)
+			}
+		})
+	}
+}
+
+// TestRunRejectsBadUsage keeps every way of asking for nothing a failure. The
+// two that matter most are a missing --exec, which would otherwise start no
+// process and report an empty run, and a name where a path belongs — which the
+// door refuses to look up on PATH, and so must this.
+func TestRunRejectsBadUsage(t *testing.T) {
+	dir := t.TempDir()
+
+	testCases := []struct {
+		name string
+		args []string
+	}{
+		{name: "no command", args: nil},
+		{name: "a command this program does not have", args: []string{"conform"}},
+		{name: "no adapter", args: []string{"check", "--corpus", dir}},
+		{name: "an adapter that is not there", args: []string{"check", "--exec", filepath.Join(dir, "nowhere")}},
+		{name: "an adapter that is a directory", args: []string{"check", "--exec", dir}},
+		{name: "a flag this program does not have", args: []string{"check", "--image", "example.com/x"}},
+		{name: "a deadline of zero", args: []string{"check", "--exec", os.Args[0], "--deadline", "0"}},
+		{name: "a negative build deadline", args: []string{"check", "--exec", os.Args[0], "--build-deadline", "-1s"}},
+		{name: "an operand digest does not take", args: []string{"digest", "extra"}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if _, _, err := drive(t, testCase.args...); err == nil {
+				t.Error("run accepted arguments it should have refused")
+			}
+		})
+	}
+}
+
+// drive runs the program with args and returns what it wrote to each stream.
+func drive(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+
+	var stdout, stderr bytes.Buffer
+
+	err := run(t.Context(), args, &stdout, &stderr)
+
+	return stdout.String(), stderr.String(), err
+}
+
+// build compiles pkg from root into a fresh directory and returns the path to
+// it, which is what --exec is given.
+//
+// Built rather than found, for the reason [engine.Command.Path] refuses a name:
+// a run is against the tree under test, and resolving a name would find
+// whichever adapter happened to be installed on the machine running the tests.
+func build(t *testing.T, root, pkg string) string {
+	t.Helper()
+
+	name := filepath.Base(pkg)
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+
+	path := filepath.Join(t.TempDir(), name)
+
+	cmd := exec.CommandContext(t.Context(), "go", "build", "-o", path, pkg)
+	cmd.Dir = root
+
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build %s: %v\n%s", pkg, err, out)
+	}
+
+	return path
+}
+
+// writeCorpus writes a corpus to a fresh directory and returns its path.
+//
+// It is deliberately not a loadable one. Every case that uses it is refused
+// before the corpus is loaded — the digest is checked first, which is what makes
+// a half-unpacked download a refusal rather than a generator that appears to
+// disagree with entries nobody published.
+func writeCorpus(t *testing.T) string {
+	t.Helper()
+
+	dir := filepath.Join(t.TempDir(), conformance.PublishedCorpusDir)
+
+	write(t, filepath.Join(dir, "orders-fixed", "entry.json"), []byte(`{"description":"x"}`))
+	write(t, filepath.Join(dir, "orders-fixed", "input.bin"), []byte{0x00, 0xff})
+
+	return dir
+}
+
+// write writes b to path, creating the directories above it.
+func write(t *testing.T, path string, b []byte) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// repoRoot walks up from the test's working directory to the directory holding
+// go.mod, which for this module is the repository root and so the directory
+// testdata/ sits in.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("working directory: %v", err)
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("no go.mod found above %q", dir)
+		}
+
+		dir = parent
+	}
+}

--- a/cmd/cpybkc-conform/main_test.go
+++ b/cmd/cpybkc-conform/main_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/Zaba505/cpybkc/internal/conformance"
+	"github.com/Zaba505/cpybkc/internal/conformance/engine"
 )
 
 // TestCheckRunsTheCorpusThroughAnAdapter is the whole program, over the corpus
@@ -72,6 +73,55 @@ func TestCheckFailsWhenTheRunDoes(t *testing.T) {
 
 	if !errors.Is(err, errFailed) {
 		t.Fatalf("a failed run came back as %v, and not as errFailed", err)
+	}
+}
+
+// TestCheckRunsTheAdapterItChecked is a silent failure that would otherwise be
+// very hard to see. os/exec resolves a relative Path against Cmd.Dir, so with
+// --dir set, `--exec ./adapter` would be checked against the file the caller
+// meant and started from the adapter's working directory instead — a different
+// program of the same name, or none at all.
+//
+// The case is built to fail loudly if that ever comes back: the adapter is
+// named relative to this test's own directory, --dir points somewhere holding a
+// file of the same name that is not an adapter, and the run must be the one the
+// caller named.
+func TestCheckRunsTheAdapterItChecked(t *testing.T) {
+	root := repoRoot(t)
+	adapter := build(t, root, "./internal/conformance/descriptive/cmd/adapter")
+
+	// A decoy at the same base name, in the directory the adapter is told to run
+	// in. It is not executable, so a run that started it fails.
+	elsewhere := t.TempDir()
+	write(t, filepath.Join(elsewhere, filepath.Base(adapter)), []byte("not an adapter"))
+
+	t.Chdir(filepath.Dir(adapter))
+
+	_, stderr, err := drive(t, "check",
+		"--corpus", conformance.CorpusPath(root),
+		"--exec", "."+string(filepath.Separator)+filepath.Base(adapter),
+		"--dir", elsewhere,
+		"--", "--name", "graph")
+	if err != nil {
+		t.Fatalf("check ran something other than the adapter it was given: %v\n%s", err, stderr)
+	}
+}
+
+// TestAdapterPathIsAbsolute states the rule the case above depends on, so that a
+// failure names the cause rather than only the symptom.
+func TestAdapterPathIsAbsolute(t *testing.T) {
+	dir := t.TempDir()
+	write(t, filepath.Join(dir, "adapter"), []byte("x"))
+
+	t.Chdir(dir)
+
+	got, err := adapterPath("." + string(filepath.Separator) + "adapter")
+	if err != nil {
+		t.Fatalf("adapterPath: %v", err)
+	}
+
+	if !filepath.IsAbs(got) {
+		t.Errorf("adapterPath returned %q, which os/exec would resolve against the adapter's own directory", got)
 	}
 }
 
@@ -195,6 +245,56 @@ func TestHelpIsAnAnswer(t *testing.T) {
 	}
 }
 
+// TestHelpIsAnAnswerFromASubcommandToo is the invocation the archive's own
+// README tells a first-time offline reader to type. flag reports -h and --help
+// as ErrHelp, and left as an ordinary error they would land on standard error
+// with exit 2 — the status this program reserves for a run that could not be
+// attempted, which is a poor thing to tell somebody who asked a question.
+func TestHelpIsAnAnswerFromASubcommandToo(t *testing.T) {
+	for _, args := range [][]string{
+		{"check", "-h"},
+		{"check", "--help"},
+		{"digest", "-h"},
+		{"digest", "--help"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			stdout, stderr, err := drive(t, args...)
+			if err != nil {
+				t.Fatalf("%v: %v", args, err)
+			}
+
+			if !strings.Contains(stdout, "cpybkc-conform check") {
+				t.Errorf("%v did not write the synopsis to standard output:\n%s", args, stdout)
+			}
+
+			if stderr != "" {
+				t.Errorf("%v wrote to standard error:\n%s", args, stderr)
+			}
+		})
+	}
+}
+
+// TestUsageStatesTheDefaultsTheFlagsCarry pins the synopsis against the values
+// the flags are actually registered with.
+//
+// The text is written out rather than rendered, because a hand-written synopsis
+// reads far better than flag's own — but that makes it a second spelling of four
+// values, in the one artifact whose reader has no clone to check it against. A
+// default that moved in the engine and not here would be a shipped binary whose
+// --help lies.
+func TestUsageStatesTheDefaultsTheFlagsCarry(t *testing.T) {
+	for _, want := range []string{
+		engine.DefaultDeadline.String(),
+		engine.DefaultBuildDeadline.String(),
+		engine.DefaultGrace.String(),
+		`(default "` + defaultCorpus + `")`,
+	} {
+		if !strings.Contains(usage, want) {
+			t.Errorf("the synopsis does not state %s, so it describes flags this program does not have", want)
+		}
+	}
+}
+
 // TestRunRejectsBadUsage keeps every way of asking for nothing a failure. The
 // two that matter most are a missing --exec, which would otherwise start no
 // process and report an empty run, and a name where a path belongs — which the
@@ -210,6 +310,8 @@ func TestRunRejectsBadUsage(t *testing.T) {
 		{name: "a command this program does not have", args: []string{"conform"}},
 		{name: "no adapter", args: []string{"check", "--corpus", dir}},
 		{name: "an adapter that is not there", args: []string{"check", "--exec", filepath.Join(dir, "nowhere")}},
+		{name: "an adapter named rather than pathed", args: []string{"check", "--exec", "adapter"}},
+		{name: "an adapter named as a bare word that exists on PATH", args: []string{"check", "--exec", "sh"}},
 		{name: "an adapter that is a directory", args: []string{"check", "--exec", dir}},
 		{name: "a flag this program does not have", args: []string{"check", "--image", "example.com/x"}},
 		{name: "a deadline of zero", args: []string{"check", "--exec", os.Args[0], "--deadline", "0"}},

--- a/cmd/cpybkc-conform/usage.go
+++ b/cmd/cpybkc-conform/usage.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+// usage is what the program says when it is asked, and when it is given
+// something it cannot act on.
+//
+// It names where the corpus and the contract are written down rather than
+// summarising either. This command implements two documents and specifies
+// neither, and a synopsis that explained what an entry is would be a third
+// description for the other two to drift from.
+const usage = `cpybkc-conform runs the cpybkc conformance corpus against a generator's adapter.
+
+  cpybkc-conform check --exec <path> [flags] [-- args for the adapter...]
+  cpybkc-conform digest [--corpus <dir>]
+  cpybkc-conform help
+
+check drives the adapter through the contract and reports every entry. It exits
+0 when nothing failed, 1 when an entry disagreed or could not be asked, and 2
+when the run could not be attempted at all.
+
+  --exec <path>              the adapter executable, as a path and not a name to
+                             find on PATH (required)
+  --corpus <dir>             the unpacked corpus (default "corpus")
+  --dir <dir>                the adapter's working directory (default: this
+                             program's own)
+  --deadline <duration>      bounds one operation (default 1m0s)
+  --build-deadline <duration>
+                             bounds generate, which may run a compiler over the
+                             whole corpus (default 10m0s)
+  --grace <duration>         how long the adapter is given to exit once the
+                             conversation is over (default 10s)
+
+Everything left over is the adapter's own argument vector. Put a bare -- in
+front of it: an adapter that takes flags of its own takes them at the same
+spelling this program takes its, and without the terminator they are read as
+this program's and refused.
+
+digest writes the corpus's SHA-256 to standard output, and fails if a digest is
+published beside the corpus and disagrees with it.
+
+This door runs the adapter directly and provides no isolation of any kind: no
+network namespace, no read-only root and no resource cap. A result produced
+through it is your own working result rather than one to hand to somebody else.
+
+What an entry holds and what an answer is written in:
+    https://github.com/Zaba505/cpybkc/blob/main/docs/conformance/SPEC.md
+How an adapter is asked, so that you can write one:
+    https://github.com/Zaba505/cpybkc/blob/main/docs/adapter/SPEC.md
+`

--- a/docs/conformance/SPEC.md
+++ b/docs/conformance/SPEC.md
@@ -719,6 +719,17 @@ ill-formed. A symbolic link is a file whose content depends on where the archive
 was unpacked, so a digest that followed one would move between machines and one
 that skipped it would certify a member it never read.
 
+A `corpus/` holding no file at all is ill-formed too, and this is stated rather
+than left to follow from the rule. Applied literally the rule computes a
+perfectly good digest of nothing —
+`e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`, the SHA-256
+of the empty stream — and a reader who published or accepted that would be
+certifying an empty download as the corpus. An implementation **MUST** refuse
+it instead.
+
+The corpus **MUST** hold at least one entry in any case ([*An
+entry*](#an-entry)), so nothing well-formed is refused by this.
+
 `corpus.sha256` is deliberately **not** a `sha256sum` file. That format names a
 file and this digest covers a directory, and a line that looked like
 `sha256sum`'s would invite `sha256sum -c` — which would check one file that is

--- a/docs/conformance/SPEC.md
+++ b/docs/conformance/SPEC.md
@@ -43,7 +43,8 @@ In scope: the directory an entry is, the members it holds and the one member
 that is reserved; the value language every decoded record is written in, down to
 the admissible spelling of each scalar; how a file the generated reader refused
 is reported; what a runner is asked to do and what it is deliberately not asked
-to do; and the answer document it returns.
+to do; the answer document it returns; and how the corpus is published, down to
+the digest a downloader checks it against.
 
 Out of scope, with reasons, in [Out of Scope](#out-of-scope).
 
@@ -651,6 +652,78 @@ records the writer was given. That holds for all four framings and every
 encoding, it is what `written` states, and it needs nothing of a runner that the
 reading direction did not already need.
 
+## The published corpus
+
+Every release attaches the corpus as `cpybkc-conformance.tar.gz`, so that
+running it needs neither a clone of this repository nor a container runtime
+(#202). The archive unpacks into one directory:
+
+```
+cpybkc-conformance/
+  README.md            how to run it
+  corpus.sha256        the digest of corpus/
+  corpus/              the corpus, one directory per entry
+  bin/                 this repository's engine, built per platform
+```
+
+`corpus/` is the corpus and is what this document specifies: one directory per
+entry, each holding exactly what [*An entry*](#an-entry) says. `bin/` and
+`README.md` are cpybkc's own, and a runner may ignore both — the archive is a
+way of getting the corpus onto a machine, not a second definition of it.
+
+A published corpus is a *snapshot*. It grows an entry whenever one is written,
+so two archives are two corpora and comparing a result against one of them says
+nothing about the other; which release an archive came from is the release it is
+attached to.
+
+### The corpus digest
+
+`corpus.sha256` is a SHA-256 over `corpus/`, written as 64 lowercase hexadecimal
+characters followed by a newline and nothing else.
+
+A runner that unpacked an archive **SHOULD** check it before it runs anything,
+and **MUST NOT** report a result as being about the published corpus where it
+does not match. A download that finished halfway is otherwise indistinguishable
+from a generator disagreeing with entries nobody published, and the entries it
+disagrees with are the ones that arrived.
+
+The digest is computed over every regular file under `corpus/`, taken in
+ascending order of the slash-separated path each is at relative to `corpus/`.
+For each file in that order, the hash is fed:
+
+1. the path, as UTF-8;
+2. one zero byte;
+3. the file's length in bytes, written in decimal as ASCII;
+4. one zero byte;
+5. the file's contents.
+
+The result is the sum, lowercase hexadecimal. Nothing else contributes.
+
+Three properties of that rule are the whole of it, and each is there for a
+reason worth stating:
+
+- **The length is in the stream** because a corpus holds arbitrary bytes —
+  `input.bin` is bytes by definition — so the contents cannot be their own
+  delimiter. Without it, two different corpora whose concatenations happened to
+  coincide would agree, which is the one thing a digest exists to deny.
+- **The path is in the stream** because a file that moved between two entries is
+  a different corpus, and a digest over contents alone would not say so.
+- **Nothing a filesystem supplies is in the stream.** Not a mode, not an owner,
+  not a modification time, and directories contribute nothing of their own.
+  Those are properties of the unpacking rather than of the corpus, and a digest
+  that included one would fail on an archive that had merely been extracted
+  twice.
+
+Anything under `corpus/` that is not a regular file makes the corpus
+ill-formed. A symbolic link is a file whose content depends on where the archive
+was unpacked, so a digest that followed one would move between machines and one
+that skipped it would certify a member it never read.
+
+`corpus.sha256` is deliberately **not** a `sha256sum` file. That format names a
+file and this digest covers a directory, and a line that looked like
+`sha256sum`'s would invite `sha256sum -c` — which would check one file that is
+not there and report success for a corpus it never read.
+
 ## Out of Scope
 
 ### What a value means
@@ -716,7 +789,10 @@ disagreement, and the conversation is the half that changes.
 - **A test framework.** Nothing here says how a runner is built, what a harness
   reports, or what exit code a failing comparison produces. `go test
   ./internal/conformance/...` is this repository's answer and it is one answer
-  among many.
+  among many; `cpybkc-conform`, which [the published
+  corpus](#the-published-corpus) ships in `bin/`, is the same answer with a
+  command line on it. What either of them prints and exits with is its own
+  documentation's, and neither is a requirement on anybody else's.
 - **A conformance level or a badge.** There is no partial conformance, no
   profile and no score. An entry either compares equal or it does not.
 - **A descriptive generator's oracle.** A generator that never reads bytes has
@@ -763,6 +839,8 @@ to every row.
 | [The answer document](#the-answer-document) | #68 `conformance`; #198 `conformance` for a read-only generator's absent `written` being declared rather than discovered, and #199 for the engine that honours it |
 | [How a runner is started and spoken to](#how-a-runner-is-started-and-spoken-to) | #198 `conformance` specifies it in [`adapter/SPEC.md`](../adapter/SPEC.md); no section here |
 | [Why the writing direction is checked by reading](#why-the-writing-direction-is-checked-by-reading-and-not-by-comparing-bytes) | #68 `conformance`; the rule it rests on, *Writing a file*, #17 `ir` |
+| [The published corpus](#the-published-corpus) | #202 `conformance` for the release asset, the engine that ships in it and the pipeline that builds it |
+| [The corpus digest](#the-corpus-digest) | #202 `conformance` |
 | [The grammar corpus](#appendix-the-grammar-corpus) | #197 `conformance` for [GRAMMAR.md](GRAMMAR.md), the writer it holds to it, and the test that reads one against the other |
 | The corpus's entries, and what each covers | #67 `conformance`, and one story per entry since |
 | This document | #194 `conformance` |

--- a/internal/conformance/corpus.go
+++ b/internal/conformance/corpus.go
@@ -30,6 +30,17 @@ import (
 // wrong.
 const CorpusFile = "testdata/conformance"
 
+// PublishedCorpusDir is where the corpus sits inside cpybkc-conformance.tar.gz,
+// the archive a release attaches (#202).
+//
+// It is a second path because a release asset is not a checkout: an adopter
+// unpacks the archive and works in it, and `testdata/` there would name a
+// convention of a Go repository they do not have. It is a constant here, beside
+// [CorpusFile], for exactly the reason that one is — the tool that writes the
+// archive and the command that reads one have to mean the same directory, and
+// they are two programs.
+const PublishedCorpusDir = "corpus"
+
 // The names an entry's members are written under. They are fixed rather than
 // declared in entry.json because a tuple whose members could be anywhere is a
 // tuple every reader has to be told about, and a third-party runner reading the

--- a/internal/conformance/digest.go
+++ b/internal/conformance/digest.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package conformance
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// DigestExt is appended to a corpus directory's path to name the file its
+// digest is published in: the corpus at `corpus/` is checked against
+// `corpus.sha256`.
+//
+// Beside the corpus rather than inside it, and that is not a filing preference.
+// A digest of a directory cannot live in that directory: it would have to cover
+// itself. Putting it inside would mean naming one member every reader has to be
+// told to leave out — which is a change to the corpus format
+// (docs/conformance/SPEC.md, *An entry*) and a change [Load] would have to
+// carry, for the sake of a file that is not part of the corpus but a statement
+// about it.
+const DigestExt = ".sha256"
+
+// digestLen is how many characters a SHA-256 digest is written in.
+const digestLen = sha256.Size * 2
+
+// DigestPath is where the digest of the corpus at dir is published.
+func DigestPath(dir string) string {
+	return filepath.Clean(dir) + DigestExt
+}
+
+// Digest reduces the corpus at dir to one SHA-256, written lowercase
+// hexadecimal.
+//
+// # The rule, so that a third party can recompute it
+//
+// Every regular file under dir contributes, in ascending order of its
+// slash-separated path relative to dir. For each one the hash is fed
+//
+//	the path, a zero byte, the length in decimal, a zero byte, then the bytes
+//
+// and the digest is the sum. Directories contribute nothing of their own, so an
+// empty one is not part of a corpus; anything that is not a regular file is an
+// error rather than something to skip, because a symbolic link in a published
+// corpus is a file whose content depends on where it was unpacked.
+//
+// The length is in there because a corpus holds arbitrary bytes — `input.bin`
+// is bytes by definition — so the contents cannot be their own delimiter.
+// Without it two different corpora whose concatenations happened to coincide
+// would agree, which is the one property a digest exists to deny. The path goes
+// in for the same reason: a file that moved between entries is a different
+// corpus, and a digest over contents alone would not say so.
+//
+// Nothing about a *file* other than its path and its bytes contributes. A
+// corpus is text and bytes an author wrote down, so a mode, an owner or a
+// modification time here would make the digest a function of the unpacking as
+// well as of the corpus — and the same archive unpacked twice would fail its own
+// check.
+func Digest(dir string) (string, error) {
+	digest, err := DigestFS(os.DirFS(dir))
+	if err != nil {
+		return "", fmt.Errorf("failed to digest the conformance corpus at %s: %w", dir, err)
+	}
+
+	return digest, nil
+}
+
+// DigestFS is [Digest] over an [io/fs.FS].
+//
+// It is exported for the producer's sake rather than for testing. The tool that
+// writes cpybkc-conformance.tar.gz has to digest exactly the tree it is
+// archiving, and a second walk of the same directory is a second read that a
+// concurrent edit can make disagree with the first — which would publish a
+// digest for a corpus the archive does not hold. One filesystem, archived and
+// digested, is what makes the two the same corpus by construction.
+func DigestFS(corpus fs.FS) (string, error) {
+	names, err := digestFiles(corpus)
+	if err != nil {
+		return "", err
+	}
+
+	if len(names) == 0 {
+		return "", fmt.Errorf("it holds no file, and a digest of nothing would certify an empty download")
+	}
+
+	sum := sha256.New()
+
+	for _, name := range names {
+		b, err := fs.ReadFile(corpus, name)
+		if err != nil {
+			return "", fmt.Errorf("failed to read %s: %w", name, err)
+		}
+
+		// Writing to a hash cannot fail — sha256's Write never returns an error
+		// — so the errors are dropped rather than checked into noise.
+		_, _ = sum.Write([]byte(name))
+		_, _ = sum.Write([]byte{0})
+		_, _ = sum.Write([]byte(strconv.Itoa(len(b))))
+		_, _ = sum.Write([]byte{0})
+		_, _ = sum.Write(b)
+	}
+
+	return hex.EncodeToString(sum.Sum(nil)), nil
+}
+
+// digestFiles returns every regular file under corpus, as slash-separated paths
+// relative to it, in sorted order.
+//
+// [io/fs.WalkDir] already walks lexically, so the sort is belt and braces — but
+// the ordering is what makes the digest a function of the corpus rather than of
+// a directory read, and a property that load-bearing is worth stating where a
+// reader can see it. internal/tools/ir-protos says the same of the archive it
+// writes, for the same reason.
+func digestFiles(corpus fs.FS) ([]string, error) {
+	var names []string
+
+	err := fs.WalkDir(corpus, ".", func(name string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if entry.IsDir() {
+			return nil
+		}
+
+		if !entry.Type().IsRegular() {
+			return fmt.Errorf("%s is not a regular file, and a corpus is the files somebody wrote", name)
+		}
+
+		names = append(names, name)
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	slices.Sort(names)
+
+	return names, nil
+}
+
+// FormatDigest is what a digest file holds: the digest and a newline, and
+// nothing else.
+//
+// Deliberately not sha256sum's `<digest>  <name>` line. That format names a
+// file, this digest covers a directory, and a line that looked like sha256sum's
+// would invite `sha256sum -c` — which would check one file that is not there
+// and report success for a corpus it never read.
+func FormatDigest(digest string) []byte {
+	return []byte(digest + "\n")
+}
+
+// ReadDigest reads a digest file and returns the digest it holds.
+func ReadDigest(path string) (string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	digest := strings.TrimSpace(string(b))
+
+	if len(digest) != digestLen {
+		return "", fmt.Errorf("%s holds %q, and a digest is %d hexadecimal characters", path, digest, digestLen)
+	}
+
+	if _, err := hex.DecodeString(digest); err != nil {
+		return "", fmt.Errorf("%s holds %q, which is not hexadecimal", path, digest)
+	}
+
+	if strings.ToLower(digest) != digest {
+		return "", fmt.Errorf("%s holds %q, and a digest is written in lowercase", path, digest)
+	}
+
+	return digest, nil
+}
+
+// CheckDigest digests the corpus at dir and holds it against the digest
+// published beside it, at [DigestPath].
+//
+// The digest it computed comes back either way, so that a caller can report
+// which corpus it ran against whether or not there was anything to check it
+// against.
+//
+// checked is false where no digest file is there at all, and that is not an
+// error. The corpus in this repository's own tree has none and cannot: the
+// digest is a function of the corpus, so a committed copy would be a second
+// statement of it for an entry to be added without — the same reason
+// CONTRIBUTING.md, *The release artifacts*, gives for ir.binpb not being
+// committed. A caller that ran against an unchecked corpus should say so rather
+// than report a bare pass.
+func CheckDigest(dir string) (string, bool, error) {
+	computed, err := Digest(dir)
+	if err != nil {
+		return "", false, err
+	}
+
+	path := DigestPath(dir)
+
+	published, err := ReadDigest(path)
+	if os.IsNotExist(err) {
+		return computed, false, nil
+	}
+
+	if err != nil {
+		return computed, false, fmt.Errorf("failed to read the corpus digest: %w", err)
+	}
+
+	if published != computed {
+		return computed, true, fmt.Errorf(
+			"the corpus at %s digests to %s and %s says it should be %s: the download is incomplete, was "+
+				"unpacked over something else, or has been edited — and a run against it would be a run "+
+				"against a corpus nobody published",
+			dir, computed, path, published)
+	}
+
+	return computed, true, nil
+}

--- a/internal/conformance/digest.go
+++ b/internal/conformance/digest.go
@@ -34,8 +34,24 @@ const DigestExt = ".sha256"
 const digestLen = sha256.Size * 2
 
 // DigestPath is where the digest of the corpus at dir is published.
+//
+// A corpus named `.` — which is what `--corpus .` from inside an unpacked
+// corpus means, and a plausible thing for somebody to type — has no name for a
+// file to sit beside, and appending to it produces `..sha256`: a path nobody
+// can have created, so the digest reads as absent and the run proceeds
+// unchecked. Resolving against the working directory is what gives it one. It
+// is done only in that case, because a relative path that already has a name
+// reads far better in a diagnostic than the absolute one it would become.
 func DigestPath(dir string) string {
-	return filepath.Clean(dir) + DigestExt
+	cleaned := filepath.Clean(dir)
+
+	if base := filepath.Base(cleaned); base == "." || base == ".." {
+		if absolute, err := filepath.Abs(cleaned); err == nil {
+			cleaned = absolute
+		}
+	}
+
+	return cleaned + DigestExt
 }
 
 // Digest reduces the corpus at dir to one SHA-256, written lowercase
@@ -115,11 +131,14 @@ func DigestFS(corpus fs.FS) (string, error) {
 // digestFiles returns every regular file under corpus, as slash-separated paths
 // relative to it, in sorted order.
 //
-// [io/fs.WalkDir] already walks lexically, so the sort is belt and braces — but
-// the ordering is what makes the digest a function of the corpus rather than of
-// a directory read, and a property that load-bearing is worth stating where a
-// reader can see it. internal/tools/ir-protos says the same of the archive it
-// writes, for the same reason.
+// The sort is load-bearing and is not a belt-and-braces repeat of the walk.
+// [io/fs.WalkDir] orders each *directory's* entries, which is a different order
+// from sorting the full paths: beside a directory `a/` holding `b.txt`, a file
+// `a.txt` is visited second, because the walk compares `a` against `a.txt` —
+// so the walk emits `a/b.txt` first while `.` (0x2E) sorting below `/` (0x2F)
+// puts `a.txt` first. Only the sorted order is the one
+// docs/conformance/SPEC.md's *The corpus digest* states, so removing this line
+// would silently stop the digest being the published rule.
 func digestFiles(corpus fs.FS) ([]string, error) {
 	var names []string
 

--- a/internal/conformance/digest_test.go
+++ b/internal/conformance/digest_test.go
@@ -1,0 +1,345 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package conformance
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+)
+
+// tree is the corpus every case below varies from.
+func tree() fstest.MapFS {
+	return fstest.MapFS{
+		"README.md":                 &fstest.MapFile{Data: []byte("the corpus\n")},
+		"orders-fixed/entry.json":   &fstest.MapFile{Data: []byte(`{"description":"x"}`)},
+		"orders-fixed/input.bin":    &fstest.MapFile{Data: []byte{0x00, 0xff, 0x00}},
+		"orders-fixed/values.json":  &fstest.MapFile{Data: []byte(`{"records":[]}`)},
+		"zoned-ebcdic/entry.json":   &fstest.MapFile{Data: []byte(`{"description":"y"}`)},
+		"zoned-ebcdic/input.bin":    &fstest.MapFile{Data: []byte{0xf1}},
+		"zoned-ebcdic/nested/a.cpy": &fstest.MapFile{Data: []byte("01 A.\n")},
+	}
+}
+
+// TestDigestIsAFunctionOfTheCorpus is the property the published digest rests
+// on: the same corpus digests to the same thing, twice, through two independent
+// walks. A producer that memoised would pass a comparison of one call against
+// itself while still varying between the release that wrote the digest and the
+// download that checks it.
+func TestDigestIsAFunctionOfTheCorpus(t *testing.T) {
+	first := mustDigest(t, tree())
+	second := mustDigest(t, tree())
+
+	if first != second {
+		t.Fatalf("two digests of one corpus differ: %s then %s", first, second)
+	}
+
+	if len(first) != digestLen {
+		t.Errorf("digested to %q, which is %d characters and not %d", first, len(first), digestLen)
+	}
+}
+
+// TestDigestMovesWhenTheCorpusDoes covers the three ways a corpus can change,
+// each of which a downloader has to be able to detect: a byte of an entry, the
+// path a file is at, and a file arriving or going missing. The second is why the
+// path is hashed at all — a digest over contents alone would call a file moved
+// between two entries the same corpus.
+func TestDigestMovesWhenTheCorpusDoes(t *testing.T) {
+	base := mustDigest(t, tree())
+
+	testCases := []struct {
+		name   string
+		change func(fstest.MapFS)
+	}{
+		{
+			name: "a byte of an entry",
+			change: func(corpus fstest.MapFS) {
+				corpus["orders-fixed/input.bin"] = &fstest.MapFile{Data: []byte{0x00, 0xfe, 0x00}}
+			},
+		},
+		{
+			name: "a file at a different path",
+			change: func(corpus fstest.MapFS) {
+				corpus["zoned-ascii/input.bin"] = corpus["zoned-ebcdic/input.bin"]
+				delete(corpus, "zoned-ebcdic/input.bin")
+			},
+		},
+		{
+			name: "one more file",
+			change: func(corpus fstest.MapFS) {
+				corpus["orders-fixed/layout.sexpr"] = &fstest.MapFile{Data: []byte("(layout)")}
+			},
+		},
+		{
+			name: "one fewer file",
+			change: func(corpus fstest.MapFS) {
+				delete(corpus, "README.md")
+			},
+		},
+		{
+			name: "a file emptied",
+			change: func(corpus fstest.MapFS) {
+				corpus["orders-fixed/input.bin"] = &fstest.MapFile{Data: nil}
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			corpus := tree()
+			testCase.change(corpus)
+
+			if got := mustDigest(t, corpus); got == base {
+				t.Errorf("changing %s left the digest at %s", testCase.name, got)
+			}
+		})
+	}
+}
+
+// TestDigestSeparatesTheFilesItCovers is the length delimiter's own test. Two
+// corpora that differ only in where one file's contents end and the next file's
+// name begins must not agree, and they would if the hash were fed the paths and
+// the bytes with nothing between them.
+func TestDigestSeparatesTheFilesItCovers(t *testing.T) {
+	first := mustDigest(t, fstest.MapFS{
+		"a": &fstest.MapFile{Data: []byte("bc")},
+		"d": &fstest.MapFile{Data: []byte{}},
+	})
+
+	second := mustDigest(t, fstest.MapFS{
+		"a": &fstest.MapFile{Data: []byte("b")},
+		"d": &fstest.MapFile{Data: []byte("c")},
+	})
+
+	if first == second {
+		t.Errorf("two corpora holding different files digest to the same %s", first)
+	}
+}
+
+// TestDigestRefusesWhatIsNotAFile keeps a link out of a published corpus. Its
+// content is a property of where the archive was unpacked rather than of the
+// corpus, so a digest that followed one would move between machines and a digest
+// that skipped one would certify a member it never read.
+func TestDigestRefusesWhatIsNotAFile(t *testing.T) {
+	corpus := tree()
+	corpus["orders-fixed/link.bin"] = &fstest.MapFile{Mode: fs.ModeSymlink, Data: []byte("input.bin")}
+
+	if _, err := DigestFS(corpus); err == nil {
+		t.Error("digest accepted a corpus holding something that is not a regular file")
+	}
+}
+
+// TestDigestRefusesAnEmptyCorpus keeps a misdirected path from producing a
+// perfectly good digest of nothing. That failure is invisible where it happens
+// and arrives as a downloader whose empty directory checked out fine.
+func TestDigestRefusesAnEmptyCorpus(t *testing.T) {
+	if _, err := DigestFS(fstest.MapFS{}); err == nil {
+		t.Error("digest accepted a corpus holding no file")
+	}
+}
+
+// TestDigestCoversTheCorpusOnDisk is the staleness gate, and it is what the
+// tests above cannot be: they all run over a tree this file built, which cannot
+// notice that the digest has stopped covering the corpus this repository
+// actually publishes. So this one digests testdata/conformance and requires
+// every file under it to have contributed.
+func TestDigestCoversTheCorpusOnDisk(t *testing.T) {
+	dir := CorpusPath(repoRoot(t))
+
+	if _, err := Digest(dir); err != nil {
+		t.Fatalf("Digest: %v", err)
+	}
+
+	covered, err := digestFiles(os.DirFS(dir))
+	if err != nil {
+		t.Fatalf("digestFiles: %v", err)
+	}
+
+	var want int
+
+	err = filepath.WalkDir(dir, func(_ string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !entry.IsDir() {
+			want++
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", dir, err)
+	}
+
+	if want == 0 {
+		t.Fatal("the corpus on disk holds no file: the check would pass vacuously")
+	}
+
+	if len(covered) != want {
+		t.Errorf("the digest covers %d of the corpus's %d files", len(covered), want)
+	}
+}
+
+// TestCheckDigestReadsThePublishedDigest covers the three states a downloaded
+// corpus can be in, because they are three different things to tell somebody:
+// checked and right, checked and wrong, and nothing to check against.
+func TestCheckDigestReadsThePublishedDigest(t *testing.T) {
+	dir := writeCorpus(t)
+
+	computed, err := Digest(dir)
+	if err != nil {
+		t.Fatalf("Digest: %v", err)
+	}
+
+	t.Run("no digest beside it", func(t *testing.T) {
+		got, checked, err := CheckDigest(dir)
+		if err != nil {
+			t.Fatalf("CheckDigest: %v", err)
+		}
+
+		if checked {
+			t.Error("CheckDigest reported a check against a digest that is not there")
+		}
+
+		if got != computed {
+			t.Errorf("CheckDigest computed %s, want %s", got, computed)
+		}
+	})
+
+	t.Run("the published digest agrees", func(t *testing.T) {
+		writeFile(t, DigestPath(dir), FormatDigest(computed))
+
+		got, checked, err := CheckDigest(dir)
+		if err != nil {
+			t.Fatalf("CheckDigest: %v", err)
+		}
+
+		if !checked {
+			t.Error("CheckDigest read a digest file and reported no check")
+		}
+
+		if got != computed {
+			t.Errorf("CheckDigest computed %s, want %s", got, computed)
+		}
+	})
+
+	t.Run("the published digest disagrees", func(t *testing.T) {
+		writeFile(t, DigestPath(dir), FormatDigest("0000000000000000000000000000000000000000000000000000000000000000"))
+
+		if _, _, err := CheckDigest(dir); err == nil {
+			t.Error("CheckDigest passed a corpus that does not match its published digest")
+		}
+	})
+}
+
+// TestReadDigestRefusesWhatIsNotADigest keeps a truncated or rewritten digest
+// file from being read as agreement. A file that arrived half-downloaded is
+// exactly the case the digest is there to catch, and it is the same download
+// that carried the corpus.
+func TestReadDigestRefusesWhatIsNotADigest(t *testing.T) {
+	testCases := []struct {
+		name    string
+		content string
+	}{
+		{name: "empty", content: ""},
+		{name: "truncated", content: "abc123\n"},
+		{name: "not hexadecimal", content: "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz\n"},
+		{
+			name:    "uppercase",
+			content: "0000000000000000000000000000000000000000000000000000000000ABCDEF\n",
+		},
+		{
+			name:    "an sha256sum line",
+			content: "0000000000000000000000000000000000000000000000000000000000000000  corpus\n",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "corpus.sha256")
+			writeFile(t, path, []byte(testCase.content))
+
+			if _, err := ReadDigest(path); err == nil {
+				t.Errorf("ReadDigest accepted %q", testCase.content)
+			}
+		})
+	}
+}
+
+// TestFormatDigestIsReadBack pins the two halves of the file format to each
+// other. They are a producer in one command and a reader in another, and a
+// trailing newline one of them stopped writing would be a mismatch reported as
+// a corrupted download.
+func TestFormatDigestIsReadBack(t *testing.T) {
+	const want = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+	path := filepath.Join(t.TempDir(), "corpus.sha256")
+	writeFile(t, path, FormatDigest(want))
+
+	got, err := ReadDigest(path)
+	if err != nil {
+		t.Fatalf("ReadDigest: %v", err)
+	}
+
+	if got != want {
+		t.Errorf("read back %s, want %s", got, want)
+	}
+}
+
+// TestDigestPathSitsBesideTheCorpus states the naming rule a downloader follows
+// to find the file at all, including that a trailing separator does not change
+// where it looks.
+func TestDigestPathSitsBesideTheCorpus(t *testing.T) {
+	want := filepath.Join("a", "corpus") + DigestExt
+
+	for _, dir := range []string{filepath.Join("a", "corpus"), filepath.Join("a", "corpus") + string(filepath.Separator)} {
+		if got := DigestPath(dir); got != want {
+			t.Errorf("DigestPath(%q) is %q, want %q", dir, got, want)
+		}
+	}
+}
+
+// mustDigest digests corpus through the unexported walk and fails the test if it
+// cannot.
+func mustDigest(t *testing.T, corpus fstest.MapFS) string {
+	t.Helper()
+
+	got, err := DigestFS(corpus)
+	if err != nil {
+		t.Fatalf("digest: %v", err)
+	}
+
+	return got
+}
+
+// writeCorpus writes a small corpus to a fresh directory and returns its path.
+func writeCorpus(t *testing.T) string {
+	t.Helper()
+
+	dir := filepath.Join(t.TempDir(), "corpus")
+
+	for name, file := range tree() {
+		writeFile(t, filepath.Join(dir, filepath.FromSlash(name)), file.Data)
+	}
+
+	return dir
+}
+
+// writeFile writes b to path, creating the directories above it.
+func writeFile(t *testing.T, path string, b []byte) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/conformance/digest_test.go
+++ b/internal/conformance/digest_test.go
@@ -101,19 +101,24 @@ func TestDigestMovesWhenTheCorpusDoes(t *testing.T) {
 	}
 }
 
-// TestDigestSeparatesTheFilesItCovers is the length delimiter's own test. Two
-// corpora that differ only in where one file's contents end and the next file's
-// name begins must not agree, and they would if the hash were fed the paths and
-// the bytes with nothing between them.
+// TestDigestSeparatesTheFilesItCovers is the length delimiter's own test, and
+// the two corpora below are chosen so that it is: without the length, both
+// flatten to exactly `a\0xb\0` and the digest cannot tell them apart. Remove
+// the length from [DigestFS] and this test goes red, which is the only way a
+// test of that property is worth having.
+//
+// It takes a NUL inside a file's contents to build the collision, which is
+// exactly the case docs/conformance/SPEC.md's justification names: `input.bin`
+// is arbitrary bytes by definition, so the contents cannot be their own
+// delimiter.
 func TestDigestSeparatesTheFilesItCovers(t *testing.T) {
 	first := mustDigest(t, fstest.MapFS{
-		"a": &fstest.MapFile{Data: []byte("bc")},
-		"d": &fstest.MapFile{Data: []byte{}},
+		"a": &fstest.MapFile{Data: []byte("xb\x00")},
 	})
 
 	second := mustDigest(t, fstest.MapFS{
-		"a": &fstest.MapFile{Data: []byte("b")},
-		"d": &fstest.MapFile{Data: []byte("c")},
+		"a": &fstest.MapFile{Data: []byte("x")},
+		"b": &fstest.MapFile{Data: []byte{}},
 	})
 
 	if first == second {
@@ -301,6 +306,31 @@ func TestDigestPathSitsBesideTheCorpus(t *testing.T) {
 	for _, dir := range []string{filepath.Join("a", "corpus"), filepath.Join("a", "corpus") + string(filepath.Separator)} {
 		if got := DigestPath(dir); got != want {
 			t.Errorf("DigestPath(%q) is %q, want %q", dir, got, want)
+		}
+	}
+}
+
+// TestDigestPathNamesACorpusThatNamesItselfNothing is the case a downloader
+// reaches by working inside the corpus: `--corpus .`. Cleaning leaves a
+// directory with no name for a file to sit beside, and appending would produce
+// `..sha256` — a path nobody can have created, so the digest reads as absent and
+// the run proceeds unchecked, which is the one outcome the digest exists to
+// prevent.
+func TestDigestPathNamesACorpusThatNamesItselfNothing(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	for _, corpus := range []string{".", "", "a" + string(filepath.Separator) + ".."} {
+		got := DigestPath(corpus)
+
+		if !filepath.IsAbs(got) {
+			t.Errorf("DigestPath(%q) is %q, which names no corpus to sit beside", corpus, got)
+
+			continue
+		}
+
+		if base := filepath.Base(got); base == DigestExt || base == "."+DigestExt {
+			t.Errorf("DigestPath(%q) is %q, which is a file nobody could have written", corpus, got)
 		}
 	}
 }

--- a/internal/tools/conformance-bundle/bundle/README.md
+++ b/internal/tools/conformance-bundle/bundle/README.md
@@ -1,0 +1,82 @@
+# The cpybkc conformance archive
+
+Everything you need to run the cpybkc conformance corpus against your own
+generator, on a machine with no container runtime, no registry access and no Go
+toolchain.
+
+```
+cpybkc-conformance/
+  README.md            this file
+  corpus.sha256        the digest of corpus/
+  corpus/              the conformance corpus, one directory per entry
+  bin/                 cpybkc-conform, built per platform
+```
+
+## Running it
+
+Write an **adapter**: a program that reads request frames on standard input,
+writes response frames on standard output, and drives your generator in
+between. The contract it implements is
+[`docs/adapter/SPEC.md`](https://github.com/Zaba505/cpybkc/blob/main/docs/adapter/SPEC.md),
+and the smallest conforming one is a shell script.
+
+Then, from the directory this archive unpacked into:
+
+```sh
+./bin/cpybkc-conform-linux-amd64 check --exec ../my-adapter
+```
+
+`--corpus` defaults to `corpus`, which is why the line above names no corpus.
+Anything after a bare `--` is your adapter's own argument vector:
+
+```sh
+./bin/cpybkc-conform-linux-amd64 check --exec ../my-adapter -- --generator ./gen-rust
+```
+
+It exits **0** when nothing failed, **1** when an entry disagreed or could not
+be asked, and **2** when the run could not be attempted at all. `--help` is the
+rest of the flags.
+
+## Checking what you downloaded
+
+`corpus.sha256` holds a SHA-256 over `corpus/`. `check` verifies it before it
+starts a process and refuses to run against a corpus that does not match, so
+there is nothing you have to remember to do. To see the number yourself:
+
+```sh
+./bin/cpybkc-conform-linux-amd64 digest
+cat corpus.sha256
+```
+
+The rule the digest follows is written down in
+[`docs/conformance/SPEC.md`](https://github.com/Zaba505/cpybkc/blob/main/docs/conformance/SPEC.md#the-published-corpus),
+so you can recompute it without this program.
+
+## What a result from this archive is, and is not
+
+`--exec` runs your adapter directly. There is no network isolation, no
+read-only root and no resource cap, and `cpybkc-conform` says so in every
+report it writes. A run through this door is **your own working result** — a
+fine thing to have and to publish, as long as it is labelled as one.
+
+It is also a self-report in a second sense: a run computed on your machine,
+against a corpus you downloaded, by a program you are holding. Nothing here is
+a conformance claim a third party should be asked to trust without
+qualification, and cpybkc awards no level, profile, score or badge.
+
+## Where the rest of it is written down
+
+- **What an entry holds, and the language a decoded record is written in** —
+  [`docs/conformance/SPEC.md`](https://github.com/Zaba505/cpybkc/blob/main/docs/conformance/SPEC.md)
+- **Every rule of that language as a worked table** —
+  [`docs/conformance/GRAMMAR.md`](https://github.com/Zaba505/cpybkc/blob/main/docs/conformance/GRAMMAR.md),
+  which is where to check a values-document writer before running a single
+  entry
+- **How your adapter is asked** —
+  [`docs/adapter/SPEC.md`](https://github.com/Zaba505/cpybkc/blob/main/docs/adapter/SPEC.md)
+- **What a descriptor means** —
+  [`docs/ir/SPEC.md`](https://github.com/Zaba505/cpybkc/blob/main/docs/ir/SPEC.md)
+- **Which entries the corpus holds and what each covers** — `corpus/README.md`,
+  beside the entries
+
+Licensed under the MIT License, like the rest of cpybkc.

--- a/internal/tools/conformance-bundle/bundle/README.md
+++ b/internal/tools/conformance-bundle/bundle/README.md
@@ -41,7 +41,15 @@ rest of the flags.
 
 `corpus.sha256` holds a SHA-256 over `corpus/`. `check` verifies it before it
 starts a process and refuses to run against a corpus that does not match, so
-there is nothing you have to remember to do. To see the number yourself:
+there is nothing you have to remember to do about the corpus.
+
+It covers the corpus and only the corpus. Nothing here checks `bin/` or this
+file, so a download truncated inside one of the executables shows up as an
+executable that will not start rather than as a digest that disagrees. Treat the
+number below as "this is the corpus that was published", not as "this download
+arrived intact".
+
+To see the number yourself:
 
 ```sh
 ./bin/cpybkc-conform-linux-amd64 digest

--- a/internal/tools/conformance-bundle/main.go
+++ b/internal/tools/conformance-bundle/main.go
@@ -1,0 +1,401 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Command conformance-bundle writes the conformance archive — the published
+// cpybkc-conformance.tar.gz — to a file.
+//
+// It is the fourth asset a release attaches, and the first that is not a
+// description of an interface but a program somebody runs. It carries the
+// corpus, a digest of the corpus, and cpybkc-conform built for every platform
+// this repository builds it for, under one directory:
+//
+//	cpybkc-conformance/README.md
+//	cpybkc-conformance/corpus.sha256
+//	cpybkc-conformance/corpus/...
+//	cpybkc-conformance/bin/cpybkc-conform-linux-amd64
+//	cpybkc-conformance/bin/...
+//
+// # Why an archive of binaries, rather than an image
+//
+// A generator author checking their work has to get the engine and the corpus
+// onto a machine, and until this existed the only route was cloning this
+// repository. The natural next thought is a container image, and it fails a
+// specific and common adopter: an engineer whose builders have no egress and
+// whose images come from an internal mirror with an allowlist, where adding an
+// external image is a ticket with a security review and a named internal owner.
+// Conformance is what an outsider runs once, on a whim, before they are
+// invested — the worst possible place to spend a procurement ticket, and a
+// first-day bounce costs the adoption entirely (#202).
+//
+// So the offline path is a download and an `--exec`: no registry, no daemon and
+// no image. A container door is the other door and is #203's, and it is where
+// the properties that make a result believable live.
+//
+// # Why the binaries are in it
+//
+// The corpus alone is what a third party already had — a set of files with the
+// right answer written down, and nothing that would ask their generator about
+// it. What makes the archive worth downloading is the program on the other side
+// of that question, and a program that has to be compiled first is one that
+// needs a Go toolchain the adopter has no other reason to have.
+//
+// One archive rather than one per platform, because the whole point is that a
+// person on a machine with no egress can be handed a file. Which platforms are
+// in it is the pipeline's (.dagger/main.go, conformPlatforms), not this
+// command's: it archives every regular file it is given under -bin, so a
+// platform is added there and arrives here without this file changing.
+//
+// # Why the bytes are stable
+//
+// Every tar field the filesystem could have supplied — modification time,
+// owner, group, and any permission beyond the two modes written here — is a
+// constant, and the entries are emitted in sorted order rather than in the
+// order a directory read happened to return. The gzip layer contributes no
+// timestamp and no original file name for the same reason. What is left is a
+// function of the paths and the contents, so two builds of one commit produce
+// one archive, exactly as internal/tools/ir-protos does for the schema.
+//
+// That is a property of the *wrapper*. Whether the binaries inside are
+// themselves reproducible is the Go toolchain's, and holds for the same reason
+// the published CLI's does: they are built CGO-free and -trimpath by a
+// container that pins its toolchain from go.mod.
+//
+// It lives under internal/ for the reason ir-protos does: nothing outside this
+// repository has a reason to run it, and cmd/ is where a shipped command goes.
+//
+//	go run ./internal/tools/conformance-bundle -bin ./bin -o cpybkc-conformance.tar.gz
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"embed"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"time"
+
+	"github.com/Zaba505/cpybkc/internal/conformance"
+)
+
+// bundle is the archive's own content: what is in it that is neither the corpus
+// nor a binary.
+//
+// A directory rather than a single embedded file, so that a second file arrives
+// in the artifact by being added to it — the same reason
+// internal/tools/ir-protos archives a tree rather than naming one .proto. It is
+// committed rather than generated because it is prose somebody wrote, and the
+// place to review it is a diff.
+//
+//go:embed bundle
+var bundle embed.FS
+
+const (
+	// archiveRoot is the one directory everything unpacks into, so that the
+	// archive can be opened anywhere without scattering files where it landed.
+	// It is also what makes the documented invocation a cd and a command.
+	archiveRoot = "cpybkc-conformance"
+
+	// binDir is where the engines go inside the archive.
+	binDir = "bin"
+
+	// The two modes an entry carries. Nothing in here is anything else: the
+	// corpus and the documentation are read, and an engine is run.
+	fileMode = 0o644
+	execMode = 0o755
+)
+
+// epoch is the modification time every entry carries.
+//
+// A constant rather than SOURCE_DATE_EPOCH, for the reason
+// internal/tools/ir-protos gives: there is no timestamp in this artifact that
+// means anything, and a build time recorded here would be the one field
+// distinguishing two builds of the same commit.
+var epoch = time.Unix(0, 0).UTC()
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "conformance-bundle: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// run is separated from main so that the exit path is the only thing main owns,
+// and so that a test can drive the whole program without ending the test
+// binary.
+func run(args []string) error {
+	flags := flag.NewFlagSet("conformance-bundle", flag.ContinueOnError)
+	out := flags.String("o", "", "path to write the archive to (required)")
+	corpus := flags.String("corpus", filepath.FromSlash(conformance.CorpusFile), "the corpus to publish")
+	bin := flags.String("bin", "", "a directory of built cpybkc-conform executables (required)")
+
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+
+	if *out == "" {
+		return fmt.Errorf("-o is required: name the file to write")
+	}
+
+	if *bin == "" {
+		return fmt.Errorf("-bin is required: name the directory holding the built engines")
+	}
+
+	if rest := flags.Args(); len(rest) > 0 {
+		return fmt.Errorf("unexpected arguments %v", rest)
+	}
+
+	// The parent directory is created rather than required, for the reason
+	// ir-descriptor-set gives: the caller is a pipeline naming a path in a fresh
+	// container filesystem.
+	if dir := filepath.Dir(*out); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("failed to create %s: %w", dir, err)
+		}
+	}
+
+	// Written beside the destination and renamed into place, so that a failure
+	// part-way through leaves no half-written archive for a release job to
+	// upload. ir-protos buys the same property by buffering in memory, which is
+	// right for an artifact of kilobytes; this one carries an executable per
+	// platform and is tens of megabytes, so it is streamed and the rename is
+	// what makes the file appear whole or not at all.
+	temporary := *out + ".part"
+
+	file, err := os.Create(temporary)
+	if err != nil {
+		return fmt.Errorf("failed to create %s: %w", temporary, err)
+	}
+
+	if err := writeArchive(file, os.DirFS(*corpus), os.DirFS(*bin)); err != nil {
+		_ = file.Close()
+		_ = os.Remove(temporary)
+
+		return err
+	}
+
+	if err := file.Close(); err != nil {
+		_ = os.Remove(temporary)
+
+		return fmt.Errorf("failed to finish %s: %w", temporary, err)
+	}
+
+	if err := os.Rename(temporary, *out); err != nil {
+		_ = os.Remove(temporary)
+
+		return fmt.Errorf("failed to write %s: %w", *out, err)
+	}
+
+	return nil
+}
+
+// writeArchive writes the corpus, its digest, the embedded documentation and
+// every engine to w as a gzipped tar.
+//
+// Both trees are [io/fs.FS] rather than directory names so that the determinism
+// the package comment claims can be asserted against trees a test builds,
+// rather than only against the ones on disk beside it.
+func writeArchive(w io.Writer, corpus, engines fs.FS) error {
+	entries, err := contents(corpus, engines)
+	if err != nil {
+		return err
+	}
+
+	// BestCompression rather than the default, because the artifact is written
+	// once per release and downloaded many times, and because a fixed level is
+	// one more thing the output does not vary with.
+	gz, err := gzip.NewWriterLevel(w, gzip.BestCompression)
+	if err != nil {
+		return fmt.Errorf("failed to start the gzip stream: %w", err)
+	}
+
+	// Neither field is set from the artifact being written: a name here would
+	// record whatever the caller passed to -o, and a modification time would be
+	// the build's clock.
+	gz.Name = ""
+	gz.ModTime = time.Time{}
+
+	archive := tar.NewWriter(gz)
+
+	for _, entry := range entries {
+		if err := writeEntry(archive, entry); err != nil {
+			return err
+		}
+	}
+
+	if err := archive.Close(); err != nil {
+		return fmt.Errorf("failed to finish the archive: %w", err)
+	}
+
+	if err := gz.Close(); err != nil {
+		return fmt.Errorf("failed to finish the gzip stream: %w", err)
+	}
+
+	return nil
+}
+
+// entry is one file of the archive: where it goes, how it is read, and whether
+// it is run.
+type entry struct {
+	// name is the path inside the archive, under [archiveRoot], slash
+	// separated.
+	name string
+
+	// mode is [fileMode] or [execMode].
+	mode int64
+
+	// read is the bytes, read when the entry is written rather than when the
+	// listing is built, so that the whole archive is never held at once.
+	read func() ([]byte, error)
+}
+
+// contents is every entry of the archive, in the order they are written.
+//
+// Sorted by the path inside the archive, so that the listing is a function of
+// what goes in rather than of the order three trees were walked in. That is the
+// same property internal/tools/ir-protos states of its own sort, and it is what
+// makes the artifact comparable across releases at all.
+func contents(corpus, engines fs.FS) ([]entry, error) {
+	// The digest is taken over the same filesystem that is about to be
+	// archived, and not over the directory again: two walks are two reads, and
+	// an edit between them would publish a digest for a corpus the archive does
+	// not hold.
+	digest, err := conformance.DigestFS(corpus)
+	if err != nil {
+		return nil, fmt.Errorf("failed to digest the corpus: %w", err)
+	}
+
+	documentation, err := fs.Sub(bundle, "bundle")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read the archive's own documentation: %w", err)
+	}
+
+	entries := []entry{{
+		name: conformance.PublishedCorpusDir + conformance.DigestExt,
+		mode: fileMode,
+		read: func() ([]byte, error) { return conformance.FormatDigest(digest), nil },
+	}}
+
+	from := []struct {
+		tree   fs.FS
+		under  string
+		mode   int64
+		reason string
+	}{
+		{tree: documentation, under: "", mode: fileMode, reason: "the archive's own documentation"},
+		{tree: corpus, under: conformance.PublishedCorpusDir, mode: fileMode, reason: "the corpus"},
+		{tree: engines, under: binDir, mode: execMode, reason: "the engines"},
+	}
+
+	for _, source := range from {
+		names, err := files(source.tree)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read %s: %w", source.reason, err)
+		}
+
+		if len(names) == 0 {
+			// Named rather than tolerated. An archive missing its engines, its
+			// corpus or its documentation is well-formed, uploads as happily as
+			// a good one, and is discovered by whoever downloaded it.
+			return nil, fmt.Errorf("%s is empty, and an archive without it is not the published artifact",
+				source.reason)
+		}
+
+		for _, name := range names {
+			entries = append(entries, entry{
+				name: path.Join(source.under, name),
+				mode: source.mode,
+				read: func() ([]byte, error) { return fs.ReadFile(source.tree, name) },
+			})
+		}
+	}
+
+	slices.SortFunc(entries, func(a, b entry) int {
+		switch {
+		case a.name < b.name:
+			return -1
+		case a.name > b.name:
+			return 1
+		default:
+			return 0
+		}
+	})
+
+	return entries, nil
+}
+
+// files returns every regular file under tree, as slash-separated paths
+// relative to it, in sorted order.
+//
+// Anything that is not a regular file is an error rather than something to
+// skip: a symbolic link in a published archive is a file whose content depends
+// on where it was unpacked, which is the same rule the corpus digest holds
+// itself to.
+func files(tree fs.FS) ([]string, error) {
+	var names []string
+
+	err := fs.WalkDir(tree, ".", func(name string, item fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if item.IsDir() {
+			return nil
+		}
+
+		if !item.Type().IsRegular() {
+			return fmt.Errorf("%s is not a regular file", name)
+		}
+
+		names = append(names, name)
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	slices.Sort(names)
+
+	return names, nil
+}
+
+// writeEntry writes one file into the archive under a header carrying nothing
+// the filesystem supplied.
+//
+// The header's Format is left unset, so the tar writer picks the narrowest
+// encoding each header fits in — USTAR for the paths in here, PAX for one long
+// enough to need it. That is a function of the header, so it costs nothing in
+// determinism and it means a deeply nested corpus entry is archived rather than
+// refused.
+func writeEntry(archive *tar.Writer, item entry) error {
+	b, err := item.read()
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", item.name, err)
+	}
+
+	header := &tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     path.Join(archiveRoot, item.name),
+		Size:     int64(len(b)),
+		Mode:     item.mode,
+		ModTime:  epoch,
+	}
+
+	if err := archive.WriteHeader(header); err != nil {
+		return fmt.Errorf("failed to write the header for %s: %w", header.Name, err)
+	}
+
+	if _, err := archive.Write(b); err != nil {
+		return fmt.Errorf("failed to write %s: %w", header.Name, err)
+	}
+
+	return nil
+}

--- a/internal/tools/conformance-bundle/main.go
+++ b/internal/tools/conformance-bundle/main.go
@@ -80,6 +80,7 @@ import (
 	"path"
 	"path/filepath"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/Zaba505/cpybkc/internal/conformance"
@@ -94,7 +95,12 @@ import (
 // committed rather than generated because it is prose somebody wrote, and the
 // place to review it is a diff.
 //
-//go:embed bundle
+// The all: prefix is what makes that claim true rather than nearly true. A bare
+// //go:embed of a directory silently drops every file whose name begins with a
+// dot or an underscore, so a .well-known or a _template added here would be
+// reviewed, committed, and then not be in the archive.
+//
+//go:embed all:bundle
 var bundle embed.FS
 
 const (
@@ -203,7 +209,12 @@ func run(args []string) error {
 // the package comment claims can be asserted against trees a test builds,
 // rather than only against the ones on disk beside it.
 func writeArchive(w io.Writer, corpus, engines fs.FS) error {
-	entries, err := contents(corpus, engines)
+	documentation, err := fs.Sub(bundle, "bundle")
+	if err != nil {
+		return fmt.Errorf("failed to read the archive's own documentation: %w", err)
+	}
+
+	entries, err := contents(documentation, corpus, engines)
 	if err != nil {
 		return err
 	}
@@ -262,7 +273,11 @@ type entry struct {
 // what goes in rather than of the order three trees were walked in. That is the
 // same property internal/tools/ir-protos states of its own sort, and it is what
 // makes the artifact comparable across releases at all.
-func contents(corpus, engines fs.FS) ([]entry, error) {
+// The documentation tree is a parameter rather than read from [bundle] here so
+// that the collision check below can be exercised. It is the only one of the
+// three whose contents this repository controls, so it is the only one a test
+// can make collide with another.
+func contents(documentation, corpus, engines fs.FS) ([]entry, error) {
 	// The digest is taken over the same filesystem that is about to be
 	// archived, and not over the directory again: two walks are two reads, and
 	// an edit between them would publish a digest for a corpus the archive does
@@ -270,11 +285,6 @@ func contents(corpus, engines fs.FS) ([]entry, error) {
 	digest, err := conformance.DigestFS(corpus)
 	if err != nil {
 		return nil, fmt.Errorf("failed to digest the corpus: %w", err)
-	}
-
-	documentation, err := fs.Sub(bundle, "bundle")
-	if err != nil {
-		return nil, fmt.Errorf("failed to read the archive's own documentation: %w", err)
 	}
 
 	entries := []entry{{
@@ -317,16 +327,21 @@ func contents(corpus, engines fs.FS) ([]entry, error) {
 		}
 	}
 
-	slices.SortFunc(entries, func(a, b entry) int {
-		switch {
-		case a.name < b.name:
-			return -1
-		case a.name > b.name:
-			return 1
-		default:
-			return 0
+	slices.SortFunc(entries, func(a, b entry) int { return strings.Compare(a.name, b.name) })
+
+	// A path contributed by two of the three trees would be written twice, and
+	// what a consumer then has is decided by whichever entry their tar extracted
+	// last. Nothing collides today — the documentation is at the root, the corpus
+	// under corpus/ and the engines under bin/ — but that is a property of three
+	// trees somebody can add a file to, and the way it would go wrong is a file
+	// whose contents depend on the order it was unpacked in. Adjacent
+	// comparison is enough because the entries are sorted.
+	for i := 1; i < len(entries); i++ {
+		if entries[i].name == entries[i-1].name {
+			return nil, fmt.Errorf("%s would be archived twice, and a consumer's tar would keep whichever "+
+				"copy it extracted last", entries[i].name)
 		}
-	})
+	}
 
 	return entries, nil
 }

--- a/internal/tools/conformance-bundle/main_test.go
+++ b/internal/tools/conformance-bundle/main_test.go
@@ -166,6 +166,27 @@ func TestArchiveRefusesToShipWithoutAPart(t *testing.T) {
 	}
 }
 
+// TestArchiveRefusesToCarryOnePathTwice is about a failure that would be silent
+// on both sides. Two of the three trees contributing one path writes two entries
+// under it, and which one a consumer ends up with is decided by whichever their
+// tar extracted last — so the artifact would be well-formed, uploadable, and
+// hold a file whose contents depend on how it was unpacked.
+//
+// Nothing collides today. What this pins is that adding a file to the archive's
+// own documentation cannot quietly shadow the corpus digest.
+func TestArchiveRefusesToCarryOnePathTwice(t *testing.T) {
+	documentation := fstest.MapFS{
+		"README.md": &fstest.MapFile{Data: []byte("how to run it\n")},
+		conformance.PublishedCorpusDir + conformance.DigestExt: &fstest.MapFile{
+			Data: []byte("not the digest\n"),
+		},
+	}
+
+	if _, err := contents(documentation, corpus(), engines()); err == nil {
+		t.Error("contents archived one path twice")
+	}
+}
+
 // TestArchiveRefusesWhatIsNotAFile keeps a link out of a published archive, for
 // the reason the corpus digest refuses one: its content is a property of where
 // the archive was unpacked rather than of what was archived.

--- a/internal/tools/conformance-bundle/main_test.go
+++ b/internal/tools/conformance-bundle/main_test.go
@@ -1,0 +1,432 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/Zaba505/cpybkc/internal/conformance"
+)
+
+// corpus is a stand-in for testdata/conformance: enough of an entry's shape for
+// the layout claims below, and nothing the loader would have to accept.
+func corpus() fstest.MapFS {
+	return fstest.MapFS{
+		"README.md":                &fstest.MapFile{Data: []byte("the corpus\n")},
+		"orders-fixed/entry.json":  &fstest.MapFile{Data: []byte(`{"description":"x"}`)},
+		"orders-fixed/input.bin":   &fstest.MapFile{Data: []byte{0x00, 0xff}},
+		"orders-fixed/values.json": &fstest.MapFile{Data: []byte(`{"records":[]}`)},
+	}
+}
+
+// engines is a stand-in for a directory of built executables.
+func engines() fstest.MapFS {
+	return fstest.MapFS{
+		"cpybkc-conform-linux-amd64":  &fstest.MapFile{Data: []byte("\x7fELF linux")},
+		"cpybkc-conform-darwin-arm64": &fstest.MapFile{Data: []byte("\xcf\xfa\xed\xfe darwin")},
+	}
+}
+
+// TestArchiveIsReproducible is the acceptance criterion for this artifact: the
+// same corpus and the same engines produce the same bytes. It archives one pair
+// twice through two independent writers, because a producer that memoised its
+// output would pass a comparison of one run against itself while still varying
+// between builds.
+func TestArchiveIsReproducible(t *testing.T) {
+	first := archive(t, corpus(), engines())
+	second := archive(t, corpus(), engines())
+
+	if len(first) == 0 {
+		t.Fatal("the archive is empty")
+	}
+
+	if !bytes.Equal(first, second) {
+		t.Fatalf("two archives of one corpus differ: %d bytes then %d bytes", len(first), len(second))
+	}
+}
+
+// TestArchiveCarriesNothingFromTheFilesystem asserts what makes the property
+// above hold across machines rather than only across two calls in one process. A
+// modification time, an owner or a group taken from the trees being archived
+// would make the artifact a function of the checkout as well as of its contents,
+// and the two builds that disagree would be on different machines, where nobody
+// is comparing.
+func TestArchiveCarriesNothingFromTheFilesystem(t *testing.T) {
+	for _, header := range headers(t, archive(t, corpus(), engines())) {
+		if got := header.ModTime.Unix(); got != 0 {
+			t.Errorf("%s carries modification time %d, want 0", header.Name, got)
+		}
+
+		if header.Uid != 0 || header.Gid != 0 {
+			t.Errorf("%s carries uid/gid %d/%d, want 0/0", header.Name, header.Uid, header.Gid)
+		}
+
+		if header.Uname != "" || header.Gname != "" {
+			t.Errorf("%s carries owner names %q/%q, want empty", header.Name, header.Uname, header.Gname)
+		}
+
+		want := int64(fileMode)
+		if strings.HasPrefix(header.Name, path.Join(archiveRoot, binDir)+"/") {
+			want = execMode
+		}
+
+		if header.Mode != want {
+			t.Errorf("%s carries mode %o, want %o", header.Name, header.Mode, want)
+		}
+	}
+}
+
+// TestArchiveUnpacksIntoOneDirectory states the layout the archive's README
+// documents and the invocation in it depends on: one root everything is under,
+// the corpus where cpybkc-conform looks for it by default, the digest beside
+// that rather than inside it, and the engines executable.
+func TestArchiveUnpacksIntoOneDirectory(t *testing.T) {
+	want := []string{
+		archiveRoot + "/README.md",
+		archiveRoot + "/bin/cpybkc-conform-darwin-arm64",
+		archiveRoot + "/bin/cpybkc-conform-linux-amd64",
+		archiveRoot + "/corpus.sha256",
+		archiveRoot + "/corpus/README.md",
+		archiveRoot + "/corpus/orders-fixed/entry.json",
+		archiveRoot + "/corpus/orders-fixed/input.bin",
+		archiveRoot + "/corpus/orders-fixed/values.json",
+	}
+
+	if got := entryNames(t, archive(t, corpus(), engines())); !slices.Equal(got, want) {
+		t.Errorf("archived\n got: %v\nwant: %v", got, want)
+	}
+}
+
+// TestArchiveCarriesTheDigestOfTheCorpusInIt is the claim the whole digest rests
+// on. The number published in the archive has to be the number a downloader
+// computes from the corpus in the same archive, and the two are written by
+// different programs — so a producer that digested a different tree, or a
+// different reading of the same one, would ship an artifact that fails its own
+// check on arrival.
+func TestArchiveCarriesTheDigestOfTheCorpusInIt(t *testing.T) {
+	unpacked := unpack(t, archive(t, corpus(), engines()))
+
+	published, ok := unpacked[archiveRoot+"/corpus.sha256"]
+	if !ok {
+		t.Fatal("the archive carries no corpus.sha256")
+	}
+
+	held := fstest.MapFS{}
+
+	for name, b := range unpacked {
+		if inside, ok := strings.CutPrefix(name, archiveRoot+"/"+conformance.PublishedCorpusDir+"/"); ok {
+			held[inside] = &fstest.MapFile{Data: b}
+		}
+	}
+
+	want, err := conformance.DigestFS(held)
+	if err != nil {
+		t.Fatalf("digest the archived corpus: %v", err)
+	}
+
+	if got := string(published); got != string(conformance.FormatDigest(want)) {
+		t.Errorf("corpus.sha256 holds %q, and the corpus in the archive digests to %s", got, want)
+	}
+}
+
+// TestArchiveRefusesToShipWithoutAPart keeps a well-formed archive that is
+// missing a third of itself from being published. Each of these is invisible at
+// the point it happens — a misdirected flag, a build step that wrote nowhere —
+// and arrives as a consumer's release download that cannot do what it says.
+func TestArchiveRefusesToShipWithoutAPart(t *testing.T) {
+	testCases := []struct {
+		name    string
+		corpus  fs.FS
+		engines fs.FS
+	}{
+		{name: "no corpus", corpus: fstest.MapFS{}, engines: engines()},
+		{name: "no engines", corpus: corpus(), engines: fstest.MapFS{}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if err := writeArchive(io.Discard, testCase.corpus, testCase.engines); err == nil {
+				t.Error("writeArchive published an archive missing a part of itself")
+			}
+		})
+	}
+}
+
+// TestArchiveRefusesWhatIsNotAFile keeps a link out of a published archive, for
+// the reason the corpus digest refuses one: its content is a property of where
+// the archive was unpacked rather than of what was archived.
+func TestArchiveRefusesWhatIsNotAFile(t *testing.T) {
+	built := engines()
+	built["cpybkc-conform"] = &fstest.MapFile{Mode: fs.ModeSymlink, Data: []byte("cpybkc-conform-linux-amd64")}
+
+	if err := writeArchive(io.Discard, corpus(), built); err == nil {
+		t.Error("writeArchive accepted a tree holding something that is not a regular file")
+	}
+}
+
+// TestRunArchivesTheCorpusOnDisk is the staleness gate. Everything above works
+// on trees a test built, which cannot notice that the archive has stopped
+// carrying the corpus this repository actually publishes. So this one runs the
+// program over testdata/conformance and requires every file in it to be in the
+// archive, at its own path under corpus/.
+func TestRunArchivesTheCorpusOnDisk(t *testing.T) {
+	root := repoRoot(t)
+	dir := t.TempDir()
+	out := filepath.Join(dir, "cpybkc-conformance.tar.gz")
+
+	// A stand-in for the engines, because building five of them here would make
+	// this test a cross-compilation. What is being checked is the corpus half;
+	// that the real engines are built and put where this reads them is
+	// .dagger/main.go's ConformanceBundle, and that they are non-empty is
+	// ConformanceArtifact.
+	built := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(built, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", built, err)
+	}
+
+	if err := os.WriteFile(filepath.Join(built, "cpybkc-conform-linux-amd64"), []byte("elf"), 0o755); err != nil {
+		t.Fatalf("write the stand-in engine: %v", err)
+	}
+
+	if err := run([]string{"-corpus", conformance.CorpusPath(root), "-bin", built, "-o", out}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	b, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read %s: %v", out, err)
+	}
+
+	archived := entryNames(t, b)
+
+	var want int
+
+	err = filepath.WalkDir(conformance.CorpusPath(root), func(name string, item fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if item.IsDir() {
+			return nil
+		}
+
+		want++
+
+		relative, err := filepath.Rel(conformance.CorpusPath(root), name)
+		if err != nil {
+			return err
+		}
+
+		inside := path.Join(archiveRoot, conformance.PublishedCorpusDir, filepath.ToSlash(relative))
+
+		if !slices.Contains(archived, inside) {
+			t.Errorf("the archive does not carry %s", inside)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk the corpus: %v", err)
+	}
+
+	if want == 0 {
+		t.Fatal("the corpus on disk holds no file: the check would pass vacuously")
+	}
+}
+
+// TestRunLeavesNothingBehindWhenItFails is what the rename buys. A release job
+// uploads whatever is at the path it asked for, so a half-written archive left
+// by a failed build is one that ships.
+func TestRunLeavesNothingBehindWhenItFails(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "cpybkc-conformance.tar.gz")
+
+	// An empty engines directory, which is a failure contents refuses after the
+	// destination has already been created.
+	built := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(built, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", built, err)
+	}
+
+	if err := run([]string{"-corpus", conformance.CorpusPath(repoRoot(t)), "-bin", built, "-o", out}); err == nil {
+		t.Fatal("run published an archive with no engine in it")
+	}
+
+	for _, name := range []string{out, out + ".part"} {
+		if _, err := os.Stat(name); !os.IsNotExist(err) {
+			t.Errorf("%s is still there after a failed build", name)
+		}
+	}
+}
+
+// TestRunRejectsBadUsage keeps the failure modes failures, for the reason
+// ir-protos' copy of this test gives: a release job that uploads nothing and
+// reports success is the one outcome nobody notices.
+func TestRunRejectsBadUsage(t *testing.T) {
+	dir := t.TempDir()
+
+	testCases := []struct {
+		name string
+		args []string
+	}{
+		{name: "no output path", args: []string{"-bin", dir}},
+		{name: "no engines directory", args: []string{"-o", filepath.Join(dir, "a.tar.gz")}},
+		{name: "empty output path", args: []string{"-o", "", "-bin", dir}},
+		{
+			name: "unexpected operand",
+			args: []string{"-o", filepath.Join(dir, "b.tar.gz"), "-bin", dir, "extra"},
+		},
+		{
+			name: "missing corpus",
+			args: []string{"-o", filepath.Join(dir, "c.tar.gz"), "-bin", dir, "-corpus", filepath.Join(dir, "nowhere")},
+		},
+		{
+			name: "missing engines directory",
+			args: []string{"-o", filepath.Join(dir, "d.tar.gz"), "-bin", filepath.Join(dir, "nowhere")},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if err := run(testCase.args); err == nil {
+				t.Error("run accepted arguments it should have refused")
+			}
+		})
+	}
+}
+
+// archive writes one corpus and one set of engines through writeArchive and
+// returns the bytes.
+func archive(t *testing.T, corpus, engines fs.FS) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	if err := writeArchive(&buf, corpus, engines); err != nil {
+		t.Fatalf("writeArchive: %v", err)
+	}
+
+	return buf.Bytes()
+}
+
+// entryNames reads the entry paths out of a gzipped archive, in the order they
+// were written.
+func entryNames(t *testing.T, b []byte) []string {
+	t.Helper()
+
+	var names []string
+	for _, header := range headers(t, b) {
+		names = append(names, header.Name)
+	}
+
+	return names
+}
+
+// unpack reads a gzipped archive into its entries' contents, by path.
+func unpack(t *testing.T, b []byte) map[string][]byte {
+	t.Helper()
+
+	held := map[string][]byte{}
+
+	gz, err := gzip.NewReader(bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("open the gzip stream: %v", err)
+	}
+
+	reader := tar.NewReader(gz)
+
+	for {
+		header, err := reader.Next()
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			t.Fatalf("read the archive: %v", err)
+		}
+
+		content, err := io.ReadAll(reader)
+		if err != nil {
+			t.Fatalf("read %s: %v", header.Name, err)
+		}
+
+		held[header.Name] = content
+	}
+
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close the gzip stream: %v", err)
+	}
+
+	return held
+}
+
+// headers reads every tar header out of a gzipped archive, in order.
+func headers(t *testing.T, b []byte) []*tar.Header {
+	t.Helper()
+
+	var got []*tar.Header
+
+	gz, err := gzip.NewReader(bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("open the gzip stream: %v", err)
+	}
+
+	reader := tar.NewReader(gz)
+
+	for {
+		header, err := reader.Next()
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			t.Fatalf("read the archive: %v", err)
+		}
+
+		got = append(got, header)
+	}
+
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close the gzip stream: %v", err)
+	}
+
+	return got
+}
+
+// repoRoot walks up from the test's working directory to the directory holding
+// go.mod, which for this module is the repository root and so the directory
+// testdata/ sits in.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("working directory: %v", err)
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("no go.mod found above %q", dir)
+		}
+
+		dir = parent
+	}
+}

--- a/internal/tools/ir-protos/main.go
+++ b/internal/tools/ir-protos/main.go
@@ -184,10 +184,14 @@ func writeArchive(w io.Writer, schema fs.FS) error {
 // protoFiles returns every .proto under schema, as slash-separated paths
 // relative to it, in sorted order.
 //
-// [io/fs.WalkDir] already walks lexically, so the sort is belt and braces — but
-// the ordering is what makes the archive a function of its contents rather than
-// of a directory read, and a property that load-bearing is worth stating where a
-// reader can see it.
+// The sort is load-bearing and is not a belt-and-braces repeat of the walk,
+// which is what this comment used to say (#202). [io/fs.WalkDir] orders each
+// *directory's* entries, and that is a different order from sorting the full
+// paths: beside a directory `a/` holding `b.proto`, a file `a.proto` is visited
+// second, because the walk compares `a` against `a.proto` — so the walk emits
+// `a/b.proto` first while `.` (0x2E) sorting below `/` (0x2F) puts `a.proto`
+// first. The sorted order is what makes the archive a function of its contents
+// rather than of a directory read.
 func protoFiles(schema fs.FS) ([]string, error) {
 	var names []string
 

--- a/testdata/conformance/README.md
+++ b/testdata/conformance/README.md
@@ -130,6 +130,15 @@ values document is a different record: *Slack survives a read* puts the bytes no
 item covers on the record a reader produced, and a constructed one has a writer
 fill them instead.
 
+`cmd/cpybkc-conform` is the engine with a command line on it, and it is what
+somebody outside this repository runs. Every release attaches it and this
+directory together as `cpybkc-conformance.tar.gz` — [*The published
+corpus*](../../docs/conformance/SPEC.md#the-published-corpus) is the archive's
+layout and the digest rule that says whether a download is this corpus (#202) —
+so checking a generator needs no clone, no registry and no container runtime.
+Nothing here is committed for it: the digest is a function of the corpus, so
+adding an entry below changes what a release publishes and nothing else.
+
 `go test ./internal/conformance/...` runs the corpus against `cpybkc-gen-go`
 built from the tree under test, in both directions and over every entry (#68).
 


### PR DESCRIPTION
Closes #202

Every release now attaches a fourth asset, `cpybkc-conformance.tar.gz`, carrying the conformance corpus, a digest of it, and the engine that runs it built for five platforms. Unpack it and run `cpybkc-conform check --exec ./my-adapter` — no clone, no registry, no daemon and no image.

The motivation is the issue's: conformance is the thing an outsider runs once, on a whim, before they are invested, and the natural alternative — a container image — is a ticket with a security review for anybody whose builders have no egress and whose registry runs an allowlist. That is the worst possible place to spend one, and a first-day bounce costs the adoption entirely.

## Acceptance criteria

- [x] **A release attaches an archive carrying the engine and the corpus.** `.github/workflows/release.yaml` gains one `dagger call conformance-bundle export` and one more path in the existing `gh release upload`, exactly as the issue predicted.
- [x] **It is built inside the pipeline, by a function on the root module, next to the IR artifacts.** `ConformanceBundle` sits beside `IrDescriptorSet`, `IrProtos` and `LayoutSchema`, and is built the same way: `dag.Go().Container(m.Source)` running a tool under `internal/tools/`.
- [x] **The archive carries a corpus digest the engine can check.** `corpus.sha256`, beside `corpus/`. `check` verifies it before it starts a process and refuses a corpus that does not match; `digest` prints it for anybody who would rather not take the program's word for it.
- [x] **It is usable with no container runtime and no registry access.** Verified end to end: built the archive, unpacked it into a scratch directory, ran `./bin/cpybkc-conform-linux-amd64 digest` and `check --exec …` from inside it, then appended a byte to a corpus file and watched the run refuse with exit 2 naming both digests.
- [x] **`dagger call ci` builds it.** `ConformanceArtifact` is the sixteenth part of `Ci`.

## Judgment calls that shaped the public surface

**The engine is a command, `cmd/cpybkc-conform`, and it had to be.** There was no runnable engine before this — `internal/conformance/engine` was driven only from tests — so "ship the engine" meant giving it a command line. #203 is written against `conform check --exec`, so `check` is a subcommand rather than the whole program, which is where `--image` slots in. The name carries the repository's prefix like `cpybkc-gen-go` and `cpybkc-gen-graph`; inside the archive the files are `bin/cpybkc-conform-<os>-<arch>`.

**Prebuilt binaries, not source.** A generator author writing in Rust has a toolchain, but not a Go one, and an engine they have to compile before they can run it is an engine that costs them the thing this artifact exists to remove. `conformPlatforms` is `darwin/{amd64,arm64}`, `linux/{amd64,arm64}` and `windows/amd64` — wider than `imagePlatforms`, because the image is a container base and this is a download onto whatever machine somebody writes a generator on. One archive rather than one per platform: the point is that a person with no egress can be handed a file.

**The digest sits beside the corpus rather than inside it.** A digest of a directory cannot live in that directory, and putting it in would have meant a member every reader has to be told to skip — a change to the published corpus format, and to `Load`, for a file that is a statement *about* the corpus rather than part of it. So the rule is `<corpus>.sha256`, and `corpus/` in the archive is unchanged from `testdata/conformance/` byte for byte.

**A corpus with no digest beside it is not an error.** The corpus in this tree has none and cannot have one: the digest is a function of the corpus, so a committed copy would be a second statement of it for the next entry to be added without — the reason `ir.binpb` is not committed either. `check` runs, and says on standard error that nothing checked it, rather than passing over it in silence.

**`--exec` names a path and is not looked up on `PATH`.** That is the rule `engine.Command.Path` already stated and the reason it gave; refusing a bare name is the honest half of it, since silently reading it as a relative path would make `--exec adapter` mean something a shell does not.

**Three exit codes, not two.** 0 nothing failed, 1 the run happened and something failed, 2 the run could not be attempted. A script that conflates the last two cannot tell a generator that failed the corpus from a corpus that never ran, and only the first is a fact about the generator. `docs/conformance/SPEC.md` leaves the exit code out of scope, so this is the command's own contract and is documented as such.

**`ConformanceArtifact` asserts more than its siblings do.** `IrArtifacts` and `LayoutArtifact` check only that a non-empty file appeared, on the argument that the Go tests own the contents. That argument does not fully carry here: which platforms exist is decided in `.dagger/main.go`, and `internal/tools/conformance-bundle`'s tests run against a stand-in for the engines because building five of them in a unit test would make it a cross-compilation. So the pipeline check also requires every platform's engine to have compiled non-empty and to be in the archive at the path the archive's own README tells somebody to run.

## What is specified, and where

`docs/conformance/SPEC.md` gains **The published corpus** — the archive's layout, and the digest rule stated precisely enough for a third party to recompute it without running anything of ours (path, NUL, decimal length, NUL, bytes; sorted; nothing the filesystem supplied). It is in the spec rather than in a README because a downloader in another language has to implement it, which is `docs/CONVENTIONS.md`'s test for what belongs there. The harness itself stays out of scope, as it already was.

`CONTRIBUTING.md`, `README.md` and `testdata/conformance/README.md` follow the fourth artifact through.

## Verified

- `dagger call ci` — green, run cold from an ordinary clone after `dagger core engine local-cache prune` (the pipeline does not run from a git worktree; CONTRIBUTING.md says why).
- `go test -race` over `./internal/conformance/...`, `./cmd/cpybkc-conform/...` and `./internal/tools/...`.
- The whole corpus through the real Go adapter via the new command: 32 entries, 32 passed.
- The unpacked archive driven offline, including the tamper case above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)