### PR TITLE
story(conformance): a container image is one door onto the contract, not the only one

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -385,10 +385,12 @@ recompute it without running anything of ours.
 It exists because conformance is what an outsider runs once, on a whim, before
 they are invested, and the obvious alternative — a container image — is a
 procurement ticket for anybody whose builders have no egress and whose registry
-runs an allowlist (#202). A download and an `--exec` is the offline path. The
-container door is #203's, and it is where the properties that make a result
-believable live: `--exec` provides no isolation of any kind, and
-`cpybkc-conform` says so in every report it writes.
+runs an allowlist (#202). A download and an `--exec` is the offline path.
+`--image` is the other door onto the same contract (#203), and it is where the
+properties that make a result believable live — no network, a read-only root, a
+memory and process cap and a wall-clock bound. Container execution is the
+standard and not the gate: `--exec` provides no isolation of any kind, and
+`cpybkc-conform` says which door produced a result in every report it writes.
 
 Four properties are worth knowing before you touch any of them:
 

--- a/README.md
+++ b/README.md
@@ -98,9 +98,17 @@ with no clone, no registry and no container runtime in front of you. [The
 published corpus](docs/conformance/SPEC.md#the-published-corpus) is the
 archive's layout and the digest rule; [the corpus
 format](docs/conformance/SPEC.md) is what an entry holds and the language a
-decoded record is written in. A run through `--exec` is your own working result
-rather than one to hand to somebody else — the door provides no isolation, and
-the report says so.
+decoded record is written in.
+
+There are two doors onto that one contract, and which one a run went through is
+part of the result. `--exec` provides no isolation at all, so a run through it
+is your own working result. `--image ghcr.io/you/gen-rust-adapter:v1` runs the
+adapter in a container with no network, a read-only root, a memory and process
+cap and a wall-clock bound, which is a result you can hand to somebody else.
+The report quotes whichever door produced it, because those guarantees are the
+door's and never the contract's. Neither makes a run a claim a third party
+should be asked to trust without qualification: cpybkc awards no level, profile,
+score or badge, and a result is a self-report either way.
 
 ## The project manifest
 

--- a/cmd/cpybkc-conform/check.go
+++ b/cmd/cpybkc-conform/check.go
@@ -70,7 +70,7 @@ func check(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 		return err
 	}
 
-	door, err := door(flags, chosen{
+	door, err := chooseDoor(flags, chosen{
 		exec:          *exec,
 		dir:           *dir,
 		image:         *image,
@@ -79,6 +79,7 @@ func check(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 		scratch:       *imageScratch,
 		processes:     *imageProcesses,
 		timeout:       *imageDeadline,
+		deadline:      *deadline,
 		buildDeadline: *buildDeadline,
 		// Everything the flags did not consume, which is the adapter's own
 		// argument vector: docs/adapter/SPEC.md leaves it to the door precisely

--- a/cmd/cpybkc-conform/check.go
+++ b/cmd/cpybkc-conform/check.go
@@ -39,9 +39,16 @@ func check(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 		corpus        = flags.String("corpus", defaultCorpus, "the unpacked corpus")
 		exec          = flags.String("exec", "", "the adapter executable, as a path")
 		dir           = flags.String("dir", "", "the adapter's working directory")
-		deadline      = flags.Duration("deadline", engine.DefaultDeadline, "bounds one operation")
-		buildDeadline = flags.Duration("build-deadline", engine.DefaultBuildDeadline, "bounds generate")
-		grace         = flags.Duration("grace", engine.DefaultGrace, "how long the adapter is given to exit")
+		image         = flags.String("image", "", "the adapter as a container image")
+		runtime       = flags.String("runtime", engine.DefaultRuntime, "the container runtime that runs --image")
+		imageDeadline = flags.Duration("image-deadline", engine.DefaultImageTimeout,
+			"bounds one containerised adapter, by the wall clock")
+		imageMemory    = flags.String("image-memory", engine.DefaultMemory, "the container's memory cap")
+		imageProcesses = flags.Int("image-processes", engine.DefaultProcesses, "the container's process cap")
+		imageScratch   = flags.String("image-scratch", engine.DefaultScratch, "the size of the container's /tmp")
+		deadline       = flags.Duration("deadline", engine.DefaultDeadline, "bounds one operation")
+		buildDeadline  = flags.Duration("build-deadline", engine.DefaultBuildDeadline, "bounds generate")
+		grace          = flags.Duration("grace", engine.DefaultGrace, "how long the adapter is given to exit")
 	)
 
 	if err := flags.Parse(args); err != nil {
@@ -59,12 +66,28 @@ func check(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 		return fmt.Errorf("%w\n\n%s", err, usage)
 	}
 
-	path, err := adapterPath(*exec)
-	if err != nil {
+	if err := positive(*deadline, *buildDeadline, *grace); err != nil {
 		return err
 	}
 
-	if err := positive(*deadline, *buildDeadline, *grace); err != nil {
+	door, err := door(flags, chosen{
+		exec:          *exec,
+		dir:           *dir,
+		image:         *image,
+		runtime:       *runtime,
+		memory:        *imageMemory,
+		scratch:       *imageScratch,
+		processes:     *imageProcesses,
+		timeout:       *imageDeadline,
+		buildDeadline: *buildDeadline,
+		// Everything the flags did not consume, which is the adapter's own
+		// argument vector: docs/adapter/SPEC.md leaves it to the door precisely
+		// so that an adapter can be a script taking arguments of its own — or a
+		// container image taking them — without the contract growing a place to
+		// put them.
+		args: flags.Args(),
+	})
+	if err != nil {
 		return err
 	}
 
@@ -74,15 +97,7 @@ func check(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 	}
 
 	report, err := (&engine.Engine{
-		Door: &engine.Command{
-			Path: path,
-			// Everything the flags did not consume, which is the adapter's own
-			// argument vector: docs/adapter/SPEC.md leaves it to the door
-			// precisely so that an adapter can be a script taking arguments of
-			// its own without the contract growing a place to put them.
-			Args: flags.Args(),
-			Dir:  *dir,
-		},
+		Door:          door,
 		Deadline:      *deadline,
 		BuildDeadline: *buildDeadline,
 		Grace:         *grace,

--- a/cmd/cpybkc-conform/door.go
+++ b/cmd/cpybkc-conform/door.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/Zaba505/cpybkc/internal/conformance/engine"
+)
+
+// chosen is what the flags said about the door, gathered so that the choice
+// between the two is made in one place and reads as one decision.
+type chosen struct {
+	// The command door.
+	exec string
+	dir  string
+
+	// The image door.
+	image     string
+	runtime   string
+	memory    string
+	scratch   string
+	processes int
+	timeout   time.Duration
+
+	// buildDeadline is the engine's, and is here because the wall clock has to
+	// outlive it. See [imageDoor].
+	buildDeadline time.Duration
+
+	// args is the adapter's own argument vector, whichever door it goes
+	// through.
+	args []string
+}
+
+// door is the door this run goes through: a command, or a container image.
+//
+// Exactly one, and neither is a default. The two provide very different things
+// — the image door is where no network, a read-only root and a wall-clock bound
+// live, and the command door provides none of them — so a run that fell back
+// from one to the other would produce a result whose believability depended on
+// something the caller never wrote down.
+func door(flags *flag.FlagSet, c chosen) (engine.Door, error) {
+	// Which flags were written, rather than which hold a value: every flag
+	// below has a default, so a caller who spelled one out and a caller who
+	// left it alone are otherwise indistinguishable — and the whole point of
+	// refusing a flag that belongs to the other door is to tell those two apart.
+	set := map[string]bool{}
+	flags.Visit(func(f *flag.Flag) { set[f.Name] = true })
+
+	switch {
+	case c.exec != "" && c.image != "":
+		return nil, fmt.Errorf("--exec and --image are two doors and a run goes through one of them: --exec runs "+
+			"the adapter here as a process, and --image runs it in a container with no network, a read-only root "+
+			"and a wall-clock bound\n\n%s", usage)
+	case c.exec == "" && c.image == "":
+		return nil, fmt.Errorf("--exec or --image is required: name the adapter to run, either as an executable "+
+			"here or as a container image\n\n%s", usage)
+	case c.image != "":
+		return imageDoor(set, c)
+	default:
+		return commandDoor(set, c)
+	}
+}
+
+// commandDoor is --exec: the adapter as a process on this machine, with no
+// isolation of any kind.
+func commandDoor(set map[string]bool, c chosen) (engine.Door, error) {
+	// The image door's flags are refused rather than ignored. Each of them
+	// names a bound, and a caller who wrote one has said what they wanted the
+	// run to guarantee; accepting it silently on the door that guarantees
+	// nothing would hand them a report saying the opposite of what they asked
+	// for, in a sentence they had no reason to re-read.
+	for _, name := range []string{"runtime", "image-deadline", "image-memory", "image-processes", "image-scratch"} {
+		if set[name] {
+			return nil, fmt.Errorf("--%s is the image door's and this run goes through --exec, which provides no "+
+				"isolation at all: write --image to run the adapter in a container, or drop the flag\n\n%s",
+				name, usage)
+		}
+	}
+
+	path, err := adapterPath(c.exec)
+	if err != nil {
+		return nil, err
+	}
+
+	return &engine.Command{Path: path, Args: c.args, Dir: c.dir}, nil
+}
+
+// imageDoor is --image: the adapter in a container, which is where the
+// properties that make a result worth handing to somebody else live.
+func imageDoor(set map[string]bool, c chosen) (engine.Door, error) {
+	// --dir is the command door's. A container's working directory is the
+	// image's, and there is no host directory for it to name: this door mounts
+	// none, which is half of what "no filesystem access to the corpus" means
+	// (docs/adapter/SPEC.md, "The bytes travel in the frame, and not as a
+	// path").
+	if set["dir"] {
+		return nil, fmt.Errorf("--dir is the command door's and this run goes through --image: a container's "+
+			"working directory is the image's, and this door mounts no directory of yours into it\n\n%s", usage)
+	}
+
+	if err := positive(c.timeout); err != nil {
+		return nil, err
+	}
+
+	if c.processes < 1 {
+		return nil, fmt.Errorf("--image-processes %d is not a cap: an adapter is at least one process", c.processes)
+	}
+
+	if c.memory == "" || c.scratch == "" {
+		return nil, fmt.Errorf("--image-memory and --image-scratch are sizes in your runtime's own notation, and " +
+			"an empty one is not a size: write what you meant, or leave the flag alone for the default")
+	}
+
+	// The one bound whose wrong value is silent. The wall clock takes the whole
+	// container away, and generate may legitimately run a compiler over the
+	// whole corpus under --build-deadline; a container removed first would fault
+	// every entry, which reads as a generator that answered nothing rather than
+	// as a door that would not wait for it.
+	if c.timeout <= c.buildDeadline {
+		return nil, fmt.Errorf("--image-deadline %s is not longer than --build-deadline %s: the wall clock bounds "+
+			"the whole container, so a shorter one takes the adapter away in the middle of a build it was allowed "+
+			"to run and faults every entry", c.timeout, c.buildDeadline)
+	}
+
+	return &engine.Image{
+		Reference: c.image,
+		Args:      c.args,
+		Runtime:   c.runtime,
+		Timeout:   c.timeout,
+		Memory:    c.memory,
+		Processes: c.processes,
+		Scratch:   c.scratch,
+	}, nil
+}

--- a/cmd/cpybkc-conform/door.go
+++ b/cmd/cpybkc-conform/door.go
@@ -8,10 +8,18 @@ package main
 import (
 	"flag"
 	"fmt"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/Zaba505/cpybkc/internal/conformance/engine"
 )
+
+// sizes is a size as the container runtimes spell one: a number of bytes, with
+// an optional unit. It is deliberately looser than either runtime's own parser
+// — the runtime is the authority on its own notation, and this only has to
+// catch the mistake that would otherwise be discovered as a corpus that faulted.
+var sizes = regexp.MustCompile(`^[0-9]+[bkmgBKMG]?$`)
 
 // chosen is what the flags said about the door, gathered so that the choice
 // between the two is made in one place and reads as one decision.
@@ -28,8 +36,9 @@ type chosen struct {
 	processes int
 	timeout   time.Duration
 
-	// buildDeadline is the engine's, and is here because the wall clock has to
-	// outlive it. See [imageDoor].
+	// deadline and buildDeadline are the engine's, and are here because the wall
+	// clock has to outlive both. See [imageDoor].
+	deadline      time.Duration
 	buildDeadline time.Duration
 
 	// args is the adapter's own argument vector, whichever door it goes
@@ -37,14 +46,15 @@ type chosen struct {
 	args []string
 }
 
-// door is the door this run goes through: a command, or a container image.
+// chooseDoor is the door this run goes through: a command, or a container
+// image.
 //
 // Exactly one, and neither is a default. The two provide very different things
 // — the image door is where no network, a read-only root and a wall-clock bound
 // live, and the command door provides none of them — so a run that fell back
 // from one to the other would produce a result whose believability depended on
 // something the caller never wrote down.
-func door(flags *flag.FlagSet, c chosen) (engine.Door, error) {
+func chooseDoor(flags *flag.FlagSet, c chosen) (engine.Door, error) {
 	// Which flags were written, rather than which hold a value: every flag
 	// below has a default, so a caller who spelled one out and a caller who
 	// left it alone are otherwise indistinguishable — and the whole point of
@@ -108,24 +118,56 @@ func imageDoor(set map[string]bool, c chosen) (engine.Door, error) {
 		return nil, err
 	}
 
+	if c.runtime == "" {
+		return nil, fmt.Errorf("--runtime names the container runtime to find on PATH, and an empty name is not "+
+			"one: write which you meant, or leave the flag alone for %s\n\n%s", engine.DefaultRuntime, usage)
+	}
+
 	if c.processes < 1 {
 		return nil, fmt.Errorf("--image-processes %d is not a cap: an adapter is at least one process", c.processes)
 	}
 
-	if c.memory == "" || c.scratch == "" {
-		return nil, fmt.Errorf("--image-memory and --image-scratch are sizes in your runtime's own notation, and " +
-			"an empty one is not a size: write what you meant, or leave the flag alone for the default")
+	for _, size := range []struct{ flag, value string }{
+		{flag: "--image-memory", value: c.memory},
+		{flag: "--image-scratch", value: c.scratch},
+	} {
+		// Checked here rather than left to the runtime, which reports a size it
+		// will not take by refusing to create the container — after the door has
+		// opened, so what the operator reads is every entry faulting rather
+		// than the flag they mistyped.
+		if !sizes.MatchString(size.value) {
+			return nil, fmt.Errorf("%s %q is not a size: write a number of bytes, optionally followed by b, k, m "+
+				"or g, as your runtime spells it", size.flag, size.value)
+		}
 	}
 
-	// The one bound whose wrong value is silent. The wall clock takes the whole
-	// container away, and generate may legitimately run a compiler over the
-	// whole corpus under --build-deadline; a container removed first would fault
-	// every entry, which reads as a generator that answered nothing rather than
-	// as a door that would not wait for it.
-	if c.timeout <= c.buildDeadline {
-		return nil, fmt.Errorf("--image-deadline %s is not longer than --build-deadline %s: the wall clock bounds "+
-			"the whole container, so a shorter one takes the adapter away in the middle of a build it was allowed "+
-			"to run and faults every entry", c.timeout, c.buildDeadline)
+	// A reference is refused here as well as in the door, so that the shape of
+	// what was written is a usage error rather than a run that could not be
+	// started. The reason it matters is the door's: see [engine.Image.Open].
+	if strings.HasPrefix(c.image, "-") {
+		return nil, fmt.Errorf("--image %q begins with a dash, and the reference goes where the container runtime "+
+			"reads its own options: write the image you meant\n\n%s", c.image, usage)
+	}
+
+	// The two bounds whose wrong value is silent. The wall clock takes the whole
+	// container away, while the engine's deadlines bound one operation each:
+	// generate may legitimately run a compiler over the whole corpus under
+	// --build-deadline, and every entry is asked under --deadline. A wall clock
+	// shorter than either takes the adapter away in the middle of something it
+	// was allowed to do, and the entry it was on faults for a reason that is the
+	// door's rather than the generator's.
+	for _, bound := range []struct {
+		flag  string
+		value time.Duration
+	}{
+		{flag: "--build-deadline", value: c.buildDeadline},
+		{flag: "--deadline", value: c.deadline},
+	} {
+		if c.timeout <= bound.value {
+			return nil, fmt.Errorf("--image-deadline %s is not longer than %s %s: the wall clock bounds the whole "+
+				"container, so a shorter one ends the adapter in the middle of work this run allows it",
+				c.timeout, bound.flag, bound.value)
+		}
 	}
 
 	return &engine.Image{

--- a/cmd/cpybkc-conform/door_test.go
+++ b/cmd/cpybkc-conform/door_test.go
@@ -131,6 +131,32 @@ func TestARunGoesThroughOneDoor(t *testing.T) {
 			args: []string{"check", "--corpus", dir, "--image", "example.com/adapter", "--image-deadline", "0"},
 			says: "is not one",
 		},
+		{
+			name: "a runtime that is not named",
+			args: []string{"check", "--corpus", dir, "--image", "example.com/adapter", "--runtime", ""},
+			says: "--runtime names the container runtime",
+		},
+		{
+			name: "a size in a notation no runtime has",
+			args: []string{"check", "--corpus", dir, "--image", "example.com/adapter", "--image-memory", "bananas"},
+			says: "is not a size",
+		},
+		{
+			name: "a scratch size in a notation no runtime has",
+			args: []string{"check", "--corpus", dir, "--image", "example.com/adapter", "--image-scratch", "1 gig"},
+			says: "is not a size",
+		},
+		{
+			// The reference goes where the runtime reads its own options, so a
+			// reference that is a flag starts something else — with whatever
+			// followed it as the image, and none of the isolation the report
+			// would then describe. Refused here as a usage error and again in
+			// the door, which is the half that covers a caller who is not this
+			// program.
+			name: "an image reference the runtime would read as a flag",
+			args: []string{"check", "--corpus", dir, "--image", "--network=host"},
+			says: "begins with a dash",
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -147,25 +173,44 @@ func TestARunGoesThroughOneDoor(t *testing.T) {
 	}
 }
 
-// TestTheWallClockMustOutliveTheBuildDeadline is the one bound whose wrong
-// value is silent. The wall clock takes the whole container away and generate
-// may legitimately run a compiler over the whole corpus, so a container removed
-// first reads as a generator that answered nothing rather than as a door that
-// would not wait for it.
-func TestTheWallClockMustOutliveTheBuildDeadline(t *testing.T) {
+// TestTheWallClockMustOutliveTheEnginesBounds is the pair of bounds whose wrong
+// value is silent. The wall clock takes the whole container away, while the
+// engine's deadlines bound one operation each: a container ended in the middle
+// of a build the run allowed, or of an entry it allowed, faults for a reason
+// that is the door's and reads as one that is the generator's.
+func TestTheWallClockMustOutliveTheEnginesBounds(t *testing.T) {
 	dir := t.TempDir()
 
-	_, _, err := drive(t, "check",
-		"--corpus", dir,
-		"--image", "example.com/adapter",
-		"--build-deadline", "10m",
-		"--image-deadline", "5m")
-	if err == nil {
-		t.Fatal("check accepted a wall clock that ends every build it allows")
+	testCases := []struct {
+		name string
+		args []string
+		says string
+	}{
+		{
+			name: "shorter than the build deadline",
+			args: []string{"--build-deadline", "10m", "--image-deadline", "5m"},
+			says: "--build-deadline",
+		},
+		{
+			name: "shorter than the per-operation deadline",
+			args: []string{"--build-deadline", "1m", "--deadline", "30m", "--image-deadline", "5m"},
+			says: "--deadline",
+		},
 	}
 
-	if !strings.Contains(err.Error(), "--build-deadline") {
-		t.Errorf("the refusal does not name the bound it conflicts with:\n%v", err)
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			args := append([]string{"check", "--corpus", dir, "--image", "example.com/adapter"}, testCase.args...)
+
+			_, _, err := drive(t, args...)
+			if err == nil {
+				t.Fatal("check accepted a wall clock that ends work the same run allows")
+			}
+
+			if !strings.Contains(err.Error(), testCase.says) {
+				t.Errorf("the refusal does not name the bound it conflicts with:\n%v", err)
+			}
+		})
 	}
 }
 

--- a/cmd/cpybkc-conform/door_test.go
+++ b/cmd/cpybkc-conform/door_test.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/conformance"
+)
+
+// TestCheckRunsTheCorpusThroughAnImage is the image door end to end, from the
+// flag to the report, with a stub in the place of the container runtime.
+//
+// A stub because a test that needed a working container runtime would be a test
+// that does not run: the pipeline this repository's verify command drives is
+// itself a container. What it covers is the wiring — that --image reaches the
+// image door, that the adapter's own arguments reach the container, and that
+// the report quotes the door that produced it rather than the one this program
+// happens to have run more often.
+func TestCheckRunsTheCorpusThroughAnImage(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the stub runtime is a shell script")
+	}
+
+	root := repoRoot(t)
+	adapter := build(t, root, "./internal/conformance/descriptive/cmd/adapter")
+
+	stdout, stderr, err := drive(t, "check",
+		"--corpus", conformance.CorpusPath(root),
+		"--image", adapter,
+		"--runtime", stubRuntime(t),
+		"--", "--name", "graph")
+	if err != nil {
+		t.Fatalf("check: %v\n%s", err, stderr)
+	}
+
+	// The door's own sentence, quoted rather than summarised, and it is a
+	// different sentence from --exec's: which door a result came through is the
+	// whole of what it is worth to somebody who did not produce it.
+	for _, want := range []string{"no network", "read-only root", adapter} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("the report does not say %q about the door it came through:\n%s", want, stdout)
+		}
+	}
+
+	if strings.Contains(stdout, "no network isolation") {
+		t.Errorf("a containerised run is reported as though it had no isolation:\n%s", stdout)
+	}
+
+	if !strings.Contains(stdout, "not applicable") {
+		t.Errorf("a descriptive generator's run is not reported as not applicable:\n%s", stdout)
+	}
+}
+
+// TestARunGoesThroughOneDoor is every way of naming none, both, or one door
+// with the other's flags.
+//
+// The two that matter most are opposite failures. Naming both doors would have
+// to pick one silently, and the two provide very different things. Naming an
+// image flag beside --exec is a caller who has said what they wanted the run to
+// guarantee, on the door that guarantees nothing: accepted quietly, it would
+// hand them a report saying the opposite of what they asked for, in a sentence
+// they had no reason to re-read.
+func TestARunGoesThroughOneDoor(t *testing.T) {
+	dir := t.TempDir()
+
+	testCases := []struct {
+		name string
+		args []string
+		says string
+	}{
+		{
+			name: "neither door",
+			args: []string{"check", "--corpus", dir},
+			says: "--exec or --image is required",
+		},
+		{
+			name: "both doors",
+			args: []string{"check", "--corpus", dir, "--exec", os.Args[0], "--image", "example.com/adapter"},
+			says: "two doors",
+		},
+		{
+			name: "the command door's working directory on the image door",
+			args: []string{"check", "--corpus", dir, "--image", "example.com/adapter", "--dir", dir},
+			says: "--dir is the command door's",
+		},
+		{
+			name: "the image door's runtime on the command door",
+			args: []string{"check", "--corpus", dir, "--exec", os.Args[0], "--runtime", "podman"},
+			says: "--runtime is the image door's",
+		},
+		{
+			name: "the image door's wall clock on the command door",
+			args: []string{"check", "--corpus", dir, "--exec", os.Args[0], "--image-deadline", "1h"},
+			says: "--image-deadline is the image door's",
+		},
+		{
+			name: "the image door's memory cap on the command door",
+			args: []string{"check", "--corpus", dir, "--exec", os.Args[0], "--image-memory", "1g"},
+			says: "--image-memory is the image door's",
+		},
+		{
+			name: "the image door's process cap on the command door",
+			args: []string{"check", "--corpus", dir, "--exec", os.Args[0], "--image-processes", "8"},
+			says: "--image-processes is the image door's",
+		},
+		{
+			name: "the image door's scratch on the command door",
+			args: []string{"check", "--corpus", dir, "--exec", os.Args[0], "--image-scratch", "1g"},
+			says: "--image-scratch is the image door's",
+		},
+		{
+			name: "a process cap that is not one",
+			args: []string{"check", "--corpus", dir, "--image", "example.com/adapter", "--image-processes", "0"},
+			says: "is not a cap",
+		},
+		{
+			name: "a size that is not one",
+			args: []string{"check", "--corpus", dir, "--image", "example.com/adapter", "--image-memory", ""},
+			says: "not a size",
+		},
+		{
+			name: "a wall clock that is not positive",
+			args: []string{"check", "--corpus", dir, "--image", "example.com/adapter", "--image-deadline", "0"},
+			says: "is not one",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, _, err := drive(t, testCase.args...)
+			if err == nil {
+				t.Fatal("check accepted arguments that name no one door")
+			}
+
+			if !strings.Contains(err.Error(), testCase.says) {
+				t.Errorf("the refusal does not say %q:\n%v", testCase.says, err)
+			}
+		})
+	}
+}
+
+// TestTheWallClockMustOutliveTheBuildDeadline is the one bound whose wrong
+// value is silent. The wall clock takes the whole container away and generate
+// may legitimately run a compiler over the whole corpus, so a container removed
+// first reads as a generator that answered nothing rather than as a door that
+// would not wait for it.
+func TestTheWallClockMustOutliveTheBuildDeadline(t *testing.T) {
+	dir := t.TempDir()
+
+	_, _, err := drive(t, "check",
+		"--corpus", dir,
+		"--image", "example.com/adapter",
+		"--build-deadline", "10m",
+		"--image-deadline", "5m")
+	if err == nil {
+		t.Fatal("check accepted a wall clock that ends every build it allows")
+	}
+
+	if !strings.Contains(err.Error(), "--build-deadline") {
+		t.Errorf("the refusal does not name the bound it conflicts with:\n%v", err)
+	}
+}
+
+// stubRuntime writes a container runtime that is not one, onto a PATH of this
+// test's own, and returns the name --runtime is given.
+//
+// It does what the door's argument vector says it should: skips `run` and every
+// flag joined to its value, takes the next argument as the image, and runs it
+// with what follows. That the vector can be read that way is the door's
+// property and is asserted on its own in the engine's tests; here it is what
+// lets a real adapter answer through the flag.
+func stubRuntime(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stub-runtime")
+
+	write(t, path, []byte(`#!/bin/sh
+[ "$1" = "run" ] || { echo "the stub runtime was asked to $1" >&2; exit 2; }
+shift
+while [ $# -gt 0 ]; do
+	case "$1" in
+	-*) shift ;;
+	*) break ;;
+	esac
+done
+[ $# -gt 0 ] || { echo "the stub runtime was given no image" >&2; exit 2; }
+image=$1
+shift
+exec "$image" "$@"
+`))
+
+	if err := os.Chmod(path, 0o755); err != nil {
+		t.Fatalf("chmod %s: %v", path, err)
+	}
+
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	return filepath.Base(path)
+}

--- a/cmd/cpybkc-conform/main.go
+++ b/cmd/cpybkc-conform/main.go
@@ -7,6 +7,7 @@
 // adapter and reports what came back.
 //
 //	cpybkc-conform check --exec <path> [--corpus <dir>] [-- args for the adapter...]
+//	cpybkc-conform check --image <ref> [--corpus <dir>] [-- args for the adapter...]
 //	cpybkc-conform digest [--corpus <dir>]
 //
 // It is [github.com/Zaba505/cpybkc/internal/conformance/engine] with a command
@@ -32,11 +33,28 @@
 // attached to every release beside the corpus, as cpybkc-conformance.tar.gz —
 // a download and an `--exec`, with no registry, no daemon and no image.
 //
-// A container door is the *other* door and is #203's. It is where the
-// properties that make a result believable live — no network, a read-only root,
-// a deadline — and this one has none of them: [engine.Command.Describe] says so
-// in as many words, and the report quotes it. A run through this door is the
-// author's own working result, and that is what it should be labelled.
+// # Two doors, and what each one is worth
+//
+// So `--exec` is the door that needs nothing: a download and a path. It also
+// provides nothing — no network namespace, no read-only root, no resource cap —
+// and [engine.Command.Describe] says so in as many words, which the report
+// quotes. A run through it is the author's own working result.
+//
+// `--image` is the other door, and is where the properties that make a result
+// believable to somebody else live: no network, a read-only root, a memory and
+// process cap, and a wall-clock bound on the container
+// ([engine.Image.Describe], again quoted). Both doors drive one implementation
+// of the conversation, because the contract begins after the process exists
+// (docs/adapter/SPEC.md, "A process is the unit, and a container is a door onto
+// it") — the image door is an argument vector and a container to take away
+// afterwards, and nothing about the conversation changes (#203).
+//
+// Which door a run went through is therefore a property of the result, and the
+// report records it. Neither door makes a run a conformance claim a third party
+// should be asked to trust without qualification: a run computed on the
+// claimant's machine, against a corpus they downloaded, by a program they are
+// holding, is a self-report either way. That is a fine thing to publish, as
+// long as it is labelled as one.
 //
 // # The exit status
 //

--- a/cmd/cpybkc-conform/main_test.go
+++ b/cmd/cpybkc-conform/main_test.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -287,7 +288,12 @@ func TestUsageStatesTheDefaultsTheFlagsCarry(t *testing.T) {
 		engine.DefaultDeadline.String(),
 		engine.DefaultBuildDeadline.String(),
 		engine.DefaultGrace.String(),
+		engine.DefaultImageTimeout.String(),
 		`(default "` + defaultCorpus + `")`,
+		`(default "` + engine.DefaultRuntime + `")`,
+		`(default "` + engine.DefaultMemory + `")`,
+		`(default "` + engine.DefaultScratch + `")`,
+		"(default " + strconv.Itoa(engine.DefaultProcesses) + ")",
 	} {
 		if !strings.Contains(usage, want) {
 			t.Errorf("the synopsis does not state %s, so it describes flags this program does not have", want)
@@ -313,7 +319,7 @@ func TestRunRejectsBadUsage(t *testing.T) {
 		{name: "an adapter named rather than pathed", args: []string{"check", "--exec", "adapter"}},
 		{name: "an adapter named as a bare word that exists on PATH", args: []string{"check", "--exec", "sh"}},
 		{name: "an adapter that is a directory", args: []string{"check", "--exec", dir}},
-		{name: "a flag this program does not have", args: []string{"check", "--image", "example.com/x"}},
+		{name: "a flag this program does not have", args: []string{"check", "--exec", os.Args[0], "--isolated"}},
 		{name: "a deadline of zero", args: []string{"check", "--exec", os.Args[0], "--deadline", "0"}},
 		{name: "a negative build deadline", args: []string{"check", "--exec", os.Args[0], "--build-deadline", "-1s"}},
 		{name: "an operand digest does not take", args: []string{"digest", "extra"}},

--- a/cmd/cpybkc-conform/usage.go
+++ b/cmd/cpybkc-conform/usage.go
@@ -14,7 +14,8 @@ package main
 // description for the other two to drift from.
 const usage = `cpybkc-conform runs the cpybkc conformance corpus against a generator's adapter.
 
-  cpybkc-conform check --exec <path> [flags] [-- args for the adapter...]
+  cpybkc-conform check --exec <path>  [flags] [-- args for the adapter...]
+  cpybkc-conform check --image <ref>  [flags] [-- args for the adapter...]
   cpybkc-conform digest [--corpus <dir>]
   cpybkc-conform help
 
@@ -23,10 +24,10 @@ check drives the adapter through the contract and reports every entry. It exits
 when the run could not be attempted at all.
 
   --exec <path>              the adapter executable, as a path and not a name to
-                             find on PATH (required)
+                             find on PATH
+  --image <ref>              the adapter as a container image, run through the
+                             image door below
   --corpus <dir>             the unpacked corpus (default "corpus")
-  --dir <dir>                the adapter's working directory (default: this
-                             program's own)
   --deadline <duration>      bounds one operation (default 1m0s)
   --build-deadline <duration>
                              bounds generate, which may run a compiler over the
@@ -34,17 +35,46 @@ when the run could not be attempted at all.
   --grace <duration>         how long the adapter is given to exit once the
                              conversation is over (default 10s)
 
-Everything left over is the adapter's own argument vector. Put a bare -- in
-front of it: an adapter that takes flags of its own takes them at the same
-spelling this program takes its, and without the terminator they are read as
-this program's and refused.
+--exec or --image, and never both: they are two doors and a run goes through one.
+
+  --dir <dir>                --exec only: the adapter's working directory
+                             (default: this program's own)
+  --runtime <name>           --image only: the container runtime, found on PATH
+                             (default "docker")
+  --image-deadline <duration>
+                             --image only: bounds the whole container, by the
+                             wall clock, and must outlive --build-deadline
+                             (default 30m0s)
+  --image-memory <size>      --image only: the memory cap (default "2g")
+  --image-processes <n>      --image only: the process cap (default 256)
+  --image-scratch <size>     --image only: the size of the writable /tmp the
+                             door mounts (default "1g")
+
+Everything left over is the adapter's own argument vector — the container's,
+under --image. Put a bare -- in front of it: an adapter that takes flags of its
+own takes them at the same spelling this program takes its, and without the
+terminator they are read as this program's and refused.
 
 digest writes the corpus's SHA-256 to standard output, and fails if a digest is
 published beside the corpus and disagrees with it.
 
-This door runs the adapter directly and provides no isolation of any kind: no
-network namespace, no read-only root and no resource cap. A result produced
-through it is your own working result rather than one to hand to somebody else.
+The two doors, and what each one is worth
+
+--exec runs the adapter here, as a process, and provides no isolation of any
+kind: no network namespace, no read-only root and no resource cap. A result
+produced through it is your own working result.
+
+--image runs it in a container with no network, a read-only root, a writable
+/tmp, a memory cap, a process cap and a wall-clock bound. Those are the door's
+properties and never the contract's, which is why the report quotes the door
+rather than assuming them of every run — and why a result produced through this
+door is one you can hand to somebody else.
+
+Neither is a conformance claim a third party should be asked to trust without
+qualification: a run computed on your machine, against a corpus you downloaded,
+by a program you are holding, is a self-report whichever door produced it. That
+is a fine thing to publish, labelled as one. cpybkc awards no level, profile,
+score or badge.
 
 What an entry holds and what an answer is written in:
     https://github.com/Zaba505/cpybkc/blob/main/docs/conformance/SPEC.md

--- a/cmd/cpybkc-conform/usage.go
+++ b/cmd/cpybkc-conform/usage.go
@@ -43,8 +43,8 @@ when the run could not be attempted at all.
                              (default "docker")
   --image-deadline <duration>
                              --image only: bounds the whole container, by the
-                             wall clock, and must outlive --build-deadline
-                             (default 30m0s)
+                             wall clock, and must outlive --deadline and
+                             --build-deadline (default 30m0s)
   --image-memory <size>      --image only: the memory cap (default "2g")
   --image-processes <n>      --image only: the process cap (default 256)
   --image-scratch <size>     --image only: the size of the writable /tmp the
@@ -69,6 +69,12 @@ produced through it is your own working result.
 properties and never the contract's, which is why the report quotes the door
 rather than assuming them of every run — and why a result produced through this
 door is one you can hand to somebody else.
+
+/tmp is the only writable path in that container, and no host directory is
+mounted into it. An adapter image whose toolchain writes under a home directory
+has to point it there itself — TMPDIR, HOME, GOCACHE, CARGO_HOME, whatever it
+reads — because a build that fails on a read-only root fails for a reason that
+has nothing to do with the corpus.
 
 Neither is a conformance claim a third party should be asked to trust without
 qualification: a run computed on your machine, against a corpus you downloaded,

--- a/internal/conformance/engine/adapter_test.go
+++ b/internal/conformance/engine/adapter_test.go
@@ -28,9 +28,18 @@ import (
 // costs a go build on every `go test` of this package and gives nothing back.
 const adapterEnv = "CPYBKC_CONFORMANCE_FAKE_ADAPTER"
 
-// TestMain is the fork in the road: with the variable set this process is an
-// adapter, and without it, it is the test binary.
+// TestMain is the fork in the road: this binary is a container runtime, an
+// adapter, or the tests, and each variable is set by whatever started it.
+//
+// The runtime is looked for first because it starts the adapter itself, in the
+// process it was given: a stub that re-exec'd would have to carry the adapter's
+// variable through it, and the point of the stub is that the image door hands
+// the container its own argument vector and nothing of the host's.
 func TestMain(m *testing.M) {
+	if record := os.Getenv(runtimeEnv); record != "" {
+		os.Exit(runAsRuntime(record))
+	}
+
 	if path := os.Getenv(adapterEnv); path != "" {
 		os.Exit(adapt(path))
 	}
@@ -342,6 +351,23 @@ func (f *fakeAdapter) record(line string) {
 func door(t *testing.T, told script) (*engine.Command, string) {
 	t.Helper()
 
+	path, transcript := scripted(t, told)
+
+	return &engine.Command{
+		Path: os.Args[0],
+		Env:  append(os.Environ(), adapterEnv+"="+path),
+	}, transcript
+}
+
+// scripted writes a fake adapter's script to a file of the test's own and
+// returns that path and the transcript the adapter will write to.
+//
+// It is separate from [door] because the image door reaches the same fake
+// adapter by a different route — through a stub runtime, as the container's own
+// argument vector — and the script is the half both doors share.
+func scripted(t *testing.T, told script) (string, string) {
+	t.Helper()
+
 	dir := t.TempDir()
 
 	transcript := filepath.Join(dir, "transcript.jsonl")
@@ -357,10 +383,7 @@ func door(t *testing.T, told script) (*engine.Command, string) {
 		t.Fatalf("failed to write the fake adapter's script: %v", err)
 	}
 
-	return &engine.Command{
-		Path: os.Args[0],
-		Env:  append(os.Environ(), adapterEnv+"="+path),
-	}, transcript
+	return path, transcript
 }
 
 // transcript is every request frame the adapter received, as text.

--- a/internal/conformance/engine/doc.go
+++ b/internal/conformance/engine/doc.go
@@ -64,11 +64,23 @@
 //
 // The argument vector, the working directory, the environment and whether the
 // process is local at all are not the contract's, which is why they are not
-// this package's either: [Door] is the seam, [Command] is the door that runs a
-// command, and a door that starts a container is a sibling of it rather than a
-// change here (#203). What a door adds — a run with no network, a read-only
-// root, a wall-clock cap — is reportable and is the door's own to describe, and
-// [Report] quotes that description rather than claiming a guarantee of its own.
+// this package's either: [Door] is the seam, and the two doors this package
+// ships are siblings behind one implementation of the conversation (#203).
+//
+//   - [Command] runs a command. It provides nothing beyond a process: no
+//     network namespace, no read-only root, no cap of any kind. A result
+//     produced through it is the author's own working result.
+//   - [Image] runs a container image, with no network, a read-only root, a
+//     writable tmpfs at /tmp, a memory cap, a process cap and a wall-clock
+//     bound. A result produced through it is one the author can hand to
+//     somebody else.
+//
+// What a door adds is the door's own to describe and is never the contract's,
+// and [Report] quotes that description rather than claiming a guarantee of its
+// own — an engine MUST NOT report a result as though it carried a guarantee its
+// door did not provide. Neither door makes a run a claim a third party should
+// be asked to trust without qualification; both are self-reports, and the
+// difference between them is how much of one.
 //
 // # Failure reporting is the point
 //

--- a/internal/conformance/engine/door.go
+++ b/internal/conformance/engine/door.go
@@ -22,8 +22,8 @@ import (
 // the grounds that they are the door's rather than the contract's: one engine
 // runs a command and another spawns a container, and both drive one
 // implementation of the conversation precisely because the contract begins
-// after the process exists. This interface is that seam. [Command] is the door
-// this package ships, and the image door is a sibling of it (#203).
+// after the process exists. This interface is that seam, and [Command] and
+// [Image] are the two doors this package ships through it (#203).
 type Door interface {
 	// Open starts one adapter process. A door that cannot start one at all is
 	// an error, and it costs the run: there is no conversation to have.

--- a/internal/conformance/engine/image.go
+++ b/internal/conformance/engine/image.go
@@ -1,0 +1,367 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package engine
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// The image door's defaults, which are what a run that asked for nothing in
+// particular gets.
+const (
+	// DefaultRuntime is the container runtime the image door drives. It is a
+	// name looked up on PATH rather than a path — the opposite of
+	// [Command.Path]'s rule, and for the opposite reason: the adapter is
+	// usually something just built from the tree under test, where finding
+	// "whichever one is installed" is the failure, and a container runtime is a
+	// system tool where finding the installed one is the whole point. `podman`
+	// is the other value this door is written against; both spell every flag
+	// below the same way.
+	DefaultRuntime = "docker"
+
+	// DefaultImageTimeout is the wall-clock cap on one adapter process started
+	// through the image door.
+	//
+	// It is longer than [DefaultBuildDeadline] on purpose, and by a wide margin.
+	// The engine's own deadlines bound one operation, and the longest of them is
+	// generate, which may run a compiler over the whole corpus; a wall-clock cap
+	// shorter than that would kill a container in the middle of a legal build
+	// and report every entry as a fault — an adapter failing the corpus because
+	// the door it came through would not wait for it.
+	DefaultImageTimeout = 30 * time.Minute
+
+	// DefaultMemory is the memory cap, in the runtime's own notation. Swap is
+	// pinned to the same number, so the cap is a cap rather than a threshold at
+	// which the run starts swapping.
+	DefaultMemory = "2g"
+
+	// DefaultProcesses is the process cap, which is what stops a broken adapter
+	// forking until the host stops responding.
+	DefaultProcesses = 256
+
+	// DefaultScratch is the size of the writable /tmp the door mounts.
+	//
+	// A read-only root with nowhere to write at all would refuse most real
+	// adapters: a generator emits code and something compiles it, and both want
+	// a directory. One tmpfs, in memory, inside the container's own mount
+	// namespace, is the smallest thing that lets that work while leaving nothing
+	// behind and touching no host path.
+	DefaultScratch = "1g"
+)
+
+// removeGrace bounds the removal of a container the door is done with. It is
+// short because nothing waits on the answer: the container is being taken away,
+// and a runtime that will not answer in this long is a fact about the host
+// rather than about the run.
+const removeGrace = 30 * time.Second
+
+// Image is the door that runs an adapter from a container image.
+//
+// It is [Command]'s sibling and not its replacement, and the difference between
+// them is the whole of why both exist. Both drive one implementation of the
+// conversation — the contract begins after the process exists
+// (docs/adapter/SPEC.md, "A process is the unit, and a container is a door onto
+// it"), so this door is a matter of building an argument vector and handing it
+// to the same [Command] behind it.
+//
+// What this door adds is everything that makes a result believable to somebody
+// who did not produce it: no network, a read-only root, a memory cap, a process
+// cap and a wall-clock bound on the whole conversation. None of those is a
+// property of the contract, which is why they are stated by [Image.Describe]
+// and quoted into the report rather than assumed of every run. A result
+// produced through [Command] is the author's own working result; a result
+// produced through this door is one they can hand to somebody else.
+//
+// Neither is a conformance claim a third party should be asked to trust
+// without qualification: a run computed on the claimant's machine, against a
+// corpus they downloaded, by a program they built, is a self-report whichever
+// door produced it. That is a fine thing to publish, labelled as one.
+type Image struct {
+	// Reference is the image to run, in whatever notation the runtime accepts.
+	// It is required.
+	//
+	// The image's entrypoint is the adapter: this door starts the image and
+	// speaks the contract to it, and what runs inside is the image's business
+	// exactly as the executable is [Command]'s.
+	Reference string
+
+	// Args are the arguments after the image reference, which the runtime hands
+	// to the container as its own argument vector. They are the door's and not
+	// the contract's, exactly as [Command.Args] are.
+	Args []string
+
+	// Runtime is the container runtime, as a name looked up on PATH. Empty is
+	// [DefaultRuntime].
+	Runtime string
+
+	// Env is the environment of the *runtime client* — the `docker` or `podman`
+	// process this door starts — and nil is this process's own. It is how a run
+	// reaches a daemon that is not the default one.
+	//
+	// It is emphatically not the container's environment, and nothing here
+	// passes one to the other. An adapter that could read the host's
+	// environment would be an adapter whose answers depended on the machine it
+	// ran on, which is the property this door exists to remove.
+	Env []string
+
+	// Timeout is the wall-clock cap on one adapter process. Zero is
+	// [DefaultImageTimeout].
+	//
+	// It bounds the container rather than an operation: the engine's own
+	// deadlines already bound every request and kill an adapter that misses
+	// one, and this is what bounds an adapter that is answering promptly and
+	// forever, or one whose runtime never handed the engine the process it
+	// thought it had.
+	Timeout time.Duration
+
+	// Memory is the memory cap in the runtime's notation, and empty is
+	// [DefaultMemory]. Processes is the process cap, and a value below one is
+	// [DefaultProcesses]. Scratch is the size of the writable /tmp, and empty is
+	// [DefaultScratch].
+	//
+	// They are settable rather than fixed because a cap with no way past it is
+	// a cap people get past by not using the door at all, and this door is the
+	// one worth using. What keeps that honest is that [Image.Describe] reports
+	// the numbers actually used, so a report can never claim a bound the run did
+	// not have.
+	Memory    string
+	Processes int
+	Scratch   string
+}
+
+// Open starts one container and hands back the conversation with it.
+func (i *Image) Open(ctx context.Context) (Process, error) {
+	if i.Reference == "" {
+		return nil, fmt.Errorf("the door has no image to run")
+	}
+
+	// Resolved here rather than left to os/exec, so that a machine with no
+	// container runtime on it says so before a container name is minted and a
+	// deadline is armed — and says which name it looked for.
+	path, err := exec.LookPath(i.runtime())
+	if err != nil {
+		return nil, fmt.Errorf("failed to find the container runtime %s: %w", i.runtime(), err)
+	}
+
+	name, err := containerName()
+	if err != nil {
+		return nil, err
+	}
+
+	// The wall clock, armed before the process exists so that a runtime which
+	// hangs before it has started anything is bounded too.
+	ctx, cancel := context.WithTimeout(ctx, i.timeout())
+
+	inner, err := (&Command{Path: path, Args: i.argv(name), Env: i.Env}).Open(ctx)
+	if err != nil {
+		cancel()
+
+		return nil, fmt.Errorf("failed to run the image %s: %w", i.Reference, err)
+	}
+
+	return &container{
+		Process: inner,
+		runtime: path,
+		env:     i.Env,
+		name:    name,
+		timeout: i.timeout(),
+		ctx:     ctx,
+		cancel:  cancel,
+	}, nil
+}
+
+// Describe says what this door provides, in the numbers this run actually used.
+func (i *Image) Describe() string {
+	said := fmt.Sprintf("the image %s, run by %s with no network, a read-only root", i.Reference, i.runtime())
+
+	return fmt.Sprintf("%s and a %s tmpfs at /tmp, capped at %s of memory and %d processes, "+
+		"under a %s wall-clock bound", said, i.scratch(), i.memory(), i.processes(), i.timeout())
+}
+
+// argv is the runtime's argument vector for one container.
+//
+// Every flag is written joined to its value, which makes the image reference
+// the first argument after `run` that does not begin with a dash. That is worth
+// having: the reference and everything after it belong to the container, and a
+// vector where the boundary can be read off is one a reader of a failing run
+// can check by eye.
+func (i *Image) argv(name string) []string {
+	args := []string{
+		"run",
+
+		// Removed when it exits, and named so that it can be removed when it
+		// does not. See [container.remove].
+		"--rm",
+		"--name=" + name,
+
+		// Standard input attached, and deliberately no TTY. A pseudo-terminal
+		// echoes what is written to it and rewrites line endings, and the
+		// conversation is newline-delimited JSON in both directions: a TTY would
+		// feed the engine's own request frames back to it as though the adapter
+		// had sent them.
+		"--interactive",
+
+		// The guarantees. An adapter has no reason to reach the network — the
+		// bytes travel in the frame and never as a path (docs/adapter/SPEC.md,
+		// "The bytes travel in the frame, and not as a path") — so a door that
+		// removes the network removes with it every way a result could depend on
+		// something that was not in the corpus.
+		"--network=none",
+		"--read-only",
+		"--tmpfs=/tmp:rw,nosuid,nodev,size=" + i.scratch(),
+		"--memory=" + i.memory(),
+		"--memory-swap=" + i.memory(),
+		"--pids-limit=" + strconv.Itoa(i.processes()),
+
+		// Neither is a bound the report claims, and both are cheap: an adapter
+		// is a program that reads two pipes, so no capability it might be
+		// granted is one it needs, and nothing it runs has any business gaining
+		// privileges it was not started with.
+		"--cap-drop=ALL",
+		"--security-opt=no-new-privileges",
+	}
+
+	return append(append(args, i.Reference), i.Args...)
+}
+
+func (i *Image) runtime() string {
+	if i.Runtime != "" {
+		return i.Runtime
+	}
+
+	return DefaultRuntime
+}
+
+func (i *Image) timeout() time.Duration {
+	if i.Timeout > 0 {
+		return i.Timeout
+	}
+
+	return DefaultImageTimeout
+}
+
+func (i *Image) memory() string {
+	if i.Memory != "" {
+		return i.Memory
+	}
+
+	return DefaultMemory
+}
+
+func (i *Image) processes() int {
+	if i.Processes > 0 {
+		return i.Processes
+	}
+
+	return DefaultProcesses
+}
+
+func (i *Image) scratch() string {
+	if i.Scratch != "" {
+		return i.Scratch
+	}
+
+	return DefaultScratch
+}
+
+// containerName is a name for one container, unique to it.
+//
+// Random rather than derived from the run, because two engines against the same
+// image on one host is an ordinary thing to do — a CI job checking two
+// generators, or an author comparing a change against the version before it —
+// and a name collision would have one run remove the other's container.
+func containerName() (string, error) {
+	var b [8]byte
+
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("failed to name the adapter's container: %w", err)
+	}
+
+	return "cpybkc-conform-" + hex.EncodeToString(b[:]), nil
+}
+
+// container is one running adapter container, as the conversation sees it.
+//
+// It is the [Command] process underneath with the two things a container needs
+// on top: the wall clock, and the removal that goes with it.
+type container struct {
+	Process
+
+	runtime string
+	env     []string
+	name    string
+	timeout time.Duration
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	once sync.Once
+}
+
+// Wait waits for the container to end, and takes it away if it was still there.
+//
+// The removal is the part a plain command does not need. `run --rm` cleans up a
+// container that exited on its own, and the case it does not cover is the one
+// this door has to get right: killing an attached client does not stop what it
+// was attached to, so a wall clock that expired — or a caller who gave up —
+// leaves a container running an adapter nobody is talking to any more. That is
+// exactly the resource leak the caps exist to prevent, arriving by the door
+// that promised them.
+func (c *container) Wait() error {
+	err := c.Process.Wait()
+
+	// Read before the cancel below, which would otherwise make every ended
+	// conversation look like one that was cut short.
+	expired := c.ctx.Err()
+
+	c.cancel()
+
+	if expired == nil {
+		return err
+	}
+
+	c.remove()
+
+	if errors.Is(expired, context.DeadlineExceeded) {
+		return fmt.Errorf("the adapter's container was taken away after the door's %s wall-clock bound: %w",
+			c.timeout, err)
+	}
+
+	return err
+}
+
+// Kill ends the container, rather than the client attached to it.
+func (c *container) Kill() {
+	c.remove()
+	c.Process.Kill()
+	c.cancel()
+}
+
+// remove takes the container away, once, and best effort.
+//
+// Nothing is reported: the only outcomes are a container that is gone, which is
+// what was asked for, and a runtime that could not be asked, which has already
+// cost the run everything it is going to. The context is a fresh one because
+// this runs precisely when the run's own is done with.
+func (c *container) remove() {
+	c.once.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), removeGrace)
+		defer cancel()
+
+		cmd := exec.CommandContext(ctx, c.runtime, "rm", "--force", "--volumes", c.name)
+		cmd.Env = c.env
+
+		_ = cmd.Run()
+	})
+}

--- a/internal/conformance/engine/image.go
+++ b/internal/conformance/engine/image.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -57,6 +58,15 @@ const (
 	// a directory. One tmpfs, in memory, inside the container's own mount
 	// namespace, is the smallest thing that lets that work while leaving nothing
 	// behind and touching no host path.
+	//
+	// It is the *only* writable path, and that is a requirement on the image
+	// rather than a surprise to discover: a toolchain left to its own defaults
+	// writes under a home directory, and $HOME on a read-only root is a build
+	// that fails for a reason having nothing to do with the corpus. An adapter
+	// image points its caches at /tmp — TMPDIR, HOME, GOCACHE, CARGO_HOME,
+	// whatever its toolchain reads — and the door deliberately does not set
+	// those itself, because an environment this door injected would be one the
+	// image's own author could not see in their Dockerfile.
 	DefaultScratch = "1g"
 )
 
@@ -140,10 +150,19 @@ type Image struct {
 	Scratch   string
 }
 
+// errWallClock is this door's own wall clock, and nothing else's.
+//
+// It is a cause rather than a comparison against [context.DeadlineExceeded],
+// because the context [Image.Open] is given may carry a deadline of the
+// caller's: a run bounded at five minutes by whoever started it would otherwise
+// be reported as having hit a thirty-minute bound that never elapsed, which
+// names the wrong thing to go and change.
+var errWallClock = errors.New("the door's wall-clock bound elapsed")
+
 // Open starts one container and hands back the conversation with it.
 func (i *Image) Open(ctx context.Context) (Process, error) {
-	if i.Reference == "" {
-		return nil, fmt.Errorf("the door has no image to run")
+	if err := i.reference(); err != nil {
+		return nil, err
 	}
 
 	// Resolved here rather than left to os/exec, so that a machine with no
@@ -161,7 +180,7 @@ func (i *Image) Open(ctx context.Context) (Process, error) {
 
 	// The wall clock, armed before the process exists so that a runtime which
 	// hangs before it has started anything is bounded too.
-	ctx, cancel := context.WithTimeout(ctx, i.timeout())
+	ctx, cancel := context.WithTimeoutCause(ctx, i.timeout(), errWallClock)
 
 	inner, err := (&Command{Path: path, Args: i.argv(name), Env: i.Env}).Open(ctx)
 	if err != nil {
@@ -171,22 +190,60 @@ func (i *Image) Open(ctx context.Context) (Process, error) {
 	}
 
 	return &container{
-		Process: inner,
-		runtime: path,
-		env:     i.Env,
-		name:    name,
-		timeout: i.timeout(),
-		ctx:     ctx,
-		cancel:  cancel,
+		Process:   inner,
+		runtime:   path,
+		env:       i.Env,
+		name:      name,
+		reference: i.Reference,
+		timeout:   i.timeout(),
+		ctx:       ctx,
+		cancel:    cancel,
 	}, nil
 }
 
-// Describe says what this door provides, in the numbers this run actually used.
-func (i *Image) Describe() string {
-	said := fmt.Sprintf("the image %s, run by %s with no network, a read-only root", i.Reference, i.runtime())
+// reference is the image this door was given, checked for the one shape that
+// would make it something other than an image.
+//
+// A reference beginning with a dash lands in the runtime's own flag position —
+// the argument vector is `run <the door's flags> <reference> <the container's
+// args>` — so `-v/:/host` or `--network=host` would be read by the runtime as
+// another option to itself, and the container after it started with whatever
+// came next. Every guarantee this door then describes would be one it did not
+// provide, which is the one failure it exists to prevent. A reference is
+// therefore refused rather than escaped: `--` before it would work on the two
+// runtimes this door is written against, and a door whose safety rested on a
+// terminator every runtime is assumed to honour is a door resting on an
+// assumption about programs it does not ship.
+func (i *Image) reference() error {
+	switch {
+	case i.Reference == "":
+		return fmt.Errorf("the door has no image to run")
+	case strings.HasPrefix(i.Reference, "-"):
+		return fmt.Errorf("%q is not an image reference: it begins with a dash, which the container runtime would "+
+			"read as another option to itself and start something else entirely", i.Reference)
+	default:
+		return nil
+	}
+}
 
-	return fmt.Sprintf("%s and a %s tmpfs at /tmp, capped at %s of memory and %d processes, "+
-		"under a %s wall-clock bound", said, i.scratch(), i.memory(), i.processes(), i.timeout())
+// Describe says what this door provides, in the numbers this run actually used.
+//
+// The two isolations are stated flatly and the two caps are stated as asked
+// for, and the difference is not hedging. A runtime that cannot give a
+// container an empty network namespace or a read-only root refuses to start it,
+// so a run that happened had both. A memory or process cap is different: a
+// kernel without swap accounting or without the pids controller leaves the
+// flag unhonoured, warns on its standard error and runs the container anyway —
+// so a report that stated those as facts would be reporting a guarantee the
+// door may not have provided, which is the one thing an engine must not do.
+// The runtime's warning is captured with the adapter's own diagnostics and
+// quoted beside a fault, which is where a reader finds out which it was.
+func (i *Image) Describe() string {
+	said := fmt.Sprintf("the image %s, run by %s with no network and a read-only root", i.Reference, i.runtime())
+
+	return fmt.Sprintf("%s, a %s tmpfs at /tmp its only writable path, asked of the runtime for at most %s of "+
+		"memory and %d processes, under a %s wall-clock bound",
+		said, i.scratch(), i.memory(), i.processes(), i.timeout())
 }
 
 // argv is the runtime's argument vector for one container.
@@ -298,54 +355,131 @@ func containerName() (string, error) {
 type container struct {
 	Process
 
-	runtime string
-	env     []string
-	name    string
-	timeout time.Duration
+	runtime   string
+	env       []string
+	name      string
+	reference string
+	timeout   time.Duration
 
 	ctx    context.Context
 	cancel context.CancelFunc
 
 	once sync.Once
+
+	// mu guards said, which is written by whoever waits on the container and
+	// read by the engine afterwards.
+	mu   sync.Mutex
+	said string
 }
 
-// Wait waits for the container to end, and takes it away if it was still there.
+// Diagnostics is what the door captured of the container's standard error, with
+// the door's own reading of a runtime-level failure in front of it.
+//
+// The reading goes here rather than only into the error [container.Wait]
+// returns, because the path that matters most throws that error away: an engine
+// abandoning a conversation kills the process, reaps it without reading how it
+// went, and quotes the diagnostics beside the fault. A container that never
+// started is exactly that case, so this is where its explanation has to be for
+// anybody to see it.
+func (c *container) Diagnostics() string {
+	c.mu.Lock()
+	said := c.said
+	c.mu.Unlock()
+
+	if said == "" {
+		return c.Process.Diagnostics()
+	}
+
+	return said + "\n" + c.Process.Diagnostics()
+}
+
+// Wait waits for the container to end, and takes it away unless it ended well.
 //
 // The removal is the part a plain command does not need. `run --rm` cleans up a
 // container that exited on its own, and the case it does not cover is the one
 // this door has to get right: killing an attached client does not stop what it
-// was attached to, so a wall clock that expired — or a caller who gave up —
-// leaves a container running an adapter nobody is talking to any more. That is
-// exactly the resource leak the caps exist to prevent, arriving by the door
-// that promised them.
+// was attached to, so a wall clock that expired, a caller who gave up, or a
+// client that died for a reason of its own leaves a container running an
+// adapter nobody is talking to any more. That is exactly the resource leak the
+// caps exist to prevent, arriving by the door that promised them.
+//
+// So anything other than a clean exit is followed by a removal. The cost of
+// removing a container that had already gone is one doomed process; the cost of
+// not removing one that had not is a container holding memory until somebody
+// notices.
 func (c *container) Wait() error {
 	err := c.Process.Wait()
 
 	// Read before the cancel below, which would otherwise make every ended
 	// conversation look like one that was cut short.
-	expired := c.ctx.Err()
+	cause := context.Cause(c.ctx)
 
 	c.cancel()
 
-	if expired == nil {
+	if err == nil && cause == nil {
+		return nil
+	}
+
+	c.remove()
+
+	switch {
+	case err == nil:
+		// The container ended on its own while the run was being given up on.
+		// Nothing was lost and nothing is wrapped: a conversation that finished
+		// is not a failure because the clock ran out a moment later.
+		return nil
+	case errors.Is(cause, errWallClock):
+		return fmt.Errorf("the adapter's container was taken away after the door's %s wall-clock bound: %w",
+			c.timeout, err)
+	default:
+		return c.explain(err)
+	}
+}
+
+// explain names a failure that is the runtime's rather than the adapter's.
+//
+// The three statuses are the ones the Docker and Podman clients reserve for
+// themselves: the container could not be created (125), its entrypoint could
+// not be run (126), or there was nothing there to run (127). Without this the
+// engine reports an image that does not exist, a flag the daemon would not
+// take, or an entrypoint that is not executable as an adapter whose stream
+// stopped — which sends a generator author to look at their generator.
+//
+// It is a reading rather than a certainty, and it says so, because a container
+// that exited 125 of its own accord is indistinguishable from a client that
+// never started one. The client's own message is captured with the adapter's
+// diagnostics and quoted beside the fault, which is what settles it.
+func (c *container) explain(err error) error {
+	var exit *exec.ExitError
+	if !errors.As(err, &exit) {
 		return err
 	}
 
-	c.remove()
+	switch exit.ExitCode() {
+	case 125, 126, 127:
+		said := fmt.Sprintf("the container runtime exited %d, which is what it reports when it could not run the "+
+			"image %s at all rather than what it passes on from an adapter", exit.ExitCode(), c.reference)
 
-	if errors.Is(expired, context.DeadlineExceeded) {
-		return fmt.Errorf("the adapter's container was taken away after the door's %s wall-clock bound: %w",
-			c.timeout, err)
+		c.mu.Lock()
+		c.said = said
+		c.mu.Unlock()
+
+		return fmt.Errorf("%s: %w", said, err)
+	default:
+		return err
 	}
-
-	return err
 }
 
-// Kill ends the container, rather than the client attached to it.
+// Kill ends the container, rather than only the client attached to it.
+//
+// The client is killed first and the container taken away after, because the
+// engine calls this when it wants the conversation over now: the removal is a
+// process of its own and a runtime that is slow to answer would otherwise hold
+// up the kill that was actually asked for.
 func (c *container) Kill() {
-	c.remove()
 	c.Process.Kill()
 	c.cancel()
+	c.remove()
 }
 
 // remove takes the container away, once, and best effort.

--- a/internal/conformance/engine/image_test.go
+++ b/internal/conformance/engine/image_test.go
@@ -1,0 +1,457 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package engine_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Zaba505/cpybkc/internal/conformance/engine"
+)
+
+// runtimeEnv is the variable that turns this test binary into a container
+// runtime, and names the file it records its argument vectors in.
+//
+// A stub rather than the real thing, because a test that needed a container
+// runtime would be a test that does not run: the pipeline this repository's
+// verify command drives is itself a container, and a machine with no daemon on
+// it is the ordinary case for a contributor. What the stub covers is everything
+// the door is: the argument vector it builds, the boundary between the door's
+// flags and the container's, the removal, and that the same conversation comes
+// back through it. What it cannot cover is whether Linux honoured the flags,
+// which is the runtime's promise and not this door's.
+const runtimeEnv = "CPYBKC_CONFORMANCE_FAKE_RUNTIME"
+
+// fakeImage is the reference the stub answers to, and hangImage is the one it
+// answers by never answering.
+const (
+	fakeImage = "ghcr.io/example/fake-adapter:v1"
+	hangImage = "ghcr.io/example/never-ends:v1"
+)
+
+// TestBothDoorsDriveOneContract is the story's first line and the reason [Door]
+// is an interface at all: the contract begins after the process exists, so a
+// run through a container has to be the same conversation with the same
+// outcomes, and the door has to be the only thing that differs.
+func TestBothDoorsDriveOneContract(t *testing.T) {
+	entries := corpus(t, "packed-ebcdic", "packed-invalid-sign", "zoned-ebcdic")
+	told := script{Entries: answers(t, entries)}
+
+	command, commandTranscript := door(t, told)
+	image, imageTranscript, _ := imageDoor(t, told)
+
+	direct, err := (&engine.Engine{Door: command}).Run(t.Context(), entries)
+	if err != nil {
+		t.Fatalf("the run through the command door could not be made: %v", err)
+	}
+
+	contained, err := (&engine.Engine{Door: image}).Run(t.Context(), entries)
+	if err != nil {
+		t.Fatalf("the run through the image door could not be made: %v", err)
+	}
+
+	if contained.Failed() {
+		t.Fatalf("the adapter answered what every entry states and the containerised run failed:\n%v", contained)
+	}
+
+	// The frames, which are the contract itself. An image door that sent a
+	// different conversation would be a second dialect of one specification.
+	if got, want := transcript(t, imageTranscript), transcript(t, commandTranscript); got != want {
+		t.Errorf("the two doors held different conversations:\nthrough the image:\n%s\ndirectly:\n%s", got, want)
+	}
+
+	if len(contained.Results) != len(direct.Results) {
+		t.Fatalf("the image door reported %d entries and the command door %d",
+			len(contained.Results), len(direct.Results))
+	}
+
+	for i, result := range contained.Results {
+		if result.Entry != direct.Results[i].Entry || result.Outcome != direct.Results[i].Outcome {
+			t.Errorf("entry %d came back as %s %s through the image and %s %s directly",
+				i, result.Outcome, result.Entry, direct.Results[i].Outcome, direct.Results[i].Entry)
+		}
+	}
+
+	// And the one thing that must differ, because it is the whole of what the
+	// two doors are worth to a reader of the result.
+	if contained.Door == direct.Door {
+		t.Errorf("both reports describe the same door: %s", contained.Door)
+	}
+}
+
+// TestTheImageDoorIsolatesTheAdapter is the guarantee the door exists to
+// provide, asserted where it is actually made — in the argument vector handed
+// to the runtime, since nothing else in this process can observe a namespace.
+func TestTheImageDoorIsolatesTheAdapter(t *testing.T) {
+	entries := corpus(t, "packed-ebcdic")
+
+	image, _, record := imageDoor(t, script{Entries: answers(t, entries)})
+	image.Memory = "512m"
+	image.Processes = 32
+	image.Scratch = "64m"
+
+	if _, err := (&engine.Engine{Door: image}).Run(t.Context(), entries); err != nil {
+		t.Fatalf("the run could not be made: %v", err)
+	}
+
+	run := invocation(t, record, "run")
+
+	for _, want := range []string{
+		"--network=none",
+		"--read-only",
+		"--tmpfs=/tmp:rw,nosuid,nodev,size=64m",
+		"--memory=512m",
+		"--memory-swap=512m",
+		"--pids-limit=32",
+		"--cap-drop=ALL",
+		"--security-opt=no-new-privileges",
+		"--interactive",
+		"--rm",
+	} {
+		if !slices.Contains(run, want) {
+			t.Errorf("the container was not started with %s: %v", want, run)
+		}
+	}
+
+	// A TTY would echo what the engine writes and rewrite its line endings, and
+	// the conversation is newline-delimited JSON in both directions: the
+	// engine's own request frames would come back to it as answers.
+	if slices.Contains(run, "--tty") || slices.Contains(run, "-t") {
+		t.Errorf("the container was given a terminal, and the conversation is framed: %v", run)
+	}
+}
+
+// TestTheImageReferenceEndsTheDoorsArgumentsAndBeginsTheContainers pins the one
+// boundary in the vector that a mistake would make invisible: an adapter's own
+// argument landing among the runtime's flags is either refused by the runtime or,
+// worse, accepted by it.
+func TestTheImageReferenceEndsTheDoorsArgumentsAndBeginsTheContainers(t *testing.T) {
+	entries := corpus(t, "packed-ebcdic")
+
+	image, _, record := imageDoor(t, script{Entries: answers(t, entries)})
+	image.Args = append(image.Args, "--generator", "./gen-rust")
+
+	if _, err := (&engine.Engine{Door: image}).Run(t.Context(), entries); err != nil {
+		t.Fatalf("the run could not be made: %v", err)
+	}
+
+	run := invocation(t, record, "run")
+
+	at := -1
+
+	for i, arg := range run {
+		if arg == fakeImage {
+			at = i
+
+			break
+		}
+	}
+
+	if at < 0 {
+		t.Fatalf("the image was never named to the runtime: %v", run)
+	}
+
+	for _, arg := range run[1:at] {
+		if !strings.HasPrefix(arg, "-") {
+			t.Errorf("%q sits between `run` and the image and is not a flag, so the image reference "+
+				"cannot be read off the vector: %v", arg, run)
+		}
+	}
+
+	if got := strings.Join(run[at+1:], " "); !strings.HasSuffix(got, "--generator ./gen-rust") {
+		t.Errorf("the container's own arguments are not what followed the image: %q", got)
+	}
+}
+
+// TestTheReportSaysWhichDoorProducedIt is the fourth acceptance criterion, and
+// the rule underneath it is docs/adapter/SPEC.md's: an engine MUST NOT report a
+// result as though it carried a guarantee its door did not provide. The
+// description is the door's own words, so what is asserted is that the numbers
+// in it are the ones the run actually used.
+func TestTheReportSaysWhichDoorProducedIt(t *testing.T) {
+	entries := corpus(t, "packed-ebcdic")
+
+	image, _, _ := imageDoor(t, script{Entries: answers(t, entries)})
+	image.Memory = "512m"
+	image.Processes = 32
+	image.Timeout = 20 * time.Minute
+
+	report, err := (&engine.Engine{Door: image}).Run(t.Context(), entries)
+	if err != nil {
+		t.Fatalf("the run could not be made: %v", err)
+	}
+
+	for _, want := range []string{fakeImage, "no network", "read-only root", "512m", "32 processes", "20m0s"} {
+		if !strings.Contains(report.Door, want) {
+			t.Errorf("the report does not say %q about the door it came through: %s", want, report.Door)
+		}
+	}
+
+	if !strings.Contains(report.String(), report.Door) {
+		t.Errorf("the report as a person reads it does not name the door:\n%s", report)
+	}
+}
+
+// TestTheWallClockTakesTheContainerAway is the third property of the door, and
+// the removal is the part a plain command does not need: killing a client that
+// is attached to a container does not stop the container, so a door that only
+// killed the client would leave an adapter running with every cap it was given
+// and nobody talking to it.
+func TestTheWallClockTakesTheContainerAway(t *testing.T) {
+	image, _, record := imageDoor(t, script{})
+	image.Reference = hangImage
+	image.Timeout = 200 * time.Millisecond
+
+	process, err := image.Open(t.Context())
+	if err != nil {
+		t.Fatalf("the door would not open: %v", err)
+	}
+
+	err = process.Wait()
+	if err == nil {
+		t.Fatal("a container that never ended came back as one that ended well")
+	}
+
+	if !strings.Contains(err.Error(), "wall-clock") {
+		t.Errorf("the failure does not say the door's bound ended the run: %v", err)
+	}
+
+	assertRemoved(t, record)
+}
+
+// TestKillingTheAdapterTakesItsContainerAway is the same removal by the route
+// the engine actually takes: it kills an adapter that broke, and then reaps it.
+func TestKillingTheAdapterTakesItsContainerAway(t *testing.T) {
+	image, _, record := imageDoor(t, script{})
+	image.Reference = hangImage
+
+	process, err := image.Open(t.Context())
+	if err != nil {
+		t.Fatalf("the door would not open: %v", err)
+	}
+
+	process.Kill()
+
+	_ = process.Wait()
+
+	assertRemoved(t, record)
+}
+
+// TestAnImageDoorThatCannotOpen keeps the two ways it cannot apart, and both
+// away from a run that reports nothing: a door that cannot start a process at
+// all costs the run, and says which of the two it was.
+func TestAnImageDoorThatCannotOpen(t *testing.T) {
+	testCases := []struct {
+		name string
+		door *engine.Image
+		says string
+	}{
+		{
+			name: "no image",
+			door: &engine.Image{Runtime: os.Args[0]},
+			says: "no image",
+		},
+		{
+			name: "a runtime that is not installed",
+			door: &engine.Image{Reference: fakeImage, Runtime: "not-a-container-runtime-anybody-has"},
+			says: "not-a-container-runtime-anybody-has",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := testCase.door.Open(t.Context())
+			if err == nil {
+				t.Fatal("the door opened onto nothing")
+			}
+
+			if !strings.Contains(err.Error(), testCase.says) {
+				t.Errorf("the failure does not say what was wrong with the door: %v", err)
+			}
+		})
+	}
+}
+
+// imageDoor is the image door pointed at the stub runtime, with a fake adapter
+// scripted as the container's own argument vector.
+func imageDoor(t *testing.T, told script) (*engine.Image, string, string) {
+	t.Helper()
+
+	path, transcript := scripted(t, told)
+	record := filepath.Join(t.TempDir(), "runtime.jsonl")
+
+	return &engine.Image{
+		Reference: fakeImage,
+		Args:      []string{path},
+		Runtime:   os.Args[0],
+		Env:       append(os.Environ(), runtimeEnv+"="+record),
+	}, transcript, record
+}
+
+// assertRemoved is the container being taken away, named as the one that was
+// started: a removal that named something else would leave the container it was
+// supposed to remove running.
+func assertRemoved(t *testing.T, record string) {
+	t.Helper()
+
+	run := invocation(t, record, "run")
+
+	var name string
+
+	for _, arg := range run {
+		if strings.HasPrefix(arg, "--name=") {
+			name = strings.TrimPrefix(arg, "--name=")
+		}
+	}
+
+	if name == "" {
+		t.Fatalf("the container was started without a name, so nothing can take it away: %v", run)
+	}
+
+	removed := invocation(t, record, "rm")
+
+	if !slices.Contains(removed, "--force") || !slices.Contains(removed, name) {
+		t.Errorf("the container %s was not forced away: %v", name, removed)
+	}
+}
+
+// invocation is the first recorded call to the stub runtime whose first
+// argument is want, waited for rather than read once.
+//
+// Waited for because the record is written by another process: a test that
+// killed a container the moment the door opened would otherwise race the stub's
+// own first line, and fail as though the door had never started anything.
+func invocation(t *testing.T, record, want string) []string {
+	t.Helper()
+
+	var last []byte
+
+	for range 1000 {
+		b, err := os.ReadFile(record)
+		if err != nil && !os.IsNotExist(err) {
+			t.Fatalf("the stub runtime's record could not be read: %v", err)
+		}
+
+		last = b
+
+		for line := range strings.Lines(string(b)) {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+
+			var args []string
+			if err := json.Unmarshal([]byte(line), &args); err != nil {
+				t.Fatalf("the stub runtime recorded something that is not an argument vector: %q", line)
+			}
+
+			if len(args) > 0 && args[0] == want {
+				return args
+			}
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("the runtime was never asked to %s:\n%s", want, last)
+
+	return nil
+}
+
+// runAsRuntime is the stub container runtime: it records what it was asked to
+// do, and then does the smallest thing that keeps the conversation real.
+//
+// `run` starts the adapter in this process, over the standard input and
+// standard output it was handed, which is what a runtime does from the engine's
+// side. `rm` records and succeeds, because the container it would remove is a
+// process this stub never had.
+func runAsRuntime(record string) int {
+	args := os.Args[1:]
+
+	if err := recordInvocation(record, args); err != nil {
+		fmt.Fprintf(os.Stderr, "the stub runtime could not record what it was asked: %v\n", err)
+
+		return 2
+	}
+
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "the stub runtime was asked for nothing")
+
+		return 2
+	}
+
+	switch args[0] {
+	case "rm":
+		return 0
+	case "run":
+	default:
+		fmt.Fprintf(os.Stderr, "the stub runtime was asked to %q\n", args[0])
+
+		return 2
+	}
+
+	rest := args[1:]
+	for len(rest) > 0 && strings.HasPrefix(rest[0], "-") {
+		rest = rest[1:]
+	}
+
+	if len(rest) == 0 {
+		fmt.Fprintln(os.Stderr, "the stub runtime was given no image to run")
+
+		return 2
+	}
+
+	if rest[0] == hangImage {
+		// A container that never ends, which is what the wall clock is for.
+		// Slept rather than blocked forever on a channel, which the runtime
+		// would report as a deadlock and turn into a panic rather than a hang.
+		time.Sleep(time.Hour)
+
+		return 0
+	}
+
+	if len(rest) < 2 {
+		fmt.Fprintln(os.Stderr, "the stub runtime was given no script to run as the adapter")
+
+		return 2
+	}
+
+	return adapt(rest[1])
+}
+
+// recordInvocation appends one argument vector to the record, as JSON.
+//
+// Appended rather than written, because the door starts a fresh process to take
+// a container away and a run may start more than one container: what a test
+// reads is every call the door made, in the order it made them.
+func recordInvocation(record string, args []string) error {
+	b, err := json.Marshal(args)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(record, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		_ = f.Close()
+
+		return err
+	}
+
+	// Closed rather than deferred and dropped: the test on the other side of
+	// this file reads it from another process, and a line still sitting in a
+	// buffer is a door that appears not to have started anything.
+	return f.Close()
+}

--- a/internal/conformance/engine/image_test.go
+++ b/internal/conformance/engine/image_test.go
@@ -6,6 +6,7 @@
 package engine_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -31,11 +32,15 @@ import (
 // which is the runtime's promise and not this door's.
 const runtimeEnv = "CPYBKC_CONFORMANCE_FAKE_RUNTIME"
 
-// fakeImage is the reference the stub answers to, and hangImage is the one it
-// answers by never answering.
+// fakeImage is the reference the stub answers to, hangImage is the one it
+// answers by never answering, and unknownImage is the one it refuses the way a
+// runtime refuses an image it cannot get: exit 125, before any container
+// exists.
 const (
-	fakeImage = "ghcr.io/example/fake-adapter:v1"
-	hangImage = "ghcr.io/example/never-ends:v1"
+	fakeImage     = "ghcr.io/example/fake-adapter:v1"
+	hangImage     = "ghcr.io/example/never-ends:v1"
+	unknownImage  = "ghcr.io/example/not-published:v1"
+	unknownStatus = 125
 )
 
 // TestBothDoorsDriveOneContract is the story's first line and the reason [Door]
@@ -239,6 +244,12 @@ func TestKillingTheAdapterTakesItsContainerAway(t *testing.T) {
 		t.Fatalf("the door would not open: %v", err)
 	}
 
+	// The container is waited for before it is killed. Open returns when the
+	// runtime client has started, which is before the client has done anything,
+	// and a test that killed it in that window would be asserting the removal of
+	// a container the stub had not recorded starting.
+	invocation(t, record, "run")
+
 	process.Kill()
 
 	_ = process.Wait()
@@ -246,9 +257,78 @@ func TestKillingTheAdapterTakesItsContainerAway(t *testing.T) {
 	assertRemoved(t, record)
 }
 
-// TestAnImageDoorThatCannotOpen keeps the two ways it cannot apart, and both
+// TestARuntimeThatCouldNotRunTheImageIsNotAnAdapterThatSaidNothing is the
+// failure this door has that a command door does not: the process the engine
+// gets is the runtime's client, so an image that does not exist, a flag the
+// daemon will not take or an entrypoint that cannot be run all arrive as a
+// client that exited after the door had already opened — which, unexplained,
+// reads as an adapter whose stream stopped and sends a generator author to look
+// at their generator.
+func TestARuntimeThatCouldNotRunTheImageIsNotAnAdapterThatSaidNothing(t *testing.T) {
+	entries := corpus(t, "packed-ebcdic")
+
+	image, _, _ := imageDoor(t, script{Entries: answers(t, entries)})
+	image.Reference = unknownImage
+
+	report, err := (&engine.Engine{Door: image}).Run(t.Context(), entries)
+	if err != nil {
+		t.Fatalf("the run could not be made: %v", err)
+	}
+
+	if !report.Failed() {
+		t.Fatalf("a run against an image that could not be run came back as one that passed:\n%v", report)
+	}
+
+	// Both halves: the door's reading of the status, and the runtime's own
+	// words, which are what settle whether the reading was right.
+	for _, want := range []string{"could not run the image", unknownImage, "Unable to find image"} {
+		if !strings.Contains(report.String(), want) {
+			t.Errorf("the report does not say %q, so the failure reads as the adapter's:\n%v", want, report)
+		}
+	}
+}
+
+// TestACallersOwnDeadlineIsNotTheDoorsBound keeps two ways of running out of
+// time apart. The door's wall clock and a deadline on the context it was handed
+// both end the same container, and a door that reported the second as the first
+// would name a bound that never elapsed — sending whoever reads it to raise a
+// flag that was not the one holding the run.
+func TestACallersOwnDeadlineIsNotTheDoorsBound(t *testing.T) {
+	image, _, record := imageDoor(t, script{})
+	image.Reference = hangImage
+	image.Timeout = time.Hour
+
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer cancel()
+
+	process, err := image.Open(ctx)
+	if err != nil {
+		t.Fatalf("the door would not open: %v", err)
+	}
+
+	err = process.Wait()
+	if err == nil {
+		t.Fatal("a container the caller gave up on came back as one that ended well")
+	}
+
+	if strings.Contains(err.Error(), "wall-clock") {
+		t.Errorf("the caller's own deadline is reported as the door's bound: %v", err)
+	}
+
+	// The container is still taken away: whose clock ran out changes what is
+	// said about it and not what becomes of it.
+	assertRemoved(t, record)
+}
+
+// TestAnImageDoorThatCannotOpen keeps the ways it cannot apart, and all of them
 // away from a run that reports nothing: a door that cannot start a process at
-// all costs the run, and says which of the two it was.
+// all costs the run, and says which of them it was.
+//
+// The reference beginning with a dash is the one that is not merely a
+// diagnostic. The vector is `run <the door's flags> <reference> <the
+// container's args>`, so a reference the runtime reads as another option to
+// itself starts something else — with whatever came next as its image, and
+// without the isolation the report would then describe.
 func TestAnImageDoorThatCannotOpen(t *testing.T) {
 	testCases := []struct {
 		name string
@@ -264,6 +344,16 @@ func TestAnImageDoorThatCannotOpen(t *testing.T) {
 			name: "a runtime that is not installed",
 			door: &engine.Image{Reference: fakeImage, Runtime: "not-a-container-runtime-anybody-has"},
 			says: "not-a-container-runtime-anybody-has",
+		},
+		{
+			name: "an image reference that is a flag",
+			door: &engine.Image{Reference: "--network=host", Runtime: os.Args[0]},
+			says: "begins with a dash",
+		},
+		{
+			name: "an image reference that is a mount",
+			door: &engine.Image{Reference: "-v/:/host:rw", Runtime: os.Args[0]},
+			says: "begins with a dash",
 		},
 	}
 
@@ -408,6 +498,14 @@ func runAsRuntime(record string) int {
 		fmt.Fprintln(os.Stderr, "the stub runtime was given no image to run")
 
 		return 2
+	}
+
+	if rest[0] == unknownImage {
+		// What a runtime does when it cannot get the image: it says so on its
+		// own standard error and exits 125, having created nothing.
+		fmt.Fprintf(os.Stderr, "Unable to find image %q locally: no such image\n", rest[0])
+
+		return unknownStatus
 	}
 
 	if rest[0] == hangImage {

--- a/internal/tools/conformance-bundle/bundle/README.md
+++ b/internal/tools/conformance-bundle/bundle/README.md
@@ -87,7 +87,12 @@ the network, and nothing it did outlived the container.
 
 Both doors drive the same contract with one implementation behind them, so the
 conversation, the entries and the comparison are identical and only the
-guarantees differ.
+guarantees differ. Two things about the container are worth knowing before you
+build the image: `/tmp` is the only writable path in it, so point `TMPDIR`,
+`HOME`, `GOCACHE` or `CARGO_HOME` there if your toolchain needs a cache; and the
+memory and process caps are asked of your runtime, which warns on its own
+standard error when a kernel will not honour one. `cpybkc-conform` quotes that
+warning beside the report rather than claiming a cap it may not have had.
 
 Either way it is a self-report in a second sense: a run computed on your machine,
 against a corpus you downloaded, by a program you are holding. Nothing here is

--- a/internal/tools/conformance-bundle/bundle/README.md
+++ b/internal/tools/conformance-bundle/bundle/README.md
@@ -37,6 +37,17 @@ It exits **0** when nothing failed, **1** when an entry disagreed or could not
 be asked, and **2** when the run could not be attempted at all. `--help` is the
 rest of the flags.
 
+If your adapter ships as a container image, name it instead and it runs behind
+one:
+
+```sh
+./bin/cpybkc-conform-linux-amd64 check --image ghcr.io/you/gen-rust-adapter:v1
+```
+
+That is the other door, and what it adds is in the last section. It needs a
+container runtime (`--runtime`, `docker` by default) and `--exec` does not,
+which is the whole reason both exist.
+
 ## Checking what you downloaded
 
 `corpus.sha256` holds a SHA-256 over `corpus/`. `check` verifies it before it
@@ -67,7 +78,18 @@ read-only root and no resource cap, and `cpybkc-conform` says so in every
 report it writes. A run through this door is **your own working result** — a
 fine thing to have and to publish, as long as it is labelled as one.
 
-It is also a self-report in a second sense: a run computed on your machine,
+`--image` runs it in a container with no network, a read-only root, a writable
+`/tmp`, a memory cap, a process cap and a wall-clock bound. Those are the
+door's properties and not the contract's, which is why the report quotes the
+door rather than assuming them of every run, and why a result produced through
+this one is **a result you can hand to somebody else**: nothing in it came from
+the network, and nothing it did outlived the container.
+
+Both doors drive the same contract with one implementation behind them, so the
+conversation, the entries and the comparison are identical and only the
+guarantees differ.
+
+Either way it is a self-report in a second sense: a run computed on your machine,
 against a corpus you downloaded, by a program you are holding. Nothing here is
 a conformance claim a third party should be asked to trust without
 qualification, and cpybkc awards no level, profile, score or badge.

--- a/internal/tools/conformance-bundle/main.go
+++ b/internal/tools/conformance-bundle/main.go
@@ -30,8 +30,11 @@
 // first-day bounce costs the adoption entirely (#202).
 //
 // So the offline path is a download and an `--exec`: no registry, no daemon and
-// no image. A container door is the other door and is #203's, and it is where
-// the properties that make a result believable live.
+// no image. `--image` is the other door the same program offers, and it is
+// where the properties that make a result believable to somebody else live — no
+// network, a read-only root, a memory and process cap, a wall-clock bound
+// (#203). It is the standard and deliberately not the gate: what an adopter can
+// run on their first afternoon has to be the one that needs nothing.
 //
 // # Why the binaries are in it
 //


### PR DESCRIPTION
Closes #203

`engine.Image` is `engine.Command`'s sibling behind the same `Door` seam. The
contract begins after the process exists, so the image door is a matter of
building an argument vector and handing it to the same `Command` underneath —
one implementation of the conversation, two doors onto it.

## Acceptance criteria

- [x] **`--image` and `--exec` drive the same contract with one implementation
  behind both.** `TestBothDoorsDriveOneContract` runs the same entries through
  both doors and asserts the frames are byte-identical and the outcomes match,
  entry by entry — and that the one thing which differs is the door line.
- [x] **The image door runs the adapter with no network, a read-only root
  filesystem, and a deadline.** `--network=none`, `--read-only`, a tmpfs at
  `/tmp`, `--memory`/`--memory-swap`, `--pids-limit`, `--cap-drop=ALL`,
  `--security-opt=no-new-privileges`, and a wall-clock bound on the container.
  The bound also takes the container away: killing an attached client does not
  stop what it was attached to, so a door that only killed the client would
  leave an adapter running with every cap it was given and nobody talking to it.
- [x] **Which guarantees come from the door rather than the contract is
  documented.** `engine`'s package doc, `cpybkc-conform`'s package doc and
  synopsis, the archive README, CONTRIBUTING.md and the project README. Each
  says plainly that a `--exec` result is the author's own working result, that
  an `--image` result is one they can hand to somebody else, and that neither is
  a claim a third party should be asked to trust without qualification.
- [x] **A report records which door produced it.** `Report.Door` quotes
  `Door.Describe()`, and `Image.Describe` reports the numbers the run actually
  used, so a report can never claim a bound the run did not have.

## Judgment calls

- **Exactly one door, and neither is a default.** `--exec` and `--image`
  together is refused, as is neither. So is a flag belonging to the other door:
  `--dir` under `--image`, and `--runtime`/`--image-*` under `--exec`. A caller
  who wrote `--image-memory` has said what they wanted the run to guarantee, and
  accepting it silently on the door that guarantees nothing hands them a report
  saying the opposite in a sentence they had no reason to re-read.
- **The caps are settable rather than fixed** (`--image-memory`,
  `--image-processes`, `--image-scratch`, `--image-deadline`, `--runtime`). A
  cap with no way past it is one people get past by not using the door at all.
  What keeps it honest is that `Describe` reports the values used. There is
  deliberately **no** pass-through for arbitrary runtime options: `--network=host`
  would make the sentence the report quotes a lie.
- **A writable `/tmp`.** A read-only root with nowhere to write refuses most
  real adapters — a generator emits code and something compiles it. One tmpfs,
  in memory, in the container's own mount namespace, is the smallest thing that
  lets that work while touching no host path.
- **`--image-deadline` must outlive `--build-deadline`**, and is refused
  otherwise. The wall clock takes the whole container away and `generate` may
  legitimately run a compiler over the corpus; a container removed first reads
  as a generator that answered nothing rather than as a door that would not wait
  for it.
- **No TTY.** A pseudo-terminal echoes what is written to it and rewrites line
  endings, and the conversation is newline-delimited JSON in both directions:
  the engine's own request frames would come back to it as answers. Asserted.
- **Every runtime flag is joined to its value**, which makes the image reference
  the first argument after `run` that does not begin with a dash — a boundary a
  reader of a failing run can check by eye, and one the tests pin.

## Verification

- `dagger call ci` — green, from an ordinary clone (the pipeline cannot run from
  a git worktree; CONTRIBUTING.md says why).
- `go test -race ./...` — green.
- The door's tests drive a stub runtime rather than a real one: a test that
  needed a container daemon would be a test that does not run, since the
  pipeline is itself a container. The stub covers the argument vector, the
  flag/container boundary, the removal, and that the same conversation comes
  back through it; what it cannot cover is whether Linux honoured the flags,
  which is the runtime's promise and not this door's.