### PR TITLE
story(gen-go): decide what a nameless item generates, so a copybook with FILLER is not refused

### DIFF
--- a/cmd/cpybkc-gen-go/README.md
+++ b/cmd/cpybkc-gen-go/README.md
@@ -299,6 +299,82 @@ missing from it. An **edited** item is a `string` for the same reason and a
 different one: its storage really is characters, and what the field holds is the
 edited text as it stands in the record.
 
+### An item your copybook gives no name
+
+`FILLER` is generated, not refused. It has no data-name, so there is nothing to
+munge into an identifier and nothing in the table above to look it up in — and
+it is in most copybooks anybody actually has, so a refusal here is a refusal of
+the whole package over an item nobody was looking at.
+
+There are two shapes, and they are two decisions rather than one:
+
+| The item | What is generated |
+|---|---|
+| An elementary `FILLER` | no field; its bytes are retained beside the slack, in an unexported `filler` run |
+| A `FILLER` **group** | no field; its members become fields of the enclosing struct |
+
+```cobol
+       01  LEDGER-TRAILER.
+           05  TRL-TYPE                PIC X(2).
+           05  FILLER.
+               10  NOTE-CODE           PIC X(2).
+           05  FILLER                  PIC X(8).
+```
+
+```go
+type LedgerTrailer struct {
+	// TrlType is TRL-TYPE — alphanumeric, DISPLAY, 2 bytes.
+	TrlType string
+
+	// NoteCode is NOTE-CODE — alphanumeric, DISPLAY, 2 bytes.
+	NoteCode string
+
+	filler [1][]byte
+}
+```
+
+An elementary `FILLER` holds no value anybody named, so it is retained the way
+slack is — see *Where the slack goes*: one run per item, in the order they
+occupy the record, one set per occurrence of the struct. A record that was read
+writes those bytes back exactly; a record you built rather than read carries no
+run for them and the writer emits zero bytes, for the reason it does for slack.
+If a `FILLER` is somewhere you need a particular value, that item is not filler:
+give it a data-name in the copybook and it becomes a field like any other.
+
+A `FILLER` **group** is the half that had to be argued rather than derived. A
+run of retained bytes cannot stand in for it, because it holds members your
+copybook *does* name and hiding them would lose items you can see in your own
+source. So its members are lifted into the enclosing struct — which is what
+COBOL already says about them: qualification skips an unnamed group, so
+`NOTE-CODE` above is `NOTE-CODE OF LEDGER-TRAILER` in a program and there is no
+intermediate name it could be qualified by. If lifting them makes two names
+collide, that is reported like any other collision.
+
+Nothing is named `Filler1`, `Filler2`, or anything else positional. Such a name
+is one your copybook does not contain and one that moves the moment an unrelated
+item is inserted ahead of it, which is what this generator refuses to produce
+everywhere else.
+
+Three cases are **refused**, and the refusal names the record or group holding
+the item rather than calling your descriptor malformed:
+
+- A `FILLER` **group that repeats**. Its members would have to move up a level
+  once per occurrence, and there is no name for the occurrences to be an array
+  of.
+- A `FILLER` whose `OCCURS DEPENDING ON` count is data. The retained run would
+  have to be as long as a count field says, over bytes you cannot supply.
+- A `FILLER` standing as one alternative of a `REDEFINES` inside a table. An
+  alternation is a field per alternative and exactly one of them is non-nil;
+  an alternative with no name has no way to say it is the one the record holds.
+
+In all three the answer is in the copybook: give the item a data-name. And in
+none of them is the descriptor at fault — `ir/SPEC.md`'s *Names* says what a
+**named** node carries and never that every node is named, so an item with no
+names message is exactly what a producer emits for a `FILLER`. A names message
+that is *present* and states no name is the opposite: a named item whose name
+went missing, which is a bug in whatever produced the IR, and that one is still
+reported as a malformed descriptor.
+
 ### `OCCURS`
 
 A constant `OCCURS n` is an array, `[n]T`, and an `OCCURS DEPENDING ON` is a

--- a/cmd/cpybkc-gen-go/README.md
+++ b/cmd/cpybkc-gen-go/README.md
@@ -314,17 +314,17 @@ There are two shapes, and they are two decisions rather than one:
 | A `FILLER` **group** | no field; its members become fields of the enclosing struct |
 
 ```cobol
-       01  LEDGER-TRAILER.
-           05  TRL-TYPE                PIC X(2).
+       01  ORDER-RECORD.
+           05  ORDER-TYPE              PIC X(2).
            05  FILLER.
                10  NOTE-CODE           PIC X(2).
            05  FILLER                  PIC X(8).
 ```
 
 ```go
-type LedgerTrailer struct {
-	// TrlType is TRL-TYPE — alphanumeric, DISPLAY, 2 bytes.
-	TrlType string
+type OrderRecord struct {
+	// OrderType is ORDER-TYPE — alphanumeric, DISPLAY, 2 bytes.
+	OrderType string
 
 	// NoteCode is NOTE-CODE — alphanumeric, DISPLAY, 2 bytes.
 	NoteCode string
@@ -335,9 +335,11 @@ type LedgerTrailer struct {
 
 An elementary `FILLER` holds no value anybody named, so it is retained the way
 slack is — see *Where the slack goes*: one run per item, in the order they
-occupy the record, one set per occurrence of the struct. A record that was read
-writes those bytes back exactly; a record you built rather than read carries no
-run for them and the writer emits zero bytes, for the reason it does for slack.
+occupy the record, one set per occurrence of the struct, so a `FILLER` inside a
+group that `OCCURS` gets a run in every element of the array or slice that group
+became. A record that was read writes those bytes back exactly; a record you
+built rather than read carries no run for them and the writer emits zero bytes,
+for the reason it does for slack.
 If a `FILLER` is somewhere you need a particular value, that item is not filler:
 give it a data-name in the copybook and it becomes a field like any other.
 

--- a/cmd/cpybkc-gen-go/accessor.go
+++ b/cmd/cpybkc-gen-go/accessor.go
@@ -461,19 +461,23 @@ file that implements it.`))
 	return b.String()
 }
 
-// zeroFillDeclaration is the run of zero bytes a writer emits for a slack node
-// the record it was handed carries no run for.
+// zeroFillDeclaration is the run of zero bytes a writer emits for a slack node,
+// or an item the copybook gives no data-name, the record it was handed carries
+// no run for.
 func zeroFillDeclaration(width uint32) string {
-	return commentLines(fmt.Sprintf(`%s is what a writer emits for a slack node of a record its caller built
-rather than read: zero bytes, %d of them at the most, sliced to the node's own
-width.
+	return commentLines(fmt.Sprintf(`%s is what a writer emits for a slack node — or for an item the copybook
+gives no data-name — of a record its caller built rather than read: zero
+bytes, %d of them at the most, sliced to the run's own width.
 
-Zero rather than a space, because charset is a property of a field and slack
-is not a field, so there is no charset to resolve a space against and zero is
-the byte that names none. Those bytes were never in a file, so nothing is
-being overwritten — a record that was read carries the bytes it was read
-from and they are emitted instead. See docs/ir/SPEC.md, "What the descriptor
-determines, a writer supplies".`, zeroFillHelper, width)) +
+Zero rather than a space. Charset is a property of a field and slack is not a
+field, so there is no charset to resolve a space against and zero is the byte
+that names none. A FILLER is a field and does have one, and it gets the same
+answer for a different reason: its value is nobody's — no program names it
+and nothing outside this package can set it — so filling it with spaces would
+be choosing a value on behalf of a caller who never had one to give. Those
+bytes were never in a file, so nothing is being overwritten — a record that
+was read carries the bytes it was read from and they are emitted instead. See
+docs/ir/SPEC.md, "What the descriptor determines, a writer supplies".`, zeroFillHelper, width)) +
 		fmt.Sprintf("var %s = make([]byte, %d)", zeroFillHelper, width)
 }
 

--- a/cmd/cpybkc-gen-go/codec.go
+++ b/cmd/cpybkc-gen-go/codec.go
@@ -295,7 +295,8 @@ func (c *coder) unmarshal(name string, record *irpb.Record) (string, error) {
 	}
 
 	doc := commentLines(fmt.Sprintf(`UnmarshalCOBOL reads one %s out of r, in the order docs/ir/SPEC.md
-resolved its items, and retains the bytes of every slack node it carries.
+resolved its items, and retains the bytes of every slack node it carries and
+of every item the copybook gives no data-name.
 
 It is codec's Unmarshaler. The Encoding is r's: the four axes are properties
 of the file in hand, and %s is what this descriptor resolved.`,
@@ -324,15 +325,16 @@ func (c *coder) marshal(name string, record *irpb.Record) (string, error) {
 	}
 
 	doc := commentLines(fmt.Sprintf(`MarshalCOBOL writes this %s into w, in the order docs/ir/SPEC.md
-resolved its items, emitting the bytes retained for every slack node it
-carries and zero bytes for a slack node it does not.
+resolved its items, emitting the bytes retained for every slack node and
+every unnamed item it carries, and zero bytes for one it does not.
 
 It is codec's Marshaler. Two values are the descriptor's rather than the
 caller's and are supplied rather than taken from the record: an OCCURS
 DEPENDING ON count is emitted as the number of occurrences written, and
-slack is emitted as what was retained for it. Everything else is the
-caller's, including the value a discriminator tests — a writer evaluates a
-predicate and never inverts one.`, record.GetNames().GetOriginal()))
+slack — and the bytes of an item the copybook gives no data-name — is
+emitted as what was retained for it. Everything else is the caller's,
+including the value a discriminator tests — a writer evaluates a predicate
+and never inverts one.`, record.GetNames().GetOriginal()))
 
 	return doc + fmt.Sprintf("func (%s *%s) MarshalCOBOL(w *codec.Writer) error {\n%s\nreturn nil\n}",
 		c.receiver, name, c.prologue(body.String())), nil
@@ -357,9 +359,14 @@ func (c *coder) decodeGroup(b *strings.Builder, id uint64, expr string, s scope)
 		return err
 	}
 
-	runs := 0
+	members, err := c.flattened(id)
+	if err != nil {
+		return err
+	}
 
