### PR TITLE
story(dagger): settle whether the companion module curates or mirrors the CLI, and rewrite the prose either way

### DIFF
--- a/.dagger/companion.go
+++ b/.dagger/companion.go
@@ -36,7 +36,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"maps"
 	"slices"
 	"strings"
 
@@ -270,9 +269,12 @@ var companionRunExceptions = map[string]coverage.Exception{
 	// So these are a gap rather than a decision, and the stance is why: the
 	// resolved descriptor is the single most useful thing to attach to a bug
 	// report, and it is a capability the CLI has.
+	//
+	// What will still be Run's afterwards is `--emit-ir -`, exactly as `--out -`
+	// is — a spelling rather than a flag, and so not an entry here at all.
 	"--emit-ir": {
-		Reason: "the emission may go to standard output, and --emit-ir-format is only legal beside it; #251 curates " +
-			"both onto one File-returning function, which makes the illegal pairing unstateable",
+		Reason: "it replaces generation outright and --emit-ir-format is only legal beside it; #251 curates both " +
+			"onto one File-returning function, which makes the illegal pairing unstateable rather than enforced",
 		Tracking: "#251",
 	},
 	"--emit-ir-format": {
@@ -323,20 +325,18 @@ const runFunction = "Run"
 //
 // The surface that can drift away from the module is the flag table: a flag
 // added to the CLI is the event that would otherwise leave the module quietly
-// unable to express a run somebody can perform by hand. That is what this fails
-// on, in five directions — a flag neither table covers, a flag both cover, an
-// entry naming a function the module does not declare, an exception that claims
-// nothing, and an entry naming a flag the CLI no longer accepts.
+// unable to express a run somebody can perform by hand. What this fails on, in
+// six directions, is [coverage.Record.Check]'s to say; this function is the
+// reading that feeds it.
 //
-// The second and fourth are #253's, and they are what the stance cost this
-// check. While the module curated deliberately (#62), a flag recorded against
-// Run was the design working, so one map with "Run" as an ordinary value said
-// everything there was to say. Under a mirroring stance it is the opposite: a new
-// flag quietly recorded against Run, passing CI, *is* the drift this check exists
-// to catch, and one map cannot tell that from the two flags nobody has curated
-// on purpose. Two tables can, because writing an exception is writing a reason
-// and saying whether it is settled or tracked — see [coverage.Exception], whose
-// rules are pinned by tests rather than by this comment.
+// Two of those six are #253's, and they are what the stance cost this check.
+// While the module curated deliberately (#62), a flag recorded against Run was
+// the design working, so one map with "Run" as an ordinary value said everything
+// there was to say. Under a mirroring stance it is the opposite: a new flag
+// quietly recorded against Run, passing CI, *is* the drift this check exists to
+// catch, and one map cannot tell that from the flags nobody has curated on
+// purpose. So Run is refused as a mapping, and a flag that reaches it is an
+// exception carrying a reason and saying whether it is settled or tracked.
 //
 // What none of that buys is that an exception is *right*. No check can read an
 // argument; what this one does is make sure there is one, and make adding a flag
@@ -452,85 +452,21 @@ func (m *Cpybkc) CliSurface(ctx context.Context) error {
 		return err
 	}
 
-	var errs []error
-
-	// Where each flag is recorded, and what it is recorded as reaching, which is
-	// the reverse direction's message as well as this one's bookkeeping.
-	recorded := map[string]string{}
-	for flag, function := range companionCoverage {
-		recorded[flag] = function
+	// Everything above is the reading, which needs a Dagger session; everything
+	// below is the rules, which do not. The split is deliberate and it is not
+	// tidiness: the rules used to be written out here, where no test can reach
+	// them, and the first version of them asserted in three comments that the flag
+	// table does not accept Run as a value while enforcing it nowhere. Review
+	// caught that; a test would have. So the rules live in a package that imports
+	// no Dagger, and this function hands them what it read.
+	record := coverage.Record{
+		Module:     companionModuleDir,
+		Fallback:   runFunction,
+		Mapped:     companionCoverage,
+		Exceptions: companionRunExceptions,
 	}
 
-	// Sorted, because these are diagnostics: two runs over one tree should report
-	// the same faults in the same order, and a map's is whatever the runtime felt
-	// like.
-	for _, flag := range slices.Sorted(maps.Keys(companionRunExceptions)) {
-		if function, both := recorded[flag]; both {
-			errs = append(errs, fmt.Errorf(
-				"%s is recorded both as mapped onto %s's %s and as an exception reaching it through %s: a flag has "+
-					"one answer, and the two tables are how a curated flag and an uncurated one are told apart, so a "+
-					"flag in both says the module mirrors it and does not at once",
-				flag, companionModuleDir, function, runFunction))
-
-			continue
-		}
-
-		recorded[flag] = runFunction
-	}
-
-	for _, flag := range flags {
-		if exception, excepted := companionRunExceptions[flag]; excepted {
-			if err := exception.Check(flag); err != nil {
-				errs = append(errs, err)
-			}
-
-			continue
-		}
-
-		function, covered := companionCoverage[flag]
-		if !covered {
-			errs = append(errs, fmt.Errorf(
-				"the cpybkc CLI accepts %s and %s records nothing that covers it: %s is the cpybkc CLI daggerized, "+
-					"so the answer is ordinarily an argument on the function named for the command this flag belongs "+
-					"to, recorded in companionCoverage in this file; a flag a Dagger argument cannot express is an "+
-					"entry in companionRunExceptions instead, carrying the argument for that and the issue curating "+
-					"it if one is (#253)",
-				flag, companionModuleDir, companionModuleDir))
-
-			continue
-		}
-
-		if !slices.Contains(functions, function) {
-			errs = append(errs, fmt.Errorf(
-				"%s is recorded as covered by %s's %s, and that module declares no such function; either the "+
-					"function was renamed and this table was not, or the flag now reaches the module some other way",
-				flag, companionModuleDir, function))
-		}
-	}
-
-	// The route every exception is an exception *to*. An entry saying a flag
-	// reaches the module through a function the module no longer declares covers
-	// nothing, and it would otherwise be the one claim in either table that is
-	// checked against nothing.
-	if len(companionRunExceptions) > 0 && !slices.Contains(functions, runFunction) {
-		errs = append(errs, fmt.Errorf(
-			"companionRunExceptions records flags as reaching %s through %s, and that module declares no such "+
-				"function: the escape hatch is what every exception in that table is an exception to, so a rename "+
-				"of it is a rewrite of the table rather than a rename",
-			companionModuleDir, runFunction))
-	}
-
-	for _, flag := range slices.Sorted(maps.Keys(recorded)) {
-		if !slices.Contains(flags, flag) {
-			errs = append(errs, fmt.Errorf(
-				"%s records %s as covered by %s and the cpybkc CLI no longer accepts that flag; a module argument "+
-					"is public API for as long as the published module ref exists, so a flag leaving the CLI is a "+
-					"decision about the module rather than a line to delete from this table without one",
-				companionModuleDir, flag, recorded[flag]))
-		}
-	}
-
-	return errors.Join(errs...)
+	return record.Check(flags, functions)
 }
 
 // companionType is the companion module's own type, whose exported methods are
@@ -656,11 +592,13 @@ var exampleInitVector = []string{
 // dagger.json and its function names. None of them makes a call, so a module
 // whose calls no longer compose into a working image would fail none of them.
 // This is the only place `dagger call -m daggerverse/cpybkc …` actually happens,
-// and the module implements contracts written elsewhere rather than one of its
-// own — docs/cli/SPEC.md's and docs/container/SPEC.md's — which is exactly why a
-// broken one is worse than none: a caller reaches for it because they did not
-// want to learn the contract underneath, so the failure lands on somebody with
-// no reason to know where to look.
+// and the module implements contracts specified elsewhere — docs/cli/SPEC.md's
+// and docs/container/SPEC.md's — while adding no specification of its own. That
+// is exactly why a broken one is worse than none: a caller reaches for it
+// because they did not want to learn the contract underneath, so the failure
+// lands on somebody with no reason to know where to look. Being an interface of
+// its own (#253) makes that argument stronger rather than weaker — more people
+// arrive through it, with less idea of what is behind it.
 //
 // # Why it drives the image built here
 //

--- a/.dagger/companion.go
+++ b/.dagger/companion.go
@@ -16,10 +16,13 @@
 // it — see the function's comment, which records what was measured rather than
 // what was assumed.
 //
-// CliSurface asserts the module has an answer for every flag the CLI accepts.
-// The module curates deliberately rather than mapping the flag table one-to-one
-// (#62), and a curated surface is only safe if adding a flag to the CLI forces
-// somebody to say which side of the curation it falls on.
+// CliSurface asserts the module has an answer for every flag the CLI accepts,
+// and that the answer is the one the module's stance says it should be. The
+// module mirrors the CLI (#253): a flag's answer is an argument on a function
+// named for the command it belongs to, and a flag that reaches the module
+// through the escape hatch instead is an exception carrying the argument for
+// itself. Adding a flag to the CLI therefore fails CI until somebody writes one
+// or the other down.
 //
 // CompanionModule runs the module's functions — over the image this pull request
 // built rather than over the last release (#64). The three above read the
@@ -37,6 +40,7 @@ import (
 	"slices"
 	"strings"
 
+	"dagger/cpybkc/internal/coverage"
 	"dagger/cpybkc/internal/dagger"
 	"dagger/cpybkc/internal/surface"
 )
@@ -168,11 +172,20 @@ const generatedFile = "dagger.gen.go"
 // failure the empty-result guard below cannot catch.
 const cliPackageDir = "cmd/cpybkc"
 
-// companionCoverage is what the companion module answers each of the CLI's
-// flags with. It is the record the curation of #62 is worth having: the module
-// maps the two runs a caller asks for by name and hands the rest to one escape
-// hatch, and without a written record of which flag went where, "curated" and
-// "forgotten" are the same thing to read.
+// companionCoverage is the function each of the CLI's flags is mapped onto by
+// name. daggerverse/cpybkc is the CLI daggerized (#253), so this is the ordinary
+// answer for a flag and the two tables below are read in that order: a flag
+// belongs here unless there is an argument for it not being here.
+//
+// It was not always. #62 built the module as a deliberately small surface with
+// one escape hatch behind it, and under that stance a flag recorded against Run
+// was the design working rather than a gap — which is why this map used to hold
+// "Run" as a value five times, beside the reasons. #253 settled the other way:
+// the module should expose every capability the CLI has as a named function, Run
+// is the fallback rather than the plan, and a flag on the escape hatch is an
+// exception. So Run is no longer a value this map accepts. An exception is an
+// entry in [companionRunExceptions], which is a different thing to write and
+// therefore a different thing to read.
 //
 // Be exact about what an entry claims, because it is less than it looks. It is a
 // person's assertion that they thought about this flag and decided where it
@@ -185,20 +198,14 @@ const cliPackageDir = "cmd/cpybkc"
 // accident.
 //
 // Every value names a function on daggerverse/cpybkc's own type, checked to
-// exist rather than taken on trust. Run appears five times over because it is the
-// escape hatch and that is what an escape hatch looks like when it is working; a
-// flag moving from Run to a curated argument is an edit here in the same commit
-// that adds the argument, which is what happened to `init`'s two below.
-//
-// That five is counted off the map rather than carried forward. It read "six"
-// while the map held seven, which is the kind of thing a number in prose does if
-// nobody re-derives it — and it is worth saying rather than quietly fixing,
-// because this comment is the drift record and a count nobody checked is exactly
-// what it warns about everywhere else.
+// exist rather than taken on trust. No count of the entries is written down
+// anywhere in this file, deliberately: the prose here used to say how many flags
+// reached Run, it read "six" while the map held seven, and a number nobody
+// re-derives is exactly what this comment warns about everywhere else.
 //
 // This is a table in the pipeline rather than a list in the module because it is
 // this repository's opinion about the module, in the file that already holds the
-// other two (#61). The module states the same split in prose, in its package
+// other two (#61). The module states the same stance in prose, in its package
 // comment, where a caller reading `dagger call --help` will meet it.
 var companionCoverage = map[string]string{
 	// The one flag Generate maps by name: it says which project is being
@@ -206,61 +213,134 @@ var companionCoverage = map[string]string{
 	// --source.
 	"--manifest": "Generate",
 
-	// Terminal, and mutually constrained: --emit-ir replaces generation outright
-	// and --emit-ir-format is a usage error without it. A Directory-returning
-	// function cannot express either — the emission may go to standard output —
-	// and two Dagger arguments cannot express "one is only legal beside the
-	// other" at all.
-	"--emit-ir":        "Run",
-	"--emit-ir-format": "Run",
-
-	// Questions about the program rather than about a project, whose answer is a
-	// line on standard output. Image() reaches them too; Run is what reaches them
-	// with no project and no with-exec spelled out.
-	"--version": "Run",
-	"--help":    "Run",
-
-	// The one single-hyphen spelling docs/cli/SPEC.md states. It is recorded
-	// rather than filtered out as "a synonym of a covered flag", because that
-	// reasoning is true of -h and of nothing else: filtering the whole class would
-	// let a future short flag that is nobody's synonym land with this check green,
-	// and an entry costs one line.
-	"-h": "Run",
-
 	// `init`'s two flags (#183, #214), curated onto one function (#228). This is
 	// the move this table was kept for: they were recorded against Run while the
 	// module expressed a scaffolding run through the escape hatch alone, and
 	// they came off it in the commit that added the function.
 	//
 	// The name is the CLI's verb rather than the `Scaffold` this comment used to
-	// name in prose. #62 is *map cpybkc commands to dagger functions*, there are
-	// two commands, and mapping the second one's name straight through is what
-	// lets somebody who read docs/cli/SPEC.md find it here — a second name for
-	// one command would be this module's own vocabulary, which is exactly what
-	// the curation is trying not to grow.
+	// name in prose. There are two commands, and mapping the second one's name
+	// straight through is what lets somebody who read docs/cli/SPEC.md find it
+	// here — a second name for one command would be this module's own vocabulary,
+	// which is what a module mirroring the CLI has the least business growing.
 	//
 	// Init takes copybook *paths* into --source rather than files, because
 	// docs/cli/SPEC.md has the scaffold record each path as it was typed and a
 	// layout's paths are relative to the layout; and it supplies --out itself, at
 	// a path outside the mounted project, so *nothing at <dest> is ever replaced*
-	// holds without the module reasoning about the caller's tree. The one
-	// spelling it does not offer is `--out -`, which a File-returning function
-	// cannot express — that stays Run's, as --emit-ir's is:
+	// holds without the module reasoning about the caller's tree.
+	//
+	// The one spelling Init does not offer is `--out -`, and that is not an
+	// exception in the sense below, because a spelling is not a flag and this
+	// table is keyed by flags. --out is curated; a stream destination is what a
+	// File-returning function cannot express, and it stays Run's:
 	//
 	//	dagger call run --source . --args=init,--copybook,posting.cpy,--out,-
 	"--copybook": "Init",
 	"--out":      "Init",
 }
 
+// companionRunExceptions are the CLI's flags that reach the module through Run
+// rather than through a function named for a command, each with the argument for
+// why.
+//
+// This table is the whole of what the mirroring stance costs. Under #62's
+// curation an uncurated flag needed no defence — the small surface was the design
+// — and the record could be one word. Under #253's it needs one, because "this
+// flag's answer is the escape hatch" and "nobody has got to this flag" are now
+// different claims that used to be written identically. [coverage.Exception] is
+// what makes them different to write: a reason is required, and an entry says
+// either that the escape hatch is the answer or which issue is writing the
+// function.
+//
+// Neither claim is one this pipeline can verify, and it does not pretend to. It
+// enforces that the claim was made, which is the same thing companionCoverage
+// enforces about a curated flag and for the same reason: an assertion that has to
+// be re-made whenever the CLI's surface moves is one that stops being true on
+// purpose rather than by accident.
+var companionRunExceptions = map[string]coverage.Exception{
+	// Terminal, and mutually constrained: --emit-ir replaces generation outright
+	// and --emit-ir-format is a usage error without it. That was the argument for
+	// leaving both on Run, and #251 answers it: a curated function need not return
+	// a Directory — Init already returns a File — and one function taking the
+	// format as an argument makes the illegal pairing unstateable rather than
+	// enforced, because there is no call that names a format without asking for an
+	// emission.
+	//
+	// So these are a gap rather than a decision, and the stance is why: the
+	// resolved descriptor is the single most useful thing to attach to a bug
+	// report, and it is a capability the CLI has.
+	"--emit-ir": {
+		Reason: "the emission may go to standard output, and --emit-ir-format is only legal beside it; #251 curates " +
+			"both onto one File-returning function, which makes the illegal pairing unstateable",
+		Tracking: "#251",
+	},
+	"--emit-ir-format": {
+		Reason:   "it is only legal beside --emit-ir, so it is that function's argument rather than a function",
+		Tracking: "#251",
+	},
+
+	// Questions about the program rather than about a project, and the one place
+	// the mirroring stance stops on purpose (#253). Both have a Dagger-native
+	// form that is not a function on this module: `dagger call --help` and the
+	// per-function documentation are what a caller reaches for instead of
+	// --help, and which release runs is something they state at `New --version`
+	// rather than ask the CLI afterwards.
+	//
+	// The reason does not cover everything, which is why Run remains the answer
+	// for the rest of it: --version defaults to the moving "v0" tag, so *which
+	// tag was asked for* and *which build is running* are different questions,
+	// and `run --args=--version` is how the second one is asked.
+	"--version": {
+		Reason: "a caller states the release at `New --version` rather than asking the CLI afterwards; " +
+			"`run --args=--version` is how the moving v0 tag's actual build is read back",
+		Settled: true,
+	},
+	"--help": {
+		Reason:  "`dagger call --help` and the per-function documentation are the Dagger-native form of the question",
+		Settled: true,
+	},
+
+	// The one single-hyphen spelling docs/cli/SPEC.md states. It is recorded
+	// rather than filtered out as "a synonym of a covered flag", because that
+	// reasoning is true of -h and of nothing else: filtering the whole class would
+	// let a future short flag that is nobody's synonym land with this check green,
+	// and an entry costs a few lines.
+	"-h": {
+		Reason:  "the short spelling of --help, and settled with it",
+		Settled: true,
+	},
+}
+
+// runFunction is the escape hatch every entry in [companionRunExceptions]
+// reaches its flag through. It is checked to exist for the reason a curated
+// function is: an exception naming a route the module no longer has is an
+// exception covering nothing.
+const runFunction = "Run"
+
 // CliSurface checks that every flag the CLI accepts is one the companion module
-// has an answer for.
+// has an answer for, and that the answer is one the module's stance allows.
 //
 // The surface that can drift away from the module is the flag table: a flag
 // added to the CLI is the event that would otherwise leave the module quietly
 // unable to express a run somebody can perform by hand. That is what this fails
-// on, in three directions — a flag no entry covers, an entry naming a function
-// the module does not declare, and an entry naming a flag the CLI no longer
-// accepts.
+// on, in five directions — a flag neither table covers, a flag both cover, an
+// entry naming a function the module does not declare, an exception that claims
+// nothing, and an entry naming a flag the CLI no longer accepts.
+//
+// The second and fourth are #253's, and they are what the stance cost this
+// check. While the module curated deliberately (#62), a flag recorded against
+// Run was the design working, so one map with "Run" as an ordinary value said
+// everything there was to say. Under a mirroring stance it is the opposite: a new
+// flag quietly recorded against Run, passing CI, *is* the drift this check exists
+// to catch, and one map cannot tell that from the two flags nobody has curated
+// on purpose. Two tables can, because writing an exception is writing a reason
+// and saying whether it is settled or tracked — see [coverage.Exception], whose
+// rules are pinned by tests rather than by this comment.
+//
+// What none of that buys is that an exception is *right*. No check can read an
+// argument; what this one does is make sure there is one, and make adding a flag
+// to the escape hatch a visibly different act from mapping it onto a function.
 //
 // The CLI has a verb now — `init` (#183, #214) — and the flag table is still the
 // whole of what this checks. That is a decision rather than an omission, and it
@@ -292,11 +372,39 @@ var companionCoverage = map[string]string{
 // decides whether an argument is accepted, which is the only reading that cannot
 // be true of the document and false of the program.
 //
-// What that leaves outside is a flag matched inline on a string literal rather
-// than through a constant — a shape the parser does not use, and the one this
-// check cannot see. Everything else a constant can be written as is read:
-// package scope or a function body, one hyphen or two, a literal or one flag's
-// spelling built from another's. The rules are internal/surface's and each of
+// # What the flag table is not
+//
+// It is not the CLI's surface, and the mirroring stance is what makes the
+// difference matter. This check reads flag *constants*, so a capability the CLI
+// has that is not spelled as a flag is invisible to it by construction — and
+// there is one today: cpybkc passes its whole environment through to a generator,
+// which is how docs/plugin/SPEC.md propagates SOURCE_DATE_EPOCH, and the
+// companion module has no way to state an environment at all (#252). No check in
+// this repository noticed, and none could have.
+//
+// So the honest answer to how a non-flag capability is caught is that it is
+// caught by a person, at the document that promises it: a change to
+// docs/cli/SPEC.md or docs/plugin/SPEC.md that adds a capability which is not a
+// flag is answered in the companion module in the same review, and CONTRIBUTING.md
+// says so where the stance is argued. That is a weaker guarantee than this check
+// and it is stated as one rather than dressed up.
+//
+// The mechanical version was considered and is not worth having. Anything that
+// could notice "docs/cli/SPEC.md changed" is a check comparing a document against
+// a copy of itself, which is the shape #65 was closed for being: it fails on
+// every edit to that document and on nothing else, so it is answered by updating
+// the copy, and a check whose remedy is *tell it what happened* has taught
+// nobody anything. What is available instead is that the gap this one missed is
+// written down where the stance is, as the standing reminder that the flag table
+// is a lower bound on the module's obligations.
+//
+// # What is outside the reading itself
+//
+// A flag matched inline on a string literal rather than through a constant — a
+// shape the parser does not use, and the one this check cannot see. Everything
+// else a constant can be written as is read: package scope or a function body,
+// one hyphen or two, a literal or one flag's spelling built from another's.
+// The rules are internal/surface's and each of
 // them is a test rather than a sentence here, because a drift guard's failure
 // mode is staying green and a sentence cannot fail.
 //
@@ -346,14 +454,48 @@ func (m *Cpybkc) CliSurface(ctx context.Context) error {
 
 	var errs []error
 
+	// Where each flag is recorded, and what it is recorded as reaching, which is
+	// the reverse direction's message as well as this one's bookkeeping.
+	recorded := map[string]string{}
+	for flag, function := range companionCoverage {
+		recorded[flag] = function
+	}
+
+	// Sorted, because these are diagnostics: two runs over one tree should report
+	// the same faults in the same order, and a map's is whatever the runtime felt
+	// like.
+	for _, flag := range slices.Sorted(maps.Keys(companionRunExceptions)) {
+		if function, both := recorded[flag]; both {
+			errs = append(errs, fmt.Errorf(
+				"%s is recorded both as mapped onto %s's %s and as an exception reaching it through %s: a flag has "+
+					"one answer, and the two tables are how a curated flag and an uncurated one are told apart, so a "+
+					"flag in both says the module mirrors it and does not at once",
+				flag, companionModuleDir, function, runFunction))
+
+			continue
+		}
+
+		recorded[flag] = runFunction
+	}
+
 	for _, flag := range flags {
+		if exception, excepted := companionRunExceptions[flag]; excepted {
+			if err := exception.Check(flag); err != nil {
+				errs = append(errs, err)
+			}
+
+			continue
+		}
+
 		function, covered := companionCoverage[flag]
 		if !covered {
 			errs = append(errs, fmt.Errorf(
-				"the cpybkc CLI accepts %s and %s records nothing that covers it: add it to companionCoverage in "+
-					"this file, against the curated function that maps it or against Run, which is the escape hatch "+
-					"an uncurated flag reaches through (#62)",
-				flag, companionModuleDir))
+				"the cpybkc CLI accepts %s and %s records nothing that covers it: %s is the cpybkc CLI daggerized, "+
+					"so the answer is ordinarily an argument on the function named for the command this flag belongs "+
+					"to, recorded in companionCoverage in this file; a flag a Dagger argument cannot express is an "+
+					"entry in companionRunExceptions instead, carrying the argument for that and the issue curating "+
+					"it if one is (#253)",
+				flag, companionModuleDir, companionModuleDir))
 
 			continue
 		}
@@ -366,13 +508,25 @@ func (m *Cpybkc) CliSurface(ctx context.Context) error {
 		}
 	}
 
-	for _, flag := range slices.Sorted(maps.Keys(companionCoverage)) {
+	// The route every exception is an exception *to*. An entry saying a flag
+	// reaches the module through a function the module no longer declares covers
+	// nothing, and it would otherwise be the one claim in either table that is
+	// checked against nothing.
+	if len(companionRunExceptions) > 0 && !slices.Contains(functions, runFunction) {
+		errs = append(errs, fmt.Errorf(
+			"companionRunExceptions records flags as reaching %s through %s, and that module declares no such "+
+				"function: the escape hatch is what every exception in that table is an exception to, so a rename "+
+				"of it is a rewrite of the table rather than a rename",
+			companionModuleDir, runFunction))
+	}
+
+	for _, flag := range slices.Sorted(maps.Keys(recorded)) {
 		if !slices.Contains(flags, flag) {
 			errs = append(errs, fmt.Errorf(
 				"%s records %s as covered by %s and the cpybkc CLI no longer accepts that flag; a module argument "+
 					"is public API for as long as the published module ref exists, so a flag leaving the CLI is a "+
 					"decision about the module rather than a line to delete from this table without one",
-				companionModuleDir, flag, companionCoverage[flag]))
+				companionModuleDir, flag, recorded[flag]))
 		}
 	}
 
@@ -502,11 +656,11 @@ var exampleInitVector = []string{
 // dagger.json and its function names. None of them makes a call, so a module
 // whose calls no longer compose into a working image would fail none of them.
 // This is the only place `dagger call -m daggerverse/cpybkc …` actually happens,
-// and the module is a convenience over docs/container/SPEC.md rather than a
-// contract of its own, which is exactly why a broken one is worse than none: a
-// caller reaches for it because they did not want to learn the contract
-// underneath, so the failure lands on somebody with no reason to know where to
-// look.
+// and the module implements contracts written elsewhere rather than one of its
+// own — docs/cli/SPEC.md's and docs/container/SPEC.md's — which is exactly why a
+// broken one is worse than none: a caller reaches for it because they did not
+// want to learn the contract underneath, so the failure lands on somebody with
+// no reason to know where to look.
 //
 // # Why it drives the image built here
 //
@@ -680,10 +834,16 @@ func (m *Cpybkc) CompanionModule(ctx context.Context) error {
 // to what `run --args=init,--copybook,…,--out,-` writes on standard output over
 // the same copybooks. That is cheap, it needs no second reading of
 // docs/cli/SPEC.md's `init` section — what a record is derived from, which forms
-// are commented, what a note says — and it is exactly the property the escape
-// hatch entry in [companionCoverage] used to stand in for: a caller who reached
-// for `run` before this function existed should get the same file from the
-// function that replaced it.
+// are commented, what a note says — and it is exactly the property `init`'s
+// escape-hatch entry used to stand in for, back when its flags were recorded
+// against Run: a caller who reached for `run` before this function existed
+// should get the same file from the function that replaced it.
+//
+// That is worth keeping in view now that every command is meant to have a
+// function (#253), because it generalises. What makes a curated function safe to
+// add is that the run it replaces is still spellable through Run and still
+// produces the same bytes, which is a check the next curated function can be
+// written against as easily as this one was.
 //
 // What the scaffold *contains* is checked where it is decided:
 // internal/scaffold's tests and cmd/cpybkc's. A second expectation here would be

--- a/.dagger/internal/coverage/exception.go
+++ b/.dagger/internal/coverage/exception.go
@@ -1,0 +1,126 @@
+// Package coverage is the shape of an exception to the companion module's
+// stance, and the rules an exception has to satisfy to be one.
+//
+// daggerverse/cpybkc mirrors the cpybkc CLI: a flag's answer is an argument on a
+// function named for the command it belongs to (#253). A flag that reaches the
+// module through the escape hatch instead is an exception, and an exception is
+// worth nothing unless it can be told apart from a flag nobody got to. That is
+// the whole of what [Exception] is for — it makes the two different things to
+// write, so that the difference survives into a diff a reviewer reads.
+//
+// It is a package of its own for the reason internal/surface is: the pipeline's
+// own package main imports the generated Dagger client, whose init panics
+// without a session, so a test beside it cannot run under plain `go test`. This
+// package imports no Dagger, so the rules below are pinned by tests rather than
+// asserted by a comment — which matters here for the same reason it matters
+// there, because what is built on them is a drift guard and a drift guard with a
+// hole fails by staying green.
+//
+// The files here are named for the type rather than for the package because
+// .gitignore's `coverage.*` — Go's test-coverage profiles — would match a
+// coverage.go and quietly leave it out of a commit. That is worth a sentence
+// rather than a rediscovery: `git add -A` says nothing, and what lands is a
+// package that does not compile.
+package coverage
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+// issueRef is how an exception names the story that will curate its flag: a
+// GitHub issue reference in this repository, `#` and a number.
+//
+// The shape is checked rather than the issue's existence, for the reason
+// internal/imageref validates the shape of an image reference and not what is
+// behind it: a check that resolved references would need a network and a token
+// to say whether somebody's exception was well formed, and would fail on a
+// private fork of this repository rather than on anything a contributor did.
+//
+// A leading zero is refused because GitHub has no issue #0 and none whose number
+// is written with one, so "#0" and "#012" are a typo rather than a reference —
+// and a typo in the one field that says *this gap is tracked* is the field
+// failing silently.
+var issueRef = regexp.MustCompile(`^#[1-9][0-9]*$`)
+
+// Exception is what the record says about one CLI flag the companion module
+// answers through Run rather than through a function named for a command.
+//
+// Every field is load bearing and none of them is decoration. The zero value is
+// not a valid exception: it claims nothing, which is exactly the state this type
+// exists to make unwritable.
+type Exception struct {
+	// Reason is the argument for this flag not being curated, in prose, and it is
+	// required.
+	//
+	// What it has to answer is why an argument on a named function is the wrong
+	// shape for this flag — not that nobody has written one yet, which is what
+	// Tracking says.
+	Reason string
+
+	// Settled says the module is not going to grow a function for this flag, and
+	// that the answer it has is the answer.
+	//
+	// It is an explicit claim rather than something derived from an empty
+	// Tracking, because the two are the whole distinction this type carries and
+	// deriving one of them from the absence of the other would let it be made by
+	// forgetting. Somebody writing an exception says which of the two they mean,
+	// in a word, in the diff.
+	Settled bool
+
+	// Tracking is the issue where this flag's curated function is being written,
+	// as `#<number>`, and it is what makes an uncurated flag a gap with an owner
+	// rather than an omission.
+	//
+	// It is set when Settled is not, and the two are mutually exclusive: a gap
+	// that is being closed is not settled, and a decision that is settled has no
+	// story left to name.
+	Tracking string
+}
+
+// Check reports whether e is a well-formed exception for flag.
+//
+// It says nothing about whether the exception is *right* — no rule here can, and
+// pretending otherwise is what the flag table's own comment warns about
+// everywhere else. What it enforces is that a claim was made: that somebody
+// wrote down why this flag is not curated, and said whether that is a decision
+// or a gap somebody is closing. A flag arriving on the escape hatch with neither
+// is the drift the mirroring stance exists to end, and before this it was one
+// word in a map.
+//
+// Every failure is reported rather than the first, because an exception written
+// in a hurry is usually wrong in more than one way at once and a contributor
+// should learn both in one run.
+func (e Exception) Check(flag string) error {
+	var errs []error
+
+	if e.Reason == "" {
+		errs = append(errs, fmt.Errorf(
+			"%s is recorded as reaching the companion module through its escape hatch and no reason is written "+
+				"beside it: the module mirrors the cpybkc CLI, so a flag with no function of its own is an exception "+
+				"that carries the argument for itself (#253)", flag))
+	}
+
+	switch {
+	case e.Settled && e.Tracking != "":
+		errs = append(errs, fmt.Errorf(
+			"%s is recorded as both settled and tracked by %s: settled says the module will not grow a function for "+
+				"this flag, and a tracking issue says one is being written, so the two together do not say which "+
+				"happens next", flag, e.Tracking))
+
+	case !e.Settled && e.Tracking == "":
+		errs = append(errs, fmt.Errorf(
+			"%s is recorded as reaching the companion module through its escape hatch and is neither settled nor "+
+				"tracked: say Settled when the escape hatch is this flag's answer and the argument for that is "+
+				"written beside it, or name the issue curating it in Tracking, so that a decision and a gap nobody "+
+				"got to stop looking the same (#253)", flag))
+
+	case e.Tracking != "" && !issueRef.MatchString(e.Tracking):
+		errs = append(errs, fmt.Errorf(
+			"%s names %q as the issue curating it, which is not an issue reference: it is written as # and the "+
+				"number, so that the story closing this gap can be found from here", flag, e.Tracking))
+	}
+
+	return errors.Join(errs...)
+}

--- a/.dagger/internal/coverage/exception.go
+++ b/.dagger/internal/coverage/exception.go
@@ -102,6 +102,10 @@ func (e Exception) Check(flag string) error {
 				"that carries the argument for itself (#253)", flag))
 	}
 
+	// Which claim was made, reported independently of whether the claim is well
+	// formed. The two cases here are exclusive of each other and of nothing else:
+	// an entry can be settled-and-tracked *and* name a tracking value that is not
+	// a reference, and a contributor should learn both before they re-run.
 	switch {
 	case e.Settled && e.Tracking != "":
 		errs = append(errs, fmt.Errorf(
@@ -115,8 +119,9 @@ func (e Exception) Check(flag string) error {
 				"tracked: say Settled when the escape hatch is this flag's answer and the argument for that is "+
 				"written beside it, or name the issue curating it in Tracking, so that a decision and a gap nobody "+
 				"got to stop looking the same (#253)", flag))
+	}
 
-	case e.Tracking != "" && !issueRef.MatchString(e.Tracking):
+	if e.Tracking != "" && !issueRef.MatchString(e.Tracking) {
 		errs = append(errs, fmt.Errorf(
 			"%s names %q as the issue curating it, which is not an issue reference: it is written as # and the "+
 				"number, so that the story closing this gap can be found from here", flag, e.Tracking))

--- a/.dagger/internal/coverage/exception_test.go
+++ b/.dagger/internal/coverage/exception_test.go
@@ -127,14 +127,46 @@ func TestCheckRefusesAnExceptionThatClaimsNothing(t *testing.T) {
 func TestCheckReportsEveryFaultAtOnce(t *testing.T) {
 	// An exception written in a hurry is usually wrong in more than one way, and
 	// learning about the second one on the next run is a second run.
-	err := Exception{Tracking: "nope"}.Check("--flag")
-	if err == nil {
-		t.Fatal("Check() = nil, want an error")
-	}
+	for _, tc := range []struct {
+		name      string
+		exception Exception
+		want      []string
+	}{
+		{
+			name:      "a missing reason beside a malformed reference",
+			exception: Exception{Tracking: "nope"},
+			want:      []string{"no reason is written beside it", "not an issue reference"},
+		},
+		{
+			// The row that pins the claim rather than passing by accident: these
+			// two faults are decided in the same place, so a version of Check that
+			// stopped at the first would report only the mutual exclusion. Review
+			// found exactly that, and this is what it is fixed against.
+			name:      "settled and tracked at once, by something that is not a reference",
+			exception: Exception{Reason: "because", Settled: true, Tracking: "nope"},
+			want:      []string{"both settled and tracked", "not an issue reference"},
+		},
+		{
+			name:      "all three at once",
+			exception: Exception{Settled: true, Tracking: "nope"},
+			want: []string{
+				"no reason is written beside it",
+				"both settled and tracked",
+				"not an issue reference",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.exception.Check("--flag")
+			if err == nil {
+				t.Fatal("Check() = nil, want an error")
+			}
 
-	for _, want := range []string{"no reason is written beside it", "not an issue reference"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Errorf("Check() = %q, want it to mention %q", err, want)
-		}
+			for _, want := range tc.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("Check() = %q, want it to mention %q", err, want)
+				}
+			}
+		})
 	}
 }

--- a/.dagger/internal/coverage/exception_test.go
+++ b/.dagger/internal/coverage/exception_test.go
@@ -1,0 +1,140 @@
+// These tests are the whole reason this package exists apart from the pipeline
+// that uses it, for the reason internal/surface's are: what is built on it is a
+// drift guard, and a drift guard is the one kind of check whose failure mode is
+// staying green.
+//
+// The rows below are the ways an exception can be written badly, and each one is
+// a way the mirroring stance would otherwise go unenforced — a flag on the escape
+// hatch with no argument for being there, a gap nobody is closing recorded as
+// though it were a decision, and a decision recorded as though somebody were
+// still working on it.
+
+package coverage
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheckAcceptsTheTwoShapesOfException(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		exception Exception
+	}{
+		{
+			// The escape hatch is this flag's answer, and the argument for that is
+			// written down. --version, --help and -h are this shape.
+			name:      "settled, with a reason",
+			exception: Exception{Reason: "the question is answered Dagger-natively", Settled: true},
+		},
+		{
+			// A curated function is coming and the story writing it is named, so a
+			// reader can tell this from a flag nobody thought about. --emit-ir is
+			// this shape.
+			name:      "tracked, with a reason and an issue",
+			exception: Exception{Reason: "a Directory return cannot express a stream", Tracking: "#251"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.exception.Check("--flag"); err != nil {
+				t.Fatalf("Check() = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestCheckRefusesAnExceptionThatClaimsNothing(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		exception Exception
+		want      string
+	}{
+		{
+			// The state this type exists to make unwritable: a flag on the escape
+			// hatch and nothing said about why.
+			name:      "the zero value",
+			exception: Exception{},
+			want:      "no reason is written beside it",
+		},
+		{
+			// Settled without an argument is the old one-word entry wearing a
+			// longer spelling.
+			name:      "settled with no reason",
+			exception: Exception{Settled: true},
+			want:      "no reason is written beside it",
+		},
+		{
+			name:      "tracked with no reason",
+			exception: Exception{Tracking: "#251"},
+			want:      "no reason is written beside it",
+		},
+		{
+			// Neither claim made. This is the one that would otherwise pass by
+			// being derived: an empty Tracking read as "settled" lets the claim be
+			// made by forgetting.
+			name:      "a reason, and neither settled nor tracked",
+			exception: Exception{Reason: "because"},
+			want:      "neither settled nor tracked",
+		},
+		{
+			// Both claims made, which does not say which happens next.
+			name:      "settled and tracked at once",
+			exception: Exception{Reason: "because", Settled: true, Tracking: "#251"},
+			want:      "both settled and tracked",
+		},
+		{
+			name:      "a tracking value that is not an issue reference",
+			exception: Exception{Reason: "because", Tracking: "251"},
+			want:      "not an issue reference",
+		},
+		{
+			// A typo in the one field that says this gap has an owner.
+			name:      "issue zero",
+			exception: Exception{Reason: "because", Tracking: "#0"},
+			want:      "not an issue reference",
+		},
+		{
+			name:      "a leading zero",
+			exception: Exception{Reason: "because", Tracking: "#012"},
+			want:      "not an issue reference",
+		},
+		{
+			name:      "a URL rather than a reference",
+			exception: Exception{Reason: "because", Tracking: "https://github.com/Zaba505/cpybkc/issues/251"},
+			want:      "not an issue reference",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.exception.Check("--flag")
+			if err == nil {
+				t.Fatalf("Check() = nil, want an error mentioning %q", tc.want)
+			}
+
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("Check() = %q, want it to mention %q", err, tc.want)
+			}
+
+			// Every message names the flag, because the caller reports these
+			// alongside one another and a diagnostic that does not say which entry
+			// it is about sends a contributor to read the whole table.
+			if !strings.Contains(err.Error(), "--flag") {
+				t.Errorf("Check() = %q, want it to name the flag it is about", err)
+			}
+		})
+	}
+}
+
+func TestCheckReportsEveryFaultAtOnce(t *testing.T) {
+	// An exception written in a hurry is usually wrong in more than one way, and
+	// learning about the second one on the next run is a second run.
+	err := Exception{Tracking: "nope"}.Check("--flag")
+	if err == nil {
+		t.Fatal("Check() = nil, want an error")
+	}
+
+	for _, want := range []string{"no reason is written beside it", "not an issue reference"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Check() = %q, want it to mention %q", err, want)
+		}
+	}
+}

--- a/.dagger/internal/coverage/record.go
+++ b/.dagger/internal/coverage/record.go
@@ -1,0 +1,155 @@
+package coverage
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+)
+
+// Record is this repository's account of how the companion Dagger module answers
+// every flag the cpybkc CLI accepts: the flags mapped onto a function by name,
+// and the flags that reach the module through the fallback instead.
+//
+// It is here rather than beside the pipeline's package main for the reason the
+// package comment gives, and the reason is not a formality. The rules below are
+// the whole of what holds the module to its stance, and the first version of
+// them lived where no test could reach — which is exactly where a rule that is
+// asserted in three comments and enforced in none goes unnoticed. That is not
+// hypothetical: it is what review found in the first draft of this change, and
+// [Record.Check]'s refusal of a mapping onto Fallback is the rule that was
+// missing.
+type Record struct {
+	// Module names the module being held to this record, for diagnostics. A
+	// message that says which module's surface is wrong is one a contributor can
+	// act on without opening the pipeline.
+	Module string
+
+	// Fallback is the module's escape-hatch function — the one that takes an
+	// argument vector verbatim. It is the route every entry in Exceptions is an
+	// exception *to*, and it is not a legal value in Mapped: mirroring the CLI
+	// means a flag's answer is a function named for its command, and forwarding
+	// it is what an exception says instead.
+	Fallback string
+
+	// Mapped is each flag against the function that carries it by name.
+	Mapped map[string]string
+
+	// Exceptions is each flag that reaches the module through Fallback, against
+	// the argument for it being there.
+	Exceptions map[string]Exception
+}
+
+// Check holds the record against the flags the CLI actually accepts and the
+// functions the module actually declares.
+//
+// It fails in six directions, and every one of them was a way the module and the
+// CLI could drift apart while this looked healthy:
+//
+//   - a flag neither table answers, which is the CLI having grown one;
+//   - a flag mapped onto [Record.Fallback], which is the stance being abandoned
+//     one flag at a time, in a diff that reads like any other mapping;
+//   - a flag in both tables, which does not say which answer is the module's;
+//   - a mapping onto a function the module does not declare;
+//   - an exception that claims neither settled nor tracked, or gives no reason;
+//   - either table naming a flag the CLI no longer accepts.
+//
+// Every fault is reported rather than the first, and the flags are walked in a
+// fixed order, because two runs over one tree should say the same thing in the
+// same order — a map's iteration order is whatever the runtime felt like, and a
+// diagnostic that reshuffles is one a contributor cannot diff against the last.
+//
+// What none of this establishes is that an answer is *right*. Nothing here proves
+// the named function can reach the flag, and since the fallback forwards an
+// arbitrary vector, every flag is reachable through it by construction. What the
+// rules buy is that somebody had to say which answer they meant, in a form that
+// distinguishes a decision from a gap — and had to say it again the next time the
+// CLI's surface moved.
+func (r Record) Check(flags, functions []string) error {
+	var errs []error
+
+	// Where each flag is recorded, and as what: the reverse direction's message
+	// as well as this loop's bookkeeping.
+	recorded := map[string]string{}
+	maps.Copy(recorded, r.Mapped)
+
+	for _, flag := range slices.Sorted(maps.Keys(r.Exceptions)) {
+		if function, both := r.Mapped[flag]; both {
+			errs = append(errs, fmt.Errorf(
+				"%s is recorded both as mapped onto %s's %s and as an exception reaching it through %s: a flag has "+
+					"one answer, and the two tables are how a mapped flag and an excepted one are told apart, so a "+
+					"flag in both says the module mirrors it and does not at once",
+				flag, r.Module, function, r.Fallback))
+
+			continue
+		}
+
+		recorded[flag] = r.Fallback
+	}
+
+	for _, flag := range flags {
+		function, mapped := r.Mapped[flag]
+		exception, excepted := r.Exceptions[flag]
+
+		// Both are checked when a flag is in both tables, rather than one of them
+		// standing in for the pair. The flag is already a failure by then, but the
+		// contributor about to delete one of the two entries should learn now
+		// whether the one they are keeping is sound.
+		if mapped {
+			switch {
+			case function == r.Fallback:
+				errs = append(errs, fmt.Errorf(
+					"%s is mapped onto %s in the flag table, and %s is the escape hatch rather than a function that "+
+						"carries a flag: %s mirrors the cpybkc CLI, so a flag's answer is an argument on the function "+
+						"named for its command — record it there, or, if a Dagger argument cannot express it, as an "+
+						"exception carrying the argument for that and the issue curating it if one is",
+					flag, r.Fallback, r.Fallback, r.Module))
+
+			case !slices.Contains(functions, function):
+				errs = append(errs, fmt.Errorf(
+					"%s is recorded as covered by %s's %s, and that module declares no such function; either the "+
+						"function was renamed and this table was not, or the flag now reaches the module some other way",
+					flag, r.Module, function))
+			}
+		}
+
+		if excepted {
+			if err := exception.Check(flag); err != nil {
+				errs = append(errs, err)
+			}
+		}
+
+		if !mapped && !excepted {
+			errs = append(errs, fmt.Errorf(
+				"the cpybkc CLI accepts %s and %s records nothing that answers it: %s is the cpybkc CLI daggerized, "+
+					"so the answer is ordinarily an argument on the function named for the command this flag belongs "+
+					"to; a flag a Dagger argument cannot express is an exception instead, carrying the argument for "+
+					"that and the issue curating it if one is",
+				flag, r.Module, r.Module))
+		}
+	}
+
+	// The route every exception is an exception *to*. An entry saying a flag
+	// reaches the module through a function the module no longer declares covers
+	// nothing, and it would otherwise be the one claim in either table checked
+	// against nothing.
+	if len(r.Exceptions) > 0 && !slices.Contains(functions, r.Fallback) {
+		errs = append(errs, fmt.Errorf(
+			"flags are recorded as reaching %s through %s, and that module declares no such function: the escape "+
+				"hatch is what every exception is an exception to, so a rename of it is a rewrite of the exceptions "+
+				"rather than a rename",
+			r.Module, r.Fallback))
+	}
+
+	for _, flag := range slices.Sorted(maps.Keys(recorded)) {
+		if !slices.Contains(flags, flag) {
+			errs = append(errs, fmt.Errorf(
+				"%s records %s as answered by %s and the cpybkc CLI no longer accepts that flag; a module argument "+
+					"is public API for as long as the published module ref exists, so a flag leaving the CLI is a "+
+					"decision about the module rather than a line to delete from this table without one",
+				r.Module, flag, recorded[flag]))
+		}
+	}
+
+	return errors.Join(errs...)
+}

--- a/.dagger/internal/coverage/record_test.go
+++ b/.dagger/internal/coverage/record_test.go
@@ -1,0 +1,182 @@
+// Every rule the mirroring stance rests on is a row here, and one of them is a
+// row because it was missing. The first draft of this change asserted in three
+// comments that the flag table does not accept the escape hatch as a value, and
+// enforced it nowhere: a flag recorded as `"--new-flag": "Run"` passed the check
+// green, which is precisely the drift the stance exists to catch. It was found in
+// review rather than by a test, because the rule lived where no test could reach
+// it.
+//
+// That is the argument for this file existing at all, so the rules stay here even
+// though the tables they are applied to live in the pipeline.
+
+package coverage
+
+import (
+	"strings"
+	"testing"
+)
+
+// theModule is a stand-in for daggerverse/cpybkc: the rules are the same
+// whichever module a record is about, and a fixture that named the real one
+// would read as though they were not.
+const theModule = "the/module"
+
+// sound is a record with an answer of each kind and nothing wrong with it. The
+// tests below break one thing about it at a time, which is what keeps a row's
+// name honest — a fixture broken in two ways passes a test looking for either.
+func sound() Record {
+	return Record{
+		Module:   theModule,
+		Fallback: "Run",
+		Mapped: map[string]string{
+			"--manifest": "Generate",
+			"--copybook": "Init",
+		},
+		Exceptions: map[string]Exception{
+			"--help":    {Reason: "the question has a Dagger-native form", Settled: true},
+			"--emit-ir": {Reason: "a stream destination", Tracking: "#251"},
+		},
+	}
+}
+
+func flags() []string     { return []string{"--copybook", "--emit-ir", "--help", "--manifest"} }
+func functions() []string { return []string{"Generate", "Image", "Init", "Run"} }
+
+func TestCheckAcceptsARecordThatAnswersEveryFlag(t *testing.T) {
+	if err := sound().Check(flags(), functions()); err != nil {
+		t.Fatalf("Check() = %v, want nil", err)
+	}
+}
+
+func TestCheckRefusesTheWaysTheModuleAndTheCliDrift(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		record    func(Record) Record
+		flags     []string
+		functions []string
+		want      string
+	}{
+		{
+			// The CLI grew a flag and nobody said what the module does about it.
+			name:  "a flag neither table answers",
+			flags: append(flags(), "--jobs"),
+			want:  "records nothing that answers it",
+		},
+		{
+			// The rule review found missing. A mapping onto the escape hatch reads
+			// in a diff exactly like a mapping onto a real function, and it is the
+			// stance being abandoned one flag at a time.
+			name: "a flag mapped onto the escape hatch",
+			record: func(r Record) Record {
+				r.Mapped["--jobs"] = "Run"
+				return r
+			},
+			flags: append(flags(), "--jobs"),
+			want:  "is the escape hatch rather than a function that carries a flag",
+		},
+		{
+			name: "a flag in both tables",
+			record: func(r Record) Record {
+				r.Exceptions["--manifest"] = Exception{Reason: "because", Settled: true}
+				return r
+			},
+			want: "does not at once",
+		},
+		{
+			name: "a mapping onto a function the module does not declare",
+			record: func(r Record) Record {
+				r.Mapped["--manifest"] = "Regenerate"
+				return r
+			},
+			want: "declares no such function",
+		},
+		{
+			// Exception.Check's rules reach the record through here, so a
+			// malformed entry fails the whole check rather than only the type.
+			name: "an exception that claims nothing",
+			record: func(r Record) Record {
+				r.Exceptions["--help"] = Exception{Reason: "because"}
+				return r
+			},
+			want: "neither settled nor tracked",
+		},
+		{
+			name:  "a flag the CLI no longer accepts, mapped",
+			flags: []string{"--copybook", "--emit-ir", "--help"},
+			want:  "no longer accepts that flag",
+		},
+		{
+			name:  "a flag the CLI no longer accepts, excepted",
+			flags: []string{"--copybook", "--help", "--manifest"},
+			want:  "no longer accepts that flag",
+		},
+		{
+			// The route every exception is an exception to.
+			name:      "an escape hatch the module does not declare",
+			functions: []string{"Generate", "Image", "Init"},
+			want:      "the escape hatch is what every exception is an exception to",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			record := sound()
+			if tc.record != nil {
+				record = tc.record(record)
+			}
+
+			have, declares := flags(), functions()
+			if tc.flags != nil {
+				have = tc.flags
+			}
+
+			if tc.functions != nil {
+				declares = tc.functions
+			}
+
+			err := record.Check(have, declares)
+			if err == nil {
+				t.Fatalf("Check() = nil, want an error mentioning %q", tc.want)
+			}
+
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("Check() = %q, want it to mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestCheckReportsBothAnswersForAFlagInBothTables(t *testing.T) {
+	// The flag is already a failure, but the contributor is about to delete one
+	// of the two entries and should learn now whether the one they keep is sound.
+	record := sound()
+	record.Mapped["--help"] = "Regenerate"
+
+	err := record.Check(flags(), functions())
+	if err == nil {
+		t.Fatal("Check() = nil, want an error")
+	}
+
+	for _, want := range []string{"does not at once", "declares no such function"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Check() = %q, want it to mention %q", err, want)
+		}
+	}
+}
+
+func TestCheckReportsEveryFlagsFaultAtOnce(t *testing.T) {
+	// A record is usually wrong in more than one place at a time — the CLI grew a
+	// flag and a function was renamed in the same pull request — and reporting one
+	// fault per run is one run per fault.
+	record := sound()
+	record.Mapped["--manifest"] = "Regenerate"
+
+	err := record.Check(append(flags(), "--jobs"), functions())
+	if err == nil {
+		t.Fatal("Check() = nil, want an error")
+	}
+
+	for _, want := range []string{"records nothing that answers it", "declares no such function"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Check() = %q, want it to mention %q", err, want)
+		}
+	}
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -871,11 +871,14 @@ stopped being true, this decision would be worth taking again.
 
 #### `Run` is the fallback, not the plan
 
-It takes the argument vector verbatim and hands back a `Container`, and it is
-for exactly two things. A flag the module has not caught up with is reachable
-through it in the meantime, which keeps a gap an inconvenience rather than a
-wall. And a *spelling* no Dagger type can express is reachable through it
-permanently.
+It takes the argument vector verbatim and hands back a `Container`, and three
+kinds of thing arrive here. A flag the module has not caught up with is
+reachable through it in the meantime, which keeps a gap an inconvenience rather
+than a wall — that one is temporary, and the exception recording it names the
+issue closing it. A *spelling* no Dagger type can express is reachable through
+it permanently. And a flag whose question has a Dagger-native answer that is not
+a function on this module stays here on purpose — `--version`, `--help` and `-h`,
+recorded as **settled**, which is the class `Exception.Settled` exists to name.
 
 That second one is why a named function may still decline one spelling of a
 flag without declining the flag, and the sentence is kept deliberately because
@@ -915,14 +918,23 @@ and holds each of them against two tables in
   `Run` instead, with the argument for why. An entry says either that it is
   **settled** — the escape hatch is this flag's answer — or that it is
   **tracked**, naming the issue writing the function, and a reason is required
-  either way. The rules are
-  [`.dagger/internal/coverage/`](.dagger/internal/coverage/)'s, pinned by tests.
+  either way.
 
-The check fails when a flag is in neither table, when it is in both, when a
-mapping names a function `daggerverse/cpybkc` does not declare, when an
-exception claims neither settled nor tracked, and when either table names a flag
-the CLI has stopped accepting. **So adding a flag to cpybkc fails CI until
-somebody either maps it onto a function or writes down why it cannot be.**
+Every rule above lives in
+[`.dagger/internal/coverage/`](.dagger/internal/coverage/) rather than in
+`cli-surface` itself, and is pinned by tests there; `cli-surface` reads the flags
+and the module's function names — the part that needs a Dagger session — and
+hands them over. That split is not tidiness. The first draft of #253 wrote the
+rules inline, where no test could reach them, and asserted in three comments that
+`Run` is not a legal mapping while enforcing it nowhere: `"--new-flag": "Run"`
+passed green. Review caught it; a test would have.
+
+The check fails when a flag is in neither table, when it is mapped onto `Run`,
+when it is in both tables, when a mapping names a function
+`daggerverse/cpybkc` does not declare, when an exception claims neither settled
+nor tracked, and when either table names a flag the CLI has stopped accepting.
+**So adding a flag to cpybkc fails CI until somebody either maps it onto a
+function or writes down why it cannot be.**
 
 The two tables are the tightening #253 asked for, and they are worth the second
 map for one reason. While the module curated (#62), a flag recorded against

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -698,12 +698,25 @@ to be settled before it could be written, because the answer is a default value
 in a constructor, and a default in a module directory that is never renamed is
 public API from the first release.
 
-The module gets no `SPEC.md`. It is a convenience over the [base-image
-contract](docs/container/SPEC.md) rather than an interface of its own, and what
-it needs to say it says in its module comment and in `dagger call --help`
-([`docs/CONVENTIONS.md`](docs/CONVENTIONS.md), *What belongs here*). What
-follows is the argument behind one of those comments, kept here because the
-argument is longer than the comment and outlives the reader who needs it.
+The module **is** an interface of its own — it mirrors the CLI, and a function
+name or an argument on it is public API for as long as the published ref exists
+(#253, and [the stance](#the-module-mirrors-the-cli-and-the-check-that-holds-it-to-it)
+below). It gets no `SPEC.md` all the same, and not because there would be
+nothing to specify: everything there would be to specify is specified already.
+What a flag means is [`docs/cli/SPEC.md`](docs/cli/SPEC.md)'s, what the image
+promises is [the base-image contract](docs/container/SPEC.md)'s, and what a
+generator is handed is [`docs/plugin/SPEC.md`](docs/plugin/SPEC.md)'s. A
+document here would be a second reading of those three, in another vocabulary
+and on another schedule, which is the drift the module is checked for rather
+than a defence against it ([`docs/CONVENTIONS.md`](docs/CONVENTIONS.md), *What
+belongs here*).
+
+What is the module's own is the *mapping* — which function carries which flag —
+and that lives in this repository's pipeline, in
+[`.dagger/companion.go`](.dagger/companion.go), where `dagger call cli-surface`
+fails on it. The rest it says in its module comment and in `dagger call --help`.
+What follows is the argument behind those, kept here because the argument is
+longer than the comment and outlives the reader who needs it.
 
 ### The directory name is the public ref, so it is chosen once
 
@@ -801,19 +814,28 @@ Both modules' generated code is committed, so a change to either is a
 [*After changing the module*](#after-changing-the-module) applies to the
 companion exactly as it does to the root.
 
-### The curated surface, and the check that keeps it honest
+### The module mirrors the CLI, and the check that holds it to it
+
+**The module is the cpybkc CLI daggerized.** Every capability the CLI has
+should be reachable as a function named for the command it belongs to, with the
+command's flags as arguments on it; a caller who can do something with `cpybkc`
+and cannot do it here has found a gap to file, not a decision to respect. That
+is the stance (#253), and everything else in this section follows from it.
 
 `Generate` takes a source directory and a manifest and hands back a
 `Directory`; `Init` takes a source directory and copybook paths and hands back
 the layout scaffold as a `File`; `Run` takes an argument vector verbatim and
-hands back a `Container`. Those three are the whole surface, and the split
-between them is a decision rather than a stopping point (#62).
+hands back a `Container`. The first two are the two commands cpybkc has, under
+the CLI's own names — a second name for one command would be this module's
+vocabulary rather than cpybkc's, and a module mirroring the CLI has the least
+business growing one. The third is the fallback, and the rest of this section is
+about what that means.
 
-The two curated ones are the two commands cpybkc has. `Init` is `cpybkc init`
-(#228), and it is curated for a reason the default action does not need: it is
-the run an adopter reaches **first**, before there is a manifest or a layout for
-anything else to read, so it is the one invocation they have nothing to copy
-from. It takes copybook *paths* into `--source` rather than files, because
+`Init` is `cpybkc init` (#228), and it is the run that made the case for
+mapping the commands by name at all: it is the run an adopter reaches **first**,
+before there is a manifest or a layout for anything else to read, so it is the
+one invocation they have nothing to copy from. It takes copybook *paths* into
+`--source` rather than files, because
 [`docs/cli/SPEC.md`](docs/cli/SPEC.md) has the scaffold record each path as it
 was typed and a layout's own paths are relative to the layout; and it supplies
 `--out` itself, at a path outside the mounted project, so *nothing at `<dest>`
@@ -821,53 +843,114 @@ is ever replaced* holds without the module reasoning about the caller's tree at
 all. Where the file goes in that tree is what they name at `export`, which is
 the one thing the adopter knows and cpybkc does not.
 
-The module **does not** grow an argument per entry in
-[`docs/cli/SPEC.md`](docs/cli/SPEC.md)'s flag table. A module argument is public
-API for as long as the published ref exists — the [directory name is the public
-ref](#the-directory-name-is-the-public-ref-so-it-is-chosen-once) — so a table
-mapped one-to-one would make every change to the CLI's surface a change to this
-module's, and it would have to express in Dagger arguments two things a command
-line says better: a flag that *replaces* the action rather than configuring it
-(`--emit-ir` is terminal — no generator runs, and nothing is merged or pruned),
-and a flag that is only legal beside another (`--emit-ir-format` without
-`--emit-ir` is a usage error). `Run` is what makes the small surface safe: an
-uncurated flag is reachable without the module having an opinion about it, and
-it returns the container rather than a directory because the uncurated
-invocations are exactly the ones whose answer is not a tree — `--emit-ir` may
-write to standard output, and `--version` and `--help` write nothing else at
-all.
+#### What this stance replaced, and what it costs
 
-It is also what lets a curated function decline one *spelling* of a flag
-without declining the flag. `Init` does not offer `--out -`, which a
-`File`-returning function cannot express any more than it can express
-`--emit-ir`'s stream; the scaffold on standard output is
+Until #253 the module argued the opposite, and argued it well. It curated
+deliberately: two functions, an escape hatch, and the reasoning that **a module
+argument is public API for as long as the published ref exists** — the
+[directory name is the public
+ref](#the-directory-name-is-the-public-ref-so-it-is-chosen-once) — so a surface
+mapped one-to-one onto `docs/cli/SPEC.md`'s flag table makes every change to
+that table a change to this module's. That cost is real, and mirroring **pays**
+it rather than avoids it: adding a flag to cpybkc now ordinarily means adding an
+argument here that can never be removed.
+
+What decided it the other way is what the alternative cost. A curated surface
+and a forgotten one read identically from outside, so a caller could not tell
+"not offered, on purpose" from "nobody has got to it yet" — and neither could a
+contributor, because the argument above was written in four places and read as
+settled. Every gap was therefore argued twice, once by whoever found it and once
+by whoever fixed it: #228 had to argue past it to curate `init`, and #251 has to
+argue past it again for `--emit-ir`. Two arguments per gap is a worse price than
+a permanent argument per flag, because it is paid by whoever is *least* able to
+pay it — somebody who wanted a feature, not a stance.
+
+The judgment underneath is that the flag table moves slowly. `docs/cli/SPEC.md`
+is a specification with its own review, not a place flags accumulate; if that
+stopped being true, this decision would be worth taking again.
+
+#### `Run` is the fallback, not the plan
+
+It takes the argument vector verbatim and hands back a `Container`, and it is
+for exactly two things. A flag the module has not caught up with is reachable
+through it in the meantime, which keeps a gap an inconvenience rather than a
+wall. And a *spelling* no Dagger type can express is reachable through it
+permanently.
+
+That second one is why a named function may still decline one spelling of a
+flag without declining the flag, and the sentence is kept deliberately because
+#228 and #251 both lean on it. `Init` does not offer `--out -`, which a
+`File`-returning function cannot express; `--emit-ir` will be the same when it
+is curated. A destination that is a stream rather than a file is the whole of
+that class today, and the scaffold on standard output is
 `run --source . --args=init,--copybook,posting.cpy,--out,-`, exactly as it was
 before there was an `Init`.
 
-What a curated surface risks is the CLI quietly growing a flag the module can
-no longer express, which reads from out here exactly like a module that chose
-not to express it. `dagger call cli-surface` is the difference, and it is in
-`ci`:
+It returns a container rather than a directory for the same reason: the
+invocations that arrive here are the ones whose answer is not a tree —
+`--emit-ir` may write to standard output, and `--version` and `--help` write
+nothing else at all.
+
+What `Run` is **not** is the intended route for a class of flag. A pull request
+that adds a flag to cpybkc and records it against `Run` is doing something that
+now has to be argued in the diff, and the next section is how.
+
+#### The check, and the two tables it reads
+
+What the stance risks is the CLI quietly growing a flag the module cannot
+express, which reads from out here exactly like a module that chose not to
+express it. `dagger call cli-surface` is the difference, and it is in `ci`:
 
 ```sh
 dagger call cli-surface
 ```
 
 It reads the CLI's flag constants out of the [`cmd/cpybkc/`](cmd/cpybkc/) tree
-and fails when one of them is not recorded in `companionCoverage` in
-[`.dagger/companion.go`](.dagger/companion.go), when a recorded entry names a
-function `daggerverse/cpybkc` does not declare, or when an entry names a flag
-the CLI has stopped accepting. **So adding a flag to cpybkc fails CI until
-somebody says which side of the curation it falls on** — a curated argument on
-`Generate` or `Init`, or `Run`.
+and holds each of them against two tables in
+[`.dagger/companion.go`](.dagger/companion.go):
 
-Be exact about what an entry in that table claims, because it is less than it
+- **`companionCoverage`** maps a flag onto the function that carries it, by
+  name. This is where a flag belongs, and `Run` is not a value it accepts.
+- **`companionRunExceptions`** records a flag that reaches the module through
+  `Run` instead, with the argument for why. An entry says either that it is
+  **settled** — the escape hatch is this flag's answer — or that it is
+  **tracked**, naming the issue writing the function, and a reason is required
+  either way. The rules are
+  [`.dagger/internal/coverage/`](.dagger/internal/coverage/)'s, pinned by tests.
+
+The check fails when a flag is in neither table, when it is in both, when a
+mapping names a function `daggerverse/cpybkc` does not declare, when an
+exception claims neither settled nor tracked, and when either table names a flag
+the CLI has stopped accepting. **So adding a flag to cpybkc fails CI until
+somebody either maps it onto a function or writes down why it cannot be.**
+
+The two tables are the tightening #253 asked for, and they are worth the second
+map for one reason. While the module curated (#62), a flag recorded against
+`Run` was the design working, so one map with `"Run"` as an ordinary value said
+everything; under the mirroring stance it is the opposite, and a new flag
+quietly recorded against `Run` and passing CI **is** the drift this check exists
+to catch. One map cannot tell that from the flags nobody has curated on purpose.
+Two can, because writing an exception means writing a reason and saying which of
+the two claims you are making — in the diff, where a reviewer reads it.
+
+Be exact about what an entry in either table claims, because it is less than it
 looks. It is a person's assertion that they thought about the flag and decided
 where it belongs; nothing verifies that the named function can *reach* it, and
 since `Run` forwards an arbitrary vector, every flag is reachable through `Run`
-by construction. What the check buys is that the assertion has to be re-made
+by construction. No check can read an argument and say whether it is a good one.
+What the check buys is that the assertion has to be **made**, and re-made
 whenever the CLI's surface moves, which is exactly when it stops being true by
 accident.
+
+Today's exceptions are `--emit-ir` and `--emit-ir-format`, tracked to #251, and
+`--version`, `--help` and `-h`, settled: `dagger call --help` and the
+per-function documentation are the Dagger-native form of that question, and
+which release runs is something a caller states at `New`'s `--version` rather
+than asks the CLI afterwards. That last reason does not cover everything, which
+is why the escape hatch stays the answer for the rest of it — `--version`
+defaults to the moving `v0` tag, so *which tag was asked for* and *which build
+is running* are different questions, and `run --args=--version` is how the
+second is asked.
 
 Three things about how it reads are worth knowing before changing either side.
 It reads the parser's **constants**, not `cpybkc --help` and not the spec's
@@ -899,6 +982,36 @@ This is the shape of check [#65 was closed for not
 being](#65-is-closed-rather-than-left-open). It fails on something a person does
 — adding a flag in one module and not thinking about the other — rather than on
 a constant compared against the thing it was generated from.
+
+#### The flag table is not the CLI's surface
+
+`cli-surface` reads flag **constants**, so a capability cpybkc has that is not
+spelled as a flag is invisible to it by construction. That is not a hole to be
+plugged; it is the boundary of what a check reading Go source can see, and under
+the mirroring stance it matters, because the module's obligation is every
+capability rather than every flag.
+
+There is one such capability today and it is the worked case. cpybkc passes its
+whole environment through to a generator — that pass-through **is** how
+[`docs/plugin/SPEC.md`](docs/plugin/SPEC.md) propagates `SOURCE_DATE_EPOCH` —
+and the companion module offers no way to state an environment at all, so a
+promise that document makes to every generator author does not reach a Dagger
+caller (#252). No check here noticed, and none could have.
+
+So the answer to how the next one is caught is a person, at the document that
+promises it: **a change to
+[`docs/cli/SPEC.md`](docs/cli/SPEC.md) or [`docs/plugin/SPEC.md`](docs/plugin/SPEC.md)
+that adds a capability which is not a flag is answered in the companion module
+in the same review.** That is a weaker guarantee than `cli-surface`, and saying
+so plainly is the point — a reader who believes the check covers the whole
+surface will not go looking.
+
+The mechanical version was considered and is not worth having. Anything that
+could notice "`docs/cli/SPEC.md` changed" is a check comparing a document
+against a copy of itself, which is precisely [the shape #65 was closed for
+being](#65-is-closed-rather-than-left-open): it fails on every edit to that
+document and on nothing else, so it is answered by updating the copy, and a
+check whose remedy is *tell it what happened* has taught nobody anything.
 
 ### Composing a generator is `COPY --from`, split across two methods
 
@@ -1051,9 +1164,12 @@ The curated scaffolding function has to hand back the scaffold
 `run --args=init,…,--out,-` writes over the same three copybooks in
 [`example/`](example/), byte for byte (#228). That is cheap, it needs no second
 reading of what a scaffold should contain — `internal/scaffold`'s tests own that
-— and it is the property the escape-hatch entry in `companionCoverage` stood in
-for while there was no function: a caller who reached for `run` before it existed
-gets the same file from the function that replaced it. It runs against the base
+— and it is the property `init`'s escape-hatch entry stood in for while there was
+no function: a caller who reached for `run` before it existed gets the same file
+from the function that replaced it. That generalises, which matters now that
+every command is meant to have a function: what makes a new one safe to add is
+that the run it replaces is still spellable through `run` and still produces the
+same bytes. It runs against the base
 image with nothing composed into it, because `init` resolves no layout and runs
 no generator, which is also the state an adopter is in when they run it.
 

--- a/README.md
+++ b/README.md
@@ -211,12 +211,25 @@ dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
   generate --source . export --path .
 ```
 
-It is a convenience over [the container base-image
-contract](docs/container/SPEC.md) and not an interface of its own, so it has no
-`SPEC.md`: what it needs to say it says in `dagger call --help`. Everything it
-does can be written by hand as a `docker run` or a `COPY --from` instead, and a
-caller reaching for one is not on a lesser path — `with-generator` stands for
-exactly the two lines [the worked
+It is the cpybkc CLI daggerized: what `cpybkc` can do, this module aims to do by
+name, with the CLI's commands as functions and their flags as arguments.
+`generate` and `init` are the two commands there are; `run` is the fallback for
+what has not been mapped yet and for the spellings a Dagger type cannot express,
+such as a destination that is a stream. Where the two disagree, that is a gap to
+file rather than a decision to work around.
+
+It still has no `SPEC.md`, and not because there is nothing to specify — it is
+public API, and a function or an argument here lasts as long as the published
+ref does. It is that everything there would be to specify is specified already:
+what a flag means is [the CLI's](docs/cli/SPEC.md), what the image promises is
+[the base-image contract's](docs/container/SPEC.md), and what a generator is
+handed is [the plugin contract's](docs/plugin/SPEC.md). A document here would be
+a second reading of those three. What it needs to say beyond them it says in
+`dagger call --help`.
+
+Everything it does can still be written by hand as a `docker run` or a
+`COPY --from` instead, and a caller reaching for one is not on a lesser path —
+`with-generator` stands for exactly the two lines [the worked
 example](docs/container/SPEC.md#worked-example-adding-a-generator) gives somebody
 writing a Dockerfile, and `with-generator-executable` does the same for a
 generator that has not been published yet.

--- a/daggerverse/cpybkc/internal/argv/argv.go
+++ b/daggerverse/cpybkc/internal/argv/argv.go
@@ -5,13 +5,14 @@
 // module's own package main imports the generated Dagger client, whose init
 // panics without a session, so a test beside main cannot run under plain
 // `go test` at all. Keeping the part that is only string handling in a package
-// that imports no Dagger is what turns the vector a curated function builds
-// into something a test pins rather than something a comment asserts.
+// that imports no Dagger is what turns the vector a named function builds into
+// something a test pins rather than something a comment asserts.
 //
-// What is deliberately not here is a builder covering the whole of
-// docs/cli/SPEC.md's flag table. The module curates: it maps the run a caller
-// almost always wants, and hands everything else to Run, whose vector is the
-// caller's own words and is not this package's to assemble.
+// One vector is deliberately not assembled here, and it is Run's. The module
+// mirrors the cpybkc CLI (#253), so a function is added here as each command's
+// flags are mapped onto it; but the fallback's vector is the caller's own words,
+// passed through as written, and a vector this package built for them would be a
+// second, unversioned reading of the document the CLI already implements.
 package argv
 
 import "fmt"

--- a/daggerverse/cpybkc/internal/generator/generator.go
+++ b/daggerverse/cpybkc/internal/generator/generator.go
@@ -115,7 +115,7 @@ func Repository(repository, name string) string {
 // digits and hyphens is a **SHOULD** — a convention about names that are easy to
 // type, not a constraint on what cpybkc will run — and a module refusing a name
 // cpybkc would have resolved would be making the contract smaller from the
-// outside, which is the one thing a convenience over a contract must not do.
+// outside, which is the one thing a module mirroring the CLI must not do.
 func CheckName(name string) error {
 	switch {
 	case name == "":

--- a/daggerverse/cpybkc/internal/generator/generator_test.go
+++ b/daggerverse/cpybkc/internal/generator/generator_test.go
@@ -126,8 +126,8 @@ func TestCheckNameAccepts(t *testing.T) {
 		"go",
 		"acme-cobol2",
 		// Refused by docs/plugin/SPEC.md's SHOULD and not by either MUST. cpybkc
-		// resolves it, so this module composes it: a convenience over a contract
-		// does not get to make the contract smaller.
+		// resolves it, so this module composes it: a module mirroring the CLI does
+		// not get to make the contract smaller.
 		"Weird_Name.v2",
 		// Without a separator it cannot leave the plugin directory, so it needs no
 		// rule of its own and must not acquire one by accident.

--- a/daggerverse/cpybkc/main.go
+++ b/daggerverse/cpybkc/main.go
@@ -788,12 +788,14 @@ func (m *Cpybkc) Init(
 //
 // It is not the intended route for anything. This module mirrors the CLI, so a
 // capability's ordinary answer is an argument on the function named for the
-// command it belongs to (#253), and what is left over is the two things this
-// function is for. A flag this module has not caught up with is reachable
-// through it in the meantime, which is what keeps a gap an inconvenience rather
-// than a wall. And a spelling no Dagger type can express is reachable through it
-// permanently: a destination that is a stream rather than a file — `--out -`,
-// `--emit-ir -` — which a File-returning function cannot hand back.
+// command it belongs to (#253), and three kinds of thing are left over for this
+// function. A flag this module has not caught up with is reachable through it in
+// the meantime, which is what keeps a gap an inconvenience rather than a wall. A
+// spelling no Dagger type can express is reachable through it permanently: a
+// destination that is a stream rather than a file — `--out -`, `--emit-ir -` —
+// which a File-returning function cannot hand back. And a flag whose question
+// has a Dagger-native answer that is not a function here stays on purpose, which
+// is --version, --help and -h and is meant to be the whole of that class.
 //
 // Which flags arrive here today is stated in this module's package comment and
 // recorded where a check can fail on it, in the root pipeline's

--- a/daggerverse/cpybkc/main.go
+++ b/daggerverse/cpybkc/main.go
@@ -9,22 +9,32 @@
 // Nothing is installed on the host and no Dockerfile is written: the published
 // images are pulled, composed, and run.
 //
-// # This is a convenience, not a contract
+// # An interface of its own, and why it still gets no SPEC.md
 //
-// The contract is the published image. docs/container/SPEC.md says what the
-// entrypoint is, which directory generators are discovered in, which UID the
-// process runs as and where the IR schema lives, and it is that document a third
-// party builds against. Everything here is those promises spelled as Dagger
-// calls, and every one of them can be written by hand as
-// `docker run --rm ghcr.io/zaba505/cpybkc:v0` instead.
+// This module is the cpybkc CLI daggerized (#253): a caller who reaches for it
+// should be able to do what `cpybkc` does, by name. That makes it something a
+// third party builds against rather than a convenience they could equally well
+// do without — a function name, an argument and a default here are public API
+// for as long as the directory this module is published under exists, which is
+// for as long as the directory exists at all.
 //
-// So this module gets no SPEC.md, deliberately (docs/CONVENTIONS.md, "What
-// belongs here"). A specification for it would imply the contract is a property
-// of the module — that a caller reaching for `docker run`, a Kubernetes Job or a
-// Dockerfile were on a lesser path — when the module is the one thing in this
-// repository that could be deleted without breaking a single promise cpybkc
-// makes. What it needs to say, it says in this comment and in
-// `dagger call --help`.
+// It gets no SPEC.md all the same, and the reason is not that there would be
+// nothing to specify. It is that everything there would be to specify is
+// specified already: what a flag means is docs/cli/SPEC.md's, what the image
+// promises is docs/container/SPEC.md's, and what a generator is handed is
+// docs/plugin/SPEC.md's. A document here would be a second reading of those
+// three, in another vocabulary and on another schedule, which is the drift the
+// mapping is checked for rather than a defence against it. What is this module's
+// own is the mapping — which function carries which flag — and that is written
+// down in this repository's pipeline, where `dagger call cli-surface` fails on
+// it, rather than in a document nothing can check (docs/CONVENTIONS.md, "What
+// belongs here").
+//
+// Everything here can still be written by hand as
+// `docker run --rm ghcr.io/zaba505/cpybkc:v0` or as a `COPY --from`, and a
+// caller who prefers either is not on a lesser path. What the stance changes is
+// what it means when the CLI can do something this module cannot: that is a gap
+// to be filed, not a curation working as designed.
 //
 // It states nothing about the plugin CLI contract either. `cpybkc-gen-<name>`,
 // the argument vector and the exit codes are docs/plugin/SPEC.md's, they hold
@@ -144,38 +154,59 @@
 // are the caller's (docs/container/SPEC.md's `CGO_ENABLED=0`). Nothing here can
 // check that, which is why it is said rather than enforced.
 //
-// # The curated surface, and why it is not the flag table
+// # The surface mirrors the CLI, and Run is the fallback
 //
-// Two functions map a cpybkc command by name, and they are the two commands
-// there are. Generate takes a source directory and a manifest, and is the
-// default action — what cpybkc does when nothing else is asked of it. Init takes
-// a source directory and copybook paths and hands back the layout scaffold, which
-// is `cpybkc init`; it is curated because it is the run an adopter reaches first,
-// before there is a manifest or a layout for anything else to read, and so the one
-// invocation they have nothing to copy from.
+// Every capability cpybkc has should be reachable here as a function named for
+// the command it belongs to, and every flag as an argument on that function.
+// Generate takes a source directory and a manifest, and is the default action —
+// what cpybkc does when nothing else is asked of it. Init takes a source
+// directory and copybook paths and hands back the layout scaffold, which is
+// `cpybkc init`. Those are the two commands there are, so the names are the
+// CLI's rather than this module's: somebody who read docs/cli/SPEC.md should
+// find what they read about here, under the name they read it under.
 //
-// That is the whole of what this module maps by name. It deliberately does not
-// grow an argument per entry in docs/cli/SPEC.md's flag table: a module argument
-// is public API for as long as the directory this module is published under
-// exists, so a table mapped one-to-one would make every change to that table a
-// change to this module's surface, and would have to express in Dagger arguments
-// things a command line says better — a flag that replaces the action rather
-// than configuring it, and a flag that may not appear beside another.
+// That is a stance rather than an observation, and it replaced a good argument
+// (#62, #253). This module used to curate deliberately — two functions, an
+// escape hatch, and the reasoning that a module argument is public API for as
+// long as the published ref exists, so a surface mapped one-to-one onto
+// docs/cli/SPEC.md's flag table makes every change to that table a change to
+// this module's. That cost is real, and mirroring pays it rather than avoids it.
+// What decided it the other way is what the alternative cost: a caller who can
+// do something with `cpybkc` and not with this module could not tell "not
+// offered, on purpose" from "nobody has got to it yet", and neither could
+// anybody reading this comment — so every gap was argued twice, once by whoever
+// found it and once by whoever fixed it.
 //
-// A curated function is also allowed to decline one spelling of a flag without
-// declining the flag. Init supplies --out itself, at a path inside the container
-// the caller never types, and hands back the File; `--out -` is not offered,
-// because a File-returning function cannot express a stream any more than it can
-// express --emit-ir's. That is not the command being out of reach — it is Run's,
-// below, exactly as --emit-ir is.
+// Run is the fallback, not the plan. It takes the argument vector verbatim and
+// hands back the container, so anything this module has not caught up with is
+// still reachable today; what it is not is the intended route for a class of
+// flag. A flag that reaches a caller through Run is recorded as an exception in
+// this repository's pipeline, with the argument for it and, where it is a gap
+// rather than a decision, the issue curating it — and `dagger call cli-surface`
+// fails on one that is neither. Today that is --emit-ir and --emit-ir-format,
+// which #251 is curating, and --version, --help and -h, which stay: `dagger call
+// --help` and the per-function documentation are the Dagger-native form of that
+// question, and which release runs is something a caller states at New's
+// --version rather than asks the CLI afterwards.
 //
-// Run is the other half of that decision, and the reason the first half can stay
-// small. It takes the argument vector verbatim and hands back the container, so
-// an uncurated flag — --emit-ir, --emit-ir-format, --version, --help, and
-// whatever this document has not heard of — is reachable without this module
-// having an opinion about it. The root pipeline's CliSurface check is what keeps
-// the split honest: it fails when the CLI grows a flag that neither Generate nor
-// Run is recorded as covering, so the two cannot drift quietly.
+// A function is still allowed to decline one *spelling* of a flag without
+// declining the flag, and that stays deliberately. Init supplies --out itself,
+// at a path inside the container the caller never types, and hands back the
+// File; `--out -` is not offered, because a File-returning function cannot
+// express a stream. A stream destination is the whole of that class — --emit-ir
+// will have the same one when it is curated — and the spelling stays Run's,
+// which is the command being reachable rather than out of reach:
+//
+//	dagger call run --source . --args=init,--copybook,posting.cpy,--out,- stdout
+//
+// One thing the flag table cannot say, and this comment therefore should. cpybkc
+// passes its whole environment through to a generator, which is how
+// docs/plugin/SPEC.md propagates SOURCE_DATE_EPOCH — and this module offers no
+// way to state an environment, so that promise does not reach a Dagger caller
+// (#252). It is a capability with no flag behind it, so cli-surface cannot see
+// it and did not; it is named here because the flag table is a lower bound on
+// what mirroring the CLI means, and a reader deserves to know the one place it
+// is currently short.
 package main
 
 import (
@@ -642,9 +673,10 @@ func (m *Cpybkc) Generate(
 //	  init --source . --copybook posting.cpy export --path ledger.sexpr
 //
 // It is the first thing an adopter runs, before there is a manifest, a layout or
-// a generator to speak of, and it is curated for that reason: the one invocation
-// somebody has nothing to copy from is a poor place to make them assemble an
-// argument vector by hand.
+// a generator to speak of, and it is the run that made the case for mapping
+// cpybkc's commands by name at all (#228): the one invocation somebody has
+// nothing to copy from is a poor place to make them assemble an argument vector
+// by hand.
 //
 // What comes back is **not a valid layout** and is not meant to be. `init`
 // writes what the copybooks decide — a record per 01-level, an alternative per
@@ -745,8 +777,8 @@ func (m *Cpybkc) Init(
 		File(scaffoldPath), nil
 }
 
-// Run is the escape hatch: cpybkc invoked with an argument vector this module
-// has no opinion about, in a container handed back whole.
+// Run is the fallback: cpybkc invoked with an argument vector this module has no
+// opinion about, in a container handed back whole.
 //
 //	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
 //	  run --source . --args=--emit-ir,- stdout
@@ -754,13 +786,20 @@ func (m *Cpybkc) Init(
 //	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
 //	  run --args=--help stdout
 //
-// It exists so that Generate does not have to grow an argument every time
-// docs/cli/SPEC.md's flag table does. A flag that replaces the action rather
-// than configuring it (--emit-ir is terminal: no generator runs and nothing is
-// merged or pruned), one that may only appear beside another (--emit-ir-format
-// without --emit-ir is a usage error), and one that answers a question about the
-// program rather than about a project (--version, --help) are all things a
-// command line states plainly and a set of Dagger arguments states badly.
+// It is not the intended route for anything. This module mirrors the CLI, so a
+// capability's ordinary answer is an argument on the function named for the
+// command it belongs to (#253), and what is left over is the two things this
+// function is for. A flag this module has not caught up with is reachable
+// through it in the meantime, which is what keeps a gap an inconvenience rather
+// than a wall. And a spelling no Dagger type can express is reachable through it
+// permanently: a destination that is a stream rather than a file — `--out -`,
+// `--emit-ir -` — which a File-returning function cannot hand back.
+//
+// Which flags arrive here today is stated in this module's package comment and
+// recorded where a check can fail on it, in the root pipeline's
+// companionRunExceptions: `dagger call cli-surface` fails when the CLI grows a
+// flag that neither a named function nor an argued exception covers, so a flag
+// landing on this function quietly is the one thing that cannot happen.
 //
 // A container rather than a directory, because the uncurated invocations are the
 // ones whose answer is not a tree. --emit-ir may write to standard output, and

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -38,8 +38,13 @@ That is the whole test, and it excludes more than it admits:
   corpus's own entries, their derivations and how to add one stay with the
   corpus. The test is who has to implement it, never which directory it sits
   in.
-- **Conveniences over a contract are not contracts.** The Dagger module that
-  runs cpybkc for a caller wraps the container contract; what it needs to say is
+- **An interface that restates specified ones adds no specification.** The
+  Dagger module that runs cpybkc for a caller is an interface somebody builds
+  against — it mirrors the CLI (#253) — but what they build against *through* it
+  is `cli/SPEC.md`, `container/SPEC.md` and `plugin/SPEC.md`. A document here
+  would be a second reading of those three, in another vocabulary and on another
+  schedule. What is the module's own is which function carries which flag, and
+  that is recorded where a check fails on it rather than in prose; the rest is
   said by its module comment and `dagger call --help`.
 
 Something that fails the test and still needs writing down goes in a package

--- a/docs/container/SPEC.md
+++ b/docs/container/SPEC.md
@@ -1504,13 +1504,15 @@ Go install with no document that applies to them.
 
 ### Also out of scope
 
-- **The Dagger module** (#61–#65) that runs cpybkc for a caller. It is a
-  convenience over this contract; what it needs to say, it says in its module
-  comment and `dagger call --help`. Which tag it pulls when a caller names none
-  — the moving major tag — and what pinning its module ref does and does not pin
-  about the image are settled in
-  [CONTRIBUTING.md](../../CONTRIBUTING.md#the-companion-dagger-module) (#104),
-  which is where an argument about a convenience belongs.
+- **The Dagger module** (#61–#65) that runs cpybkc for a caller. It mirrors the
+  cpybkc CLI (#253) and drives an image satisfying this contract; what it needs
+  to say, it says in its module comment and `dagger call --help`, and it gets no
+  specification of its own because what a caller builds against through it is
+  [`cli/SPEC.md`](../cli/SPEC.md) and this document rather than anything it
+  adds. Which tag it pulls when a caller names none — the moving major tag — and
+  what pinning its module ref does and does not pin about the image are settled
+  in [CONTRIBUTING.md](../../CONTRIBUTING.md#the-companion-dagger-module)
+  (#104), which is where that argument belongs.
 - **The registry.** That the image is published to `ghcr.io` (#59) is a fact
   about where to find it, not a guarantee about what is inside it. A mirror
   serving the same digest satisfies this contract identically.


### PR DESCRIPTION
Closes #253

## The decision

**`daggerverse/cpybkc` mirrors the cpybkc CLI.** Every capability the CLI has
should be reachable as a function named for the command it belongs to, with that
command's flags as arguments on it. `Run` is the fallback, not the plan. A caller
who can do something with `cpybkc` and cannot do it through the module has found
a gap to file, not a decision to respect.

The counter-argument was good, and the rewrite says so rather than deleting it: a
module argument is public API for as long as the published ref exists, so
mirroring makes every change to `docs/cli/SPEC.md`'s flag table a change to this
module's surface. **Mirroring pays that cost rather than avoiding it.** What
decided it the other way is that a curated surface and a forgotten one read
identically from outside, so every gap was argued twice — #228 argued past the
paragraph to curate `init`, #251 has to argue past it again for `--emit-ir`.

## Acceptance criteria

- [x] **The stance is decided, and the argument is written where the
  counter-argument was.** Every rewritten passage carries the argument, what it
  replaced, and what it costs — not a bare assertion.
- [x] **`daggerverse/cpybkc`'s package comment states it.** *The surface mirrors
  the CLI, and Run is the fallback*, which is where `dagger call --help` takes a
  caller.
- [x] **`companionCoverage`'s header is rewritten**, and every entry naming `Run`
  now reads as what the stance says it is — see the check below.
- [x] **`CONTRIBUTING.md`'s section is rewritten**, retitled *The module mirrors
  the CLI, and the check that holds it to it*, with subsections for what the
  stance replaced and cost, what `Run` is for, and the two tables.
- [x] **`README.md`'s claim is restated, not silently dropped.** The module *is*
  an interface of its own and still gets no `SPEC.md` — because everything there
  would be to specify is specified already, in `cli/SPEC.md`,
  `container/SPEC.md` and `plugin/SPEC.md`. A document here would be a second
  reading of those three, which is the drift the check exists to catch.
- [x] **What `Run` is for is stated**: a flag not caught up with yet, and a
  spelling no Dagger type can express. The *decline one spelling* sentence is
  **kept deliberately** — `--out -` today, `--emit-ir -` when #251 lands — and a
  stream destination is named as the whole of that class.
- [x] **`CliSurface` tightens, in this commit.**
- [x] **Every uncurated flag is enumerated and answered** — `--emit-ir` and
  `--emit-ir-format` tracked to #251, `--version`/`--help`/`-h` settled.
- [x] **`--emit-ir` and `--emit-ir-format` get a curated function (#251):**
  recorded as *tracked* gaps naming #251, which is the story that writes the
  function. See the judgment call below.
- [x] **`--version`, `--help` and `-h` stay on `Run`, settled**, with the reason
  beside them: `dagger call --help` and the per-function documentation are the
  Dagger-native form of the question, and the release is stated at `New
  --version` — plus the caveat that the moving `v0` tag makes *which tag was
  asked for* and *which build is running* different questions, so
  `run --args=--version` remains the answer for that one.
- [x] **How a non-flag capability is caught is stated**, with #252 as the worked
  case.

## The check that enforces it

`companionCoverage` no longer accepts `"Run"` as a value. A flag reaching the
escape hatch is now an entry in **`companionRunExceptions`**, which must carry a
reason and say whether it is **settled** or **tracked** to an issue. `CliSurface`
fails in five directions instead of three: a flag in neither table, a flag in
both, a mapping naming a function the module does not declare, an exception that
claims neither, and either table naming a flag the CLI dropped.

Why two tables rather than a `Reason` field on one: under #62's curation a flag
recorded against `Run` was the design working, so one word said everything. Under
this stance a new flag quietly recorded against `Run` and passing CI *is* the
drift the check exists to catch — and one map cannot tell that from the flags
nobody curated on purpose. Two can, because writing an exception means writing a
reason and choosing between two claims, in the diff.

The rules live in `.dagger/internal/coverage/` rather than beside `package main`,
for the reason `internal/surface` does: the pipeline's `main` imports the
generated Dagger client, whose `init` panics without a session, so a test beside
it cannot run. They are pinned by 14 test cases.

## Judgment calls

- **#251 is not implemented here.** `--emit-ir` is recorded as a *tracked* gap
  naming #251, which is blocked by this issue precisely so it can proceed once
  the stance says "curate it", and which carries eleven acceptance criteria of
  its own (`internal/argv` assembly and its test, `CompanionModule` asserting
  byte-identical descriptors in both formats, README guidance). Implementing it
  here would half-satisfy that story silently. This story settles the stance and
  rewrites the paragraph #251 had to argue past — which is what its own body and
  #251's *Related Issues* both say it is for.
- **The claim had reached six places, not four.** Beyond the four the issue names,
  `docs/CONVENTIONS.md`'s *What belongs here* and `docs/container/SPEC.md`'s
  out-of-scope bullet both stated it, and `internal/argv`'s package comment said
  *the module curates*. Leaving any of them would recreate exactly the condition
  this story exists to end. The `SPEC.md` edit is descriptive only — no normative
  keyword changed.
- **No `SPEC.md` is created.** Restating the claim was the option taken over
  withdrawing it, and the argument moved from *it is a mere convenience* to *its
  contract is written down three times already, and what is its own — the mapping
  — lives where a check fails on it*.
- **The non-flag answer is prose, deliberately.** Nothing mechanical can catch a
  capability with no constant to read, and the mechanical version — comparing a
  document against a copy of itself — is the shape #65 was closed for being. It
  is stated as a weaker guarantee rather than dressed up as an equal one.
- **A file named `coverage.go` is silently unstageable** here: `.gitignore`'s
  `coverage.*` matches it and `git add -A` says nothing. The files are named for
  the type instead, and the package comment records why.

## Verified

`dagger call ci` — all 16 stages green, from an ordinary clone of this branch
(the pipeline cannot run from a git worktree; `CONTRIBUTING.md` explains why).
That includes `cli-surface` against the rewritten tables, `companion-module`
driving the module's functions over the image built from this branch, and
`pipeline-ci` running the new package's tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)