### PR TITLE
story(setup): adopt avroc's Renovate configuration so dependency bumps are raised automatically

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,12 +23,14 @@ require google.golang.org/protobuf v1.36.11
 // about, and this is a dependency of the module `go install` builds the CLI
 // from.
 //
-// This commit is the one that added COMP-6 — the usage-type, its storage width,
-// and the codec accessors that read and write a field with no sign nibble in it
-// (#162). Before it the copybook reader refused `COMP-6` outright and codec
-// offered nothing that fit, so the IR could name a usage no part of this
-// repository could resolve or emit code for.
-require github.com/Zaba505/cobol-go v0.0.0-20260812022219-b6beeac1efe8
+// This commit is the one that taught the parser the listing-control statements
+// — `EJECT`, `SKIP1`/`SKIP2`/`SKIP3` and `TITLE` (Zaba505/cobol-go#106). They
+// direct a compiler's source listing and say nothing about the data, so nothing
+// downstream of the parse changes; before it, a copybook out of a real mainframe
+// library that carried one failed to read at all, and `cpybkc init` reported it
+// as "this is not a copybook this build can read". That is the whole of what
+// this repository gets from the move — no code here changed for it.
+require github.com/Zaba505/cobol-go v0.0.0-20260815031026-444b99aad1b5
 
 // The grammar underneath the layout format. docs/layout/SPEC.md delegates the
 // lexis and the parse of a layout file to it — what a symbol is, where a number

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Zaba505/cobol-go v0.0.0-20260812022219-b6beeac1efe8 h1:Tu8Igj5W2DCu1JX7kMbaWGr9NOGpH0KSc7R+YuJ+qOY=
 github.com/Zaba505/cobol-go v0.0.0-20260812022219-b6beeac1efe8/go.mod h1:a0ImjTdXHvjbs8CWSUQ2AWOUcUj89aZ+G8hkaIPDjdo=
+github.com/Zaba505/cobol-go v0.0.0-20260815031026-444b99aad1b5 h1:mqFKG2ftgtw22Gi5RFV8Lji7BWVfMsYon2BxkjciH+k=
+github.com/Zaba505/cobol-go v0.0.0-20260815031026-444b99aad1b5/go.mod h1:a0ImjTdXHvjbs8CWSUQ2AWOUcUj89aZ+G8hkaIPDjdo=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,87 @@
+{
+    "extends": [
+        "config:best-practices"
+    ],
+    "ignorePaths": ["docs/**"],
+    "osvVulnerabilityAlerts": true,
+    "schedule": [
+        "before 4am"
+    ],
+    "baseBranchPatterns": [
+        "main"
+    ],
+    "labels": [
+        "dependencies"
+    ],
+    "packageRules": [
+        {
+            "description": "Automerge non-major updates",
+            "matchUpdateTypes": ["minor", "patch"],
+            "automerge": true
+        },
+        {
+            "matchManagers": [
+                "gomod"
+            ],
+            "matchDepTypes": [
+                "indirect"
+            ],
+            "enabled": true
+        },
+        {
+            "groupName": "opentelemetry-go and opentelemetry-go-contrib monorepos",
+            "matchSourceUrls": [
+                "https://github.com/open-telemetry/opentelemetry-go",
+                "https://github.com/open-telemetry/opentelemetry-go-contrib"
+            ],
+            "matchUpdateTypes": [
+                "digest",
+                "patch",
+                "minor",
+                "major"
+            ]
+        },
+        {
+            "groupName": "google.golang.org/genproto/googleapis monorepo",
+            "matchDatasources": [
+                "go"
+            ],
+            "matchPackageNames": [
+                "google.golang.org/genproto/googleapis/**"
+            ],
+            "matchUpdateTypes": [
+                "digest",
+                "patch",
+                "minor",
+                "major"
+            ]
+        },
+        {
+            "groupName": "golang.org/x monorepo",
+            "matchDatasources": [
+                "go"
+            ],
+            "matchPackageNames": [
+                "golang.org/x/**"
+            ],
+            "matchUpdateTypes": [
+                "digest",
+                "patch",
+                "minor",
+                "major"
+            ]
+        },
+        {
+            "description": "The dagger modules' go.mod files are codegen output, not dependency declarations: `dagger develop` rewrites them wholesale from the Go SDK's template for dagger.json's engineVersion, so anything Renovate raises here is lowered again by the next regeneration. The engine version is the lever that actually moves these requires. Scoped to the generated go.mod files by name, not to the directories holding them: nothing else in .dagger is Renovate-managed today, but a rule that names a directory is one that silently switches off whatever gets added to it, and the custom regex manager this exclusion had to leave running until #217 is the precedent.",
+            "matchFileNames": [
+                ".dagger/go.mod",
+                "daggerverse/**/go.mod"
+            ],
+            "enabled": false
+        }
+    ],
+    "postUpdateOptions": [
+        "gomodTidy",
+        "gomodUpdateImportPaths"
+    ]
+}


