### PR TITLE
story(conformance): a new entry is provisional until a second implementation agrees

### DIFF
--- a/cmd/cpybkc-conform/main.go
+++ b/cmd/cpybkc-conform/main.go
@@ -76,6 +76,13 @@
 // One and two are separate because a script that treats them alike cannot tell
 // a generator that failed the corpus from a corpus that never ran, and only the
 // first is a fact about the generator.
+//
+// The report's text does not partition the same way, deliberately: a
+// provisional entry that disagreed is printed as PROVISIONAL FAIL, so the word
+// FAIL appears in the output of a run that exits 0. The status is what a person
+// reading the report needs to see, and the exit code is the machine's answer; a
+// script that greps for a verdict rather than reading the status is a script
+// that was going to disagree with one of the two.
 package main
 
 import (

--- a/cmd/cpybkc-conform/main.go
+++ b/cmd/cpybkc-conform/main.go
@@ -64,8 +64,12 @@
 //
 //   - 0 — the run happened and nothing failed. A descriptive generator's run,
 //     which the corpus has nothing to ask, is one of these.
-//   - 1 — the run happened and something failed: an entry disagreed, or one
-//     could not be asked at all.
+//   - 1 — the run happened and something failed: a normative entry disagreed,
+//     or one could not be asked at all. An entry that declared itself
+//     provisional is reported and is in neither figure, which is
+//     docs/conformance/SPEC.md's "A provisional entry" rather than this
+//     command's — the corpus does not yet stand behind its expected answer, so
+//     a disagreement with one is not a fact about the generator.
 //   - 2 — the run could not be attempted: the arguments were wrong, the corpus
 //     could not be read, or it did not match the digest published beside it.
 //

--- a/cmd/cpybkc-conform/usage.go
+++ b/cmd/cpybkc-conform/usage.go
@@ -20,8 +20,9 @@ const usage = `cpybkc-conform runs the cpybkc conformance corpus against a gener
   cpybkc-conform help
 
 check drives the adapter through the contract and reports every entry. It exits
-0 when nothing failed, 1 when an entry disagreed or could not be asked, and 2
-when the run could not be attempted at all.
+0 when nothing failed, 1 when a normative entry disagreed or could not be asked,
+and 2 when the run could not be attempted at all. A provisional entry is
+reported and is in neither: it counts in no total and fails nothing.
 
   --exec <path>              the adapter executable, as a path and not a name to
                              find on PATH

--- a/docs/conformance/SPEC.md
+++ b/docs/conformance/SPEC.md
@@ -40,11 +40,12 @@ written down belongs here.
 ### Scope
 
 In scope: the directory an entry is, the members it holds and the one member
-that is reserved; the value language every decoded record is written in, down to
-the admissible spelling of each scalar; how a file the generated reader refused
-is reported; what a runner is asked to do and what it is deliberately not asked
-to do; the answer document it returns; and how the corpus is published, down to
-the digest a downloader checks it against.
+that is reserved; how much authority an entry's expected answer carries, and
+what promotes one that carries none yet; the value language every decoded
+record is written in, down to the admissible spelling of each scalar; how a file
+the generated reader refused is reported; what a runner is asked to do and what
+it is deliberately not asked to do; the answer document it returns; and how the
+corpus is published, down to the digest a downloader checks it against.
 
 Out of scope, with reasons, in [Out of Scope](#out-of-scope).
 
@@ -114,7 +115,7 @@ else is.
 
 | File | What it is | Required |
 |---|---|---|
-| `entry.json` | What the entry is about, and the section its expected answer came from. | yes |
+| `entry.json` | What the entry is about, the section its expected answer came from, and how much the corpus stands behind it. | yes |
 | `layout.sexpr` | The [layout](../layout/SPEC.md) the file is laid out by. | yes |
 | `*.cpy` | The copybooks that layout names, at the paths it spells them. | one or more |
 | `ir.json` | The [IR](../ir/SPEC.md) the layout and those copybooks resolve to. | yes |
@@ -146,8 +147,18 @@ parsing something else first.
 }
 ```
 
-Both members are required, both are non-empty strings, and there is no third
-member. An unknown member **MUST** be refused.
+`description` and `source` are required and are non-empty strings. `status` is
+optional, and where it is written it **MUST** be `"normative"` or
+`"provisional"` — see [*A provisional entry*](#a-provisional-entry). An entry
+that carries no `status` is normative. There is no fourth member, and an unknown
+member **MUST** be refused, as **MUST** a `status` outside those two spellings
+(#207).
+
+Absent meaning normative is what keeps every entry written before the member
+existed saying exactly what it said, without an edit and without moving the
+corpus digest. It is also the safe direction for the default to fall in: a
+status is the one thing that can take an entry out of a verdict, so the value
+nobody wrote has to be the one that leaves it counting.
 
 `source` is what a failing run prints beside the entry's name. Whoever reads
 that report has to decide whether the generator is wrong or the entry is, and
@@ -255,6 +266,70 @@ the same position sum a decoder runs and gets it wrong in the same way, so there
 is a plausible second oracle here whose shape is an offset table. Whether the
 corpus is where that oracle belongs is open, and that discussion is #193's, not
 this document's.
+
+### A provisional entry
+
+An entry whose expected answer nothing has corroborated declares itself:
+
+```json
+{
+  "description": "A record whose table slides under an ODO count of zero.",
+  "source": "cobol-go codec/SPEC.md, \"OCCURS DEPENDING ON\"",
+  "status": "provisional"
+}
+```
+
+A harness **MUST** ask about a provisional entry exactly as it asks about a
+normative one, and **MUST** report what became of it. It **MUST NOT** count it
+in any total it reports of the corpus, and it **MUST NOT** report a run as
+failed on account of one — whether that entry disagreed, or could not be asked
+about at all (#207).
+
+A runner is not told which it was given. The status is a property of the corpus
+and not of the question, and it appears nowhere in the [adapter
+contract](../adapter/SPEC.md): an adapter that could tell would be an adapter
+whose answers about the uncorroborated half of the corpus are worth less than
+its answers about the rest.
+
+#### Why the corpus needs one
+
+An entry is derived from a specification and never recorded from a run of the
+code it checks, because an entry recorded from its subject passes forever —
+including through the bug it was written to catch (#67). That rule has a mirror:
+**an entry authored from a misreading fails forever**, and every implementation
+is told it is wrong.
+
+The exposure is worst exactly where the corpus is most valuable. An entry
+covering a construct no implementation handles yet has no cross-check at all —
+nothing disagrees with it, so review is the only defence, and review of a
+hand-computed EBCDIC or hexadecimal-floating-point byte string is weak. What
+that costs is not a red mark on a report. It is a generator author who trusts
+the corpus, changes correct code to match a wrong oracle, and ships it.
+
+It also gives the corpus somewhere to put an entry whose expected answer is
+contested, rather than the two options of shipping it as normative or not
+shipping it at all.
+
+#### What promotes an entry to normative
+
+A provisional entry becomes normative when either of these has happened:
+
+- **two independent implementations agree with it** — two generators, written
+  by different authors and not derived from one another, each answering what
+  the entry states; or
+- **a second person has re-derived its expected answer from the specification**
+  — from the sections `source` cites, without reading the entry's own bytes
+  first, and reached the same answer.
+
+Neither is something a harness can check, so promotion is an edit: the `status`
+member is removed, or written as `"normative"`, and the change says in its
+description which of the two happened and names the implementation or the
+person. That is the whole mechanism, and it is deliberately a review rather than
+a computation — what makes an entry an oracle is that somebody stands behind it.
+
+A provisional entry that turns out to be **wrong** is corrected or withdrawn,
+and neither needs this section: it never counted, so nothing that ran against it
+has to be re-stated.
 
 ## The value language
 
@@ -853,7 +928,8 @@ to every row.
 | Section | Implemented by |
 |---|---|
 | [An entry](#an-entry) | #66 `conformance` for the format and the loader that holds a directory to it |
-| [`entry.json`](#entryjson) | #66 `conformance` |
+| [`entry.json`](#entryjson) | #66 `conformance`; the `status` member, #207 `conformance` |
+| [A provisional entry](#a-provisional-entry) | #207 `conformance` for the status, the rule a harness follows and what promotes an entry; the authoring rule it mirrors is #67 |
 | [`ir.json`](#irjson) | #66 `conformance`; the canonical rendering it is held to, #20 `ir` |
 | [`values.json`](#valuesjson) | #66 `conformance` |
 | [`offsets.json` is reserved](#offsetsjson-is-reserved) | #194 `conformance` for the reservation; the discussion it comes from is #193, and no story specifies its content |

--- a/docs/conformance/SPEC.md
+++ b/docs/conformance/SPEC.md
@@ -148,11 +148,11 @@ parsing something else first.
 ```
 
 `description` and `source` are required and are non-empty strings. `status` is
-optional, and where it is written it **MUST** be `"normative"` or
-`"provisional"` — see [*A provisional entry*](#a-provisional-entry). An entry
-that carries no `status` is normative. There is no fourth member, and an unknown
-member **MUST** be refused, as **MUST** a `status` outside those two spellings
-(#207).
+optional, and where it is written it **MUST** be the string `"normative"` or the
+string `"provisional"` — see [*A provisional entry*](#a-provisional-entry). An
+entry that carries no `status` is normative. There is no fourth member, and an
+unknown member **MUST** be refused, as **MUST** a `status` outside those two
+spellings — including `null`, which is written and is neither (#207).
 
 Absent meaning normative is what keeps every entry written before the member
 existed saying exactly what it said, without an edit and without moving the

--- a/internal/conformance/corpus.go
+++ b/internal/conformance/corpus.go
@@ -91,6 +91,52 @@ func CorpusPath(root string) string {
 	return filepath.Join(root, filepath.FromSlash(CorpusFile))
 }
 
+// Status is how much authority an entry's expected answer carries.
+//
+// Every other member of an entry is a claim about a file; this one is a claim
+// about the entry itself, and it exists because the rule that an entry is
+// authored from a specification and never recorded from a run of the code it
+// checks (#67) has a mirror. An entry recorded from its subject passes forever,
+// including through the bug it was written to catch — and an entry authored
+// from a misreading fails forever, telling every implementation it is wrong.
+// The exposure is worst where the corpus is most valuable: an entry covering a
+// construct no implementation handles yet has nothing to disagree with it, so
+// review of a hand-computed byte string is the only defence and review of one
+// is weak.
+//
+// A status is not part of the question. A runner is asked about a provisional
+// entry in exactly the words it is asked about a normative one and is never
+// told which it was given, because an adapter that could tell would be an
+// adapter whose answers to the uncorroborated half of the corpus are worth
+// less than its answers to the rest.
+type Status string
+
+const (
+	// Normative is an entry the corpus stands behind: it counts, and a
+	// disagreement with it is a failure.
+	//
+	// It is what an entry declaring no status is, which is the safe direction
+	// for the default to fall in — a status somebody forgot to write, or one a
+	// reader of this package never set, leaves the entry counting rather than
+	// exempt. The other default would let an entry drop out of the verdict by
+	// omission, and nothing in a passing run would say so.
+	Normative Status = "normative"
+
+	// Provisional is an entry whose expected answer nothing has corroborated
+	// yet: it runs, its result is reported, and it counts in no total and
+	// produces no failure verdict.
+	//
+	// What promotes one is written down in docs/conformance/SPEC.md, "A
+	// provisional entry", and it is a fact about the world rather than
+	// anything this package can check — a second implementation agreeing, or a
+	// second person re-deriving the answer from the specification. Promotion is
+	// therefore an edit to entry.json and a reviewer, which is the point: the
+	// corpus gains somewhere to put an entry whose expected answer is contested
+	// rather than the two options of shipping it as normative or not shipping
+	// it at all.
+	Provisional Status = "provisional"
+)
+
 // Entry is one corpus entry: the tuple, loaded, and the metadata saying what it
 // is for.
 //
@@ -116,6 +162,12 @@ type Entry struct {
 	// with it (#68).
 	Source string
 
+	// Status is whether the corpus stands behind the expected answer. An entry
+	// that declares none is [Normative]; read it through
+	// [Entry.IsProvisional] rather than comparing it, so that an Entry nothing
+	// loaded is normative rather than exempt.
+	Status Status
+
 	// Layout is the path to the entry's layout file.
 	Layout string
 
@@ -135,10 +187,25 @@ type Entry struct {
 	Values *Values
 }
 
+// IsProvisional is whether the entry's expected answer is uncorroborated, and
+// so whether a disagreement with it is reportable rather than a failure.
+//
+// It is a method rather than a comparison at each of its callers so that one
+// place decides what an unwritten status means. An [Entry] that never went
+// through [LoadEntry] — a zero value, or one a test built — carries the empty
+// status, and every reading of it has to agree that it is normative.
+func (e *Entry) IsProvisional() bool { return e != nil && e.Status == Provisional }
+
 // metadata is entry.json as it is written.
+//
+// Status is a pointer because absent and empty are different mistakes: an entry
+// that says nothing about its status is the ordinary normative entry, and one
+// that writes "" is an author who meant something and wrote nothing, which is
+// the typo the rest of this format refuses rather than reads past.
 type metadata struct {
-	Description string `json:"description"`
-	Source      string `json:"source"`
+	Description string  `json:"description"`
+	Source      string  `json:"source"`
+	Status      *string `json:"status"`
 }
 
 // Load reads every entry of the corpus rooted at dir, in ascending name order.
@@ -293,7 +360,11 @@ func (e *Entry) readListing(listing []os.DirEntry) error {
 //
 // An unknown field is refused, for the reason the project manifest refuses one:
 // a key somebody wrote expecting it to mean something is a typo they want told
-// about rather than a line that reads as metadata and does nothing.
+// about rather than a line that reads as metadata and does nothing. A status
+// outside the closed set of two is refused for the same reason and one more of
+// its own: an unknown status read as normative would fail an entry nobody
+// stands behind, and one read as provisional would drop an entry out of the
+// verdict on a typo.
 func (e *Entry) readMetadata() error {
 	b, err := os.ReadFile(filepath.Join(e.Dir, MetadataName))
 	if err != nil {
@@ -313,6 +384,21 @@ func (e *Entry) readMetadata() error {
 
 	if read.Source == "" {
 		faults = append(faults, fmt.Errorf("%s: source cites the section the expected answer came from, and is required", MetadataName))
+	}
+
+	// Set before the status is read, and left at Normative wherever it is not a
+	// status this format knows: an entry the loader refused carries no
+	// authority to be exempt from a verdict either.
+	e.Status = Normative
+
+	if read.Status != nil {
+		switch held := Status(*read.Status); held {
+		case Normative, Provisional:
+			e.Status = held
+		default:
+			faults = append(faults, fmt.Errorf("%s: status is %q, and an entry is either %q or %q; omit it to mean %q",
+				MetadataName, *read.Status, Normative, Provisional, Normative))
+		}
 	}
 
 	e.Description = read.Description

--- a/internal/conformance/corpus.go
+++ b/internal/conformance/corpus.go
@@ -7,6 +7,7 @@ package conformance
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -196,16 +197,28 @@ type Entry struct {
 // status, and every reading of it has to agree that it is normative.
 func (e *Entry) IsProvisional() bool { return e != nil && e.Status == Provisional }
 
+// IsNormative is whether the corpus stands behind the entry's expected answer,
+// and so whether it counts and can fail a run.
+//
+// It exists so that the positive question has a guarded reader too. [Status] is
+// a string type whose zero value is neither of its constants, so a caller
+// switching on the field directly would match nothing for an [Entry] nothing
+// loaded — and the direction that silently matches nothing is the direction
+// this whole member has to fall the right way in.
+func (e *Entry) IsNormative() bool { return !e.IsProvisional() }
+
 // metadata is entry.json as it is written.
 //
-// Status is a pointer because absent and empty are different mistakes: an entry
-// that says nothing about its status is the ordinary normative entry, and one
-// that writes "" is an author who meant something and wrote nothing, which is
-// the typo the rest of this format refuses rather than reads past.
+// Status is raw because absent, null and empty are three different things and
+// only one of them is admissible: an entry that says nothing about its status
+// is the ordinary normative entry, and one that writes null or "" is an author
+// who meant something and wrote nothing, which is the typo the rest of this
+// format refuses rather than reads past. A pointer would fold null in with
+// absent and read as normative without a word.
 type metadata struct {
-	Description string  `json:"description"`
-	Source      string  `json:"source"`
-	Status      *string `json:"status"`
+	Description string          `json:"description"`
+	Source      string          `json:"source"`
+	Status      json.RawMessage `json:"status"`
 }
 
 // Load reads every entry of the corpus rooted at dir, in ascending name order.
@@ -392,12 +405,23 @@ func (e *Entry) readMetadata() error {
 	e.Status = Normative
 
 	if read.Status != nil {
-		switch held := Status(*read.Status); held {
-		case Normative, Provisional:
-			e.Status = held
+		// Unmarshalled into a string rather than declared as one, so that a
+		// status written as a number or an object is refused as the wrong shape
+		// rather than failing the whole document to parse — which would report
+		// one mistaken member as an unreadable entry.json. JSON null leaves the
+		// string empty and falls into the refusal below with every other way of
+		// writing nothing.
+		var spelled string
+
+		switch err := json.Unmarshal(read.Status, &spelled); {
+		case err != nil:
+			faults = append(faults, fmt.Errorf("%s: status is %s, and it is one of the strings %q and %q",
+				MetadataName, read.Status, Normative, Provisional))
+		case Status(spelled) == Normative, Status(spelled) == Provisional:
+			e.Status = Status(spelled)
 		default:
 			faults = append(faults, fmt.Errorf("%s: status is %q, and an entry is either %q or %q; omit it to mean %q",
-				MetadataName, *read.Status, Normative, Provisional, Normative))
+				MetadataName, spelled, Normative, Provisional, Normative))
 		}
 	}
 

--- a/internal/conformance/corpus_test.go
+++ b/internal/conformance/corpus_test.go
@@ -181,6 +181,24 @@ func TestAnEntryTheFormatRefuses(t *testing.T) {
 			},
 			says: `omit it to mean "normative"`,
 		},
+		// null is written, and a member that is written is held to the two
+		// spellings. Folded in with absent it would read as normative without a
+		// word, which is the one way of writing nothing that would slip past
+		// the case above.
+		"metadata carrying a null status": {
+			breaks: func(t *testing.T, dir string) {
+				write(t, filepath.Join(dir, MetadataName),
+					`{"description": "a", "source": "b", "status": null}`)
+			},
+			says: `omit it to mean "normative"`,
+		},
+		"metadata carrying a status that is not a string": {
+			breaks: func(t *testing.T, dir string) {
+				write(t, filepath.Join(dir, MetadataName),
+					`{"description": "a", "source": "b", "status": 1}`)
+			},
+			says: "status is 1",
+		},
 		"a descriptor that is not the canonical rendering": {
 			breaks: func(t *testing.T, dir string) {
 				write(t, filepath.Join(dir, DescriptorName), `{"version":"IR_VERSION_1","nodes":[`+
@@ -357,6 +375,11 @@ func TestAnEntryDeclaresItselfProvisional(t *testing.T) {
 			if entry.IsProvisional() != test.provisional {
 				t.Errorf("IsProvisional is %t for an entry that loaded as %q", entry.IsProvisional(), entry.Status)
 			}
+
+			if entry.IsNormative() == test.provisional {
+				t.Errorf("IsNormative is %t for an entry that loaded as %q, and the two readings disagree",
+					entry.IsNormative(), entry.Status)
+			}
 		})
 	}
 }
@@ -371,7 +394,7 @@ func TestAnEntryDeclaresItselfProvisional(t *testing.T) {
 func TestAnEntryNothingLoadedIsNormative(t *testing.T) {
 	var entry Entry
 
-	if entry.IsProvisional() {
+	if entry.IsProvisional() || !entry.IsNormative() {
 		t.Error("an entry nothing filled in is provisional, and a status nobody wrote must not exempt one")
 	}
 

--- a/internal/conformance/corpus_test.go
+++ b/internal/conformance/corpus_test.go
@@ -167,6 +167,20 @@ func TestAnEntryTheFormatRefuses(t *testing.T) {
 			},
 			says: "source cites the section",
 		},
+		"metadata carrying a status outside the two": {
+			breaks: func(t *testing.T, dir string) {
+				write(t, filepath.Join(dir, MetadataName),
+					`{"description": "a", "source": "b", "status": "draft"}`)
+			},
+			says: `status is "draft"`,
+		},
+		"metadata carrying an empty status": {
+			breaks: func(t *testing.T, dir string) {
+				write(t, filepath.Join(dir, MetadataName),
+					`{"description": "a", "source": "b", "status": ""}`)
+			},
+			says: `omit it to mean "normative"`,
+		},
 		"a descriptor that is not the canonical rendering": {
 			breaks: func(t *testing.T, dir string) {
 				write(t, filepath.Join(dir, DescriptorName), `{"version":"IR_VERSION_1","nodes":[`+
@@ -299,6 +313,93 @@ func TestTheReservedMemberIsAdmittedAndReadByNothing(t *testing.T) {
 	if with.Layout != without.Layout || with.Description != without.Description ||
 		with.Source != without.Source || !bytes.Equal(with.Input, without.Input) {
 		t.Errorf("the entry loaded differently with %s beside it, and nothing reads it", OffsetsName)
+	}
+}
+
+// TestAnEntryDeclaresItselfProvisional is the whole of what an entry can say
+// about how much the corpus stands behind it, and what each spelling means.
+//
+// The three cases are the three an author writes: nothing, which is the
+// ordinary entry and has to stay normative or every entry shipped before the
+// member existed would change meaning; the word written out, which is the same
+// thing said aloud; and provisional, which is the one that changes anything.
+func TestAnEntryDeclaresItselfProvisional(t *testing.T) {
+	tests := map[string]struct {
+		status      string
+		want        Status
+		provisional bool
+	}{
+		"an entry that says nothing about its status": {status: "", want: Normative},
+		"an entry that writes normative out":          {status: `, "status": "normative"`, want: Normative},
+		"an entry that declares itself provisional": {
+			status:      `, "status": "provisional"`,
+			want:        Provisional,
+			provisional: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			dir := entryCopy(t, "orders-fixed")
+
+			write(t, filepath.Join(dir, MetadataName),
+				`{"description": "an entry", "source": "docs/conformance/SPEC.md"`+test.status+`}`)
+
+			entry, err := LoadEntry(dir)
+			if err != nil {
+				t.Fatalf("%v", err)
+			}
+
+			if entry.Status != test.want {
+				t.Errorf("the entry loaded as %q, and it declares %q", entry.Status, test.want)
+			}
+
+			if entry.IsProvisional() != test.provisional {
+				t.Errorf("IsProvisional is %t for an entry that loaded as %q", entry.IsProvisional(), entry.Status)
+			}
+		})
+	}
+}
+
+// TestAnEntryNothingLoadedIsNormative pins the direction the default falls in.
+//
+// A status is the one member of an entry that can exempt it from a verdict, so
+// the value nobody set has to be the one that does not: an [Entry] a test built,
+// or one whose metadata the loader never reached, counts and can fail. The other
+// default would let an entry drop out of a run by omission, and nothing in a
+// passing report would say so.
+func TestAnEntryNothingLoadedIsNormative(t *testing.T) {
+	var entry Entry
+
+	if entry.IsProvisional() {
+		t.Error("an entry nothing filled in is provisional, and a status nobody wrote must not exempt one")
+	}
+
+	if (*Entry)(nil).IsProvisional() {
+		t.Error("no entry at all is provisional")
+	}
+}
+
+// TestEveryShippedEntryIsNormative holds the corpus to the promise the
+// provisional status was added under: it is somewhere to put an entry nothing
+// has corroborated, and not a status anything already shipped acquires.
+//
+// It is a test of its own because it is a claim about the corpus rather than
+// about the loader. An entry that became provisional would stop counting and
+// stop being able to fail a run, which is a change to what this repository's own
+// conformance result means — and it would make that change silently, since every
+// other test would go on passing.
+func TestEveryShippedEntryIsNormative(t *testing.T) {
+	entries, err := Load(CorpusPath(repoRoot(t)))
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsProvisional() {
+			t.Errorf("%s is provisional, so it counts in no total and can fail nothing; promoting it is "+
+				"docs/conformance/SPEC.md's \"A provisional entry\"", entry.Name)
+		}
 	}
 }
 

--- a/internal/conformance/doc.go
+++ b/internal/conformance/doc.go
@@ -56,7 +56,8 @@
 // # What Load checks, and what it declines to
 //
 // Loading an entry parses every member and holds it to what the format
-// requires: entry.json carries a description and a source and nothing else,
+// requires: entry.json carries a description, a source, at most a [Status] and
+// nothing else,
 // ir.json is a descriptor that passes
 // [github.com/Zaba505/cpybkc/internal/assemble.Validate] and is written in the
 // canonical rendering [github.com/Zaba505/cpybkc/internal/emit.MarshalJSON]

--- a/internal/conformance/engine/provisional_test.go
+++ b/internal/conformance/engine/provisional_test.go
@@ -6,7 +6,10 @@
 package engine_test
 
 import (
+	"encoding/json"
 	"maps"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -185,6 +188,96 @@ func TestARunOfNothingButProvisionalEntriesSaysSo(t *testing.T) {
 	if said := report.String(); !strings.Contains(said, "states nothing about conformance") {
 		t.Errorf("the report is\n%s\nand it does not say that nothing it asked about is corroborated", said)
 	}
+}
+
+// TestAnEntryThatDeclaresItselfProvisionalOnDiskIsExempt is the one path the
+// tests above take a short cut around.
+//
+// They set the status in Go, which is the readable way to write them and leaves
+// exactly one link untested: entry.json to the verdict. A regression that
+// dropped the status while loading — a renamed member, a metadata struct that
+// stopped carrying it — would leave every one of them passing, because they
+// never read the file. So this one declares it where an author declares it, in
+// entry.json, and asserts the far end: the run does not fail.
+func TestAnEntryThatDeclaresItselfProvisionalOnDiskIsExempt(t *testing.T) {
+	entry, err := conformance.LoadEntry(declaredProvisional(t, "packed-ebcdic"))
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	if !entry.IsProvisional() {
+		t.Fatalf("%s declares itself provisional in %s and did not load as one", entry.Name, conformance.MetadataName)
+	}
+
+	entries := []*conformance.Entry{entry}
+
+	open, _ := door(t, script{Entries: map[string]entryScript{
+		entry.Name: {Decoded: wrong(t, entry, "P-SIGNED-POS")},
+	}})
+
+	report, err := (&engine.Engine{Door: open}).Run(t.Context(), entries)
+	if err != nil {
+		t.Fatalf("the run could not be made: %v", err)
+	}
+
+	if report.Failed() {
+		t.Errorf("an entry that declares itself provisional in %s disagreed and the run failed:\n%v",
+			conformance.MetadataName, report)
+	}
+
+	if !report.StatesNothing() {
+		t.Errorf("the run asked about nothing but a provisional entry and does not say it states nothing:\n%v", report)
+	}
+}
+
+// declaredProvisional is a copy of a shipped entry with "provisional" written
+// into its entry.json, in a directory of the test's own.
+//
+// A copy rather than a fixture of its own: what the case is about is the
+// status, and an entry written for this test would be a second author's reading
+// of every other member. The corpus's own entries are all normative and a test
+// holds them that way, so the status has to be put there by the case that needs
+// it.
+func declaredProvisional(t *testing.T, name string) string {
+	t.Helper()
+
+	source := filepath.Join(conformance.CorpusPath(repoRoot(t)), name)
+
+	dir := filepath.Join(t.TempDir(), name)
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	listing, err := os.ReadDir(source)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	for _, item := range listing {
+		b, err := os.ReadFile(filepath.Join(source, item.Name()))
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		if item.Name() == conformance.MetadataName {
+			var held map[string]any
+			if err := json.Unmarshal(b, &held); err != nil {
+				t.Fatalf("%s: %v", conformance.MetadataName, err)
+			}
+
+			held["status"] = string(conformance.Provisional)
+
+			if b, err = json.Marshal(held); err != nil {
+				t.Fatalf("%s: %v", conformance.MetadataName, err)
+			}
+		}
+
+		if err := os.WriteFile(filepath.Join(dir, item.Name()), b, 0o600); err != nil {
+			t.Fatalf("%v", err)
+		}
+	}
+
+	return dir
 }
 
 // wrong is the entry's own answer with one named item changed, which is a

--- a/internal/conformance/engine/provisional_test.go
+++ b/internal/conformance/engine/provisional_test.go
@@ -1,0 +1,215 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package engine_test
+
+import (
+	"maps"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/conformance"
+	"github.com/Zaba505/cpybkc/internal/conformance/engine"
+)
+
+// TestAProvisionalEntryDisagreesAndTheRunDoesNotFail is the whole of what
+// declaring an entry provisional buys (#207).
+//
+// The corpus's authoring rule is that an entry is derived from a specification
+// and never recorded from the code it checks, because an entry recorded from
+// its subject passes forever — including through the bug it was written to
+// catch. The mirror of that rule is an entry authored from a misreading, which
+// fails forever and tells every implementation it is wrong, and the failure it
+// causes is not a red mark: it is a generator author who trusts the corpus,
+// changes correct code to match a wrong oracle, and ships it.
+//
+// So a provisional entry's disagreement is reported and is not a verdict. All
+// three halves of that are asserted, because any one of them alone would be a
+// different behaviour: the run does not fail, the disagreement is in the report
+// in the reader's face, and the entry is in no total.
+func TestAProvisionalEntryDisagreesAndTheRunDoesNotFail(t *testing.T) {
+	entries := corpus(t, "packed-ebcdic", "zoned-ebcdic")
+
+	uncorroborated := entries[0]
+	uncorroborated.Status = conformance.Provisional
+
+	told := answers(t, entries)
+	told[uncorroborated.Name] = entryScript{Decoded: wrong(t, uncorroborated, "P-SIGNED-POS")}
+
+	open, _ := door(t, script{Entries: told})
+
+	report, err := (&engine.Engine{Door: open}).Run(t.Context(), entries)
+	if err != nil {
+		t.Fatalf("the run could not be made: %v", err)
+	}
+
+	if report.Failed() {
+		t.Errorf("a provisional entry disagreed and the run failed:\n%v", report)
+	}
+
+	if got := outcomes(report)[uncorroborated.Name]; got != engine.Mismatched {
+		t.Errorf("the provisional entry came back %s, and the adapter answered a value the file does not hold:\n%v",
+			got, report)
+	}
+
+	if passed, mismatched, faulted := report.Counts(); passed != 1 || mismatched != 0 || faulted != 0 {
+		t.Errorf("the normative half of the corpus scored %d passed, %d disagreed and %d could not be asked, and "+
+			"one normative entry was asked about:\n%v", passed, mismatched, faulted, report)
+	}
+
+	if agreed, disagreed, unanswered := report.ProvisionalCounts(); agreed != 0 || disagreed != 1 || unanswered != 0 {
+		t.Errorf("the provisional half scored %d agreed, %d disagreed and %d could not be asked, and one "+
+			"provisional entry disagreed:\n%v", agreed, disagreed, unanswered, report)
+	}
+
+	said := report.String()
+
+	for _, says := range []string{
+		"PROVISIONAL FAIL",                   // the disagreement, marked as no verdict
+		uncorroborated.Name,                  // and about which entry
+		"1 entries: 1 passed",                // the total the provisional entry is not in
+		"1 provisional entries, in no total", // and the line it is in instead
+	} {
+		if !strings.Contains(said, says) {
+			t.Errorf("the report is\n%s\nand it does not say %q", said, says)
+		}
+	}
+}
+
+// TestAProvisionalEntryThatAgreesIsStillInNoTotal is the direction that would
+// go unnoticed.
+//
+// A provisional entry that disagrees is conspicuous; one that agrees would
+// quietly raise the number an implementation reports having passed, and the
+// entry would have scored a generator on an answer nobody has corroborated.
+// Counting in no total is stated in both directions for that reason.
+func TestAProvisionalEntryThatAgreesIsStillInNoTotal(t *testing.T) {
+	entries := corpus(t, "packed-ebcdic", "zoned-ebcdic")
+	entries[0].Status = conformance.Provisional
+
+	open, _ := door(t, script{Entries: answers(t, entries)})
+
+	report, err := (&engine.Engine{Door: open}).Run(t.Context(), entries)
+	if err != nil {
+		t.Fatalf("the run could not be made: %v", err)
+	}
+
+	if report.Failed() {
+		t.Fatalf("the adapter answered what every entry states and the run failed:\n%v", report)
+	}
+
+	if passed, mismatched, faulted := report.Counts(); passed != 1 || mismatched != 0 || faulted != 0 {
+		t.Errorf("the normative half scored %d passed, %d disagreed and %d could not be asked, and one normative "+
+			"entry agreed:\n%v", passed, mismatched, faulted, report)
+	}
+
+	if agreed, disagreed, unanswered := report.ProvisionalCounts(); agreed != 1 || disagreed != 0 || unanswered != 0 {
+		t.Errorf("the provisional half scored %d agreed, %d disagreed and %d could not be asked, and one "+
+			"provisional entry agreed:\n%v", agreed, disagreed, unanswered, report)
+	}
+
+	if said := report.String(); !strings.Contains(said, "PROVISIONAL PASS") {
+		t.Errorf("the report is\n%s\nand it does not mark the provisional entry that agreed", said)
+	}
+}
+
+// TestAProvisionalEntryNothingCouldBeAskedAboutIsNotAFailureEither closes the
+// third outcome.
+//
+// An entry the adapter could not be asked about at all is a fault rather than a
+// disagreement, and it fails a run for a reason of its own — nothing was
+// learned. On a provisional entry there was nothing to learn that anybody
+// stands behind, so it is reported and it is not a verdict, exactly as a
+// disagreement is. Left out, a provisional entry would be exempt from the
+// verdict for one outcome and not the other, which is the sort of gap that is
+// found by an implementation being failed by it.
+func TestAProvisionalEntryNothingCouldBeAskedAboutIsNotAFailureEither(t *testing.T) {
+	entries := corpus(t, "packed-ebcdic", "zoned-ebcdic")
+
+	uncorroborated := entries[0]
+	uncorroborated.Status = conformance.Provisional
+
+	open, _ := door(t, script{
+		GenerateFail: map[string]string{uncorroborated.Name: "this generator does not handle that construct"},
+		Entries:      answers(t, entries),
+	})
+
+	report, err := (&engine.Engine{Door: open}).Run(t.Context(), entries)
+	if err != nil {
+		t.Fatalf("the run could not be made: %v", err)
+	}
+
+	if report.Failed() {
+		t.Errorf("a provisional entry could not be asked about and the run failed:\n%v", report)
+	}
+
+	if got := outcomes(report)[uncorroborated.Name]; got != engine.Faulted {
+		t.Errorf("the provisional entry came back %s, and the generator refused its descriptor:\n%v", got, report)
+	}
+
+	if agreed, disagreed, unanswered := report.ProvisionalCounts(); agreed != 0 || disagreed != 0 || unanswered != 1 {
+		t.Errorf("the provisional half scored %d agreed, %d disagreed and %d could not be asked:\n%v",
+			agreed, disagreed, unanswered, report)
+	}
+
+	if said := report.String(); !strings.Contains(said, "PROVISIONAL FAULT") {
+		t.Errorf("the report is\n%s\nand it does not mark the provisional entry nothing was learned about", said)
+	}
+}
+
+// TestARunOfNothingButProvisionalEntriesSaysSo is the shape a report has to be
+// loudest about.
+//
+// Every line of it would otherwise read as a clean run: nothing disagreed,
+// nothing faulted, and the total is zero out of zero. A reader who took that
+// for a pass would be reading a conformance result about a corpus nobody stands
+// behind, which is the one thing a report of no entries must not look like.
+func TestARunOfNothingButProvisionalEntriesSaysSo(t *testing.T) {
+	entries := corpus(t, "packed-ebcdic")
+	entries[0].Status = conformance.Provisional
+
+	open, _ := door(t, script{Entries: answers(t, entries)})
+
+	report, err := (&engine.Engine{Door: open}).Run(t.Context(), entries)
+	if err != nil {
+		t.Fatalf("the run could not be made: %v", err)
+	}
+
+	if passed, mismatched, faulted := report.Counts(); passed != 0 || mismatched != 0 || faulted != 0 {
+		t.Errorf("the normative half scored %d passed, %d disagreed and %d could not be asked, out of a run that "+
+			"asked about no normative entry:\n%v", passed, mismatched, faulted, report)
+	}
+
+	if said := report.String(); !strings.Contains(said, "states nothing about conformance") {
+		t.Errorf("the report is\n%s\nand it does not say that nothing it asked about is corroborated", said)
+	}
+}
+
+// wrong is the entry's own answer with one named item changed, which is a
+// values document the adapter can be scripted with and the entry disagrees
+// with.
+//
+// The entry's document is the starting point rather than an invented one, so
+// that what the comparison reports is the one item this changed and not the
+// shape of a record somebody wrote in a test.
+func wrong(t *testing.T, entry *conformance.Entry, item string) []byte {
+	t.Helper()
+
+	held, ok := entry.Values.Records[0].Value.(map[string]any)
+	if !ok {
+		t.Fatalf("%s: the first record is not a group", entry.Name)
+	}
+
+	if _, carries := held[item]; !carries {
+		t.Fatalf("%s: the first record carries no item called %s", entry.Name, item)
+	}
+
+	changed := maps.Clone(held)
+	changed[item] = "99999"
+
+	return marshalled(t, &conformance.Values{
+		Records: []conformance.Record{{Name: entry.Values.Records[0].Name, Value: changed}},
+	})
+}

--- a/internal/conformance/engine/report.go
+++ b/internal/conformance/engine/report.go
@@ -158,6 +158,13 @@ type Report struct {
 	Restarts int
 
 	// Results are the entries, in the order they were asked about.
+	//
+	// Normative and provisional entries are both in here, so a reading of this
+	// slice has to consult [Result.Provisional]: len(Results) is not the sum of
+	// [Report.Counts], and the obvious loop testing Outcome != Passed counts a
+	// provisional entry as a failure — which is exactly what [Report.Failed]
+	// stopped doing. Ask [Report.Failed] and the two count methods rather than
+	// summing this.
 	Results []*Result
 
 	// Notes are what happened to the run rather than to an entry: an adapter
@@ -216,6 +223,27 @@ func (r *Report) Counts() (passed, mismatched, faulted int) {
 // would have been dropped into those sums by whoever updated the call.
 func (r *Report) ProvisionalCounts() (agreed, disagreed, unanswered int) {
 	return r.count(true)
+}
+
+// StatesNothing is whether the run asked about entries and none of them was
+// one the corpus stands behind.
+//
+// It is the one shape a reader must not take for a pass: [Report.Failed] is
+// false, [Report.Counts] is three zeros and the process exits zero, and every
+// line of the report agrees, because nothing disagreed and nothing faulted. A
+// caller that has to act on it — a job that fails a build on a result that
+// learned nothing — should ask this rather than match the report's text, which
+// is prose and may be reworded.
+//
+// A run of no entries at all is not this. A descriptive generator is asked
+// about nothing by design ([Report.NotApplicable]), and calling that a run that
+// states nothing would fail the one case the engine goes out of its way not to
+// score.
+func (r *Report) StatesNothing() bool {
+	passed, mismatched, faulted := r.Counts()
+	agreed, disagreed, unanswered := r.ProvisionalCounts()
+
+	return passed+mismatched+faulted == 0 && agreed+disagreed+unanswered > 0
 }
 
 // count is either half of the corpus, by whether the entry was provisional.
@@ -284,10 +312,13 @@ func (r *Report) String() string {
 			"%d agreed, %d disagreed, %d could not be asked\n",
 			agreed+disagreed+unanswered, agreed, disagreed, unanswered)
 
-		if normative == 0 {
+		if r.StatesNothing() {
 			// Said out loud, because every other line of this report would
 			// otherwise read as a clean run: nothing disagreed, nothing
-			// faulted, and nothing was asked that anybody stands behind.
+			// faulted, and nothing was asked that anybody stands behind. The
+			// condition is [Report.StatesNothing] rather than a second reading
+			// of the counts, so that the sentence and the accessor cannot come
+			// to disagree.
 			said.WriteString("every entry asked about was provisional, so this run states nothing about conformance\n")
 		}
 	}

--- a/internal/conformance/engine/report.go
+++ b/internal/conformance/engine/report.go
@@ -70,6 +70,17 @@ type Result struct {
 
 	Outcome Outcome
 
+	// Provisional is whether the entry it is about declared itself provisional
+	// — an entry whose expected answer nothing has corroborated yet
+	// ([github.com/Zaba505/cpybkc/internal/conformance.Provisional]).
+	//
+	// It sits beside the outcome rather than replacing one of its values,
+	// because what happened to the entry and how much the corpus stands behind
+	// the entry are two facts and a reader of a report wants both: an
+	// implementation that disagrees with a provisional entry has learned
+	// something worth reading even though it has not failed.
+	Provisional bool
+
 	// Err is the disagreement or the fault, and is nil where the entry passed.
 	// It is a
 	// [github.com/Zaba505/cpybkc/internal/conformance.MismatchError] or a
@@ -154,15 +165,28 @@ type Report struct {
 	Notes []string
 }
 
-// Failed is whether anything went wrong: an entry that disagreed, or one that
-// could not be asked at all.
+// Failed is whether anything went wrong: a normative entry that disagreed, or
+// one that could not be asked at all.
 //
 // A run that could not ask is a failed run and not an empty one. An entry lost
 // to a broken adapter has told nobody anything about the generator, and a
 // caller that read "nothing mismatched" as "everything passed" would report a
 // conformant generator on the strength of never having asked it.
+//
+// A provisional entry produces no failure verdict, whatever became of it. The
+// corpus does not yet stand behind its expected answer, so a run that failed on
+// one would be telling an implementation it is wrong on the authority of a byte
+// string one person computed by hand — and the failure that guards against is
+// not a red mark, it is a generator author who trusts the corpus, changes
+// correct code to match a wrong oracle and ships it (#207). What became of it
+// is in [Report.Results] and in the report's text either way; it is reported
+// and it is not a verdict.
 func (r *Report) Failed() bool {
 	for _, result := range r.Results {
+		if result.Provisional {
+			continue
+		}
+
 		if result.Outcome != Passed {
 			return true
 		}
@@ -171,9 +195,36 @@ func (r *Report) Failed() bool {
 	return false
 }
 
-// Counts is how many entries passed, disagreed and could not be asked.
+// Counts is how many normative entries passed, disagreed and could not be
+// asked.
+//
+// Provisional entries are in none of the three and are counted by
+// [Report.ProvisionalCounts] instead, which is what "counts in no total" means:
+// a corpus that grew an uncorroborated entry must not move the number an
+// implementation reports, in either direction, or the entry has scored a
+// generator nobody agreed it could score.
 func (r *Report) Counts() (passed, mismatched, faulted int) {
+	return r.count(false)
+}
+
+// ProvisionalCounts is how many provisional entries agreed with what they
+// state, disagreed with it, and could not be asked.
+//
+// It is a second set of three rather than an extra value on the first, so that
+// a caller adding up a total cannot accidentally include them: every existing
+// reading of [Report.Counts] means normative entries, and a fourth return value
+// would have been dropped into those sums by whoever updated the call.
+func (r *Report) ProvisionalCounts() (agreed, disagreed, unanswered int) {
+	return r.count(true)
+}
+
+// count is either half of the corpus, by whether the entry was provisional.
+func (r *Report) count(provisional bool) (passed, mismatched, faulted int) {
 	for _, result := range r.Results {
+		if result.Provisional != provisional {
+			continue
+		}
+
 		switch result.Outcome {
 		case Passed:
 			passed++
@@ -181,8 +232,9 @@ func (r *Report) Counts() (passed, mismatched, faulted int) {
 			mismatched++
 		case Faulted, Unknown:
 			// An outcome nobody set is counted with the faults rather than
-			// dropped, so that the three numbers always sum to the entries and
-			// a result that was never filled in cannot go missing from a total.
+			// dropped, so that the three numbers always sum to the entries of
+			// their half and a result that was never filled in cannot go
+			// missing from a total.
 			faulted++
 		}
 	}
@@ -218,9 +270,27 @@ func (r *Report) String() string {
 	}
 
 	passed, mismatched, faulted := r.Counts()
+	normative := passed + mismatched + faulted
 
 	fmt.Fprintf(&said, "%d entries: %d passed, %d disagreed, %d could not be asked\n",
-		len(r.Results), passed, mismatched, faulted)
+		normative, passed, mismatched, faulted)
+
+	if agreed, disagreed, unanswered := r.ProvisionalCounts(); agreed+disagreed+unanswered > 0 {
+		// A line of its own, and outside the total above rather than added to
+		// it. The number a run reports is the number of entries the corpus
+		// stands behind, and a provisional entry that moved it would have
+		// scored a generator on an answer nothing has corroborated.
+		fmt.Fprintf(&said, "%d provisional entries, in no total above and in no verdict: "+
+			"%d agreed, %d disagreed, %d could not be asked\n",
+			agreed+disagreed+unanswered, agreed, disagreed, unanswered)
+
+		if normative == 0 {
+			// Said out loud, because every other line of this report would
+			// otherwise read as a clean run: nothing disagreed, nothing
+			// faulted, and nothing was asked that anybody stands behind.
+			said.WriteString("every entry asked about was provisional, so this run states nothing about conformance\n")
+		}
+	}
 
 	if r.Restarts == 1 {
 		said.WriteString("a fresh adapter was started after one broke\n")
@@ -236,39 +306,61 @@ func (r *Report) String() string {
 
 	for _, result := range r.Results {
 		if result.Err == nil {
-			fmt.Fprintf(&said, "%s %s\n", result.Outcome, result.Entry)
+			fmt.Fprintf(&said, "%s %s\n", result.mark(), result.Entry)
 
 			continue
 		}
 
-		fmt.Fprintf(&said, "%s %v\n", result.Outcome, result.Err)
+		fmt.Fprintf(&said, "%s %v\n", result.mark(), result.Err)
 	}
 
 	return said.String()
 }
 
+// mark is how a result's line opens: the outcome, and for a provisional entry
+// the word that says the line is a report rather than a verdict.
+//
+// The outcome is kept and prefixed rather than replaced, because a reader
+// scanning for FAIL wants to find a provisional disagreement too — it is the
+// one that most needs looking at, since either the implementation or the entry
+// is wrong and nothing yet says which.
+func (r *Result) mark() string {
+	if r.Provisional {
+		return "PROVISIONAL " + r.Outcome.String()
+	}
+
+	return r.Outcome.String()
+}
+
 // pass records an entry whose answer is what the entry states.
 func (r *Report) pass(entry *conformance.Entry) {
-	r.Results = append(r.Results, &Result{Entry: entry.Name, Source: entry.Source, Outcome: Passed})
+	r.Results = append(r.Results, &Result{
+		Entry:       entry.Name,
+		Source:      entry.Source,
+		Outcome:     Passed,
+		Provisional: entry.IsProvisional(),
+	})
 }
 
 // mismatch records an entry the adapter answered and disagreed about.
 func (r *Report) mismatch(entry *conformance.Entry, err error) {
 	r.Results = append(r.Results, &Result{
-		Entry:   entry.Name,
-		Source:  entry.Source,
-		Outcome: Mismatched,
-		Err:     &conformance.MismatchError{Entry: entry.Name, Source: entry.Source, Err: err},
+		Entry:       entry.Name,
+		Source:      entry.Source,
+		Outcome:     Mismatched,
+		Provisional: entry.IsProvisional(),
+		Err:         &conformance.MismatchError{Entry: entry.Name, Source: entry.Source, Err: err},
 	})
 }
 
 // fault records an entry nothing was learned about.
 func (r *Report) fault(entry *conformance.Entry, err error) {
 	r.Results = append(r.Results, &Result{
-		Entry:   entry.Name,
-		Source:  entry.Source,
-		Outcome: Faulted,
-		Err:     &conformance.RunError{Entry: entry.Name, Source: entry.Source, Err: err},
+		Entry:       entry.Name,
+		Source:      entry.Source,
+		Outcome:     Faulted,
+		Provisional: entry.IsProvisional(),
+		Err:         &conformance.RunError{Entry: entry.Name, Source: entry.Source, Err: err},
 	})
 }
 

--- a/testdata/conformance/README.md
+++ b/testdata/conformance/README.md
@@ -162,7 +162,10 @@ platform they are run.
    not from what a generator printed. An entry recorded from the code it checks
    passes forever, including through the bug it was written to catch.
 4. Cite the section in `entry.json`.
-5. `go test ./internal/conformance/...`. The loader reports what is wrong with
+5. Decide whether the entry is normative or provisional — see below. Most are
+   normative and say nothing; an entry nothing can cross-check yet writes
+   `"status": "provisional"`.
+6. `go test ./internal/conformance/...`. The loader reports what is wrong with
    the entry, and the run reports what the generated code decoded where it
    differs from what you wrote.
 
@@ -176,6 +179,32 @@ appearing to disagree with you about a number.
 
 The rendering of `ir.json` is the one thing worth generating: write the content
 by hand, then let the canonicalisation check tell you where the whitespace goes.
+
+### A new entry may be provisional
+
+Hand-authoring is what makes an entry an oracle, and it is also the one way an
+entry goes wrong that nothing here can catch. An entry recorded from the code it
+checks passes forever; an entry authored from a *misreading* fails forever, and
+tells every implementation it is wrong. Nothing in a run distinguishes that from
+a generator with a bug, and the entries where it is likeliest are the ones worth
+most — a construct no implementation handles yet has nothing to disagree with
+it, so the only defence is somebody reviewing a byte string computed by hand.
+
+So an entry may declare `"status": "provisional"`, and then it runs, its result
+is reported, and it counts in no total and fails nothing. The rule a harness
+follows and the two things that promote one — two independent implementations
+agreeing with it, or a second person re-deriving its answer from the
+specification — are [*A provisional
+entry*](../../docs/conformance/SPEC.md#a-provisional-entry).
+
+**Every entry here is normative**, and a test says so, because an entry that
+became provisional would stop counting and stop being able to fail a run without
+any other test noticing. The status is for a *new* entry that cannot be
+cross-checked yet, and today nothing is in that position: the corpus predates a
+second implementation, and every entry in it was reviewed as normative. When one
+is added provisionally, promoting it is an ordinary pull request — remove the
+member, and say in the description which of the two things happened and who or
+what did it.
 
 ## The entries
 


### PR DESCRIPTION
Closes #207

An entry is authored from a specification and never recorded from a run of the
code it checks, because an entry recorded from its subject passes forever —
including through the bug it was written to catch (#67). This is the mirror of
that rule: **an entry authored from a misreading fails forever**, and every
implementation is told it is wrong. The exposure is worst where the corpus is
most valuable, because an entry covering a construct no implementation handles
yet has nothing to cross-check it. What it costs is not a red mark: it is a
generator author who trusts the corpus, changes correct code to match a wrong
oracle, and ships it.

## Acceptance criteria

- [x] **An entry can declare itself provisional.** `entry.json` gains an
  optional `status` member, one of `"normative"` and `"provisional"`. A value
  outside the two is refused, as is an empty one — the loader tells an author
  about a typo rather than reading past it.
- [x] **A provisional entry's disagreement is reported and is not a failure.**
  `Report.Failed` skips provisional results, and the report prints them marked
  `PROVISIONAL FAIL` rather than dropping them. A provisional entry that could
  not be asked about at all is treated the same way, so the exemption does not
  hold for one outcome and not the other.
- [x] **A provisional entry counts in no total.** `Report.Counts` is the
  normative half only; `Report.ProvisionalCounts` is a second set of three, so
  that a caller adding up a total cannot include them by accident. The report
  prints them on a line of its own, and says plainly when a run asked about
  nothing but provisional entries — every other line of such a report reads as a
  clean run.
- [x] **What promotes an entry to normative is written down.**
  `docs/conformance/SPEC.md`, *A provisional entry*: two independent
  implementations agreeing with it, or a second person re-deriving its answer
  from the specification. Neither is checkable, so promotion is an edit and a
  review — which is the point.
- [x] **Every entry shipped today remains normative.** Absent means normative,
  so no `entry.json` changed and the corpus digest does not move. A test asserts
  it: an entry that became provisional would stop counting and stop being able
  to fail a run, and nothing else would notice.

## Judgment calls that shaped the public interface

- **Absent means normative**, rather than the status being required. It keeps
  every entry written before the member existed saying what it said, and it is
  the safe direction for the default to fall in — the value nobody wrote is the
  one that leaves an entry counting, so an entry cannot drop out of a verdict by
  omission.
- **The status is not communicated to the runner.** It appears nowhere in the
  adapter contract: an adapter that could tell which entries were
  uncorroborated would be one whose answers about them are worth less than its
  answers about the rest.
- **`Provisional` sits beside the outcome rather than being a fourth
  `Outcome`.** What happened to the entry and how much the corpus stands behind
  the entry are two facts, and a reader of a report wants both.
- **`ProvisionalCounts` is a second set of three** rather than a fourth return
  value on `Counts`, so no existing sum silently acquires them.
- **No provisional entry is shipped.** The status is for an entry that cannot
  be cross-checked yet; every entry in the corpus was reviewed as normative, and
  a test holds it that way.

## Verified

- `dagger call ci` — green, run from an ordinary clone (a worktree cannot run it
  since #185; CONTRIBUTING.md documents that).
- New tests: the three spellings of `status` and the two refusals; that an
  `Entry` nothing loaded is normative; that every shipped entry is normative;
  and four engine tests covering a provisional entry that disagrees, one that
  agrees, one that could not be asked about, and a run holding nothing else.