### PR TITLE
story(container): decide what a breaking CLI change does to the image's major tag, and which release number carries it

### DIFF
--- a/.dagger/release.go
+++ b/.dagger/release.go
@@ -579,12 +579,13 @@ func (m *Cpybkc) ReleaseNotes(
 // and below 1.0.0 the only release that is one is 1.0.0 — see
 // docs/container/SPEC.md's "A breaking change to either contract takes a new
 // major version". That is a rule about which *diff* a number may carry, and
-// every input this function has is a ref: `v0.3.0` is a canonical version tag
-// pointing at HEAD whether the tree under it withdrew a rejection or fixed a
-// typo, so a check here would either pass on both or fail on both. The reading
-// is the releaser's, CONTRIBUTING.md's "Which number a breaking change takes" is
-// where it is written down for them, and the release notes carry the
-// announcement the CLI contract requires.
+// nothing planRelease is given describes a diff: it sees the refs at HEAD and
+// the name of the release object that triggered the run, and `v0.3.0` is a
+// canonical version tag pointing at HEAD whether the tree under it withdrew a
+// rejection or fixed a typo. A check here would pass on both or fail on both.
+// The reading is the releaser's, CONTRIBUTING.md's "Which number a breaking
+// change takes" is where it is written down for them, and the release notes
+// carry the announcement the CLI contract requires.
 //
 // What the rule does *not* touch is anything below, and that is the reading
 // #213's fourth criterion asks for: it decides which number is cut, while this
@@ -610,9 +611,13 @@ func (m *Cpybkc) TagScheme() error {
 		{refs: []string{"refs/tags/v1.10.3"}, version: "v1.10.3"},
 		// The number #213 names for the first breaking change, pinned because it
 		// is now a requirement in docs/cli/SPEC.md rather than a version like any
-		// other. It plans exactly as the rows above do, which is the point: the
+		// other. It reaches no branch the v1.10.3 row above does not, and saying
+		// so is the honest description: this row is documentation of a decision
+		// sitting where the decision's number would otherwise appear nowhere in
+		// the pipeline, not coverage of a path that was previously unchecked. The
 		// rule decides which diff may carry a number, and nothing about cutting
-		// that number had to change to accommodate it.
+		// that number had to change to accommodate it — which is the reading the
+		// paragraph above records, in the one place a reader can see it is true.
 		{refs: []string{"refs/tags/v1.0.0", "refs/heads/main"}, version: "v1.0.0"},
 		// A prerelease is a release of the image too. What it does *not* do —
 		// move the tags a derived Dockerfile pins to pick up fixes — is the

--- a/.dagger/release.go
+++ b/.dagger/release.go
@@ -573,6 +573,26 @@ func (m *Cpybkc) ReleaseNotes(
 // tagged, is discovered afterwards, and by then the tag is out and this
 // project's own contract says it is never repointed.
 //
+// What #213 added to the contract is not checkable here, and the reason is worth
+// stating where somebody would come looking for it. Since #213 a break in either
+// the CLI contract's covered surface or the image's takes a new major version,
+// and below 1.0.0 the only release that is one is 1.0.0 — see
+// docs/container/SPEC.md's "A breaking change to either contract takes a new
+// major version". That is a rule about which *diff* a number may carry, and
+// every input this function has is a ref: `v0.3.0` is a canonical version tag
+// pointing at HEAD whether the tree under it withdrew a rejection or fixed a
+// typo, so a check here would either pass on both or fail on both. The reading
+// is the releaser's, CONTRIBUTING.md's "Which number a breaking change takes" is
+// where it is written down for them, and the release notes carry the
+// announcement the CLI contract requires.
+//
+// What the rule does *not* touch is anything below, and that is the reading
+// #213's fourth criterion asks for: it decides which number is cut, while this
+// function and the archetype's table decide what a number, once cut, publishes
+// and moves. The two still agree because they answer different questions — 1.0.0
+// plans exactly as v0.2.0 does, and the family it implies is derived from it the
+// same way.
+//
 // Every expected value below is a literal, never one of this file's own
 // constants, so the check cannot move with the code it checks.
 //
@@ -588,6 +608,12 @@ func (m *Cpybkc) TagScheme() error {
 		// A release: a single canonical version tag at HEAD.
 		{refs: []string{"refs/tags/v0.2.0", "refs/heads/main"}, version: "v0.2.0"},
 		{refs: []string{"refs/tags/v1.10.3"}, version: "v1.10.3"},
+		// The number #213 names for the first breaking change, pinned because it
+		// is now a requirement in docs/cli/SPEC.md rather than a version like any
+		// other. It plans exactly as the rows above do, which is the point: the
+		// rule decides which diff may carry a number, and nothing about cutting
+		// that number had to change to accommodate it.
+		{refs: []string{"refs/tags/v1.0.0", "refs/heads/main"}, version: "v1.0.0"},
 		// A prerelease is a release of the image too. What it does *not* do —
 		// move the tags a derived Dockerfile pins to pick up fixes — is the
 		// archetype's rule now, and its table is where that is checked.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -512,13 +512,22 @@ looking for the check that would. Whether a change is breaking is a property of
 the change and not of the tag: `dagger call tag-scheme` can say that `v0.3.0` is
 a canonical version pointing at HEAD, and that the family it implies is the
 archetype's, and it cannot say that the diff under it withdrew a rejection. The
-reading is the releaser's, and [the release
-notes](#the-version-a-release-publishes-is-the-version-it-was-cut-from) are where
-the announcement it obliges goes.
+reading is the releaser's, and the release notes are where the announcement it
+obliges goes — written by hand, above the [generated
+block](#whether-a-commit-is-a-release-is-a-function-not-a-step), which is
+spliced in rather than appended and so leaves what somebody wrote alone.
 
 The next release is where this first bites. `init` is on `main` and unreleased,
 and [the CLI contract requires the release that first carries it to be
 1.0.0](docs/cli/SPEC.md#the-subcommand-is-the-first-change-under-this-rule-and-it-breaks-it).
+
+That release is also when [the companion module's `v0`
+default](#the-default-image-tag-is-the-moving-major-tag) stops picking anything
+up: `v0` receives no release after the last `0.y.z`, and the argument that the
+default cannot go stale holds within a major and not across one. What to do
+about it — move the default to `v1`, or keep a moving default at all — is a
+decision for the module and not one this section makes; what this section says
+is that 1.0.0 is when it has to be made rather than noticed.
 
 ### The version a release publishes is the version it was cut from
 
@@ -1096,6 +1105,17 @@ asserts that a constant equals the git tag, and the release runbook grows no
 step that could be forgotten. A caller who pins nothing picks up every fix in
 the major version without editing anything — which is what a moving tag is for,
 and what the container contract already recommends to a derived Dockerfile.
+
+**Within a major**, and that bound is now dated rather than theoretical. A break
+in either contract takes [a new major
+version](docs/container/SPEC.md#a-breaking-change-to-either-contract-takes-a-new-major-version),
+and [below 1.0.0 the release that is
+one](docs/container/SPEC.md#below-100-the-rule-produces-100) is 1.0.0 — so `v0`
+stops receiving releases at 1.0.0 and this default stops picking fixes up on the
+same day. It does not go stale in the sense the paragraph above rules out (no
+constant to forget, no release step to miss); it goes stale by the image moving
+on without it, which is [a decision for that
+release](#which-number-a-breaking-change-takes) rather than a bug to fix now.
 
 ### What pinning the module ref buys, and what it does not
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -491,6 +491,35 @@ which IR version that image speaks.
 Nothing else is a step, after the first one. There is no version to bump by hand
 and no tag to push beyond the one the release object carries.
 
+### Which number a breaking change takes
+
+Choosing the tag is the only judgment left in a release, and it is not a free
+one. A change breaking a covered thing in [the CLI
+contract](docs/cli/SPEC.md#compatibility-guarantees) or [the base-image
+contract](docs/container/SPEC.md#compatibility-guarantees) takes a **new major
+version**, and below 1.0.0 the only release that is one is
+[**1.0.0**](docs/container/SPEC.md#below-100-the-rule-produces-100) (#213). A
+`0.y.z` is additive, always; the first release that is not additive is 1.0.0.
+
+The two contracts share one number, which is why one of them decides for both:
+the image's major version [tracks the CLI's covered surface as well as its
+own](docs/container/SPEC.md#a-breaking-change-to-either-contract-takes-a-new-major-version),
+so nothing that breaks either can ride a moving tag a derived Dockerfile pinned
+in order to pick up fixes.
+
+**Nothing in the pipeline checks this**, and that is worth knowing before going
+looking for the check that would. Whether a change is breaking is a property of
+the change and not of the tag: `dagger call tag-scheme` can say that `v0.3.0` is
+a canonical version pointing at HEAD, and that the family it implies is the
+archetype's, and it cannot say that the diff under it withdrew a rejection. The
+reading is the releaser's, and [the release
+notes](#the-version-a-release-publishes-is-the-version-it-was-cut-from) are where
+the announcement it obliges goes.
+
+The next release is where this first bites. `init` is on `main` and unreleased,
+and [the CLI contract requires the release that first carries it to be
+1.0.0](docs/cli/SPEC.md#the-subcommand-is-the-first-change-under-this-rule-and-it-breaks-it).
+
 ### The version a release publishes is the version it was cut from
 
 Both binaries learn their own version at link time, from the release. The shared

--- a/docs/cli/SPEC.md
+++ b/docs/cli/SPEC.md
@@ -1380,7 +1380,13 @@ is depending on something that may change in a patch release, with no notice:
   builds need not, because a record name is the layout's own identifier, nothing
   outside the file sees it, and the file is scaffolded once and then edited.
 - Anything about the published image, which the [base-image
-  contract](../container/SPEC.md) covers on its own terms and separately.
+  contract](../container/SPEC.md) covers on its own terms and separately. The
+  release *number* a break in this document takes is the one thing that is not
+  separable — it is a tag on that image and a `--version` line here — and it is
+  [settled
+  there](../container/SPEC.md#a-breaking-change-to-either-contract-takes-a-new-major-version)
+  (#213), which is a statement about numbering rather than about any guarantee in
+  the table above.
 
 ### How a covered thing would change
 
@@ -1401,6 +1407,14 @@ makes for a moved path. A CI pipeline that runs cpybkc is in a repository this
 project cannot see and cannot warn, and it fails with a message naming a flag
 rather than a version. A release in which both spellings work turns that into a
 deprecation somebody reads instead of a broken build somebody bisects.
+
+**Which release is a new major version** is settled in the [base-image
+contract](../container/SPEC.md#a-breaking-change-to-either-contract-takes-a-new-major-version),
+because that number reaches a consumer as an image tag as well as as a
+`--version` line and one release publishes both: a break in either contract takes
+a new major, and below 1.0.0 the release that is one is
+[1.0.0](../container/SPEC.md#below-100-the-rule-produces-100) (#213). A covered
+thing here therefore does not change in a `0.y.z` at all.
 
 #### The subcommand is the first change under this rule, and it breaks it
 
@@ -1427,15 +1441,25 @@ have checked is the announcement: the release that first carries `init`
 **MUST** say the command set gained a member. That is the only shape a
 deprecation takes when the behaviour being replaced was an error message.
 
-Which release *number* carries it is deliberately **not** stated as a
-requirement here, and that is why the paragraph above asks for an announcement
-rather than for a version. cpybkc is below 1.0.0, where SemVer leaves a `0.y.z`
-release outside the stability rules altogether, so "a new major version" has no
-number this document could hold a release to; and the published image carries a
-floating major tag whose promise is the [base-image
-contract](../container/SPEC.md)'s rather than this one's. Both questions are
-filed together (#213), and a **MUST** written before they are answered would be
-one nothing could check and nothing could violate.
+Which release *number* carries it is **`1.0.0`** (#213). It took a decision
+outside this document to say so, which is why the paragraph above asked for an
+announcement and not for a version: cpybkc is below 1.0.0, where SemVer leaves a
+`0.y.z` release outside the stability rules altogether, and the same number is a
+floating tag on an image whose promises are the [base-image
+contract](../container/SPEC.md)'s rather than this one's. Both halves are settled
+there, together, because the number reaches a consumer as a tag as well as as a
+`--version` line: [the image's major version tracks this document's covered
+surface as well as its
+own](../container/SPEC.md#a-breaking-change-to-either-contract-takes-a-new-major-version),
+so a break here takes a new major version of the release, and [below 1.0.0 the
+only release that is one](../container/SPEC.md#below-100-the-rule-produces-100)
+is 1.0.0.
+
+So this section now states two requirements rather than one. The release that
+first carries `init` **MUST** be `1.0.0`, and **MUST** say the command set gained
+a member. The first is checkable against the tag the release was cut from; the
+second is what a deprecation looks like when the behaviour being replaced was an
+error message.
 
 ## Out of Scope
 
@@ -1601,7 +1625,7 @@ the layout is resolved, not by `init`, which read no layout to compare against
 | [The environment](#the-environment) | #41 and #43 `plugin` for the two variables read, #147 `cli` for reading no others |
 | [`--version`](#--version) | #147 `cli`; the IR version it reports, #17 `ir`; the version it reports being the release's, #181 `cli` |
 | [Compatibility guarantees](#compatibility-guarantees) | #146 `cli` — decided here, in the shape #54 `container` uses for the image; #183 `cli` for the command set's new value and the first breaking change under it |
-| [How a covered thing would change](#how-a-covered-thing-would-change) | #146 `cli`; the subcommand priced against it, #183 `cli`; which release number pays it and what it does to the image's major tag, #213 `container` |
+| [How a covered thing would change](#how-a-covered-thing-would-change) | #146 `cli`; the subcommand priced against it, #183 `cli`; which release number pays it and what it does to the image's major tag, #213 `container`, which answers `1.0.0` and settles both halves in [the base-image contract](../container/SPEC.md#a-breaking-change-to-either-contract-takes-a-new-major-version) |
 | The project manifest — out of scope, see above | #40 `plugin` |
 | Flags that would state an adopter's knowledge, and scaffolding anything but a layout — out of scope, see above | #183 `cli` |
 | Extending a layout that already exists — out of scope, see above | #212 `cli` |

--- a/docs/cli/SPEC.md
+++ b/docs/cli/SPEC.md
@@ -1385,8 +1385,8 @@ is depending on something that may change in a patch release, with no notice:
   separable — it is a tag on that image and a `--version` line here — and it is
   [settled
   there](../container/SPEC.md#a-breaking-change-to-either-contract-takes-a-new-major-version)
-  (#213), which is a statement about numbering rather than about any guarantee in
-  the table above.
+  (#213), which is a statement about numbering rather than about any guarantee
+  in the table above.
 
 ### How a covered thing would change
 
@@ -1411,8 +1411,8 @@ deprecation somebody reads instead of a broken build somebody bisects.
 **Which release is a new major version** is settled in the [base-image
 contract](../container/SPEC.md#a-breaking-change-to-either-contract-takes-a-new-major-version),
 because that number reaches a consumer as an image tag as well as as a
-`--version` line and one release publishes both: a break in either contract takes
-a new major, and below 1.0.0 the release that is one is
+`--version` line and one release publishes both: a break in either contract
+takes a new major, and below 1.0.0 the release that is one is
 [1.0.0](../container/SPEC.md#below-100-the-rule-produces-100) (#213). A covered
 thing here therefore does not change in a `0.y.z` at all.
 
@@ -1443,23 +1443,26 @@ deprecation takes when the behaviour being replaced was an error message.
 
 Which release *number* carries it is **`1.0.0`** (#213). It took a decision
 outside this document to say so, which is why the paragraph above asked for an
-announcement and not for a version: cpybkc is below 1.0.0, where SemVer leaves a
-`0.y.z` release outside the stability rules altogether, and the same number is a
-floating tag on an image whose promises are the [base-image
-contract](../container/SPEC.md)'s rather than this one's. Both halves are settled
-there, together, because the number reaches a consumer as a tag as well as as a
-`--version` line: [the image's major version tracks this document's covered
-surface as well as its
+announcement and not for a version: cpybkc is below 1.0.0, where SemVer leaves
+a `0.y.z` release outside the stability rules altogether, and the same number
+is a floating tag on an image whose promises are the [base-image
+contract](../container/SPEC.md)'s rather than this one's. Both halves are
+settled there, together, because the number reaches a consumer as a tag as well
+as as a `--version` line: [the image's major version tracks this document's
+covered surface as well as its
 own](../container/SPEC.md#a-breaking-change-to-either-contract-takes-a-new-major-version),
 so a break here takes a new major version of the release, and [below 1.0.0 the
 only release that is one](../container/SPEC.md#below-100-the-rule-produces-100)
 is 1.0.0.
 
 So this section now states two requirements rather than one. The release that
-first carries `init` **MUST** be `1.0.0`, and **MUST** say the command set gained
-a member. The first is checkable against the tag the release was cut from; the
-second is what a deprecation looks like when the behaviour being replaced was an
-error message.
+first carries `init` **MUST** be `1.0.0`, and **MUST** say the command set
+gained a member. Neither is checked by anything, and for one reason: which
+release first carries `init` is a property of a diff, and every artifact a
+pipeline can read — the tag, the refs, the built binary — is the same whichever
+diff is under it. A releaser reads both requirements and satisfies both, which
+is what [`CONTRIBUTING.md`](../../CONTRIBUTING.md#which-number-a-breaking-change-takes)
+says in the place a release is actually cut from.
 
 ## Out of Scope
 
@@ -1624,7 +1627,7 @@ the layout is resolved, not by `init`, which read no layout to compare against
 | [Cancellation](#cancellation) | #148 `cli` |
 | [The environment](#the-environment) | #41 and #43 `plugin` for the two variables read, #147 `cli` for reading no others |
 | [`--version`](#--version) | #147 `cli`; the IR version it reports, #17 `ir`; the version it reports being the release's, #181 `cli` |
-| [Compatibility guarantees](#compatibility-guarantees) | #146 `cli` — decided here, in the shape #54 `container` uses for the image; #183 `cli` for the command set's new value and the first breaking change under it |
+| [Compatibility guarantees](#compatibility-guarantees) | #146 `cli` — decided here, in the shape #54 `container` uses for the image; #183 `cli` for the command set's new value and the first breaking change under it; #213 `container` for the release number a break here takes, which is the one thing about the published image this table does not hand over whole |
 | [How a covered thing would change](#how-a-covered-thing-would-change) | #146 `cli`; the subcommand priced against it, #183 `cli`; which release number pays it and what it does to the image's major tag, #213 `container`, which answers `1.0.0` and settles both halves in [the base-image contract](../container/SPEC.md#a-breaking-change-to-either-contract-takes-a-new-major-version) |
 | The project manifest — out of scope, see above | #40 `plugin` |
 | Flags that would state an adopter's knowledge, and scaffolding anything but a layout — out of scope, see above | #183 `cli` |

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -288,8 +288,10 @@ the entrypoint is *always* a flag. It may be a flag, as it is for every
 invocation published before this — the CLI's default action is all flags — or it
 may now be a subcommand name; which names are admitted is [the
 CLI's](../cli/SPEC.md#the-first-operand-is-a-subcommand-name) rather than this
-document's. Whether a breaking change to that command set moves
-this image's own major tag is a separate question, filed as #213.
+document's. What a breaking change to that command set does to this image's own
+major tag is settled below, and the answer is that the moving major tag does not
+carry one: a break in either contract takes [a new major version of the
+release](#a-breaking-change-to-either-contract-takes-a-new-major-version) (#213).
 
 ## The user
 
@@ -599,7 +601,11 @@ every fix in the major version and, by the [guarantee
 below](#compatibility-guarantees), keeps every path this document names; it is
 the right pin for a derived image that wants security updates without a
 Dockerfile change, and it is what the [worked
-example](#worked-example-adding-a-generator) uses. A **prerelease** —
+example](#worked-example-adding-a-generator) uses. It keeps the CLI's covered
+surface as well, which is a decision rather than a consequence of the sentence
+before it: see [A breaking change to either contract takes a new major
+version](#a-breaking-change-to-either-contract-takes-a-new-major-version).
+A **prerelease** —
 `v0.3.0-rc.1` — publishes its own full version tag and **MUST NOT** move any of
 the other three, because a release candidate is not a fix anybody consented to
 be given (#59).
@@ -618,6 +624,88 @@ position the plugin contract takes under [Plugin
 distribution](../plugin/SPEC.md#also-out-of-scope). Pinning a digest fixes the
 generators in the image along with cpybkc itself, which is the whole reason this
 project has no lockfile.
+
+### A breaking change to either contract takes a new major version
+
+The image and the CLI inside it are **one release under one version number**. A
+release publishes `vX.Y.Z` and the executable in it answers `X.Y.Z` to
+[`--version`](../cli/SPEC.md#--version), so there is no image major that can
+move independently of the CLI's, and the question [the subcommand
+raised](#the-arrangement-survives-a-subcommand) is not which of two numbers
+advances but what the one number is entitled to carry.
+
+**The image's major version tracks the CLI's covered surface as well as its
+own** (#213). A change breaking [this document's
+guarantees](#compatibility-guarantees) **or** [the CLI contract's
+guarantees](../cli/SPEC.md#compatibility-guarantees) is a breaking change of the
+release, and the release carrying it **MUST** be a new major version, by [How a
+covered thing would change](#how-a-covered-thing-would-change). The moving major
+tag therefore never carries one: `v0` stops at the last release before it and
+`v1` begins with it, and a derived Dockerfile pinning `v0` keeps the command set
+it was written against as surely as it keeps the plugin directory.
+
+The other answer was available and is refused. The two contracts do cover
+different things — [`docs/cli/SPEC.md` says so in as many
+words](../cli/SPEC.md#compatibility-guarantees), listing anything about the
+published image as not its own — and on this image's own terms nothing broke
+when `init` arrived: every path here survives it and the entrypoint still takes
+cpybkc's arguments. A rule reading only the table below would let `v0` move
+across it.
+
+What refuses that is who is holding the tag. A `FROM …:v0` line is in a
+repository this project cannot see, and what it pulls the image *for* is the
+program inside it. A caller whose wrapper passes a word of its own user's input
+through as cpybkc's first argument is broken by [the subcommand's
+arrival](../cli/SPEC.md#the-subcommand-is-the-first-change-under-this-rule-and-it-breaks-it)
+whether they reached cpybkc through a `docker run` or through a `go install`,
+and telling them afterwards that the break was covered by a document they were
+not reading is telling them the pin this section recommends bought less than the
+sentence recommending it said.
+
+The cost is stated rather than hidden: a `v0` pinner stops receiving fixes once
+`v1` is cut. That is what a compatibility boundary *is*, it is what the [full
+version tag](#tags-and-what-pinning-one-buys) already means one release at a
+time, and moving across it is one edited line at a moment of the pinner's
+choosing rather than a build that changed under them.
+
+Nothing here makes the CLI's requirements this document's. Which names the
+command set admits, which flags exist and what they mean stay [the CLI
+contract's](../cli/SPEC.md) to state and to change; what this section fixes is
+only which release number a change to them may appear in, because that number is
+a tag on this image.
+
+### Below 1.0.0, the rule produces 1.0.0
+
+cpybkc is below 1.0.0, and SemVer 2.0.0 §4 puts a `0.y.z` release outside the
+stability rules altogether — so "a new major version" looks like a requirement
+naming no number a release could be held to. It names one (#213):
+
+> A breaking change to a covered thing in either contract **MUST NOT** be
+> published in a `0.y.z` release. Below 1.0.0 the release satisfying [How a
+> covered thing would change](#how-a-covered-thing-would-change) is **1.0.0**.
+
+The leading non-zero component is **not** treated as the major in the meantime,
+and the rule does **not** wait for 1.0.0 either. Both of those readings were
+available, and both make `v0` mean something other than what this document has
+already published about it. Under either, a break ships in `0.3.0`; [the tag
+table](#tags-and-what-pinning-one-buys) moves `v0` onto it, because SemVer's
+major is `0` and which tags a version implies is [the shared pipeline's
+derivation](#tags-and-what-pinning-one-buys) rather than this project's to
+redefine; and the boundary a reader was told to pin turns out to have been the
+*minor* tag all along. Saying so now is itself a change to a covered thing,
+which would need the major version this section is about.
+
+SemVer §4 is a permission and not an obligation, and this project has already
+declined it. Seven documents under `docs/` publish covered tables and a change
+rule, three published things rest on this one — a stranger's `FROM` line, [the
+generator images' addresses](#where-this-projects-own-generators-are-published),
+and the companion module's default tag — and a project that holds itself to
+those is one whose public API is defined in SemVer §5's sense. 1.0.0 is the
+number that says so, and the first change that cannot be made without breaking
+one of those tables is the release that has to say it.
+
+This makes 1.0.0 a consequence rather than a milestone anybody plans: releases
+below it are additive, and the first that is not is the one.
 
 ### What a tag carries besides the image
 
@@ -1261,6 +1349,7 @@ change to any of them is a breaking change:
 | [Shell or no shell](#shell-or-no-shell) | Absent; extension is `COPY`-only |
 | [Platforms](#why-the-platform-set-is-the-two-it-is) | `linux/amd64` and `linux/arm64` |
 | [Tags](#tags-and-what-pinning-one-buys) | A published full-version tag never moves |
+| [The CLI's covered surface](#a-breaking-change-to-either-contract-takes-a-new-major-version) | Holds here too: a change breaking [the CLI contract's guarantees](../cli/SPEC.md#compatibility-guarantees) takes a new major version of this image, so no moving tag carries one |
 | [This project's own generator images](#where-this-projects-own-generators-are-published) | `<repository>-gen-<name>`, in the same registry and under the same release's tags as the CLI image |
 | [Signatures](#what-a-tag-carries-besides-the-image) | The published index and each manifest beneath it are signed; the index digest carries provenance and an SBOM per platform, as referrers |
 
@@ -1358,6 +1447,16 @@ at `COPY` time with an error naming a path rather than a version. Giving it a
 release in which both the old and the new form work is what turns that into a
 deprecation notice somebody reads instead of a broken build somebody bisects.
 
+**Which release is a new major version** is not left to whoever cuts it. A break
+in [either contract](#a-breaking-change-to-either-contract-takes-a-new-major-version)
+is one of these, and [below 1.0.0 the release that satisfies this
+rule](#below-100-the-rule-produces-100) is 1.0.0 — so a covered thing does not
+change in a `0.y.z` at all (#213). Where the change withdraws a rejection rather
+than moving a form, there is nothing to hold in parallel and the announcement is
+the whole of the transition; [the CLI contract states that
+case](../cli/SPEC.md#the-subcommand-is-the-first-change-under-this-rule-and-it-breaks-it)
+for the one change that has hit it.
+
 ## Out of Scope
 
 ### How the image is built and published
@@ -1411,14 +1510,16 @@ Go install with no document that applies to them.
 | [The arrangement survives a subcommand](#the-arrangement-survives-a-subcommand) | #183 `cli` adds the subcommand and restates the promise here; #213 `container` decides what a breaking CLI change does to this image's major tag |
 | [The user](#the-user) | #55 `container` |
 | [Shell or no shell](#shell-or-no-shell) | #55 `container` |
-| [Tags and what pinning one buys](#tags-and-what-pinning-one-buys) | #59 `container`; #185 `container` moves the family's derivation to the shared pipeline |
+| [Tags and what pinning one buys](#tags-and-what-pinning-one-buys) | #59 `container`; #185 `container` moves the family's derivation to the shared pipeline; #213 `container` says what the moving major tag does with a breaking CLI change |
+| [A breaking change to either contract takes a new major version](#a-breaking-change-to-either-contract-takes-a-new-major-version) | #213 `container`, over the command set #183 `cli` broke and the guarantees #146 `cli` and #54 `container` state |
+| [Below 1.0.0, the rule produces 1.0.0](#below-100-the-rule-produces-100) | #213 `container` |
 | [What a tag carries besides the image](#what-a-tag-carries-besides-the-image) | #58 `container`; #185 `container` for the SBOM's subject and formats |
 | [Verifying a signature](#verifying-a-signature) | #58 `container` |
 | [After mirroring to an internal registry](#after-mirroring-to-an-internal-registry) | #58 `container` |
 | [Discovering the attestations](#discovering-the-attestations) | #185 `container` |
 | [Worked example: adding a generator](#worked-example-adding-a-generator) | #54 `container` |
 | [This example is built by the pipeline](#this-example-is-built-by-the-pipeline) | #54 `container` for the build stage and the reading of the final one, #55 `container` for replaying that stage onto a base image of this pipeline's own |
-| [Compatibility guarantees](#compatibility-guarantees) | #54, #58 `container` |
+| [Compatibility guarantees](#compatibility-guarantees) | #54, #58 `container`; #213 `container` adds the CLI's covered surface to the table and fixes which release number a change to a covered thing takes |
 | [Why the platform set is the two it is](#why-the-platform-set-is-the-two-it-is) | #54 `container` decides it, #55 `container` builds it, #56 `container` retires the third leg it once had |
 | [The IR schema in the image](#the-ir-schema-in-the-image) | #57 `container`; #185 `container` for its ownership and mode |
 | [Worked example: reading the IR without generated code](#worked-example-reading-the-ir-without-generated-code) | #57 `container`; #19 `ir` for what the descriptor set contains |

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -273,8 +273,21 @@ from copybooks — and nothing above changed for it (#183). The arrangement is
 what made that affordable. `Cmd` is empty, so `docker run … <image>` with no
 arguments is still cpybkc's default action, which is generating; every derived
 image already published keeps working unaltered, and no `docker run` line in a
-repository this project cannot see had to be edited. A caller who wants the
-subcommand types it where they type every other argument:
+repository this project cannot see had to be edited.
+
+**The arrangement surviving is not the same as every caller surviving**, and the
+distinction is what [the section below](#a-breaking-change-to-either-contract-takes-a-new-major-version)
+turns on. What is unaltered here is this document's own surface: empty `Cmd`, an
+entrypoint that takes cpybkc's arguments, and every literal `docker run` line
+that was already written. A caller who *composed* that line — a wrapper passing a
+word of its own user's input through as cpybkc's first argument — is broken by
+the same change, and is broken identically whether it reached cpybkc through this
+image or through a `go install`. That is [the CLI contract's
+break](../cli/SPEC.md#the-subcommand-is-the-first-change-under-this-rule-and-it-breaks-it),
+not this one's, and the section below is where this document decides what it owes
+somebody holding one of its tags when the other contract breaks.
+
+A caller who wants the subcommand types it where they type every other argument:
 
 ```console
 $ docker run --rm -v "$PWD:/src" -w /src ghcr.io/zaba505/cpybkc:v0 \
@@ -696,13 +709,21 @@ redefine; and the boundary a reader was told to pin turns out to have been the
 which would need the major version this section is about.
 
 SemVer §4 is a permission and not an obligation, and this project has already
-declined it. Seven documents under `docs/` publish covered tables and a change
-rule, three published things rest on this one — a stranger's `FROM` line, [the
-generator images' addresses](#where-this-projects-own-generators-are-published),
-and the companion module's default tag — and a project that holds itself to
-those is one whose public API is defined in SemVer §5's sense. 1.0.0 is the
-number that says so, and the first change that cannot be made without breaking
-one of those tables is the release that has to say it.
+declined it. Two documents under `docs/` price a change in a release number —
+this one and [the CLI contract](../cli/SPEC.md#compatibility-guarantees), each
+publishing a covered table and the rule that a covered thing changes in a new
+major version — and they are exactly the two whose number this section fixes.
+The others version what they specify from the inside, through a field in the
+artifact rather than through a tag: [the IR's own version
+number](../ir/SPEC.md#versioning-and-compatibility) is the one to compare against,
+and it moves on its own schedule. A project that publishes those two tables and
+then declines to be bound by them below 1.0.0 is publishing nothing, and the two
+things already resting on them from outside this repository — a stranger's `FROM`
+line and [the generator images'
+addresses](#where-this-projects-own-generators-are-published) — are what makes
+that a cost somebody else pays. 1.0.0 is the number that says the tables bind,
+and the first change that cannot be made without breaking one of them is the
+release that has to say it.
 
 This makes 1.0.0 a consequence rather than a milestone anybody plans: releases
 below it are additive, and the first that is not is the one.
@@ -1349,7 +1370,7 @@ change to any of them is a breaking change:
 | [Shell or no shell](#shell-or-no-shell) | Absent; extension is `COPY`-only |
 | [Platforms](#why-the-platform-set-is-the-two-it-is) | `linux/amd64` and `linux/arm64` |
 | [Tags](#tags-and-what-pinning-one-buys) | A published full-version tag never moves |
-| [The CLI's covered surface](#a-breaking-change-to-either-contract-takes-a-new-major-version) | Holds here too: a change breaking [the CLI contract's guarantees](../cli/SPEC.md#compatibility-guarantees) takes a new major version of this image, so no moving tag carries one |
+| [The CLI's covered surface](#a-breaking-change-to-either-contract-takes-a-new-major-version) | Holds here too: a change breaking [the CLI contract's guarantees](../cli/SPEC.md#compatibility-guarantees) takes a new major version of this image, so neither the major nor the minor tag carries one |
 | [This project's own generator images](#where-this-projects-own-generators-are-published) | `<repository>-gen-<name>`, in the same registry and under the same release's tags as the CLI image |
 | [Signatures](#what-a-tag-carries-besides-the-image) | The published index and each manifest beneath it are signed; the index digest carries provenance and an SBOM per platform, as referrers |
 


### PR DESCRIPTION
Closes #213

## The decision

Two questions collided in #183 and neither was the CLI spec's to settle: whether a breaking change to the **CLI** moves the image's floating `v0` tag, and which release number carries a "new major version" while cpybkc is below 1.0.0. They are answered together, in `docs/container/SPEC.md`, because they are one question about one number.

**The image and the CLI are one release under one version number.** A release publishes `vX.Y.Z` and the executable in it answers `X.Y.Z`, so there is no image major that can move independently of the CLI's. The image's major version therefore **tracks the CLI's covered surface as well as its own**: a change breaking either contract's guarantees takes a new major version, and no moving tag ever carries one.

**Below 1.0.0 the only release satisfying that rule is `1.0.0`.** The leading non-zero component is not treated as the major in the meantime, and the rule does not wait for 1.0.0 either.

### Why not the alternatives

Both readings the issue offered — leading-non-zero-as-major, and the-rule-waits — make a break ship in `0.3.0`, which the shared pipeline's tag derivation then moves `v0` onto, because SemVer's major is `0` and which tags a version implies is not this project's to redefine. Under either, `v0` stops being a compatibility boundary and the real boundary turns out to have been the *minor* tag all along. That is a retraction of something already published and already depended on in three places: the container spec's own recommendation, both worked examples' `FROM …:v0`, and the companion Dagger module's default tag with its skew argument. Retracting it is itself a change to a covered thing, needing the major version the question is about.

The chosen answer retracts nothing — every sentence already written about `v0` becomes exactly true — and its cost is stated in the document rather than hidden: a `v0` pinner stops receiving fixes once `v1` is cut, which is what a compatibility boundary is.

The consequence is that **`init` is carried by `1.0.0`**, now a **MUST** in `docs/cli/SPEC.md` beside the announcement requirement that was already there.

## Acceptance criteria

- [x] `docs/container/SPEC.md` states whether a breaking CLI change moves the image's floating major tag — new section *A breaking change to either contract takes a new major version*: it does not, because the release takes a new major and the moving tag never carries one; the image's major tracks the CLI's covered surface as well as its own
- [x] *Tags and what pinning one buys* and the *compatibility guarantees* both say it — the two new subsections live in the tags section, the `v0` paragraph points at them, and the covered table gains a **The CLI's covered surface** row
- [x] What a release below 1.0.0 does with the rule is stated somewhere a releaser reads — normatively in *Below 1.0.0, the rule produces 1.0.0*, restated for the CLI's half in `docs/cli/SPEC.md`'s *How a covered thing would change*, and operationally in `CONTRIBUTING.md`'s new *Which number a breaking change takes* under *Making a release*
- [x] The #181 and #185 release checks are read against the answer — `TagScheme`, `ReleaseNotesContract`, `planRelease` and `ImageContract` all still agree, because they decide what a number *publishes and moves* once cut while this rule decides which *diff* a number may carry. The reading is recorded on `TagScheme`, including why nothing in the pipeline can enforce it (whether a change is breaking is a property of the diff, not of the ref), and `v1.0.0` is pinned as a case so the number this decision names is one the release machinery is shown to plan
- [x] The Appendix mappings of both documents are extended

## Verification

`dagger call ci` — green. Run from a throwaway clone, because [the pipeline does not run from a git worktree](https://github.com/Zaba505/cpybkc/blob/main/CONTRIBUTING.md#the-pipeline-does-not-run-from-a-git-worktree) and this cycle develops in one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)