### PR DESCRIPTION
Adopts `z5labs/avroc`'s `renovate.json` at the repository root, copied verbatim, and repins cobol-go to the listing-directive fix that motivated the story.

## `renovate.json`

Nothing in the file needed changing to land here:

- **`docs/**` for `ignorePaths`** — cpybkc has that tree.
- **The dagger exclusion** — `git ls-files '*go.mod'` gives `.dagger/go.mod`, `daggerverse/cpybkc/go.mod`, `go.mod` and `irpb/go.mod`; the first two are `dagger develop` codegen output for the same reason they are in avroc (z5labs/avroc#201), and the rule's `matchFileNames` already names them.
- **`irpb/go.mod`** is matched by nothing in that rule, so it stays Renovate-managed.
- **`gomodTidy` and the local `replace`** — `go mod tidy` on the root module is a no-op against this tree (checked from a real clone), so `replace github.com/Zaba505/cpybkc/irpb => ./irpb` is left alone.
- **The three monorepo grouping rules** match nothing in cpybkc's module graph today. They stay, so one file remains diffable across both repositories.

The `dependencies` label now exists on this repository (`ededed`, matching avroc's), so the config's `labels` setting has something to apply.

## The cobol-go repin

`v0.0.0-20260812022219-b6beeac1efe8` → `v0.0.0-20260815031026-444b99aad1b5` — Zaba505/cobol-go#107, closing Zaba505/cobol-go#106. Measured either side of the pin on a copybook carrying `SKIP1` and `EJECT`. Before:

```
error: header.cpy: this is not a copybook this build can read
  unexpected token Identifier(SKIP1) at line 3, column 8, expected end of input
```

After, `cpybkc init` writes the scaffold and exits 0. No code here changed for it. `go build ./...` and `go test -race ./...` (2462 tests, 35 packages) pass locally.

## Still outstanding — needs a human

- **The Renovate GitHub App is not installed on `Zaba505/cpybkc`.** There are no Renovate-authored pull requests and no dependency dashboard issue. A `renovate.json` alone does nothing; enabling the App is a web-UI action. Once it is on, confirm the onboarding pull request / dependency dashboard appears.
- **Whether a pseudo-version bump automerges is still unobserved.** The mechanism is there — `@v/list` is empty for an untagged module and the go datasource falls back to `@latest`, which returns the latest pseudo-version as the only release — but this repin was done by hand, before the App exists, so nothing has been watched through Renovate yet. Whether it lands as `digest` (which avroc's `minor`/`patch` automerge rule would not match) or as `patch` is the thing to check on the next cobol-go move.
- **Two automerge paths will be live.** Renovate's own `automerge: true` uses GitHub's native auto-merge (`allow_auto_merge` is on); the backlog loop's `auto-merge` label and `.github/workflows/auto-merge.yaml` are a separate path Renovate pull requests never enter, because nothing labels them. Independent, as in avroc, but not written into either file.
- **No cpybkc-level regression test for the listing directives.** The behaviour is cobol-go's and is tested there; this repository has nothing that would catch a rollback of the pin.

`main`'s ruleset requires the `ci` check, squash-only, signed commits, no required approvals — nothing a Renovate-authored pull request cannot satisfy.

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)