-	for at, memberID := range group.GetMemberIds() {
+	runs, fillers := 0, 0
+
+	for at, memberID := range members {
 		member, ok := c.nodes[memberID]
 		if !ok {
 			return unresolved(memberID)
@@ -368,6 +375,26 @@ func (c *coder) decodeGroup(b *strings.Builder, id uint64, expr string, s scope)
 		// One item to a paragraph, which is what the record itself reads like.
 		if at > 0 {
 			b.WriteString("\n")
+		}
+
+		// An item the copybook gives no data-name is read into the run
+		// retained for it, the way a slack node is: it has no field, because it
+		// has no name for one. See [emitter.flattened].
+		if field := member.GetField(); field != nil && anonymous(field.GetNames()) {
+			width, err := fillerRun(field, group.GetNames().GetOriginal())
+			if err != nil {
+				return err
+			}
+
+			c.retain(b, width)
+
+			line(b, "if %s.%s[%d], err = %s.ReadBytes(%d); err != nil {", expr, fillerField, fillers, s.rw, width)
+			line(b, "%s", wrapf(s, "reading the "+plural(int(width), "byte")+" of an item the copybook gives no data-name"))
+			line(b, "}")
+
+			fillers++
+
+			continue
 		}
 
 		switch kind := member.GetKind().(type) {
@@ -597,9 +624,14 @@ func (c *coder) encodeGroup(b *strings.Builder, id uint64, expr string, s scope)
 		return err
 	}
 
-	runs := 0
+	members, err := c.flattened(id)
+	if err != nil {
+		return err
+	}
 
-	for at, memberID := range group.GetMemberIds() {
+	runs, fillers := 0, 0
+
+	for at, memberID := range members {
 		member, ok := c.nodes[memberID]
 		if !ok {
 			return unresolved(memberID)
@@ -608,6 +640,40 @@ func (c *coder) encodeGroup(b *strings.Builder, id uint64, expr string, s scope)
 		// One item to a paragraph, which is what the record itself reads like.
 		if at > 0 {
 			b.WriteString("\n")
+		}
+
+		// An item the copybook gives no data-name is written back out of the
+		// run retained for it, on the same three terms a slack node is: what
+		// was read, zero bytes where the record was never read, and a report
+		// rather than a truncation where the run is the wrong length.
+		if field := member.GetField(); field != nil && anonymous(field.GetNames()) {
+			width, err := fillerRun(field, group.GetNames().GetOriginal())
+			if err != nil {
+				return err
+			}
+
+			c.retain(b, width)
+
+			run := fmt.Sprintf("%s.%s[%d]", expr, fillerField, fillers)
+
+			line(b, "switch {")
+			line(b, "case %s == nil:", run)
+			line(b, "if err = %s.WriteBytes(%s[:%d]); err != nil {", s.rw, zeroFillHelper, width)
+			line(b, "%s", wrapf(s, "writing "+plural(int(width), "zero byte")+" for an item the copybook gives no data-name and this record carries none for"))
+			line(b, "}")
+			line(b, "case len(%s) != %d:", run, width)
+			line(b, "%s", failf(s, fmt.Sprintf(
+				"a writer reports a retained run rather than truncating or padding it, and the run for an item of %s the copybook gives no data-name is %%d", plural(int(width), "byte")),
+				"len("+run+")"))
+			line(b, "default:")
+			line(b, "if err = %s.WriteBytes(%s); err != nil {", s.rw, run)
+			line(b, "%s", wrapf(s, "writing the "+plural(int(width), "byte")+" of an item the copybook gives no data-name"))
+			line(b, "}")
+			line(b, "}")
+
+			fillers++
+
+			continue
 		}
 
 		switch kind := member.GetKind().(type) {
@@ -929,12 +995,12 @@ func (c *coder) encodeVariant(b *strings.Builder, v *irpb.Variant, expr string, 
 // than derived and stored. It runs behind the whole occurrence because a
 // target may sit behind the variant.
 func (c *coder) checkArms(b *strings.Builder, id uint64, expr string, s scope) error {
-	group, err := c.group(id)
+	members, err := c.flattened(id)
 	if err != nil {
 		return err
 	}
 
-	for _, memberID := range group.GetMemberIds() {
+	for _, memberID := range members {
 		member, ok := c.nodes[memberID]
 		if !ok {
 			return unresolved(memberID)
@@ -1021,6 +1087,10 @@ func (c *coder) arms(v *irpb.Variant, expr string, s scope) ([]arm, error) {
 	for _, a := range v.GetArms() {
 		body, err := c.armBody(a)
 		if err != nil {
+			return nil, err
+		}
+
+		if err := namedArm(body, c.record); err != nil {
 			return nil, err
 		}
 
@@ -1117,12 +1187,12 @@ func (c *coder) armMatch(a *irpb.Arm, s scope) (string, error) {
 
 // collectCounts records every repetition of a record naming a count field.
 func (c *coder) collectCounts(id uint64, expr string, loops []countLoop) error {
-	group, err := c.group(id)
+	members, err := c.flattened(id)
 	if err != nil {
 		return err
 	}
 
-	for _, memberID := range group.GetMemberIds() {
+	for _, memberID := range members {
 		member, ok := c.nodes[memberID]
 		if !ok {
 			return unresolved(memberID)
@@ -1140,6 +1210,15 @@ func (c *coder) collectCounts(id uint64, expr string, loops []countLoop) error {
 		case *irpb.Node_Group:
 			rep, names, kind = k.Group.GetRepetition(), k.Group.GetNames(), "group"
 		default:
+			continue
+		}
+
+		// An item the copybook gives no data-name has no occurrences a writer
+		// counts: an elementary one is a run of retained bytes, and a group
+		// carrying no name is not here at all — [emitter.flattened] has already
+		// put its members in this list, and each of them is walked on its own
+		// terms.
+		if anonymous(names) {
 			continue
 		}
 
@@ -1243,22 +1322,6 @@ func (c *coder) retain(_ *strings.Builder, width uint32) {
 	if width > c.zeroFill {
 		c.zeroFill = width
 	}
-}
-
-// group is the group node id names.
-func (c *coder) group(id uint64) (*irpb.Group, error) {
-	node, ok := c.nodes[id]
-	if !ok {
-		return nil, unresolved(id)
-	}
-
-	group := node.GetGroup()
-	if group == nil {
-		return nil, malformed(fmt.Sprintf("node %d is not a group node, and a group is what stands here", id),
-			"a record's top level and a group's group members are group nodes; see docs/ir/SPEC.md, \"The node kinds\"")
-	}
-
-	return group, nil
 }
 
 // armBody is the group or field node an arm's body names.

--- a/cmd/cpybkc-gen-go/codec.go
+++ b/cmd/cpybkc-gen-go/codec.go
@@ -120,6 +120,12 @@ type scope struct {
 	// record is the record node's COBOL name, which opens every message.
 	record string
 
+	// group is the innermost named group the walk is inside, as the copybook
+	// names it. It is what a refusal about an item with no name of its own has
+	// to point at, and it is carried here so that every part of this generator
+	// points at the same one.
+	group string
+
 	// rw is the *codec.Reader or *codec.Writer in scope. It is the method's own
 	// argument outside a buffered occurrence and a sub-reader or sub-writer
 	// over that occurrence's bytes inside one.
@@ -195,7 +201,7 @@ func codecMethods(d *irpb.Descriptor, opts options) (string, error) {
 			continue
 		}
 
-		name, err := identifier("record", record.GetNames())
+		name, err := recordName(record.GetNames())
 		if err != nil {
 			return "", err
 		}
@@ -359,6 +365,8 @@ func (c *coder) decodeGroup(b *strings.Builder, id uint64, expr string, s scope)
 		return err
 	}
 
+	s.group = group.GetNames().GetOriginal()
+
 	members, err := c.flattened(id)
 	if err != nil {
 		return err
@@ -381,7 +389,7 @@ func (c *coder) decodeGroup(b *strings.Builder, id uint64, expr string, s scope)
 		// retained for it, the way a slack node is: it has no field, because it
 		// has no name for one. See [emitter.flattened].
 		if field := member.GetField(); field != nil && anonymous(field.GetNames()) {
-			width, err := fillerRun(field, group.GetNames().GetOriginal())
+			width, err := fillerRun(field, s.group)
 			if err != nil {
 				return err
 			}
@@ -624,6 +632,8 @@ func (c *coder) encodeGroup(b *strings.Builder, id uint64, expr string, s scope)
 		return err
 	}
 
+	s.group = group.GetNames().GetOriginal()
+
 	members, err := c.flattened(id)
 	if err != nil {
 		return err
@@ -647,7 +657,7 @@ func (c *coder) encodeGroup(b *strings.Builder, id uint64, expr string, s scope)
 		// was read, zero bytes where the record was never read, and a report
 		// rather than a truncation where the run is the wrong length.
 		if field := member.GetField(); field != nil && anonymous(field.GetNames()) {
-			width, err := fillerRun(field, group.GetNames().GetOriginal())
+			width, err := fillerRun(field, s.group)
 			if err != nil {
 				return err
 			}
@@ -995,6 +1005,13 @@ func (c *coder) encodeVariant(b *strings.Builder, v *irpb.Variant, expr string, 
 // than derived and stored. It runs behind the whole occurrence because a
 // target may sit behind the variant.
 func (c *coder) checkArms(b *strings.Builder, id uint64, expr string, s scope) error {
+	in, err := c.groupName(id)
+	if err != nil {
+		return err
+	}
+
+	s.group = in
+
 	members, err := c.flattened(id)
 	if err != nil {
 		return err
@@ -1090,7 +1107,7 @@ func (c *coder) arms(v *irpb.Variant, expr string, s scope) ([]arm, error) {
 			return nil, err
 		}
 
-		if err := namedArm(body, c.record); err != nil {
+		if err := namedArm(body, s.group); err != nil {
 			return nil, err
 		}
 

--- a/cmd/cpybkc-gen-go/codec_test.go
+++ b/cmd/cpybkc-gen-go/codec_test.go
@@ -556,7 +556,7 @@ func TestAWidthIsSummedForAMalformedVariantWithoutPanicking(t *testing.T) {
 		},
 	}}
 
-	if _, err := c.width(2, "x.Entry[i0]", decoding); err == nil {
+	if _, err := c.width(2, "ENTRY", "x.Entry[i0]", decoding); err == nil {
 		t.Error("a variant carrying no arm was given a width")
 	}
 }

--- a/cmd/cpybkc-gen-go/errors.go
+++ b/cmd/cpybkc-gen-go/errors.go
@@ -143,6 +143,48 @@ func (e *unmungeableError) Notes() []string {
 	}
 }
 
+// fillerError is an item COBOL gave no data-name that this generator has
+// nowhere to put: a FILLER group that repeats, or a FILLER item whose number of
+// occurrences is data.
+//
+// It is deliberately **not** a [malformedError]. The descriptor is exactly what
+// docs/ir/SPEC.md admits — an item with no data-name carries no names message,
+// and "Names" opens on what a *named* node carries — so a diagnostic sending
+// the adopter to look for a producer bug would send them after an item they
+// wrote correctly. What is refused is this generator's ability to name the
+// occurrences, and the answer is in the copybook: give the item a data-name.
+//
+// The two cases share that cause. A FILLER has no name, so nothing emitted for
+// it can be named: an elementary one is retained as bytes in a field named
+// after nothing in the copybook, and a group's members are reached at the level
+// above it. Neither answer survives an occurrence count — a run of retained
+// bytes has one length per record, and members that moved up a level cannot
+// move up once per occurrence.
+type fillerError struct {
+	// Kind is what the item is: a "group" or an "item".
+	Kind string
+
+	// In is the item containing it, as the copybook names it. A FILLER has no
+	// name of its own, so this is the name a reader has to go looking with.
+	In string
+
+	// Because is what about it cannot be placed, as a phrase.
+	Because string
+}
+
+// Error implements the error interface.
+func (e *fillerError) Error() string {
+	return fmt.Sprintf("a %s of %s carries no data-name and %s", e.Kind, e.In, e.Because)
+}
+
+// Notes is what follows it as a `note:` diagnostic.
+func (e *fillerError) Notes() []string {
+	return []string{
+		"give the item a data-name in the copybook, and it becomes a field like any other",
+		"an item COBOL names nothing is generated rather than refused wherever it can be — a FILLER is retained as bytes and a FILLER group's members are reached at the level above it — and neither of those has a name for one occurrence to differ from another by",
+	}
+}
+
 // unsupportedCharsetError is a charset the IR names and cobol-go's codec has no
 // table for.
 //

--- a/cmd/cpybkc-gen-go/errors.go
+++ b/cmd/cpybkc-gen-go/errors.go
@@ -161,11 +161,18 @@ func (e *unmungeableError) Notes() []string {
 // bytes has one length per record, and members that moved up a level cannot
 // move up once per occurrence.
 type fillerError struct {
-	// Kind is what the item is: a "group" or an "item".
+	// Kind is what the item is, with the article it takes: "a group" or "an
+	// item". The article is carried rather than composed, because "a" and
+	// "an" is one more thing for a diagnostic to get wrong in front of a user
+	// and there are exactly two of them.
 	Kind string
 
-	// In is the item containing it, as the copybook names it. A FILLER has no
-	// name of its own, so this is the name a reader has to go looking with.
+	// In is the group containing it, as the copybook names it. A FILLER has no
+	// name of its own, so this is the name a reader has to go looking with —
+	// and it is the *innermost named* group every time, whichever part of this
+	// generator met the item first, because a name that moved with the order
+	// the files happen to be emitted in would be one an adopter could not act
+	// on.
 	In string
 
 	// Because is what about it cannot be placed, as a phrase.
@@ -174,7 +181,7 @@ type fillerError struct {
 
 // Error implements the error interface.
 func (e *fillerError) Error() string {
-	return fmt.Sprintf("a %s of %s carries no data-name and %s", e.Kind, e.In, e.Because)
+	return fmt.Sprintf("%s of %s carries no data-name and %s", e.Kind, e.In, e.Because)
 }
 
 // Notes is what follows it as a `note:` diagnostic.

--- a/cmd/cpybkc-gen-go/extent.go
+++ b/cmd/cpybkc-gen-go/extent.go
@@ -96,6 +96,11 @@ func (c *coder) sumWidth(id uint64, expr string, dir direction) (string, error) 
 
 // members is the sum of the widths of the group id's members.
 func (c *coder) members(id uint64, expr string, dir direction) (extent, error) {
+	in, err := c.groupName(id)
+	if err != nil {
+		return extent{}, err
+	}
+
 	members, err := c.flattened(id)
 	if err != nil {
 		return extent{}, err
@@ -104,7 +109,7 @@ func (c *coder) members(id uint64, expr string, dir direction) (extent, error) {
 	var total extent
 
 	for _, memberID := range members {
-		width, err := c.width(memberID, expr, dir)
+		width, err := c.width(memberID, in, expr, dir)
 		if err != nil {
 			return extent{}, err
 		}
@@ -116,7 +121,12 @@ func (c *coder) members(id uint64, expr string, dir direction) (extent, error) {
 }
 
 // width is the width of one member, occurrences and all.
-func (c *coder) width(id uint64, expr string, dir direction) (extent, error) {
+//
+// in is the group containing it, as the copybook names it, and it is there for
+// the one member that may have no name of its own: a refusal about a FILLER has
+// to name the same group wherever this generator met the item, so every caller
+// passes the innermost named group rather than whatever it happens to hold.
+func (c *coder) width(id uint64, in, expr string, dir direction) (extent, error) {
 	node, ok := c.nodes[id]
 	if !ok {
 		return extent{}, unresolved(id)
@@ -130,7 +140,7 @@ func (c *coder) width(id uint64, expr string, dir direction) (extent, error) {
 		// occupies, and no expression is needed to say how many: its
 		// occurrences are a constant or it is refused. See [fillerRun].
 		if anonymous(kind.Field.GetNames()) {
-			run, err := fillerRun(kind.Field, c.record)
+			run, err := fillerRun(kind.Field, in)
 			if err != nil {
 				return extent{}, err
 			}
@@ -184,7 +194,7 @@ func (c *coder) width(id uint64, expr string, dir direction) (extent, error) {
 			return extent{}, err
 		}
 
-		return c.width(arm.GetId(), expr, dir)
+		return c.width(arm.GetId(), in, expr, dir)
 	default:
 		return extent{}, malformed(fmt.Sprintf("node %d is not something a group may contain", id),
 			"a member list names a group, variant, field or slack node; see docs/ir/SPEC.md, \"The node kinds\"")
@@ -223,6 +233,11 @@ func (c *coder) occurrences(one extent, rep *irpb.Repetition, expr string, dir d
 // offsetOf is where the field target begins inside one occurrence of the group
 // root, as a Go expression, and whether it is in there at all.
 func (c *coder) offsetOf(root, target uint64, expr string, dir direction) (extent, bool, error) {
+	in, err := c.groupName(root)
+	if err != nil {
+		return extent{}, false, err
+	}
+
 	members, err := c.flattened(root)
 	if err != nil {
 		return extent{}, false, err
@@ -275,7 +290,7 @@ func (c *coder) offsetOf(root, target uint64, expr string, dir direction) (exten
 					continue
 				}
 
-				if err := namedArm(body, c.record); err != nil {
+				if err := namedArm(body, in); err != nil {
 					return extent{}, false, err
 				}
 
@@ -295,7 +310,7 @@ func (c *coder) offsetOf(root, target uint64, expr string, dir direction) (exten
 			}
 		}
 
-		width, err := c.width(memberID, expr, dir)
+		width, err := c.width(memberID, in, expr, dir)
 		if err != nil {
 			return extent{}, false, err
 		}

--- a/cmd/cpybkc-gen-go/extent.go
+++ b/cmd/cpybkc-gen-go/extent.go
@@ -96,14 +96,14 @@ func (c *coder) sumWidth(id uint64, expr string, dir direction) (string, error) 
 
 // members is the sum of the widths of the group id's members.
 func (c *coder) members(id uint64, expr string, dir direction) (extent, error) {
-	group, err := c.group(id)
+	members, err := c.flattened(id)
 	if err != nil {
 		return extent{}, err
 	}
 
 	var total extent
 
-	for _, memberID := range group.GetMemberIds() {
+	for _, memberID := range members {
 		width, err := c.width(memberID, expr, dir)
 		if err != nil {
 			return extent{}, err
@@ -126,6 +126,18 @@ func (c *coder) width(id uint64, expr string, dir direction) (extent, error) {
 	case *irpb.Node_Slack:
 		return fixed(int(kind.Slack.GetWidth())), nil
 	case *irpb.Node_Field:
+		// An item the copybook gives no data-name occupies the bytes it
+		// occupies, and no expression is needed to say how many: its
+		// occurrences are a constant or it is refused. See [fillerRun].
+		if anonymous(kind.Field.GetNames()) {
+			run, err := fillerRun(kind.Field, c.record)
+			if err != nil {
+				return extent{}, err
+			}
+
+			return fixed(int(run)), nil
+		}
+
 		name, err := identifier("field", kind.Field.GetNames())
 		if err != nil {
 			return extent{}, err
@@ -211,14 +223,14 @@ func (c *coder) occurrences(one extent, rep *irpb.Repetition, expr string, dir d
 // offsetOf is where the field target begins inside one occurrence of the group
 // root, as a Go expression, and whether it is in there at all.
 func (c *coder) offsetOf(root, target uint64, expr string, dir direction) (extent, bool, error) {
-	group, err := c.group(root)
+	members, err := c.flattened(root)
 	if err != nil {
 		return extent{}, false, err
 	}
 
 	var at extent
 
-	for _, memberID := range group.GetMemberIds() {
+	for _, memberID := range members {
 		if memberID == target {
 			return at, true, nil
 		}
@@ -261,6 +273,10 @@ func (c *coder) offsetOf(root, target uint64, expr string, dir direction) (exten
 
 				if body.GetGroup() == nil {
 					continue
+				}
+
+				if err := namedArm(body, c.record); err != nil {
+					return extent{}, false, err
 				}
 
 				name, err := identifier("arm", namesOf(body))

--- a/cmd/cpybkc-gen-go/file.go
+++ b/cmd/cpybkc-gen-go/file.go
@@ -319,7 +319,7 @@ func (f *filer) transitionsOf(state *irpb.State) ([]transition, error) {
 				"every transition consumes exactly one record; see docs/ir/SPEC.md, \"The sequencing automaton\"")
 		}
 
-		typ, err := identifier("record", record.GetNames())
+		typ, err := recordName(record.GetNames())
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/cpybkc-gen-go/internal/chunks/codec.go
+++ b/cmd/cpybkc-gen-go/internal/chunks/codec.go
@@ -38,7 +38,8 @@ var (
 )
 
 // UnmarshalCOBOL reads one CHUNK-RECORD out of r, in the order docs/ir/SPEC.md
-// resolved its items, and retains the bytes of every slack node it carries.
+// resolved its items, and retains the bytes of every slack node it carries and
+// of every item the copybook gives no data-name.
 //
 // It is codec's Unmarshaler. The Encoding is r's: the four axes are properties
 // of the file in hand, and Encoding is what this descriptor resolved.
@@ -57,15 +58,16 @@ func (x *ChunkRecord) UnmarshalCOBOL(r *codec.Reader) error {
 }
 
 // MarshalCOBOL writes this CHUNK-RECORD into w, in the order docs/ir/SPEC.md
-// resolved its items, emitting the bytes retained for every slack node it
-// carries and zero bytes for a slack node it does not.
+// resolved its items, emitting the bytes retained for every slack node and
+// every unnamed item it carries, and zero bytes for one it does not.
 //
 // It is codec's Marshaler. Two values are the descriptor's rather than the
 // caller's and are supplied rather than taken from the record: an OCCURS
 // DEPENDING ON count is emitted as the number of occurrences written, and
-// slack is emitted as what was retained for it. Everything else is the
-// caller's, including the value a discriminator tests — a writer evaluates a
-// predicate and never inverts one.
+// slack — and the bytes of an item the copybook gives no data-name — is
+// emitted as what was retained for it. Everything else is the caller's,
+// including the value a discriminator tests — a writer evaluates a predicate
+// and never inverts one.
 func (x *ChunkRecord) MarshalCOBOL(w *codec.Writer) error {
 	var err error
 

--- a/cmd/cpybkc-gen-go/internal/counted/codec.go
+++ b/cmd/cpybkc-gen-go/internal/counted/codec.go
@@ -42,7 +42,8 @@ var (
 )
 
 // UnmarshalCOBOL reads one HEADER-RECORD out of r, in the order docs/ir/SPEC.md
-// resolved its items, and retains the bytes of every slack node it carries.
+// resolved its items, and retains the bytes of every slack node it carries and
+// of every item the copybook gives no data-name.
 //
 // It is codec's Unmarshaler. The Encoding is r's: the four axes are properties
 // of the file in hand, and Encoding is what this descriptor resolved.
@@ -69,15 +70,16 @@ func (x *HeaderRecord) UnmarshalCOBOL(r *codec.Reader) error {
 }
 
 // MarshalCOBOL writes this HEADER-RECORD into w, in the order docs/ir/SPEC.md
-// resolved its items, emitting the bytes retained for every slack node it
-// carries and zero bytes for a slack node it does not.
+// resolved its items, emitting the bytes retained for every slack node and
+// every unnamed item it carries, and zero bytes for one it does not.
 //
 // It is codec's Marshaler. Two values are the descriptor's rather than the
 // caller's and are supplied rather than taken from the record: an OCCURS
 // DEPENDING ON count is emitted as the number of occurrences written, and
-// slack is emitted as what was retained for it. Everything else is the
-// caller's, including the value a discriminator tests — a writer evaluates a
-// predicate and never inverts one.
+// slack — and the bytes of an item the copybook gives no data-name — is
+// emitted as what was retained for it. Everything else is the caller's,
+// including the value a discriminator tests — a writer evaluates a predicate
+// and never inverts one.
 func (x *HeaderRecord) MarshalCOBOL(w *codec.Writer) error {
 	var err error
 
@@ -101,7 +103,8 @@ func (x *HeaderRecord) MarshalCOBOL(w *codec.Writer) error {
 }
 
 // UnmarshalCOBOL reads one DETAIL-RECORD out of r, in the order docs/ir/SPEC.md
-// resolved its items, and retains the bytes of every slack node it carries.
+// resolved its items, and retains the bytes of every slack node it carries and
+// of every item the copybook gives no data-name.
 //
 // It is codec's Unmarshaler. The Encoding is r's: the four axes are properties
 // of the file in hand, and Encoding is what this descriptor resolved.
@@ -120,15 +123,16 @@ func (x *DetailRecord) UnmarshalCOBOL(r *codec.Reader) error {
 }
 
 // MarshalCOBOL writes this DETAIL-RECORD into w, in the order docs/ir/SPEC.md
-// resolved its items, emitting the bytes retained for every slack node it
-// carries and zero bytes for a slack node it does not.
+// resolved its items, emitting the bytes retained for every slack node and
+// every unnamed item it carries, and zero bytes for one it does not.
 //
 // It is codec's Marshaler. Two values are the descriptor's rather than the
 // caller's and are supplied rather than taken from the record: an OCCURS
 // DEPENDING ON count is emitted as the number of occurrences written, and
-// slack is emitted as what was retained for it. Everything else is the
-// caller's, including the value a discriminator tests — a writer evaluates a
-// predicate and never inverts one.
+// slack — and the bytes of an item the copybook gives no data-name — is
+// emitted as what was retained for it. Everything else is the caller's,
+// including the value a discriminator tests — a writer evaluates a predicate
+// and never inverts one.
 func (x *DetailRecord) MarshalCOBOL(w *codec.Writer) error {
 	var err error
 
@@ -144,7 +148,8 @@ func (x *DetailRecord) MarshalCOBOL(w *codec.Writer) error {
 }
 
 // UnmarshalCOBOL reads one SUMMARY-RECORD out of r, in the order docs/ir/SPEC.md
-// resolved its items, and retains the bytes of every slack node it carries.
+// resolved its items, and retains the bytes of every slack node it carries and
+// of every item the copybook gives no data-name.
 //
 // It is codec's Unmarshaler. The Encoding is r's: the four axes are properties
 // of the file in hand, and Encoding is what this descriptor resolved.
@@ -171,15 +176,16 @@ func (x *SummaryRecord) UnmarshalCOBOL(r *codec.Reader) error {
 }
 
 // MarshalCOBOL writes this SUMMARY-RECORD into w, in the order docs/ir/SPEC.md
-// resolved its items, emitting the bytes retained for every slack node it
-// carries and zero bytes for a slack node it does not.
+// resolved its items, emitting the bytes retained for every slack node and
+// every unnamed item it carries, and zero bytes for one it does not.
 //
 // It is codec's Marshaler. Two values are the descriptor's rather than the
 // caller's and are supplied rather than taken from the record: an OCCURS
 // DEPENDING ON count is emitted as the number of occurrences written, and
-// slack is emitted as what was retained for it. Everything else is the
-// caller's, including the value a discriminator tests — a writer evaluates a
-// predicate and never inverts one.
+// slack — and the bytes of an item the copybook gives no data-name — is
+// emitted as what was retained for it. Everything else is the caller's,
+// including the value a discriminator tests — a writer evaluates a predicate
+// and never inverts one.
 func (x *SummaryRecord) MarshalCOBOL(w *codec.Writer) error {
 	var err error
 

--- a/cmd/cpybkc-gen-go/internal/fixed/codec.go
+++ b/cmd/cpybkc-gen-go/internal/fixed/codec.go
@@ -38,16 +38,19 @@ var (
 	_ codec.Marshaler   = (*LedgerRecord)(nil)
 )
 
-// zeroFill is what a writer emits for a slack node of a record its caller built
-// rather than read: zero bytes, 6 of them at the most, sliced to the node's own
-// width.
+// zeroFill is what a writer emits for a slack node — or for an item the copybook
+// gives no data-name — of a record its caller built rather than read: zero
+// bytes, 6 of them at the most, sliced to the run's own width.
 //
-// Zero rather than a space, because charset is a property of a field and slack
-// is not a field, so there is no charset to resolve a space against and zero is
-// the byte that names none. Those bytes were never in a file, so nothing is
-// being overwritten — a record that was read carries the bytes it was read
-// from and they are emitted instead. See docs/ir/SPEC.md, "What the descriptor
-// determines, a writer supplies".
+// Zero rather than a space. Charset is a property of a field and slack is not a
+// field, so there is no charset to resolve a space against and zero is the byte
+// that names none. A FILLER is a field and does have one, and it gets the same
+// answer for a different reason: its value is nobody's — no program names it
+// and nothing outside this package can set it — so filling it with spaces would
+// be choosing a value on behalf of a caller who never had one to give. Those
+// bytes were never in a file, so nothing is being overwritten — a record that
+// was read carries the bytes it was read from and they are emitted instead. See
+// docs/ir/SPEC.md, "What the descriptor determines, a writer supplies".
 var zeroFill = make([]byte, 6)
 
 // fresh is a zeroed arm to decode into, reusing the one the record already holds
@@ -68,7 +71,8 @@ func fresh[T any](p *T) *T {
 }
 
 // UnmarshalCOBOL reads one LEDGER-RECORD out of r, in the order docs/ir/SPEC.md
-// resolved its items, and retains the bytes of every slack node it carries.
+// resolved its items, and retains the bytes of every slack node it carries and
+// of every item the copybook gives no data-name.
 //
 // It is codec's Unmarshaler. The Encoding is r's: the four axes are properties
 // of the file in hand, and Encoding is what this descriptor resolved.
@@ -126,15 +130,16 @@ func (x *LedgerRecord) UnmarshalCOBOL(r *codec.Reader) error {
 }
 
 // MarshalCOBOL writes this LEDGER-RECORD into w, in the order docs/ir/SPEC.md
-// resolved its items, emitting the bytes retained for every slack node it
-// carries and zero bytes for a slack node it does not.
+// resolved its items, emitting the bytes retained for every slack node and
+// every unnamed item it carries, and zero bytes for one it does not.
 //
 // It is codec's Marshaler. Two values are the descriptor's rather than the
 // caller's and are supplied rather than taken from the record: an OCCURS
 // DEPENDING ON count is emitted as the number of occurrences written, and
-// slack is emitted as what was retained for it. Everything else is the
-// caller's, including the value a discriminator tests — a writer evaluates a
-// predicate and never inverts one.
+// slack — and the bytes of an item the copybook gives no data-name — is
+// emitted as what was retained for it. Everything else is the caller's,
+// including the value a discriminator tests — a writer evaluates a predicate
+// and never inverts one.
 func (x *LedgerRecord) MarshalCOBOL(w *codec.Writer) error {
 	var err error
 

--- a/cmd/cpybkc-gen-go/internal/opt/codec.go
+++ b/cmd/cpybkc-gen-go/internal/opt/codec.go
@@ -38,7 +38,8 @@ var (
 )
 
 // UnmarshalCOBOL reads one LINE-RECORD out of r, in the order docs/ir/SPEC.md
-// resolved its items, and retains the bytes of every slack node it carries.
+// resolved its items, and retains the bytes of every slack node it carries and
+// of every item the copybook gives no data-name.
 //
 // It is codec's Unmarshaler. The Encoding is r's: the four axes are properties
 // of the file in hand, and Encoding is what this descriptor resolved.
@@ -57,15 +58,16 @@ func (x *LineRecord) UnmarshalCOBOL(r *codec.Reader) error {
 }
 
 // MarshalCOBOL writes this LINE-RECORD into w, in the order docs/ir/SPEC.md
-// resolved its items, emitting the bytes retained for every slack node it
-// carries and zero bytes for a slack node it does not.
+// resolved its items, emitting the bytes retained for every slack node and
+// every unnamed item it carries, and zero bytes for one it does not.
 //
 // It is codec's Marshaler. Two values are the descriptor's rather than the
 // caller's and are supplied rather than taken from the record: an OCCURS
 // DEPENDING ON count is emitted as the number of occurrences written, and
-// slack is emitted as what was retained for it. Everything else is the
-// caller's, including the value a discriminator tests — a writer evaluates a
-// predicate and never inverts one.
+// slack — and the bytes of an item the copybook gives no data-name — is
+// emitted as what was retained for it. Everything else is the caller's,
+// including the value a discriminator tests — a writer evaluates a predicate
+// and never inverts one.
 func (x *LineRecord) MarshalCOBOL(w *codec.Writer) error {
 	var err error
 

--- a/cmd/cpybkc-gen-go/internal/orders/codec.go
+++ b/cmd/cpybkc-gen-go/internal/orders/codec.go
@@ -46,16 +46,19 @@ var (
 	_ codec.Marshaler   = (*EntryRecord)(nil)
 )
 
-// zeroFill is what a writer emits for a slack node of a record its caller built
-// rather than read: zero bytes, 8 of them at the most, sliced to the node's own
-// width.
+// zeroFill is what a writer emits for a slack node — or for an item the copybook
+// gives no data-name — of a record its caller built rather than read: zero
+// bytes, 8 of them at the most, sliced to the run's own width.
 //
-// Zero rather than a space, because charset is a property of a field and slack
-// is not a field, so there is no charset to resolve a space against and zero is
-// the byte that names none. Those bytes were never in a file, so nothing is
-// being overwritten — a record that was read carries the bytes it was read
-// from and they are emitted instead. See docs/ir/SPEC.md, "What the descriptor
-// determines, a writer supplies".
+// Zero rather than a space. Charset is a property of a field and slack is not a
+// field, so there is no charset to resolve a space against and zero is the byte
+// that names none. A FILLER is a field and does have one, and it gets the same
+// answer for a different reason: its value is nobody's — no program names it
+// and nothing outside this package can set it — so filling it with spaces would
+// be choosing a value on behalf of a caller who never had one to give. Those
+// bytes were never in a file, so nothing is being overwritten — a record that
+// was read carries the bytes it was read from and they are emitted instead. See
+// docs/ir/SPEC.md, "What the descriptor determines, a writer supplies".
 var zeroFill = make([]byte, 8)
 
 // resized is s with n zero occurrences in it.
@@ -93,7 +96,8 @@ func fresh[T any](p *T) *T {
 }
 
 // UnmarshalCOBOL reads one ORDER-RECORD out of r, in the order docs/ir/SPEC.md
-// resolved its items, and retains the bytes of every slack node it carries.
+// resolved its items, and retains the bytes of every slack node it carries and
+// of every item the copybook gives no data-name.
 //
 // It is codec's Unmarshaler. The Encoding is r's: the four axes are properties
 // of the file in hand, and Encoding is what this descriptor resolved.
@@ -130,6 +134,14 @@ func (x *OrderRecord) UnmarshalCOBOL(r *codec.Reader) error {
 		}
 	}
 
+	if x.filler[0], err = r.ReadBytes(4); err != nil {
+		return fmt.Errorf("ORDER-RECORD: reading the 4 bytes of an item the copybook gives no data-name: %w", err)
+	}
+
+	if x.NoteCode, err = r.ReadAlphanumeric(2); err != nil {
+		return fmt.Errorf("ORDER-RECORD: reading NOTE-CODE: %w", err)
+	}
+
 	if x.DetailCount, err = r.ReadZonedInt32(3, codec.SignUnsigned); err != nil {
 		return fmt.Errorf("ORDER-RECORD: reading DETAIL-COUNT: %w", err)
 	}
@@ -149,15 +161,16 @@ func (x *OrderRecord) UnmarshalCOBOL(r *codec.Reader) error {
 }
 
 // MarshalCOBOL writes this ORDER-RECORD into w, in the order docs/ir/SPEC.md
-// resolved its items, emitting the bytes retained for every slack node it
-// carries and zero bytes for a slack node it does not.
+// resolved its items, emitting the bytes retained for every slack node and
+// every unnamed item it carries, and zero bytes for one it does not.
 //
 // It is codec's Marshaler. Two values are the descriptor's rather than the
 // caller's and are supplied rather than taken from the record: an OCCURS
 // DEPENDING ON count is emitted as the number of occurrences written, and
-// slack is emitted as what was retained for it. Everything else is the
-// caller's, including the value a discriminator tests — a writer evaluates a
-// predicate and never inverts one.
+// slack — and the bytes of an item the copybook gives no data-name — is
+// emitted as what was retained for it. Everything else is the caller's,
+// including the value a discriminator tests — a writer evaluates a predicate
+// and never inverts one.
 func (x *OrderRecord) MarshalCOBOL(w *codec.Writer) error {
 	var err error
 
@@ -209,6 +222,23 @@ func (x *OrderRecord) MarshalCOBOL(w *codec.Writer) error {
 		}
 	}
 
+	switch {
+	case x.filler[0] == nil:
+		if err = w.WriteBytes(zeroFill[:4]); err != nil {
+			return fmt.Errorf("ORDER-RECORD: writing 4 zero bytes for an item the copybook gives no data-name and this record carries none for: %w", err)
+		}
+	case len(x.filler[0]) != 4:
+		return fmt.Errorf("ORDER-RECORD: a writer reports a retained run rather than truncating or padding it, and the run for an item of 4 bytes the copybook gives no data-name is %d", len(x.filler[0]))
+	default:
+		if err = w.WriteBytes(x.filler[0]); err != nil {
+			return fmt.Errorf("ORDER-RECORD: writing the 4 bytes of an item the copybook gives no data-name: %w", err)
+		}
+	}
+
+	if err = w.WriteAlphanumeric(x.NoteCode, 2); err != nil {
+		return fmt.Errorf("ORDER-RECORD: writing NOTE-CODE: %w", err)
+	}
+
 	count1 := len(x.Detail)
 	if count1 > 12 {
 		return fmt.Errorf("ORDER-RECORD: DETAIL occurs 0 to 12 times depending on DETAIL-COUNT, and the record holds %d occurrences of it", count1)
@@ -227,7 +257,8 @@ func (x *OrderRecord) MarshalCOBOL(w *codec.Writer) error {
 }
 
 // UnmarshalCOBOL reads one TRAILER-RECORD out of r, in the order docs/ir/SPEC.md
-// resolved its items, and retains the bytes of every slack node it carries.
+// resolved its items, and retains the bytes of every slack node it carries and
+// of every item the copybook gives no data-name.
 //
 // It is codec's Unmarshaler. The Encoding is r's: the four axes are properties
 // of the file in hand, and Encoding is what this descriptor resolved.
@@ -256,15 +287,16 @@ func (x *TrailerRecord) UnmarshalCOBOL(r *codec.Reader) error {
 }
 
 // MarshalCOBOL writes this TRAILER-RECORD into w, in the order docs/ir/SPEC.md
-// resolved its items, emitting the bytes retained for every slack node it
-// carries and zero bytes for a slack node it does not.
+// resolved its items, emitting the bytes retained for every slack node and
+// every unnamed item it carries, and zero bytes for one it does not.
 //
 // It is codec's Marshaler. Two values are the descriptor's rather than the
 // caller's and are supplied rather than taken from the record: an OCCURS
 // DEPENDING ON count is emitted as the number of occurrences written, and
-// slack is emitted as what was retained for it. Everything else is the
-// caller's, including the value a discriminator tests — a writer evaluates a
-// predicate and never inverts one.
+// slack — and the bytes of an item the copybook gives no data-name — is
+// emitted as what was retained for it. Everything else is the caller's,
+// including the value a discriminator tests — a writer evaluates a predicate
+// and never inverts one.
 func (x *TrailerRecord) MarshalCOBOL(w *codec.Writer) error {
 	var err error
 
@@ -293,7 +325,8 @@ func (x *TrailerRecord) MarshalCOBOL(w *codec.Writer) error {
 }
 
 // UnmarshalCOBOL reads one SYNC-RECORD out of r, in the order docs/ir/SPEC.md
-// resolved its items, and retains the bytes of every slack node it carries.
+// resolved its items, and retains the bytes of every slack node it carries and
+// of every item the copybook gives no data-name.
 //
 // It is codec's Unmarshaler. The Encoding is r's: the four axes are properties
 // of the file in hand, and Encoding is what this descriptor resolved.
@@ -320,15 +353,16 @@ func (x *SyncRecord) UnmarshalCOBOL(r *codec.Reader) error {
 }
 
 // MarshalCOBOL writes this SYNC-RECORD into w, in the order docs/ir/SPEC.md
-// resolved its items, emitting the bytes retained for every slack node it
-// carries and zero bytes for a slack node it does not.
+// resolved its items, emitting the bytes retained for every slack node and
+// every unnamed item it carries, and zero bytes for one it does not.
 //
 // It is codec's Marshaler. Two values are the descriptor's rather than the
 // caller's and are supplied rather than taken from the record: an OCCURS
 // DEPENDING ON count is emitted as the number of occurrences written, and
-// slack is emitted as what was retained for it. Everything else is the
-// caller's, including the value a discriminator tests — a writer evaluates a
-// predicate and never inverts one.
+// slack — and the bytes of an item the copybook gives no data-name — is
+// emitted as what was retained for it. Everything else is the caller's,
+// including the value a discriminator tests — a writer evaluates a predicate
+// and never inverts one.
 func (x *SyncRecord) MarshalCOBOL(w *codec.Writer) error {
 	var err error
 
@@ -370,7 +404,8 @@ func (x *SyncRecord) MarshalCOBOL(w *codec.Writer) error {
 }
 
 // UnmarshalCOBOL reads one TABLE-RECORD out of r, in the order docs/ir/SPEC.md
-// resolved its items, and retains the bytes of every slack node it carries.
+// resolved its items, and retains the bytes of every slack node it carries and
+// of every item the copybook gives no data-name.
 //
 // It is codec's Unmarshaler. The Encoding is r's: the four axes are properties
 // of the file in hand, and Encoding is what this descriptor resolved.
@@ -425,15 +460,16 @@ func (x *TableRecord) UnmarshalCOBOL(r *codec.Reader) error {
 }
 
 // MarshalCOBOL writes this TABLE-RECORD into w, in the order docs/ir/SPEC.md
-// resolved its items, emitting the bytes retained for every slack node it
-// carries and zero bytes for a slack node it does not.
+// resolved its items, emitting the bytes retained for every slack node and
+// every unnamed item it carries, and zero bytes for one it does not.
 //
 // It is codec's Marshaler. Two values are the descriptor's rather than the
 // caller's and are supplied rather than taken from the record: an OCCURS
 // DEPENDING ON count is emitted as the number of occurrences written, and
-// slack is emitted as what was retained for it. Everything else is the
-// caller's, including the value a discriminator tests — a writer evaluates a
-// predicate and never inverts one.
+// slack — and the bytes of an item the copybook gives no data-name — is
+// emitted as what was retained for it. Everything else is the caller's,
+// including the value a discriminator tests — a writer evaluates a predicate
+// and never inverts one.
 func (x *TableRecord) MarshalCOBOL(w *codec.Writer) error {
 	var err error
 
@@ -515,7 +551,8 @@ func (x *TableRecord) MarshalCOBOL(w *codec.Writer) error {
 }
 
 // UnmarshalCOBOL reads one ENTRY-RECORD out of r, in the order docs/ir/SPEC.md
-// resolved its items, and retains the bytes of every slack node it carries.
+// resolved its items, and retains the bytes of every slack node it carries and
+// of every item the copybook gives no data-name.
 //
 // It is codec's Unmarshaler. The Encoding is r's: the four axes are properties
 // of the file in hand, and Encoding is what this descriptor resolved.
@@ -565,15 +602,16 @@ func (x *EntryRecord) UnmarshalCOBOL(r *codec.Reader) error {
 }
 
 // MarshalCOBOL writes this ENTRY-RECORD into w, in the order docs/ir/SPEC.md
-// resolved its items, emitting the bytes retained for every slack node it
-// carries and zero bytes for a slack node it does not.
+// resolved its items, emitting the bytes retained for every slack node and
+// every unnamed item it carries, and zero bytes for one it does not.
 //
 // It is codec's Marshaler. Two values are the descriptor's rather than the
 // caller's and are supplied rather than taken from the record: an OCCURS
 // DEPENDING ON count is emitted as the number of occurrences written, and
-// slack is emitted as what was retained for it. Everything else is the
-// caller's, including the value a discriminator tests — a writer evaluates a
-// predicate and never inverts one.
+// slack — and the bytes of an item the copybook gives no data-name — is
+// emitted as what was retained for it. Everything else is the caller's,
+// including the value a discriminator tests — a writer evaluates a predicate
+// and never inverts one.
 func (x *EntryRecord) MarshalCOBOL(w *codec.Writer) error {
 	var err error
 

--- a/cmd/cpybkc-gen-go/internal/orders/codec.go
+++ b/cmd/cpybkc-gen-go/internal/orders/codec.go
@@ -132,6 +132,10 @@ func (x *OrderRecord) UnmarshalCOBOL(r *codec.Reader) error {
 		if x.LineItem[i0].slack[0], err = r.ReadBytes(1); err != nil {
 			return fmt.Errorf("ORDER-RECORD: reading the 1 byte no item of it covers in occurrence %d of LINE-ITEM: %w", i0, err)
 		}
+
+		if x.LineItem[i0].filler[0], err = r.ReadBytes(1); err != nil {
+			return fmt.Errorf("ORDER-RECORD: reading the 1 byte of an item the copybook gives no data-name in occurrence %d of LINE-ITEM: %w", i0, err)
+		}
 	}
 
 	if x.filler[0], err = r.ReadBytes(4); err != nil {
@@ -218,6 +222,19 @@ func (x *OrderRecord) MarshalCOBOL(w *codec.Writer) error {
 		default:
 			if err = w.WriteBytes(x.LineItem[i0].slack[0]); err != nil {
 				return fmt.Errorf("ORDER-RECORD: writing the 1 byte no item of it covers in occurrence %d of LINE-ITEM: %w", i0, err)
+			}
+		}
+
+		switch {
+		case x.LineItem[i0].filler[0] == nil:
+			if err = w.WriteBytes(zeroFill[:1]); err != nil {
+				return fmt.Errorf("ORDER-RECORD: writing 1 zero byte for an item the copybook gives no data-name and this record carries none for in occurrence %d of LINE-ITEM: %w", i0, err)
+			}
+		case len(x.LineItem[i0].filler[0]) != 1:
+			return fmt.Errorf("ORDER-RECORD: a writer reports a retained run rather than truncating or padding it, and the run for an item of 1 byte the copybook gives no data-name is %d in occurrence %d of LINE-ITEM", len(x.LineItem[i0].filler[0]), i0)
+		default:
+			if err = w.WriteBytes(x.LineItem[i0].filler[0]); err != nil {
+				return fmt.Errorf("ORDER-RECORD: writing the 1 byte of an item the copybook gives no data-name in occurrence %d of LINE-ITEM: %w", i0, err)
 			}
 		}
 	}

--- a/cmd/cpybkc-gen-go/internal/orders/records.go
+++ b/cmd/cpybkc-gen-go/internal/orders/records.go
@@ -36,6 +36,9 @@ type OrderRecord struct {
 		slack [1][]byte
 	}
 
+	// NoteCode is NOTE-CODE — alphanumeric, DISPLAY, 2 bytes.
+	NoteCode string
+
 	// DetailCount is DETAIL-COUNT — numeric, DISPLAY, 3 digits, unsigned, 3 bytes.
 	DetailCount int32
 
@@ -54,6 +57,20 @@ type OrderRecord struct {
 	// They travel with the record and there is nothing here for a caller to do.
 	// See docs/ir/SPEC.md, "Slack survives a read".
 	slack [1][]byte
+
+	// filler is the bytes of the items among this item's members that the
+	// copybook gives no data-name — its FILLER — in the order they occupy the
+	// record: one run each, as they stood when the record was read, and one set
+	// of them per occurrence of this struct. A nil run is one the record does
+	// not carry; an empty run is a run of no bytes, and the two are not the
+	// same.
+	//
+	// A FILLER is an item, and it is one no program names: it holds no value a
+	// caller of this package could set and none it could read. So it travels
+	// with the record and there is nothing here for a caller to do. An item you
+	// do want to read or write is one to give a data-name in the copybook,
+	// which makes it a field like any other.
+	filler [1][]byte
 }
 
 // TrailerRecord is the TRAILER-RECORD record, as docs/ir/SPEC.md resolved it.

--- a/cmd/cpybkc-gen-go/internal/orders/records.go
+++ b/cmd/cpybkc-gen-go/internal/orders/records.go
@@ -17,7 +17,7 @@ type OrderRecord struct {
 	// The value is unscaled: the item's value is this field times 10^-2.
 	OrderTotal int32
 
-	// LineItem is LINE-ITEM — a group of 3 members, OCCURS 3.
+	// LineItem is LINE-ITEM — a group of 4 members, OCCURS 3.
 	LineItem [3]struct {
 		// Sku is SKU — alphanumeric, DISPLAY, 8 bytes.
 		Sku string
@@ -34,6 +34,20 @@ type OrderRecord struct {
 		// They travel with the record and there is nothing here for a caller to do.
 		// See docs/ir/SPEC.md, "Slack survives a read".
 		slack [1][]byte
+
+		// filler is the bytes of the items among this item's members that the
+		// copybook gives no data-name — its FILLER — in the order they occupy the
+		// record: one run each, as they stood when the record was read, and one set
+		// of them per occurrence of this struct. A nil run is one the record does
+		// not carry; an empty run is a run of no bytes, and the two are not the
+		// same.
+		//
+		// A FILLER is an item, and it is one no program names: it holds no value a
+		// caller of this package could set and none it could read. So it travels
+		// with the record and there is nothing here for a caller to do. An item you
+		// do want to read or write is one to give a data-name in the copybook,
+		// which makes it a field like any other.
+		filler [1][]byte
 	}
 
 	// NoteCode is NOTE-CODE — alphanumeric, DISPLAY, 2 bytes.

--- a/cmd/cpybkc-gen-go/internal/orders/roundtrip_test.go
+++ b/cmd/cpybkc-gen-go/internal/orders/roundtrip_test.go
@@ -150,6 +150,14 @@ func orderBytes(t *testing.T, enc codec.Encoding, details int) []byte {
 			if err := w.WriteBytes([]byte{byte(0xe0 + i)}); err != nil {
 				return err
 			}
+
+			// The FILLER of this occurrence of LINE-ITEM, a different byte in
+			// each: a run retained once for the whole table rather than once
+			// per occurrence writes the same byte back three times and fails
+			// here.
+			if err := w.WriteBytes([]byte{byte(0xf0 + i)}); err != nil {
+				return err
+			}
 		}
 
 		// The FILLER item, and then the FILLER group's one named member.

--- a/cmd/cpybkc-gen-go/internal/orders/roundtrip_test.go
+++ b/cmd/cpybkc-gen-go/internal/orders/roundtrip_test.go
@@ -152,6 +152,18 @@ func orderBytes(t *testing.T, enc codec.Encoding, details int) []byte {
 			}
 		}
 
+		// The FILLER item, and then the FILLER group's one named member.
+		// Neither byte of the first is a space or a zero, for the reason the
+		// slack runs above are neither: a writer that filled the run rather
+		// than emitting what it read fails this rather than passing it by luck.
+		if err := w.WriteBytes([]byte{0x01, 0x02, 0xfe, 0xff}); err != nil {
+			return err
+		}
+
+		if err := w.WriteAlphanumeric("NC", 2); err != nil {
+			return err
+		}
+
 		if err := w.WriteZonedInt32(int32(details), 3, codec.SignUnsigned); err != nil {
 			return err
 		}
@@ -722,6 +734,79 @@ func TestARetainedRunOfTheWrongLengthIsReported(t *testing.T) {
 				t.Errorf("the report reads %q and does not say what it refused to do", err)
 			}
 		})
+	}
+}
+
+// TestAFillerTravelsWithTheRecordAndItsGroupsMembersDoNot is the FILLER
+// decision from the only side that can be asserted from inside a record: what
+// the two shapes do with the bytes.
+//
+// ORDER-RECORD carries both. The elementary FILLER has no field, so its four
+// bytes are written back out of the run retained for them — which
+// [TestARecordCarryingSlackWritesBackTheBytesItWasReadFrom] already covers over
+// the whole record, and which this states about the run itself. The FILLER
+// *group* is the half that could not be retained as bytes: it holds NOTE-CODE,
+// which the copybook does name, and a caller reads and writes it as a field of
+// the record — at this level, because COBOL's own qualification skips a group
+// with no name.
+func TestAFillerTravelsWithTheRecordAndItsGroupsMembersDoNot(t *testing.T) {
+	t.Parallel()
+
+	var x OrderRecord
+
+	in := orderBytes(t, Encoding(), 1)
+
+	r, err := codec.NewReader(bytes.NewReader(in), Encoding())
+	if err != nil {
+		t.Fatalf("codec.NewReader: %v", err)
+	}
+
+	if err := x.UnmarshalCOBOL(r); err != nil {
+		t.Fatalf("UnmarshalCOBOL: %v", err)
+	}
+
+	// The FILLER's own bytes, as they stood in the record: neither a space nor
+	// a zero, so a run this generator filled rather than read fails here.
+	if got, want := x.filler[0], []byte{0x01, 0x02, 0xfe, 0xff}; !bytes.Equal(got, want) {
+		t.Errorf("the FILLER of the record read back as % x, want % x", got, want)
+	}
+
+	// The member of the FILLER group, reached at the level above it.
+	if x.NoteCode != "NC" {
+		t.Errorf("NOTE-CODE is a member of a FILLER group and read back as %q, want %q", x.NoteCode, "NC")
+	}
+}
+
+// TestARecordTheCallerBuiltEmitsZeroBytesForItsFiller is the writer's half of
+// that, and the one place it invents bytes for an item rather than for slack.
+//
+// A caller cannot set a FILLER — it has no field, because the copybook gave it
+// no name — so a record built rather than read carries no run for it and the
+// writer emits zero bytes, exactly as it does for slack. Spaces would be a
+// value chosen on behalf of a caller who never had one to give; an item whose
+// value you want to choose is one to give a data-name in the copybook.
+func TestARecordTheCallerBuiltEmitsZeroBytesForItsFiller(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+
+	w, err := codec.NewWriter(&out, Encoding())
+	if err != nil {
+		t.Fatalf("codec.NewWriter: %v", err)
+	}
+
+	if err := (&OrderRecord{NoteCode: "NC"}).MarshalCOBOL(w); err != nil {
+		t.Fatalf("MarshalCOBOL: %v", err)
+	}
+
+	// The four bytes of the FILLER, ahead of the two of NOTE-CODE, which is
+	// the caller's.
+	want := append(make([]byte, 4), laidOut(t, Encoding(), func(w *codec.Writer) error {
+		return w.WriteAlphanumeric("NC", 2)
+	})...)
+
+	if !bytes.Contains(out.Bytes(), want) {
+		t.Errorf("a record the caller built writes % x, and the FILLER ahead of NOTE-CODE is not % x", out.Bytes(), want)
 	}
 }
 

--- a/cmd/cpybkc-gen-go/internal/sep/codec.go
+++ b/cmd/cpybkc-gen-go/internal/sep/codec.go
@@ -38,7 +38,8 @@ var (
 )
 
 // UnmarshalCOBOL reads one LINE-RECORD out of r, in the order docs/ir/SPEC.md
-// resolved its items, and retains the bytes of every slack node it carries.
+// resolved its items, and retains the bytes of every slack node it carries and
+// of every item the copybook gives no data-name.
 //
 // It is codec's Unmarshaler. The Encoding is r's: the four axes are properties
 // of the file in hand, and Encoding is what this descriptor resolved.
@@ -57,15 +58,16 @@ func (x *LineRecord) UnmarshalCOBOL(r *codec.Reader) error {
 }
 
 // MarshalCOBOL writes this LINE-RECORD into w, in the order docs/ir/SPEC.md
-// resolved its items, emitting the bytes retained for every slack node it
-// carries and zero bytes for a slack node it does not.
+// resolved its items, emitting the bytes retained for every slack node and
+// every unnamed item it carries, and zero bytes for one it does not.
 //
 // It is codec's Marshaler. Two values are the descriptor's rather than the
 // caller's and are supplied rather than taken from the record: an OCCURS
 // DEPENDING ON count is emitted as the number of occurrences written, and
-// slack is emitted as what was retained for it. Everything else is the
-// caller's, including the value a discriminator tests — a writer evaluates a
-// predicate and never inverts one.
+// slack — and the bytes of an item the copybook gives no data-name — is
+// emitted as what was retained for it. Everything else is the caller's,
+// including the value a discriminator tests — a writer evaluates a predicate
+// and never inverts one.
 func (x *LineRecord) MarshalCOBOL(w *codec.Writer) error {
 	var err error
 

--- a/cmd/cpybkc-gen-go/reader.go
+++ b/cmd/cpybkc-gen-go/reader.go
@@ -1157,14 +1157,12 @@ func (f *filer) registerCounts(record *irpb.Record) ([]registerCount, error) {
 
 // walkCounts is [filer.registerCounts] over one group.
 func (f *filer) walkCounts(id uint64, expr string, loops []countLoopOver, sliding bool, out *[]registerCount) error {
-	c := &coder{emitter: f.emitter}
-
-	group, err := c.group(id)
+	members, err := f.flattened(id)
 	if err != nil {
 		return err
 	}
 
-	for _, memberID := range group.GetMemberIds() {
+	for _, memberID := range members {
 		member, ok := f.nodes[memberID]
 		if !ok {
 			return unresolved(memberID)
@@ -1182,6 +1180,13 @@ func (f *filer) walkCounts(id uint64, expr string, loops []countLoopOver, slidin
 		case *irpb.Node_Group:
 			rep, names, kind = k.Group.GetRepetition(), k.Group.GetNames(), "group"
 		default:
+			continue
+		}
+
+		// An item the copybook gives no data-name is a run of retained bytes
+		// and holds no table a register could size; a group carrying no name
+		// has already been replaced here by its own members.
+		if anonymous(names) {
 			continue
 		}
 
@@ -1247,14 +1252,12 @@ func (f *filer) walkCounts(id uint64, expr string, loops []countLoopOver, slidin
 // predicate both name a field, not an occurrence of one, so a target inside a
 // table is refused where it is read rather than found here.
 func (f *filer) pathTo(root, target uint64, expr string) (string, bool, error) {
-	c := &coder{emitter: f.emitter}
-
-	group, err := c.group(root)
+	members, err := f.flattened(root)
 	if err != nil {
 		return "", false, err
 	}
 
-	for _, memberID := range group.GetMemberIds() {
+	for _, memberID := range members {
 		member, ok := f.nodes[memberID]
 		if !ok {
 			return "", false, unresolved(memberID)
@@ -1272,6 +1275,13 @@ func (f *filer) pathTo(root, target uint64, expr string) (string, bool, error) {
 		case *irpb.Node_Group:
 			rep, names, kind = k.Group.GetRepetition(), k.Group.GetNames(), "group"
 		default:
+			continue
+		}
+
+		// An item the copybook gives no data-name is not a path to anything: a
+		// binding and a predicate each name a field, and a FILLER is a field
+		// nothing can name.
+		if anonymous(names) {
 			continue
 		}
 

--- a/cmd/cpybkc-gen-go/record.go
+++ b/cmd/cpybkc-gen-go/record.go
@@ -26,13 +26,24 @@ import (
 const recordsFile = "records.go"
 
 // slackField is the name of the unexported field a struct carries for the
-// slack nodes among its members.
+// slack nodes among its members, and fillerField is the same for the items
+// among them COBOL gave no data-name.
 //
-// It cannot collide with a member's field name: a member's name is munged to
-// an exported identifier and this one is not, so the two live in disjoint sets
+// Neither can collide with a member's field name: a member's name is munged to
+// an exported identifier and these are not, so the two live in disjoint sets
 // however a copybook spells its items — including a copybook with an item
-// literally called SLACK.
-const slackField = "slack"
+// literally called SLACK, and including the FILLER this one is for.
+//
+// Two fields rather than one, because a slack node and a FILLER are two
+// different facts about a record and docs/ir/SPEC.md keeps them apart: slack is
+// bytes that belong to no item, and a FILLER *is* an item — it carries a
+// PICTURE and a USAGE, and cpybkc-gen-graph draws it as a row. Retaining both
+// in one run of storage would be that collapse in this generator instead of in
+// the producer.
+const (
+	slackField  = "slack"
+	fillerField = "filler"
+)
 
 // bigIntType is the Go type a numeric item wider than an int64 takes, and
 // bigIntImport is what the generated file imports for it.
@@ -173,18 +184,13 @@ func (e *emitter) sortedImports() []string {
 // structType is the Go struct type of the group node id names, as source.
 //
 // The members become fields in the order the member list carries them, which
-// docs/ir/SPEC.md makes record order, and the slack nodes among them become the
-// one unexported field at the end.
+// docs/ir/SPEC.md makes record order, and the two kinds of member that get no
+// field of their own — the slack nodes and the items COBOL named nothing —
+// become the unexported fields at the end.
 func (e *emitter) structType(id uint64) (string, error) {
-	node, ok := e.nodes[id]
-	if !ok {
-		return "", unresolved(id)
-	}
-
-	group := node.GetGroup()
-	if group == nil {
-		return "", malformed(fmt.Sprintf("node %d is not a group node, and a group is what stands here", id),
-			"a record's top level and a group's group members are group nodes; see docs/ir/SPEC.md, \"The node kinds\"")
+	group, err := e.group(id)
+	if err != nil {
+		return "", err
 	}
 
 	if _, cycle := e.visiting[id]; cycle {
@@ -195,16 +201,35 @@ func (e *emitter) structType(id uint64) (string, error) {
 	e.visiting[id] = struct{}{}
 	defer delete(e.visiting, id)
 
+	members, err := e.flattened(id)
+	if err != nil {
+		return "", err
+	}
+
 	var (
 		fields []string
 		named  = make(map[string]colliding)
 		slack  int
+		filler int
 	)
 
-	for _, memberID := range group.GetMemberIds() {
+	for _, memberID := range members {
 		member, ok := e.nodes[memberID]
 		if !ok {
 			return "", unresolved(memberID)
+		}
+
+		// An item COBOL gave no data-name contributes bytes and no field, the
+		// way a slack node does. Which of the two shapes a FILLER takes, and
+		// why a group's is the other one, is [emitter.flattened].
+		if field := member.GetField(); field != nil && anonymous(field.GetNames()) {
+			if _, err := fillerRun(field, group.GetNames().GetOriginal()); err != nil {
+				return "", err
+			}
+
+			filler++
+
+			continue
 		}
 
 		switch kind := member.GetKind().(type) {
@@ -219,7 +244,7 @@ func (e *emitter) structType(id uint64) (string, error) {
 		case *irpb.Node_Variant:
 			// One field per arm rather than one field for the alternation, so
 			// that this generator still names nothing the copybook did not.
-			arms, err := e.armFields(kind.Variant)
+			arms, err := e.armFields(kind.Variant, group.GetNames().GetOriginal())
 			if err != nil {
 				return "", err
 			}
@@ -263,7 +288,164 @@ func (e *emitter) structType(id uint64) (string, error) {
 		fields = append(fields, slackDeclaration(slack))
 	}
 
+	if filler > 0 {
+		fields = append(fields, fillerDeclaration(filler))
+	}
+
 	return "struct {\n" + strings.Join(fields, "\n\n") + "\n}", nil
+}
+
+// flattened is the members of the group id as the struct standing for it sees
+// them: its own member list, with each member that is a group COBOL gave no
+// data-name replaced, in place, by that group's own members.
+//
+// # A FILLER group is flattened, and a FILLER item is retained as bytes
+//
+// docs/ir/SPEC.md's "Names" says what a *named* node carries and never that
+// every node is named, so an item COBOL gives no data-name — a FILLER — carries
+// no names message at all, and a FILLER may be a group as much as an elementary
+// item. Neither is a malformed descriptor and neither is refused; what each one
+// generates is this generator's decision, and the two decisions are different
+// because the two items are.
+//
+// An elementary FILLER holds no value anybody named, so it gets no exported
+// field and its bytes are retained the way a slack node's are — see
+// [fillerDeclaration]. That answer is not available to a group: a FILLER group
+// holds members, and those members are named. Retaining the group as one run of
+// bytes would hide items the copybook does name, which is the whole reason
+// there is a second decision to make here at all.
+//
+// Flattening is what COBOL already says about them. Qualification skips an
+// unnamed group — a NOTE-CODE inside a FILLER group is reached as NOTE-CODE OF
+// THE-RECORD, because there is no intermediate name to qualify by — so its
+// members already belong to the enclosing named level, and putting them there
+// is a reading of the copybook rather than a shape invented for Go. A collision
+// after it goes through [collisionError] like any other, which is what says so
+// when two levels turn out to spell one member the same way.
+//
+// # What is refused, and why it is not "malformed"
+//
+// A FILLER group that *repeats* cannot be flattened: its members would have to
+// move up a level once per occurrence, and there is no name for the occurrences
+// to be an array of. That is a [fillerError] — the item is refused, the
+// diagnostic names the item containing it, and it does not call the descriptor
+// malformed over something the adopter wrote correctly.
+//
+// A names message that is *present* and states no original is a different thing
+// and keeps the old refusal: that is a named item whose name went missing,
+// which is a bug in the producer. [identifier] is where the two part company.
+func (e *emitter) flattened(id uint64) ([]uint64, error) {
+	group, err := e.group(id)
+	if err != nil {
+		return nil, err
+	}
+
+	return e.flatten(id, group.GetNames().GetOriginal(), map[uint64]struct{}{id: {}})
+}
+
+// flatten is [emitter.flattened] over one group, in the name of the named one
+// containing it.
+func (e *emitter) flatten(id uint64, in string, seen map[uint64]struct{}) ([]uint64, error) {
+	group, err := e.group(id)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []uint64
+
+	for _, memberID := range group.GetMemberIds() {
+		member, ok := e.nodes[memberID]
+		if !ok {
+			return nil, unresolved(memberID)
+		}
+
+		inner := member.GetGroup()
+		if inner == nil || !anonymous(inner.GetNames()) {
+			out = append(out, memberID)
+
+			continue
+		}
+
+		if inner.GetRepetition() != nil {
+			return nil, &fillerError{Kind: "group", In: in, Because: "repeats"}
+		}
+
+		// A group with no name that contains itself would otherwise be expanded
+		// for ever, and the expansion happens before [emitter.structType]'s own
+		// guard is reached.
+		if _, cycle := seen[memberID]; cycle {
+			return nil, malformed(fmt.Sprintf("node %d contains itself", memberID),
+				"docs/ir/SPEC.md requires containment to be acyclic, and a record whose group contains itself has no width")
+		}
+
+		seen[memberID] = struct{}{}
+
+		below, err := e.flatten(memberID, in, seen)
+		if err != nil {
+			return nil, err
+		}
+
+		delete(seen, memberID)
+
+		out = append(out, below...)
+	}
+
+	return out, nil
+}
+
+// group is the group node id names.
+func (e *emitter) group(id uint64) (*irpb.Group, error) {
+	node, ok := e.nodes[id]
+	if !ok {
+		return nil, unresolved(id)
+	}
+
+	group := node.GetGroup()
+	if group == nil {
+		return nil, malformed(fmt.Sprintf("node %d is not a group node, and a group is what stands here", id),
+			"a record's top level and a group's group members are group nodes; see docs/ir/SPEC.md, \"The node kinds\"")
+	}
+
+	return group, nil
+}
+
+// anonymous is whether a node's names are those of an item COBOL gave no
+// data-name: no names message at all.
+//
+// The whole of the FILLER decision turns on this being *absence* rather than
+// emptiness. A names message that is present and states no original is a named
+// item whose name went missing — a producer bug — and it is refused as one; see
+// [identifier].
+func anonymous(names *irpb.Names) bool { return names == nil }
+
+// fillerRun is the number of bytes retained for an item COBOL gave no name: its
+// width, taken as many times as it occurs.
+//
+// A constant OCCURS is one run of all of it rather than one run per occurrence.
+// The occurrences of a FILLER are indistinguishable — nothing names them and
+// nothing reads them — so a run each would be storage divided along a line no
+// caller can see.
+//
+// An OCCURS DEPENDING ON is refused. The run would have to be as long as the
+// count says, so a writer would have to agree with a count field it does not
+// derive, over bytes no caller can supply; that is a promise this generator
+// cannot keep, and it says so rather than emitting a record that fails at run
+// time.
+func fillerRun(f *irpb.Field, in string) (uint32, error) {
+	rep := f.GetRepetition()
+	if rep == nil {
+		return f.GetWidth(), nil
+	}
+
+	switch count := rep.GetCount().(type) {
+	case *irpb.Repetition_Constant:
+		return f.GetWidth() * count.Constant, nil
+	case *irpb.Repetition_Variable:
+		return 0, &fillerError{Kind: "item", In: in, Because: "occurs a number of times the record states"}
+	default:
+		return 0, malformed("an item repeats and says nothing about how many times",
+			"a repetition carries a constant count or an OCCURS DEPENDING ON one; an item that does not repeat carries no repetition at all")
+	}
 }
 
 // member is one field of a struct: the declaration with its doc comment, and
@@ -356,7 +538,7 @@ type armField struct {
 // generator invented, which is exactly what it refuses to do everywhere else.
 // Nil and non-nil say the same thing and say it in names the copybook already
 // spells: exactly one arm of an occurrence is non-nil.
-func (e *emitter) armFields(v *irpb.Variant) ([]armField, error) {
+func (e *emitter) armFields(v *irpb.Variant, in string) ([]armField, error) {
 	if len(v.GetArms()) < 2 {
 		return nil, malformed(fmt.Sprintf("a variant carries %d arms", len(v.GetArms())),
 			"a producer must not emit a variant carrying fewer than two arms; see docs/ir/SPEC.md, \"A variant is chosen once per occurrence\"")
@@ -376,6 +558,10 @@ func (e *emitter) armFields(v *irpb.Variant) ([]armField, error) {
 	names := make([]string, 0, len(bodies))
 
 	for _, body := range bodies {
+		if err := namedArm(body, in); err != nil {
+			return nil, err
+		}
+
 		name, err := identifier("arm", namesOf(body))
 		if err != nil {
 			return nil, err
@@ -400,6 +586,27 @@ func (e *emitter) armFields(v *irpb.Variant) ([]armField, error) {
 	}
 
 	return fields, nil
+}
+
+// namedArm refuses an arm whose body is an item COBOL gave no data-name.
+//
+// This is the third shape a FILLER takes and the one there is no answer for. An
+// alternation is spelled as a field per alternative, exactly one of which is
+// non-nil in an occurrence, so an alternative with no name has no way to say it
+// is the one the record holds — and it cannot be retained as bytes either,
+// because its siblings cover the same bytes and one of them is a field a caller
+// fills. Refused rather than called malformed: a `FILLER REDEFINES` is
+// something a copybook may say, and the answer is in the copybook.
+func namedArm(body *irpb.Node, in string) error {
+	if !anonymous(namesOf(body)) {
+		return nil
+	}
+
+	return &fillerError{
+		Kind:    "item",
+		In:      in,
+		Because: "is one alternative of an alternation over a run of bytes, which this generator spells as a field per alternative",
+	}
 }
 
 // armBody is the group or field node an arm's body names.
@@ -786,6 +993,32 @@ func slackDeclaration(runs int) string {
 %[1]s [%[2]d][]byte`, slackField, runs)
 }
 
+// fillerDeclaration is the one unexported field a struct carries for the items
+// among its members COBOL gave no data-name.
+//
+// The same shape as [slackDeclaration] and for a related reason: the bytes are
+// part of the record, and nothing in the copybook names them, so they travel
+// with the record where the decode and encode methods can reach them and a
+// caller cannot. Exporting them would need a name — Filler1, Filler2 — that no
+// copybook spells and that moves the moment an unrelated item is inserted ahead
+// of it, which is the one thing this generator refuses to produce everywhere
+// else.
+func fillerDeclaration(runs int) string {
+	return fmt.Sprintf(`// %[1]s is the bytes of the items among this item's members that the
+// copybook gives no data-name — its FILLER — in the order they occupy the
+// record: one run each, as they stood when the record was read, and one set
+// of them per occurrence of this struct. A nil run is one the record does
+// not carry; an empty run is a run of no bytes, and the two are not the
+// same.
+//
+// A FILLER is an item, and it is one no program names: it holds no value a
+// caller of this package could set and none it could read. So it travels
+// with the record and there is nothing here for a caller to do. An item you
+// do want to read or write is one to give a data-name in the copybook,
+// which makes it a field like any other.
+%[1]s [%[2]d][]byte`, fillerField, runs)
+}
+
 // comment is a struct field's doc comment, opening with the Go name Go's own
 // convention wants there and naming the copybook's word for it.
 //
@@ -840,11 +1073,21 @@ func renameNote(names *irpb.Names) string {
 func identifier(kind string, names *irpb.Names) (string, error) {
 	original := names.GetOriginal()
 
-	// A node the copybook named and the descriptor did not is a bug in the
-	// producer rather than a name an adopter can do anything about, so it is
-	// reported as the malformed descriptor it is. Telling them to rename an
-	// item in their layout would send them looking for a name that is not
-	// missing from anything they wrote.
+	// A names message that is present and states no original is a node the
+	// copybook named and the descriptor did not, which is a bug in the producer
+	// rather than a name an adopter can do anything about, so it is reported as
+	// the malformed descriptor it is. Telling them to rename an item in their
+	// layout would send them looking for a name that is not missing from
+	// anything they wrote.
+	//
+	// A node carrying *no names message at all* is the other descriptor this
+	// test used to collapse into that one, and it is not a fault: it is an item
+	// COBOL gave no data-name, which is a FILLER, and it is legal and common.
+	// Every caller that may meet one asks [anonymous] before it asks for an
+	// identifier — a FILLER has none — so what reaches here with an empty
+	// original really is the producer bug this refusal was written for. The
+	// exception is the record node, which is required to be named
+	// (internal/assemble/validate.go) and is refused by either half of this.
 	if original == "" {
 		return "", malformed(fmt.Sprintf("a %s node carries no name", kind),
 			"record, group and field nodes each carry the name the copybook spells; see docs/ir/SPEC.md, \"The node kinds\"")

--- a/cmd/cpybkc-gen-go/record.go
+++ b/cmd/cpybkc-gen-go/record.go
@@ -81,7 +81,7 @@ func records(d *irpb.Descriptor, opts options) (string, error) {
 			continue
 		}
 
-		name, err := identifier("record", record.GetNames())
+		name, err := recordName(record.GetNames())
 		if err != nil {
 			return "", err
 		}
@@ -367,7 +367,7 @@ func (e *emitter) flatten(id uint64, in string, seen map[uint64]struct{}) ([]uin
 		}
 
 		if inner.GetRepetition() != nil {
-			return nil, &fillerError{Kind: "group", In: in, Because: "repeats"}
+			return nil, &fillerError{Kind: "a group", In: in, Because: "repeats"}
 		}
 
 		// A group with no name that contains itself would otherwise be expanded
@@ -409,6 +409,38 @@ func (e *emitter) group(id uint64) (*irpb.Group, error) {
 	return group, nil
 }
 
+// recordName is [identifier] for a record node.
+//
+// A record is the one node kind docs/ir/SPEC.md requires to be named —
+// internal/assemble/validate.go's `names` demands an original on a record and
+// on nothing else — so a record carrying no names message is a malformed
+// descriptor rather than a FILLER, and this is where that is said. Everywhere
+// else, absence of a names message is an item COBOL named nothing and is
+// handled; see [identifier].
+func recordName(names *irpb.Names) (string, error) {
+	if anonymous(names) {
+		return "", malformed("a record node carries no name",
+			"a record node carries the name the copybook spells, and it is the one node kind that must; see docs/ir/SPEC.md, \"Names\"")
+	}
+
+	return identifier("record", names)
+}
+
+// groupName is what the copybook calls the group node id.
+//
+// It is the one thing a diagnostic about a FILLER has to go on — the item has
+// no name of its own — so it is read from the node rather than from wherever a
+// walk happened to have a name to hand, which is what keeps the same item
+// refused with the same words whichever file this generator was emitting.
+func (e *emitter) groupName(id uint64) (string, error) {
+	group, err := e.group(id)
+	if err != nil {
+		return "", err
+	}
+
+	return group.GetNames().GetOriginal(), nil
+}
+
 // anonymous is whether a node's names are those of an item COBOL gave no
 // data-name: no names message at all.
 //
@@ -441,7 +473,7 @@ func fillerRun(f *irpb.Field, in string) (uint32, error) {
 	case *irpb.Repetition_Constant:
 		return f.GetWidth() * count.Constant, nil
 	case *irpb.Repetition_Variable:
-		return 0, &fillerError{Kind: "item", In: in, Because: "occurs a number of times the record states"}
+		return 0, &fillerError{Kind: "an item", In: in, Because: "occurs a number of times the record states"}
 	default:
 		return 0, malformed("an item repeats and says nothing about how many times",
 			"a repetition carries a constant count or an OCCURS DEPENDING ON one; an item that does not repeat carries no repetition at all")
@@ -603,7 +635,7 @@ func namedArm(body *irpb.Node, in string) error {
 	}
 
 	return &fillerError{
-		Kind:    "item",
+		Kind:    "an item",
 		In:      in,
 		Because: "is one alternative of an alternation over a run of bytes, which this generator spells as a field per alternative",
 	}
@@ -1070,24 +1102,36 @@ func renameNote(names *irpb.Names) string {
 // from being a hole in the rest of this: a name that cannot become an exported
 // identifier is refused wherever it came from, and two names that arrive at one
 // identifier collide whether or not a rename put them there.
+// # The two descriptors this used to collapse
+//
+// `names.GetOriginal() == ""` is true of two different descriptors, and telling
+// them apart is this function's own job rather than a convention its callers are
+// trusted to observe:
+//
+//   - **No names message at all.** An item COBOL gave no data-name, which is a
+//     FILLER: legal, common, and generated rather than refused. A caller that
+//     may meet one asks [anonymous] first and never arrives here, so reaching
+//     this function with one is a bug in *this generator* — and it says so, in
+//     those words, rather than sending an adopter after a producer bug in an
+//     item they wrote correctly. That misdirection is the whole of what this
+//     story was opened about, and leaving it to an unenforced convention is how
+//     it would come back.
+//   - **A names message stating no original.** A node the copybook named and
+//     the descriptor did not, which is a bug in the producer and is reported as
+//     the malformed descriptor it is.
+//
+// A record node is required to be named (internal/assemble/validate.go) and so
+// is never asked for through here — [recordName] is its way in, and it turns
+// the first case back into the descriptor fault it is for that node kind.
 func identifier(kind string, names *irpb.Names) (string, error) {
+	if anonymous(names) {
+		return "", fmt.Errorf(
+			"a %s the copybook gives no data-name reached the part of %s that names things, which is a bug in %s rather than in the descriptor or in your copybook",
+			kind, pluginName, pluginName)
+	}
+
 	original := names.GetOriginal()
 
-	// A names message that is present and states no original is a node the
-	// copybook named and the descriptor did not, which is a bug in the producer
-	// rather than a name an adopter can do anything about, so it is reported as
-	// the malformed descriptor it is. Telling them to rename an item in their
-	// layout would send them looking for a name that is not missing from
-	// anything they wrote.
-	//
-	// A node carrying *no names message at all* is the other descriptor this
-	// test used to collapse into that one, and it is not a fault: it is an item
-	// COBOL gave no data-name, which is a FILLER, and it is legal and common.
-	// Every caller that may meet one asks [anonymous] before it asks for an
-	// identifier — a FILLER has none — so what reaches here with an empty
-	// original really is the producer bug this refusal was written for. The
-	// exception is the record node, which is required to be named
-	// (internal/assemble/validate.go) and is refused by either half of this.
 	if original == "" {
 		return "", malformed(fmt.Sprintf("a %s node carries no name", kind),
 			"record, group and field nodes each carry the name the copybook spells; see docs/ir/SPEC.md, \"The node kinds\"")

--- a/cmd/cpybkc-gen-go/record_test.go
+++ b/cmd/cpybkc-gen-go/record_test.go
@@ -236,43 +236,80 @@ func TestAFillerThatCannotBePlacedIsRefusedAndIsNotCalledMalformed(t *testing.T)
 	repeating := fillerItem(3, 4)
 	repeating.GetField().Repetition = depending(5, 0, 4)
 
-	for name, d := range map[string]*irpb.Descriptor{
+	// The group each refusal has to name is the innermost one the copybook
+	// *does* name, and it is asserted exactly. A test satisfied by any of the
+	// names in the descriptor would pass whichever part of this generator
+	// reached the item first, which is the same as not checking: the whole
+	// point of the message is that an adopter can go and search for the word in
+	// it.
+	for name, tc := range map[string]struct {
+		descriptor *irpb.Descriptor
+		in         string
+	}{
 		"a FILLER group that repeats": {
-			Version: supportedIRVersion,
-			Nodes: []*irpb.Node{
-				record(1, "ORDER-RECORD", 2),
-				group(2, "ORDER-RECORD", nil, 3),
-				repeated(fillerGroup(3, 4), constant(2)),
-				alphanumeric(4, "NOTE-CODE", 2),
+			in: "ORDER-RECORD",
+			descriptor: &irpb.Descriptor{
+				Version: supportedIRVersion,
+				Nodes: []*irpb.Node{
+					record(1, "ORDER-RECORD", 2),
+					group(2, "ORDER-RECORD", nil, 3),
+					repeated(fillerGroup(3, 4), constant(2)),
+					alphanumeric(4, "NOTE-CODE", 2),
+				},
 			},
 		},
 		"a FILLER item counted by another": {
-			Version: supportedIRVersion,
-			Nodes: []*irpb.Node{
-				record(1, "ORDER-RECORD", 2),
-				group(2, "ORDER-RECORD", nil, 5, 3),
-				repeating,
-				zoned(5, "NOTE-COUNT", 2, 2, 0, false),
+			in: "ORDER-RECORD",
+			descriptor: &irpb.Descriptor{
+				Version: supportedIRVersion,
+				Nodes: []*irpb.Node{
+					record(1, "ORDER-RECORD", 2),
+					group(2, "ORDER-RECORD", nil, 5, 3),
+					repeating,
+					zoned(5, "NOTE-COUNT", 2, 2, 0, false),
+				},
 			},
 		},
+		// The item is inside ENTRY and ENTRY is inside ORDER-RECORD, so this is
+		// the case that says which of the two the message names: the group the
+		// adopter would find the item under, not the record it is somewhere in.
 		"a FILLER standing as one alternative of an alternation": {
-			Version: supportedIRVersion,
-			Nodes: []*irpb.Node{
-				record(1, "ORDER-RECORD", 2),
-				group(2, "ORDER-RECORD", nil, 3),
-				group(3, "ENTRY", constant(2), 4, 5),
-				alphanumeric(4, "ENTRY-TYPE", 1),
-				variant(5, armOf(6, 7), armOf(8, 9)),
-				equals(6, 4, "\xc4"),
-				equals(8, 4, "\xe2"),
-				alphanumeric(7, "ENTRY-DETAIL", 4),
-				fillerItem(9, 4),
+			in: "ENTRY",
+			descriptor: &irpb.Descriptor{
+				Version: supportedIRVersion,
+				Nodes: []*irpb.Node{
+					record(1, "ORDER-RECORD", 2),
+					group(2, "ORDER-RECORD", nil, 3),
+					group(3, "ENTRY", constant(2), 4, 5),
+					alphanumeric(4, "ENTRY-TYPE", 1),
+					variant(5, armOf(6, 7), armOf(8, 9)),
+					equals(6, 4, "\xc4"),
+					equals(8, 4, "\xe2"),
+					alphanumeric(7, "ENTRY-DETAIL", 4),
+					fillerItem(9, 4),
+				},
+			},
+		},
+		// A FILLER inside a FILLER: the members of both are lifted to the one
+		// named level, so the group the refusal names is that level rather than
+		// either of the two anonymous ones between.
+		"a FILLER group that repeats inside another FILLER group": {
+			in: "ORDER-RECORD",
+			descriptor: &irpb.Descriptor{
+				Version: supportedIRVersion,
+				Nodes: []*irpb.Node{
+					record(1, "ORDER-RECORD", 2),
+					group(2, "ORDER-RECORD", nil, 3),
+					fillerGroup(3, 4),
+					repeated(fillerGroup(4, 5), constant(2)),
+					alphanumeric(5, "NOTE-CODE", 2),
+				},
 			},
 		},
 	} {
 		out := t.TempDir()
 
-		err := generate(d, out, options{packageName: goldenPackage})
+		err := generate(tc.descriptor, out, options{packageName: goldenPackage})
 
 		var refusal *fillerError
 		if !errors.As(err, &refusal) {
@@ -286,8 +323,14 @@ func TestAFillerThatCannotBePlacedIsRefusedAndIsNotCalledMalformed(t *testing.T)
 			t.Errorf("%s is reported as a malformed descriptor, and the descriptor says what docs/ir/SPEC.md admits", name)
 		}
 
-		if !strings.Contains(refusal.Error(), "ORDER-RECORD") && !strings.Contains(refusal.Error(), "ENTRY") {
-			t.Errorf("%s is refused as %q, which names nothing an adopter can go and look at", name, refusal.Error())
+		if refusal.In != tc.in {
+			t.Errorf("%s is refused in %q, want %q — the innermost group the copybook names", name, refusal.In, tc.in)
+		}
+
+		// "a item of ..." is what a hard-coded article produces, and this
+		// message is the one the whole story is about.
+		if !strings.HasPrefix(refusal.Error(), "a group ") && !strings.HasPrefix(refusal.Error(), "an item ") {
+			t.Errorf("%s reads %q, which opens with neither article", name, refusal.Error())
 		}
 
 		if entries, err := os.ReadDir(out); err != nil {
@@ -295,6 +338,195 @@ func TestAFillerThatCannotBePlacedIsRefusedAndIsNotCalledMalformed(t *testing.T)
 		} else if len(entries) != 0 {
 			t.Errorf("%s left %d files beneath --out, want none", name, len(entries))
 		}
+	}
+}
+
+// TestAFillerGroupInsideAFillerGroupIsFlattenedToTheNamedLevel is the recursive
+// half of the flattening rule, and the one that says what "the enclosing level"
+// means when there is more than one anonymous level to skip.
+//
+// COBOL qualification skips *every* unnamed group between an item and the name
+// it is qualified by, so two levels of FILLER lift a member exactly as far as
+// one does. The struct is the assertion: NOTE-CODE is a field of the record and
+// there is no intermediate type between them.
+func TestAFillerGroupInsideAFillerGroupIsFlattenedToTheNamedLevel(t *testing.T) {
+	t.Parallel()
+
+	d := &irpb.Descriptor{
+		Version: supportedIRVersion,
+		Nodes: []*irpb.Node{
+			record(1, "ORDER-RECORD", 2),
+			group(2, "ORDER-RECORD", nil, 3, 7),
+			fillerGroup(3, 4),
+			fillerGroup(4, 5, 6),
+			alphanumeric(5, "NOTE-CODE", 2),
+			fillerItem(6, 3),
+			alphanumeric(7, "ORDER-ID", 4),
+		},
+	}
+
+	out := t.TempDir()
+
+	if err := generate(d, out, options{packageName: goldenPackage}); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	source := written(t, out)[recordsFile]
+
+	// Both members reach the record's own struct, in record order, and the
+	// FILLER two levels down contributes to the record's own run.
+	for _, want := range []string{"NoteCode string", "OrderId string", fillerField + " [1][]byte"} {
+		if !strings.Contains(source, want) {
+			t.Errorf("%s does not contain %q", recordsFile, want)
+		}
+	}
+
+	// One struct: the record's. An anonymous group that produced a type of its
+	// own would be a type named after an item the copybook did not name.
+	if got := strings.Count(source, "struct {"); got != 1 {
+		t.Errorf("%s declares %d struct types, want 1", recordsFile, got)
+	}
+}
+
+// TestAnUnnamedGroupThatContainsItselfIsRefused is the cycle the flattening
+// walk can meet before any other guard does.
+//
+// An unnamed group is expanded in place, so one containing itself would be
+// expanded for ever — and it would do so before the containment guard over
+// struct types is reached, because no struct is emitted for it.
+func TestAnUnnamedGroupThatContainsItselfIsRefused(t *testing.T) {
+	t.Parallel()
+
+	d := &irpb.Descriptor{
+		Version: supportedIRVersion,
+		Nodes: []*irpb.Node{
+			record(1, "ORDER-RECORD", 2),
+			group(2, "ORDER-RECORD", nil, 3),
+			fillerGroup(3, 4),
+			fillerGroup(4, 3),
+		},
+	}
+
+	var refusal *malformedError
+	if err := generate(d, t.TempDir(), options{packageName: goldenPackage}); !errors.As(err, &refusal) {
+		t.Fatalf("a FILLER group containing itself generated %v, want a malformed descriptor", err)
+	}
+}
+
+// TestAMemberLiftedOutOfAFillerGroupCollidesLikeAnyOther is the cost of
+// flattening, and the thing that has to be reported rather than resolved.
+//
+// Lifting a FILLER group's members into the enclosing struct can bring two
+// names to one Go identifier that the copybook keeps at two levels. COBOL is
+// content — the two are qualified differently there — and Go is not, so it is
+// refused with the same diagnostic every other collision gets, naming both
+// items.
+func TestAMemberLiftedOutOfAFillerGroupCollidesLikeAnyOther(t *testing.T) {
+	t.Parallel()
+
+	d := &irpb.Descriptor{
+		Version: supportedIRVersion,
+		Nodes: []*irpb.Node{
+			record(1, "ORDER-RECORD", 2),
+			group(2, "ORDER-RECORD", nil, 3, 4),
+			alphanumeric(3, "NOTE-CODE", 2),
+			fillerGroup(4, 5),
+			alphanumeric(5, "NOTE_CODE", 2),
+		},
+	}
+
+	err := generate(d, t.TempDir(), options{packageName: goldenPackage})
+
+	var collision *collisionError
+	if !errors.As(err, &collision) {
+		t.Fatalf("two names lifted to one level generated %v, want a collision", err)
+	}
+
+	for _, want := range []string{"NOTE-CODE", "NOTE_CODE", "NoteCode"} {
+		if !strings.Contains(collision.Error(), want) {
+			t.Errorf("the collision reads %q and never names %s", collision.Error(), want)
+		}
+	}
+}
+
+// TestAFillerAloneDeclaresTheZeroFillItsWriterNeeds is the copybook this story
+// is actually about: one with FILLER in it and no slack anywhere.
+//
+// Every golden package that carries a FILLER also carries a slack node, so the
+// helper a writer emits zero bytes from is already declared in each of them for
+// another reason. A record whose only retained run is a FILLER has to declare
+// it on its own account, and it has to be wide enough for that run.
+func TestAFillerAloneDeclaresTheZeroFillItsWriterNeeds(t *testing.T) {
+	t.Parallel()
+
+	d := &irpb.Descriptor{
+		Version: supportedIRVersion,
+		Nodes: []*irpb.Node{
+			record(1, "ORDER-RECORD", 2),
+			group(2, "ORDER-RECORD", nil, 3, 4),
+			alphanumeric(3, "ORDER-ID", 4),
+			fillerItem(4, 6),
+		},
+	}
+
+	out := t.TempDir()
+
+	if err := generate(d, out, options{packageName: goldenPackage}); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	if source := written(t, out)[codecFile]; !strings.Contains(source, "var zeroFill = make([]byte, 6)") {
+		t.Errorf("a record whose only retained run is a FILLER of 6 bytes declares no zeroFill wide enough for it:\n%s", source)
+	}
+}
+
+// TestAFillerInsideAnArmOfAnAlternationIsRetainedLikeAnyOther is the last place
+// a FILLER can stand that the golden does not reach: inside the body of one arm
+// of a variant.
+//
+// An arm's body is a group like any other, so its struct is emitted by the same
+// walk and its FILLER is retained in that struct's own run — per arm, and per
+// occurrence of the table the variant is in.
+func TestAFillerInsideAnArmOfAnAlternationIsRetainedLikeAnyOther(t *testing.T) {
+	t.Parallel()
+
+	d := &irpb.Descriptor{
+		Version: supportedIRVersion,
+		Nodes: []*irpb.Node{
+			record(1, "ENTRY-RECORD", 2),
+			group(2, "ENTRY-RECORD", nil, 3),
+			group(3, "ENTRY", constant(2), 4, 5),
+			alphanumeric(4, "ENTRY-TYPE", 1),
+			variant(5, armOf(6, 8), armOf(7, 10)),
+			equals(6, 4, "\xc4"),
+			equals(7, 4, "\xe2"),
+			group(8, "ENTRY-DETAIL", nil, 9, 12),
+			alphanumeric(9, "DETAIL-SKU", 4),
+			group(10, "ENTRY-SUMMARY", nil, 11),
+			alphanumeric(11, "SUMMARY-TEXT", 6),
+			fillerItem(12, 2),
+		},
+	}
+
+	out := t.TempDir()
+
+	if err := generate(d, out, options{packageName: goldenPackage}); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	// The run belongs to the arm's own struct, so it is declared inside the
+	// arm and the record itself carries none.
+	source := written(t, out)[recordsFile]
+
+	if got := strings.Count(source, fillerField+" [1][]byte"); got != 1 {
+		t.Errorf("%s declares %d FILLER runs, want 1 — the one in the arm that carries it", recordsFile, got)
+	}
+
+	// And the two arms still cover the same bytes, which is what says the
+	// FILLER was counted into the width of the arm holding it.
+	codec := written(t, out)[codecFile]
+	if !strings.Contains(codec, "ReadBytes(7)") {
+		t.Errorf("%s reads an occurrence of ENTRY that is not 7 bytes wide:\n%s", codecFile, codec)
 	}
 }
 
@@ -1052,7 +1284,7 @@ func ordersDescriptor() *irpb.Descriptor {
 			alphanumeric(13, "CUSTOMER-NAME", 20),
 			slack(14, 2),
 			packed(15, "ORDER-TOTAL", 4, 7, 2, true),
-			group(16, "LINE-ITEM", constant(3), 17, 18, 19),
+			group(16, "LINE-ITEM", constant(3), 17, 18, 19, 26),
 			alphanumeric(17, "SKU", 8),
 			binary(18, "QUANTITY", 2, 4, true),
 			slack(19, 1),
@@ -1070,6 +1302,11 @@ func ordersDescriptor() *irpb.Descriptor {
 			group(23, "DETAIL", depending(22, 0, 12), 24),
 			alphanumeric(24, "DETAIL-TEXT", 10),
 			alphanumeric(25, "NOTE-CODE", 2),
+
+			// A FILLER inside a group that repeats, which is what says the
+			// retained run is per occurrence: LINE-ITEM's struct is the
+			// element type, so each of the three elements holds its own.
+			fillerItem(26, 1),
 
 			record(30, "TRAILER-RECORD", 31),
 			group(31, "TRAILER-RECORD", nil, 32, 33, 34, 35),

--- a/cmd/cpybkc-gen-go/record_test.go
+++ b/cmd/cpybkc-gen-go/record_test.go
@@ -136,6 +136,168 @@ func TestARecordCarryingSlackHoldsARunForEveryNodeOfIt(t *testing.T) {
 	}
 }
 
+// TestAFillerIsGeneratedRatherThanRefused is the case that makes the difference
+// between this generator working on real copybooks and not.
+//
+// COBOL's FILLER has no data-name, so a producer emits no names message for it
+// (internal/assemble/assemble.go's `names`), and FILLER is in most copybooks
+// anybody actually has. Refusing it refused the whole package over an item
+// nobody was looking at — and refused it as a *malformed descriptor*, which is
+// what docs/ir/SPEC.md's "Names" says it is not.
+//
+// The two halves are different decisions and are asserted separately. An
+// elementary FILLER has no value anybody named, so it gets no exported field
+// and its bytes are retained beside the slack. A FILLER *group* holds members
+// the copybook does name, which is the case a run of retained bytes could not
+// stand in for, so its members are reached at the enclosing level — which is
+// where COBOL's own qualification reaches them.
+func TestAFillerIsGeneratedRatherThanRefused(t *testing.T) {
+	t.Parallel()
+
+	source := written(t, goldenDir)[recordsFile]
+
+	// The FILLER item's bytes, retained beside ORDER-RECORD's slack rather than
+	// in it: a slack node and a FILLER are two different facts about a record.
+	if !strings.Contains(source, fillerField+" [1][]byte") {
+		t.Errorf("%s declares no run for the FILLER of ORDER-RECORD", recordsFile)
+	}
+
+	// The FILLER group's member, at the level COBOL qualifies it at.
+	for _, want := range []string{"NoteCode string", "// NoteCode is NOTE-CODE"} {
+		if !strings.Contains(source, want) {
+			t.Errorf("%s does not contain %q, and NOTE-CODE is a member of a FILLER group", recordsFile, want)
+		}
+	}
+
+	// Nothing is *named* after an item the copybook did not name. A positional
+	// name would be an identifier no copybook spells and one that moves the
+	// moment an unrelated item is inserted ahead of it. Munging produces
+	// exported identifiers, so `Filler` in any form is one — the word appears
+	// in the retained run's doc comment as COBOL spells it and nowhere else.
+	if strings.Contains(source, "Filler") {
+		t.Errorf("%s declares an identifier munged from FILLER, which no copybook and no layout named", recordsFile)
+	}
+}
+
+// TestAnItemCarryingNoNameIsRefused is the other half of the FILLER rule, and
+// the descriptor the refusal was written for.
+//
+// A names message that is *present* and states no original is not an unnamed
+// item: it is a named one whose name went missing, which is a bug in the
+// producer and reads correctly as one. The two used to be the same test —
+// `names.GetOriginal() == ""` is true of both — and collapsing them is what
+// refused every copybook with a FILLER in it.
+func TestAnItemCarryingNoNameIsRefused(t *testing.T) {
+	t.Parallel()
+
+	for name, node := range map[string]*irpb.Node{
+		"a field": {Id: 3, Kind: &irpb.Node_Field{Field: &irpb.Field{
+			Width: 4, Encoding: resolvedEncoding(), Usage: irpb.Usage_USAGE_DISPLAY,
+			Picture: &irpb.Picture{Category: irpb.Category_CATEGORY_ALPHANUMERIC},
+			Names:   &irpb.Names{},
+		}}},
+		"a group": {Id: 3, Kind: &irpb.Node_Group{Group: &irpb.Group{
+			MemberIds: []uint64{4}, Names: &irpb.Names{},
+		}}},
+	} {
+		d := &irpb.Descriptor{
+			Version: supportedIRVersion,
+			Nodes: []*irpb.Node{
+				record(1, "ORDER-RECORD", 2),
+				group(2, "ORDER-RECORD", nil, 3),
+				node,
+				alphanumeric(4, "NOTE-CODE", 2),
+			},
+		}
+
+		err := generate(d, t.TempDir(), options{packageName: goldenPackage})
+
+		var refusal *malformedError
+		if !errors.As(err, &refusal) {
+			t.Errorf("%s carrying a names message that states no name generated %v, want a malformed descriptor", name, err)
+		}
+	}
+}
+
+// TestAFillerThatCannotBePlacedIsRefusedAndIsNotCalledMalformed is the third
+// shape a FILLER takes, where there is an honest refusal rather than a
+// generated answer.
+//
+// A FILLER that repeats has no name for its occurrences to differ by, and one
+// standing as an alternative of an alternation has no name to say it is the one
+// an occurrence holds. Each is refused — and refused as the copybook item it is,
+// naming what contains it, rather than as a malformed descriptor. The
+// descriptor is exactly what docs/ir/SPEC.md admits, and telling an adopter to
+// go and find a producer bug over an item they wrote correctly is the
+// misdirection this whole story is about.
+func TestAFillerThatCannotBePlacedIsRefusedAndIsNotCalledMalformed(t *testing.T) {
+	t.Parallel()
+
+	repeating := fillerItem(3, 4)
+	repeating.GetField().Repetition = depending(5, 0, 4)
+
+	for name, d := range map[string]*irpb.Descriptor{
+		"a FILLER group that repeats": {
+			Version: supportedIRVersion,
+			Nodes: []*irpb.Node{
+				record(1, "ORDER-RECORD", 2),
+				group(2, "ORDER-RECORD", nil, 3),
+				repeated(fillerGroup(3, 4), constant(2)),
+				alphanumeric(4, "NOTE-CODE", 2),
+			},
+		},
+		"a FILLER item counted by another": {
+			Version: supportedIRVersion,
+			Nodes: []*irpb.Node{
+				record(1, "ORDER-RECORD", 2),
+				group(2, "ORDER-RECORD", nil, 5, 3),
+				repeating,
+				zoned(5, "NOTE-COUNT", 2, 2, 0, false),
+			},
+		},
+		"a FILLER standing as one alternative of an alternation": {
+			Version: supportedIRVersion,
+			Nodes: []*irpb.Node{
+				record(1, "ORDER-RECORD", 2),
+				group(2, "ORDER-RECORD", nil, 3),
+				group(3, "ENTRY", constant(2), 4, 5),
+				alphanumeric(4, "ENTRY-TYPE", 1),
+				variant(5, armOf(6, 7), armOf(8, 9)),
+				equals(6, 4, "\xc4"),
+				equals(8, 4, "\xe2"),
+				alphanumeric(7, "ENTRY-DETAIL", 4),
+				fillerItem(9, 4),
+			},
+		},
+	} {
+		out := t.TempDir()
+
+		err := generate(d, out, options{packageName: goldenPackage})
+
+		var refusal *fillerError
+		if !errors.As(err, &refusal) {
+			t.Errorf("%s generated %v, want a refusal naming the item", name, err)
+
+			continue
+		}
+
+		var wrong *malformedError
+		if errors.As(err, &wrong) {
+			t.Errorf("%s is reported as a malformed descriptor, and the descriptor says what docs/ir/SPEC.md admits", name)
+		}
+
+		if !strings.Contains(refusal.Error(), "ORDER-RECORD") && !strings.Contains(refusal.Error(), "ENTRY") {
+			t.Errorf("%s is refused as %q, which names nothing an adopter can go and look at", name, refusal.Error())
+		}
+
+		if entries, err := os.ReadDir(out); err != nil {
+			t.Fatalf("reading the output directory: %v", err)
+		} else if len(entries) != 0 {
+			t.Errorf("%s left %d files beneath --out, want none", name, len(entries))
+		}
+	}
+}
+
 // TestADescriptorCarryingNoRecordWritesOnlyTheDocFile keeps the record file
 // something a descriptor produced rather than something this generator always
 // writes. A file holding a package clause and no declaration says nothing
@@ -885,7 +1047,7 @@ func ordersDescriptor() *irpb.Descriptor {
 			admits(94, 30, 7),
 
 			record(10, "ORDER-RECORD", 11),
-			group(11, "ORDER-RECORD", nil, 12, 13, 14, 15, 16, 22, 23),
+			group(11, "ORDER-RECORD", nil, 12, 13, 14, 15, 16, 20, 21, 22, 23),
 			renamed(zoned(12, "ORDER-ID", 5, 5, 0, false), "OrderID"),
 			alphanumeric(13, "CUSTOMER-NAME", 20),
 			slack(14, 2),
@@ -894,9 +1056,20 @@ func ordersDescriptor() *irpb.Descriptor {
 			alphanumeric(17, "SKU", 8),
 			binary(18, "QUANTITY", 2, 4, true),
 			slack(19, 1),
+
+			// The two shapes an item COBOL gives no data-name takes. The first
+			// is a FILLER item, which gets no field and whose bytes are
+			// retained; the second is a FILLER group, which cannot be retained
+			// as bytes because it holds a member the copybook does name — and
+			// that member is reached at this level, exactly as COBOL's own
+			// qualification reaches it.
+			fillerItem(20, 4),
+			fillerGroup(21, 25),
+
 			zoned(22, "DETAIL-COUNT", 3, 3, 0, false),
 			group(23, "DETAIL", depending(22, 0, 12), 24),
 			alphanumeric(24, "DETAIL-TEXT", 10),
+			alphanumeric(25, "NOTE-CODE", 2),
 
 			record(30, "TRAILER-RECORD", 31),
 			group(31, "TRAILER-RECORD", nil, 32, 33, 34, 35),
@@ -992,6 +1165,32 @@ func group(id uint64, name string, rep *irpb.Repetition, members ...uint64) *irp
 	return &irpb.Node{Id: id, Kind: &irpb.Node_Group{Group: &irpb.Group{
 		MemberIds: members, Names: &irpb.Names{Original: name}, Repetition: rep,
 	}}}
+}
+
+// fillerItem and fillerGroup are an elementary item and a group COBOL gave no
+// data-name: a FILLER, and a FILLER group.
+//
+// Neither carries a names message at all, which is what a producer emits for
+// one — internal/assemble/assemble.go's `names` returns nil for a FILLER, and
+// docs/ir/SPEC.md's "Names" says what a *named* node carries rather than that
+// every node is named. That is the descriptor this generator has to make a
+// decision about, and it is a legal one.
+func fillerItem(id uint64, width uint32) *irpb.Node {
+	return &irpb.Node{Id: id, Kind: &irpb.Node_Field{Field: &irpb.Field{
+		Width: width, Encoding: resolvedEncoding(), Usage: irpb.Usage_USAGE_DISPLAY,
+		Picture: &irpb.Picture{Category: irpb.Category_CATEGORY_ALPHANUMERIC},
+	}}}
+}
+
+func fillerGroup(id uint64, members ...uint64) *irpb.Node {
+	return &irpb.Node{Id: id, Kind: &irpb.Node_Group{Group: &irpb.Group{MemberIds: members}}}
+}
+
+// repeated is a group node that occurs that many times.
+func repeated(node *irpb.Node, rep *irpb.Repetition) *irpb.Node {
+	node.GetGroup().Repetition = rep
+
+	return node
 }
 
 // slack is a slack node of that many bytes.

--- a/example/graph/graph.md
+++ b/example/graph/graph.md
@@ -173,4 +173,4 @@ Each record's items, in containment order, beginning at the first byte of the re
 | 0 | 2 | TRL-TYPE | DISPLAY | X(2) | always |
 | 2 | 6 | TRL-COUNT | DISPLAY | 9(6) | always |
 | 8 | 8 | TRL-NET | PACKED-DECIMAL | S9(13)V9(2) | always |
-| 16 | 8 | TRL-FILLER | DISPLAY | X(8) | always |
+| 16 | 8 | *filler* | DISPLAY | X(8) | always |

--- a/example/ledger/codec.go
+++ b/example/ledger/codec.go
@@ -51,20 +51,24 @@ var (
 	_ codec.Marshaler   = (*MemoPostingRef)(nil)
 )
 
-// zeroFill is what a writer emits for a slack node of a record its caller built
-// rather than read: zero bytes, 4 of them at the most, sliced to the node's own
-// width.
+// zeroFill is what a writer emits for a slack node — or for an item the copybook
+// gives no data-name — of a record its caller built rather than read: zero
+// bytes, 8 of them at the most, sliced to the run's own width.
 //
-// Zero rather than a space, because charset is a property of a field and slack
-// is not a field, so there is no charset to resolve a space against and zero is
-// the byte that names none. Those bytes were never in a file, so nothing is
-// being overwritten — a record that was read carries the bytes it was read
-// from and they are emitted instead. See docs/ir/SPEC.md, "What the descriptor
-// determines, a writer supplies".
-var zeroFill = make([]byte, 4)
+// Zero rather than a space. Charset is a property of a field and slack is not a
+// field, so there is no charset to resolve a space against and zero is the byte
+// that names none. A FILLER is a field and does have one, and it gets the same
+// answer for a different reason: its value is nobody's — no program names it
+// and nothing outside this package can set it — so filling it with spaces would
+// be choosing a value on behalf of a caller who never had one to give. Those
+// bytes were never in a file, so nothing is being overwritten — a record that
+// was read carries the bytes it was read from and they are emitted instead. See
+// docs/ir/SPEC.md, "What the descriptor determines, a writer supplies".
+var zeroFill = make([]byte, 8)
 
 // UnmarshalCOBOL reads one LEDGER-HEADER out of r, in the order docs/ir/SPEC.md
-// resolved its items, and retains the bytes of every slack node it carries.
+// resolved its items, and retains the bytes of every slack node it carries and
+// of every item the copybook gives no data-name.
 //
 // It is codec's Unmarshaler. The Encoding is r's: the four axes are properties
 // of the file in hand, and Encoding is what this descriptor resolved.
@@ -95,15 +99,16 @@ func (p *LedgerHeader) UnmarshalCOBOL(r *codec.Reader) error {
 }
 
 // MarshalCOBOL writes this LEDGER-HEADER into w, in the order docs/ir/SPEC.md
-// resolved its items, emitting the bytes retained for every slack node it
-// carries and zero bytes for a slack node it does not.
+// resolved its items, emitting the bytes retained for every slack node and
+// every unnamed item it carries, and zero bytes for one it does not.
 //
 // It is codec's Marshaler. Two values are the descriptor's rather than the
 // caller's and are supplied rather than taken from the record: an OCCURS
 // DEPENDING ON count is emitted as the number of occurrences written, and
-// slack is emitted as what was retained for it. Everything else is the
-// caller's, including the value a discriminator tests — a writer evaluates a
-// predicate and never inverts one.
+// slack — and the bytes of an item the copybook gives no data-name — is
+// emitted as what was retained for it. Everything else is the caller's,
+// including the value a discriminator tests — a writer evaluates a predicate
+// and never inverts one.
 func (p *LedgerHeader) MarshalCOBOL(w *codec.Writer) error {
 	var err error
 
@@ -131,7 +136,8 @@ func (p *LedgerHeader) MarshalCOBOL(w *codec.Writer) error {
 }
 
 // UnmarshalCOBOL reads one LEDGER-TRAILER out of r, in the order docs/ir/SPEC.md
-// resolved its items, and retains the bytes of every slack node it carries.
+// resolved its items, and retains the bytes of every slack node it carries and
+// of every item the copybook gives no data-name.
 //
 // It is codec's Unmarshaler. The Encoding is r's: the four axes are properties
 // of the file in hand, and Encoding is what this descriptor resolved.
@@ -150,23 +156,24 @@ func (p *LedgerTrailer) UnmarshalCOBOL(r *codec.Reader) error {
 		return fmt.Errorf("LEDGER-TRAILER: reading TRL-NET: %w", err)
 	}
 
-	if p.TrlFiller, err = r.ReadAlphanumeric(8); err != nil {
-		return fmt.Errorf("LEDGER-TRAILER: reading TRL-FILLER: %w", err)
+	if p.filler[0], err = r.ReadBytes(8); err != nil {
+		return fmt.Errorf("LEDGER-TRAILER: reading the 8 bytes of an item the copybook gives no data-name: %w", err)
 	}
 
 	return nil
 }
 
 // MarshalCOBOL writes this LEDGER-TRAILER into w, in the order docs/ir/SPEC.md
-// resolved its items, emitting the bytes retained for every slack node it
-// carries and zero bytes for a slack node it does not.
+// resolved its items, emitting the bytes retained for every slack node and
+// every unnamed item it carries, and zero bytes for one it does not.
 //
 // It is codec's Marshaler. Two values are the descriptor's rather than the
 // caller's and are supplied rather than taken from the record: an OCCURS
 // DEPENDING ON count is emitted as the number of occurrences written, and
-// slack is emitted as what was retained for it. Everything else is the
-// caller's, including the value a discriminator tests — a writer evaluates a
-// predicate and never inverts one.
+// slack — and the bytes of an item the copybook gives no data-name — is
+// emitted as what was retained for it. Everything else is the caller's,
+// including the value a discriminator tests — a writer evaluates a predicate
+// and never inverts one.
 func (p *LedgerTrailer) MarshalCOBOL(w *codec.Writer) error {
 	var err error
 
@@ -182,15 +189,25 @@ func (p *LedgerTrailer) MarshalCOBOL(w *codec.Writer) error {
 		return fmt.Errorf("LEDGER-TRAILER: writing TRL-NET: %w", err)
 	}
 
-	if err = w.WriteAlphanumeric(p.TrlFiller, 8); err != nil {
-		return fmt.Errorf("LEDGER-TRAILER: writing TRL-FILLER: %w", err)
+	switch {
+	case p.filler[0] == nil:
+		if err = w.WriteBytes(zeroFill[:8]); err != nil {
+			return fmt.Errorf("LEDGER-TRAILER: writing 8 zero bytes for an item the copybook gives no data-name and this record carries none for: %w", err)
+		}
+	case len(p.filler[0]) != 8:
+		return fmt.Errorf("LEDGER-TRAILER: a writer reports a retained run rather than truncating or padding it, and the run for an item of 8 bytes the copybook gives no data-name is %d", len(p.filler[0]))
+	default:
+		if err = w.WriteBytes(p.filler[0]); err != nil {
+			return fmt.Errorf("LEDGER-TRAILER: writing the 8 bytes of an item the copybook gives no data-name: %w", err)
+		}
 	}
 
 	return nil
 }
 
 // UnmarshalCOBOL reads one POSTING-RECORD out of r, in the order docs/ir/SPEC.md
-// resolved its items, and retains the bytes of every slack node it carries.
+// resolved its items, and retains the bytes of every slack node it carries and
+// of every item the copybook gives no data-name.
 //
 // It is codec's Unmarshaler. The Encoding is r's: the four axes are properties
 // of the file in hand, and Encoding is what this descriptor resolved.
@@ -229,15 +246,16 @@ func (p *DebitPosting) UnmarshalCOBOL(r *codec.Reader) error {
 }
 
 // MarshalCOBOL writes this POSTING-RECORD into w, in the order docs/ir/SPEC.md
-// resolved its items, emitting the bytes retained for every slack node it
-// carries and zero bytes for a slack node it does not.
+// resolved its items, emitting the bytes retained for every slack node and
+// every unnamed item it carries, and zero bytes for one it does not.
 //
 // It is codec's Marshaler. Two values are the descriptor's rather than the
 // caller's and are supplied rather than taken from the record: an OCCURS
 // DEPENDING ON count is emitted as the number of occurrences written, and
-// slack is emitted as what was retained for it. Everything else is the
-// caller's, including the value a discriminator tests — a writer evaluates a
-// predicate and never inverts one.
+// slack — and the bytes of an item the copybook gives no data-name — is
+// emitted as what was retained for it. Everything else is the caller's,
+// including the value a discriminator tests — a writer evaluates a predicate
+// and never inverts one.
 func (p *DebitPosting) MarshalCOBOL(w *codec.Writer) error {
 	var err error
 
@@ -273,7 +291,8 @@ func (p *DebitPosting) MarshalCOBOL(w *codec.Writer) error {
 }
 
 // UnmarshalCOBOL reads one POSTING-RECORD out of r, in the order docs/ir/SPEC.md
-// resolved its items, and retains the bytes of every slack node it carries.
+// resolved its items, and retains the bytes of every slack node it carries and
+// of every item the copybook gives no data-name.
 //
 // It is codec's Unmarshaler. The Encoding is r's: the four axes are properties
 // of the file in hand, and Encoding is what this descriptor resolved.
@@ -316,15 +335,16 @@ func (p *DebitPostingRef) UnmarshalCOBOL(r *codec.Reader) error {
 }
 
 // MarshalCOBOL writes this POSTING-RECORD into w, in the order docs/ir/SPEC.md
-// resolved its items, emitting the bytes retained for every slack node it
-// carries and zero bytes for a slack node it does not.
+// resolved its items, emitting the bytes retained for every slack node and
+// every unnamed item it carries, and zero bytes for one it does not.
 //
 // It is codec's Marshaler. Two values are the descriptor's rather than the
 // caller's and are supplied rather than taken from the record: an OCCURS
 // DEPENDING ON count is emitted as the number of occurrences written, and
-// slack is emitted as what was retained for it. Everything else is the
-// caller's, including the value a discriminator tests — a writer evaluates a
-// predicate and never inverts one.
+// slack — and the bytes of an item the copybook gives no data-name — is
+// emitted as what was retained for it. Everything else is the caller's,
+// including the value a discriminator tests — a writer evaluates a predicate
+// and never inverts one.
 func (p *DebitPostingRef) MarshalCOBOL(w *codec.Writer) error {
 	var err error
 
@@ -364,7 +384,8 @@ func (p *DebitPostingRef) MarshalCOBOL(w *codec.Writer) error {
 }
 
 // UnmarshalCOBOL reads one POSTING-RECORD out of r, in the order docs/ir/SPEC.md
-// resolved its items, and retains the bytes of every slack node it carries.
+// resolved its items, and retains the bytes of every slack node it carries and
+// of every item the copybook gives no data-name.
 //
 // It is codec's Unmarshaler. The Encoding is r's: the four axes are properties
 // of the file in hand, and Encoding is what this descriptor resolved.
@@ -407,15 +428,16 @@ func (p *CreditPosting) UnmarshalCOBOL(r *codec.Reader) error {
 }
 
 // MarshalCOBOL writes this POSTING-RECORD into w, in the order docs/ir/SPEC.md
-// resolved its items, emitting the bytes retained for every slack node it
-// carries and zero bytes for a slack node it does not.
+// resolved its items, emitting the bytes retained for every slack node and
+// every unnamed item it carries, and zero bytes for one it does not.
 //
 // It is codec's Marshaler. Two values are the descriptor's rather than the
 // caller's and are supplied rather than taken from the record: an OCCURS
 // DEPENDING ON count is emitted as the number of occurrences written, and
-// slack is emitted as what was retained for it. Everything else is the
-// caller's, including the value a discriminator tests — a writer evaluates a
-// predicate and never inverts one.
+// slack — and the bytes of an item the copybook gives no data-name — is
+// emitted as what was retained for it. Everything else is the caller's,
+// including the value a discriminator tests — a writer evaluates a predicate
+// and never inverts one.
 func (p *CreditPosting) MarshalCOBOL(w *codec.Writer) error {
 	var err error
 
@@ -464,7 +486,8 @@ func (p *CreditPosting) MarshalCOBOL(w *codec.Writer) error {
 }
 
 // UnmarshalCOBOL reads one POSTING-RECORD out of r, in the order docs/ir/SPEC.md
-// resolved its items, and retains the bytes of every slack node it carries.
+// resolved its items, and retains the bytes of every slack node it carries and
+// of every item the copybook gives no data-name.
 //
 // It is codec's Unmarshaler. The Encoding is r's: the four axes are properties
 // of the file in hand, and Encoding is what this descriptor resolved.
@@ -511,15 +534,16 @@ func (p *CreditPostingRef) UnmarshalCOBOL(r *codec.Reader) error {
 }
 
 // MarshalCOBOL writes this POSTING-RECORD into w, in the order docs/ir/SPEC.md
-// resolved its items, emitting the bytes retained for every slack node it
-// carries and zero bytes for a slack node it does not.
+// resolved its items, emitting the bytes retained for every slack node and
+// every unnamed item it carries, and zero bytes for one it does not.
 //
 // It is codec's Marshaler. Two values are the descriptor's rather than the
 // caller's and are supplied rather than taken from the record: an OCCURS
 // DEPENDING ON count is emitted as the number of occurrences written, and
-// slack is emitted as what was retained for it. Everything else is the
-// caller's, including the value a discriminator tests — a writer evaluates a
-// predicate and never inverts one.
+// slack — and the bytes of an item the copybook gives no data-name — is
+// emitted as what was retained for it. Everything else is the caller's,
+// including the value a discriminator tests — a writer evaluates a predicate
+// and never inverts one.
 func (p *CreditPostingRef) MarshalCOBOL(w *codec.Writer) error {
 	var err error
 
@@ -572,7 +596,8 @@ func (p *CreditPostingRef) MarshalCOBOL(w *codec.Writer) error {
 }
 
 // UnmarshalCOBOL reads one POSTING-RECORD out of r, in the order docs/ir/SPEC.md
-// resolved its items, and retains the bytes of every slack node it carries.
+// resolved its items, and retains the bytes of every slack node it carries and
+// of every item the copybook gives no data-name.
 //
 // It is codec's Unmarshaler. The Encoding is r's: the four axes are properties
 // of the file in hand, and Encoding is what this descriptor resolved.
@@ -603,15 +628,16 @@ func (p *MemoPosting) UnmarshalCOBOL(r *codec.Reader) error {
 }
 
 // MarshalCOBOL writes this POSTING-RECORD into w, in the order docs/ir/SPEC.md
-// resolved its items, emitting the bytes retained for every slack node it
-// carries and zero bytes for a slack node it does not.
+// resolved its items, emitting the bytes retained for every slack node and
+// every unnamed item it carries, and zero bytes for one it does not.
 //
 // It is codec's Marshaler. Two values are the descriptor's rather than the
 // caller's and are supplied rather than taken from the record: an OCCURS
 // DEPENDING ON count is emitted as the number of occurrences written, and
-// slack is emitted as what was retained for it. Everything else is the
-// caller's, including the value a discriminator tests — a writer evaluates a
-// predicate and never inverts one.
+// slack — and the bytes of an item the copybook gives no data-name — is
+// emitted as what was retained for it. Everything else is the caller's,
+// including the value a discriminator tests — a writer evaluates a predicate
+// and never inverts one.
 func (p *MemoPosting) MarshalCOBOL(w *codec.Writer) error {
 	var err error
 
@@ -639,7 +665,8 @@ func (p *MemoPosting) MarshalCOBOL(w *codec.Writer) error {
 }
 
 // UnmarshalCOBOL reads one POSTING-RECORD out of r, in the order docs/ir/SPEC.md
-// resolved its items, and retains the bytes of every slack node it carries.
+// resolved its items, and retains the bytes of every slack node it carries and
+// of every item the copybook gives no data-name.
 //
 // It is codec's Unmarshaler. The Encoding is r's: the four axes are properties
 // of the file in hand, and Encoding is what this descriptor resolved.
@@ -674,15 +701,16 @@ func (p *MemoPostingRef) UnmarshalCOBOL(r *codec.Reader) error {
 }
 
 // MarshalCOBOL writes this POSTING-RECORD into w, in the order docs/ir/SPEC.md
-// resolved its items, emitting the bytes retained for every slack node it
-// carries and zero bytes for a slack node it does not.
+// resolved its items, emitting the bytes retained for every slack node and
+// every unnamed item it carries, and zero bytes for one it does not.
 //
 // It is codec's Marshaler. Two values are the descriptor's rather than the
 // caller's and are supplied rather than taken from the record: an OCCURS
 // DEPENDING ON count is emitted as the number of occurrences written, and
-// slack is emitted as what was retained for it. Everything else is the
-// caller's, including the value a discriminator tests — a writer evaluates a
-// predicate and never inverts one.
+// slack — and the bytes of an item the copybook gives no data-name — is
+// emitted as what was retained for it. Everything else is the caller's,
+// including the value a discriminator tests — a writer evaluates a predicate
+// and never inverts one.
 func (p *MemoPostingRef) MarshalCOBOL(w *codec.Writer) error {
 	var err error
 

--- a/example/ledger/records.go
+++ b/example/ledger/records.go
@@ -32,8 +32,19 @@ type LedgerTrailer struct {
 	// The value is unscaled: the item's value is this field times 10^-2.
 	TrlNet int64
 
-	// TrlFiller is TRL-FILLER — alphanumeric, DISPLAY, 8 bytes.
-	TrlFiller string
+	// filler is the bytes of the items among this item's members that the
+	// copybook gives no data-name — its FILLER — in the order they occupy the
+	// record: one run each, as they stood when the record was read, and one set
+	// of them per occurrence of this struct. A nil run is one the record does
+	// not carry; an empty run is a run of no bytes, and the two are not the
+	// same.
+	//
+	// A FILLER is an item, and it is one no program names: it holds no value a
+	// caller of this package could set and none it could read. So it travels
+	// with the record and there is nothing here for a caller to do. An item you
+	// do want to read or write is one to give a data-name in the copybook,
+	// which makes it a field like any other.
+	filler [1][]byte
 }
 
 // DebitPosting is the POSTING-RECORD record, as docs/ir/SPEC.md resolved it.

--- a/example/trailer.cpy
+++ b/example/trailer.cpy
@@ -16,4 +16,4 @@
            05  TRL-TYPE                PIC X(2).
            05  TRL-COUNT               PIC 9(6).
            05  TRL-NET                 PIC S9(13)V99 COMP-3.
-           05  TRL-FILLER              PIC X(8).
+           05  FILLER                  PIC X(8).


### PR DESCRIPTION
Closes #250

`cpybkc-gen-go` refused every copybook holding a bare `FILLER`, and refused it as *the descriptor is malformed*, citing `docs/ir/SPEC.md` over an item the adopter wrote correctly. `identifier` tested `names.GetOriginal() == ""`, which is true of two different descriptors: an item COBOL names nothing (legal, and in most real copybooks), and a named item whose name went missing (a producer bug).

## The decision

No `SPEC.md` said what a nameless item generates. It does now, in [`cmd/cpybkc-gen-go/README.md`](cmd/cpybkc-gen-go/README.md) beside the type table — *An item your copybook gives no name*:

| The item | What is generated |
|---|---|
| An elementary `FILLER` | no field; its bytes are retained beside the slack, in an unexported `filler` run |
| A `FILLER` **group** | no field; its members become fields of the enclosing struct |

The field case is option 1 of the issue: a `FILLER` holds no value anybody named, so it is retained the way a slack node is — a run each, in record order, one set per occurrence. It round-trips byte for byte, and a record the caller *built* emits zero bytes for it, exactly as slack does.

The group case is option 2, and it is argued rather than derived. A run of retained bytes cannot stand in for a `FILLER` group, because the group holds members the copybook **does** name and retaining it would hide items the adopter can see in their own source. Flattening is what COBOL already says about them: qualification skips an unnamed group, so `NOTE-CODE` inside a `FILLER` is `NOTE-CODE OF THE-RECORD` in a program and there is no intermediate name to qualify by. A collision after flattening goes through the existing `collisionError`.

Option 3 (`Filler1`, `Filler2`) is rejected in the README for the reason the generator already gives about itself: it is a name no copybook spells and one that moves when an unrelated item is inserted ahead of it. Option 4 is kept only where there is no answer.

Three cases keep a refusal. Each names the record or group holding the item and **none** of them calls the descriptor malformed: a `FILLER` group that repeats, a `FILLER` counted by an `OCCURS DEPENDING ON`, and a `FILLER` standing as one alternative of an alternation. In all three the answer is in the copybook — give the item a data-name — and the new `fillerError` says so.

## Acceptance criteria

- [x] What a **field** node carrying no names message generates is decided and written down in `cmd/cpybkc-gen-go/README.md`, beside the type table
- [x] The same decision is made for a **group** node, explicitly: it is flattened, because a slack-shaped answer cannot hold members the copybook names
- [x] `identifier` distinguishes the two descriptors — absence of a names message is a FILLER and is handled (`anonymous`), a names message stating no original stays `malformed` (`TestAnItemCarryingNoNameIsRefused`)
- [x] Round-trip holds: `ORDER-RECORD` in the golden package now carries both shapes, and `TestARecordCarryingSlackWritesBackTheBytesItWasReadFrom` and `TestAFillerTravelsWithTheRecordAndItsGroupsMembersDoNot` assert the bytes
- [x] Nothing in the producer moves — `internal/` is untouched, and the example's `ir.json`-shaped output is unchanged apart from the item's name
- [x] Tests cover a `FILLER` field **and** a `FILLER` group carrying a named member (`TestAFillerIsGeneratedRatherThanRefused`), the shape `cpybkc-gen-graph`'s pair takes
- [x] A golden package carries a bare `FILLER`: `internal/orders` — and `example/trailer.cpy` now spells its filler `FILLER`, which is the issue's own repro, end to end
- [x] Every kept refusal names the copybook item and does not say the descriptor is malformed (`TestAFillerThatCannotBePlacedIsRefusedAndIsNotCalledMalformed`)

## Judgment calls that shaped the public API

- **A caller cannot reach a `FILLER`.** The run is unexported, like slack. Exporting it would need a name the copybook never spelled. The README says the actionable thing instead: an item whose value you want to choose is not filler — name it, and it becomes a field like any other.
- **A nil run writes zero bytes, not spaces.** A `FILLER` is a field and does have a charset, so the slack argument (*there is no charset to resolve a space against*) does not carry over; the reason given in `zeroFill`'s regenerated doc comment is the honest one — the item's value is nobody's, so filling it with spaces would choose a value on behalf of a caller who never had one to give.
- **A constant `OCCURS` on a `FILLER` is one run of all of it**, not one run per occurrence: nothing names the occurrences and nothing reads them, so a run each would divide storage along a line no caller can see.

## Verified

- `dagger call ci` — green, from an ordinary clone of this branch (`Ci` builds an App and does not run from a git worktree)
- `go test ./...`, `go vet ./...`, `golangci-lint run ./...` — clean
- All six golden packages regenerated; the five that carry no `FILLER` changed only in the doc comments this touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)