### PR TITLE
story(dagger): curate an IR-emitting function so a bug report is one dagger call

### DIFF
--- a/.dagger/companion.go
+++ b/.dagger/companion.go
@@ -237,6 +237,34 @@ var companionCoverage = map[string]string{
 	//	dagger call run --source . --args=init,--copybook,posting.cpy,--out,-
 	"--copybook": "Init",
 	"--out":      "Init",
+
+	// The emitting run's two flags, curated onto one function (#251) exactly as
+	// `init`'s were, and off Run in the same commit this table's entries were
+	// written in. What they were doing on Run is worth keeping legible, because
+	// the argument was a good one: --emit-ir is terminal and --emit-ir-format is a
+	// usage error without it, and two Dagger arguments cannot express "one is only
+	// legal beside the other" at all.
+	//
+	// Both halves of that answered the same way. A curated function need not
+	// return a Directory — Init already returns a File, and a descriptor is one
+	// file — and making the function *be* --emit-ir leaves the format as its
+	// argument, so the illegal pairing is unstateable rather than enforced: there
+	// is no call that names a format without asking for an emission, and nothing
+	// here has to check for one.
+	//
+	// The name is the flag's, for the reason Init's is the verb's. A module
+	// mirroring the CLI has the least business growing a second vocabulary for a
+	// thing docs/cli/SPEC.md already names, and somebody who read that document
+	// looking for `--emit-ir` finds `emit-ir` here.
+	//
+	// EmitIr supplies the destination itself, at a path outside the mounted
+	// project, so an emitting run writes nothing into the caller's tree — which is
+	// the whole of what a terminal flag promises. The one spelling it does not
+	// offer is `--emit-ir -`, and that is not an exception below for the reason
+	// `--out -` is not: a spelling is not a flag, and this table is keyed by
+	// flags.
+	"--emit-ir":        "EmitIr",
+	"--emit-ir-format": "EmitIr",
 }
 
 // companionRunExceptions are the CLI's flags that reach the module through Run
@@ -258,30 +286,6 @@ var companionCoverage = map[string]string{
 // be re-made whenever the CLI's surface moves is one that stops being true on
 // purpose rather than by accident.
 var companionRunExceptions = map[string]coverage.Exception{
-	// Terminal, and mutually constrained: --emit-ir replaces generation outright
-	// and --emit-ir-format is a usage error without it. That was the argument for
-	// leaving both on Run, and #251 answers it: a curated function need not return
-	// a Directory — Init already returns a File — and one function taking the
-	// format as an argument makes the illegal pairing unstateable rather than
-	// enforced, because there is no call that names a format without asking for an
-	// emission.
-	//
-	// So these are a gap rather than a decision, and the stance is why: the
-	// resolved descriptor is the single most useful thing to attach to a bug
-	// report, and it is a capability the CLI has.
-	//
-	// What will still be Run's afterwards is `--emit-ir -`, exactly as `--out -`
-	// is — a spelling rather than a flag, and so not an entry here at all.
-	"--emit-ir": {
-		Reason: "it replaces generation outright and --emit-ir-format is only legal beside it; #251 curates both " +
-			"onto one File-returning function, which makes the illegal pairing unstateable rather than enforced",
-		Tracking: "#251",
-	},
-	"--emit-ir-format": {
-		Reason:   "it is only legal beside --emit-ir, so it is that function's argument rather than a function",
-		Tracking: "#251",
-	},
-
 	// Questions about the program rather than about a project, and the one place
 	// the mirroring stance stops on purpose (#253). Both have a Dagger-native
 	// form that is not a function on this module: `dagger call --help` and the
@@ -551,6 +555,31 @@ const (
 	// hands back a File the caller names at export, and the hand-typed one hands
 	// back bytes on standard output, so neither side has a name of its own here.
 	scaffoldName = "scaffold.sexpr"
+
+	// descriptorName is what the two descriptors are called while they are being
+	// compared, and it is [scaffoldName]'s counterpart: a name for the diff and
+	// nothing else. It carries no extension because the same comparison is made
+	// of both encodings, and a name claiming one of them would be wrong for the
+	// other run.
+	descriptorName = "descriptor"
+
+	// emitIRDescriptorPath is where the hand-typed escape-hatch spelling has
+	// cpybkc write its descriptor, and where the container is then read back
+	// from.
+	//
+	// Inside the mounted project, because that is the one directory a hand-typed
+	// run can be sure it may write into: the module owns that mount to whoever
+	// the image runs as, and a scratch image has nothing else a non-root user can
+	// create in. Nothing of the caller's is at risk — the mount is a copy, and
+	// this one is a directory of committed example inputs.
+	//
+	// It is absolute rather than relative so that the vector and the read-back
+	// are one string rather than two that have to agree, and /src is where the
+	// companion module documents Run leaving a project mounted. A module that
+	// moved it fails this check on a file that is not there, which is the right
+	// way round: that path is documented behaviour of the escape hatch, and this
+	// is the only place in this repository that depends on it.
+	emitIRDescriptorPath = "/src/" + descriptorName
 )
 
 // exampleCopybooks are the copybooks in [companionExampleDir], as the paths a
@@ -580,6 +609,60 @@ var exampleInitVector = []string{
 	"--copybook", "posting.cpy",
 	"--copybook", "trailer.cpy",
 	"--out", "-",
+}
+
+// exampleEmitIRRuns are the emissions [Cpybkc.checkEmitIR] compares: each is the
+// format the curated function is asked for, beside the hand-typed escape-hatch
+// vector for the same run.
+//
+// Both encodings are here because they are different obligations. The binary one
+// is what a File return has to carry back without corrupting — it is not text,
+// and it is the form every generator in the run is handed — and the JSON one is
+// what somebody pastes into an issue. A check that exercised one would say
+// nothing about the other.
+//
+// The third row is the one that is easy to leave out. A call naming no format
+// has to be the same run as a hand-typed vector naming none, which is what says
+// the module left the default encoding to the CLI rather than spelling one out
+// here; and it says it without this pipeline stating what that default is, which
+// would be exactly the second reading of docs/cli/SPEC.md the module declines to
+// hold.
+//
+// The vectors are written out rather than assembled from the module's
+// internal/argv, for [exampleInitVector]'s reason: two statements of one run
+// arrived at independently, so that a vector the module got wrong disagrees with
+// itself instead of agreeing with its own mistake.
+var exampleEmitIRRuns = []struct {
+	// named is how the call is described when it fails, since a run naming no
+	// format has no value to quote.
+	named string
+	// at is where this comparison's two trees are mounted, so a failure's paths
+	// say which of the three it was.
+	at string
+	// format is what the curated function is asked for, and empty is the call
+	// that names none.
+	format string
+	// vector is the hand-typed spelling of the same run.
+	vector []string
+}{
+	{
+		named:  "naming no format",
+		at:     "default",
+		format: "",
+		vector: []string{"--emit-ir", emitIRDescriptorPath},
+	},
+	{
+		named:  "--format binary",
+		at:     "binary",
+		format: "binary",
+		vector: []string{"--emit-ir", emitIRDescriptorPath, "--emit-ir-format", "binary"},
+	},
+	{
+		named:  "--format json",
+		at:     "json",
+		format: "json",
+		vector: []string{"--emit-ir", emitIRDescriptorPath, "--emit-ir-format", "json"},
+	},
 }
 
 // CompanionModule drives the companion module's functions over the image this
@@ -639,9 +722,12 @@ var exampleInitVector = []string{
 // exercised only what it needed would leave the rest of the module's surface
 // covered by nothing: image, whose plugin directory has to hold the generator
 // the CLI resolves on PATH; run, the escape hatch, asked the one question
-// docs/cli/SPEC.md requires to succeed against nothing at all; and init, the
-// curated scaffolding run (#228), required to hand back the same scaffold the
-// escape hatch writes over the same copybooks — see [Cpybkc.checkInit].
+// docs/cli/SPEC.md requires to succeed against nothing at all; init, the curated
+// scaffolding run (#228), required to hand back the same scaffold the escape
+// hatch writes over the same copybooks — see [Cpybkc.checkInit]; and emit-ir,
+// the curated emitting run (#251), required to hand back the same descriptor the
+// escape hatch writes over the same project, in every encoding — see
+// [Cpybkc.checkEmitIR].
 //
 // Both compositions start from the base image this pipeline built, which carries
 // the CLI and no generator — so a generation that succeeded did so with the
@@ -747,6 +833,10 @@ func (m *Cpybkc) CompanionModule(ctx context.Context) error {
 		errs = append(errs, err)
 	}
 
+	if err := m.checkEmitIR(ctx, platform); err != nil {
+		errs = append(errs, err)
+	}
+
 	// --version through the escape hatch, with no project: it is the one
 	// invocation docs/cli/SPEC.md requires to succeed touching nothing, so a
 	// failure here is run failing to reach the CLI rather than anything about a
@@ -830,6 +920,81 @@ func (m *Cpybkc) checkInit(ctx context.Context, platform dagger.Platform) error 
 	return nil
 }
 
+// checkEmitIR requires the curated emitting function and the hand-typed escape
+// hatch to be the same run, over [companionExampleDir], in every encoding.
+//
+// # What is asserted
+//
+// The descriptor `emit-ir --source .` hands back has to be byte-identical to
+// what `run --args=--emit-ir,…` writes over the same project. That is
+// [Cpybkc.checkInit]'s property, and it generalises exactly as that function
+// says it does: what makes a curated function safe to add is that the run it
+// replaces is still spellable through Run and still produces the same bytes.
+//
+// It is worth having twice over here, because equality is not incidental to this
+// flag the way it is to `init`. The plugin contract rests reproducibility on the
+// bytes --emit-ir writes being the bytes a generator was handed, and it holds
+// that by there being one encoder rather than by two agreeing (docs/cli/SPEC.md,
+// "Emitting the IR"). A curated function that re-encoded, truncated or
+// re-indented on the way out would break that promise for every caller who
+// reached this module first — which is most of the people the emission is *for*,
+// since the descriptor is what a bug report carries.
+//
+// What the descriptor *contains* is checked where it is decided: internal/emit's
+// tests, cmd/cpybkc's, and [Cpybkc.IrArtifacts]. A second expectation here would
+// be this pipeline's own reading of docs/ir/SPEC.md, and the two would drift.
+//
+// # No generator, deliberately
+//
+// The base image with nothing composed into it, for [Cpybkc.checkInit]'s reason
+// and one more of this flag's own: an emitting run is terminal, so no generator
+// is resolved on PATH and none is started (docs/cli/SPEC.md, "Emitting replaces
+// generation"). Driving a composed image would assert less while costing more,
+// and would leave the run that made this capability worth curating — a project
+// whose generation fails and whose emission does not — the one shape not
+// exercised.
+//
+// # Both sides through a file
+//
+// The hand-typed side writes to a path in the mounted project and the container
+// is read back from there, rather than `--emit-ir -` and Stdout the way
+// [Cpybkc.checkInit] takes its scaffold. A scaffold is text and a descriptor is
+// not: the binary encoding through a GraphQL string is a comparison of two
+// decodings rather than of the bytes, and it is the encoding whose whole point
+// is that the bytes are the same ones. So both encodings come back as files, and
+// the two sides are compared as trees through the same helper every other
+// comparison here uses.
+func (m *Cpybkc) checkEmitIR(ctx context.Context, platform dagger.Platform) error {
+	bare := m.companion(platform)
+	example := m.Source.Directory(companionExampleDir)
+
+	var errs []error
+
+	// Every row, rather than stopping at the first failure: which encodings agree
+	// is the finding. One format disagreeing while the others hold is a different
+	// fault from all three disagreeing — the first is the format argument, the
+	// second is the function.
+	for _, run := range exampleEmitIRRuns {
+		handTyped := dag.Directory().WithFile(
+			descriptorName,
+			bare.Run(run.vector, dagger.CompanionRunOpts{Source: example}).File(emitIRDescriptorPath))
+		curated := dag.Directory().WithFile(
+			descriptorName,
+			bare.EmitIr(example, dagger.CompanionEmitIrOpts{Format: run.format}))
+
+		if err := m.diffTrees(ctx, handTyped, curated, "/companion-module/emit-ir/"+run.at); err != nil {
+			errs = append(errs, fmt.Errorf(
+				"emit-ir %s over %s/ did not hand back the descriptor `run --args=--emit-ir,…` writes over the same "+
+					"project (or did not get that far — the wrapped error says which): the curated function and the "+
+					"escape hatch are the same run spelled two ways, and these are the bytes a generator is handed, "+
+					"so a difference is one of them being wrong: %w",
+				run.named, companionExampleDir, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
 // companion is the module bound to the image this pipeline built, and it is the
 // one construction of it: both compositions come through here, so there is no
 // arrangement in which one of them is driving a released image and the other the
@@ -896,9 +1061,12 @@ func (m *Cpybkc) checkComposedImage(ctx context.Context, composed *dagger.Contai
 // A real diff rather than a walk comparing file contents, because the failure
 // this reports is one somebody has to act on: which file, which line, and what
 // changed is the whole of the diagnostic, and a boolean would send them to
-// regenerate the example locally to find out. --text because every file cpybkc
-// writes is text, and a diff that said only "binary files differ" would report
-// the failure without reporting what it was.
+// regenerate the example locally to find out. --text because all but one of the
+// files this compares are text, and a diff that said only "binary files differ"
+// would report the failure without reporting what it was. The one that is not is
+// the binary descriptor [Cpybkc.checkEmitIR] compares, where --text buys nothing
+// legible and costs nothing either: what is being asserted there is equality,
+// and the readable account of a disagreement is the JSON run beside it.
 //
 // The trees are mounted under one directory named by the caller, so a run with
 // more than one comparison in it says which comparison the paths in the output

--- a/.dagger/companion.go
+++ b/.dagger/companion.go
@@ -573,13 +573,24 @@ const (
 	// create in. Nothing of the caller's is at risk — the mount is a copy, and
 	// this one is a directory of committed example inputs.
 	//
+	// The name is one no worked example could plausibly want, and that is the
+	// point of spelling it this way rather than reusing [descriptorName]. This is
+	// the one destination in this check that nothing empties first, so a day when
+	// example/ gains a file of the same name is a day this comparison quietly
+	// changes what it is comparing. It also keeps the two sides' project trees as
+	// close to identical as they can be: resolution strictly precedes the write —
+	// an emission writes what it resolved — and a layout names its copybooks
+	// rather than globbing for them, so a file appearing under the mount cannot
+	// change the descriptor. Both of those are why the asymmetry is tolerable at
+	// all, and neither is a reason to make it larger than it has to be.
+	//
 	// It is absolute rather than relative so that the vector and the read-back
 	// are one string rather than two that have to agree, and /src is where the
 	// companion module documents Run leaving a project mounted. A module that
 	// moved it fails this check on a file that is not there, which is the right
 	// way round: that path is documented behaviour of the escape hatch, and this
 	// is the only place in this repository that depends on it.
-	emitIRDescriptorPath = "/src/" + descriptorName
+	emitIRDescriptorPath = "/src/.cpybkc-descriptor-check"
 )
 
 // exampleCopybooks are the copybooks in [companionExampleDir], as the paths a
@@ -621,12 +632,20 @@ var exampleInitVector = []string{
 // what somebody pastes into an issue. A check that exercised one would say
 // nothing about the other.
 //
-// The third row is the one that is easy to leave out. A call naming no format
-// has to be the same run as a hand-typed vector naming none, which is what says
-// the module left the default encoding to the CLI rather than spelling one out
-// here; and it says it without this pipeline stating what that default is, which
-// would be exactly the second reading of docs/cli/SPEC.md the module declines to
-// hold.
+// The third row is the one that is easy to leave out, and it is worth being
+// exact about what it buys, because the obvious claim for it is false. It does
+// *not* say the module left the default encoding to the CLI: a module that
+// spelled `binary` out itself would emit binary here and so would the hand-typed
+// side, and this row would be green. That property is observable only in the
+// vector, and it is pinned where the vector is — internal/argv's
+// TestEmitIRAssemblesTheVector, in its "no manifest and no format" case, which
+// requires no --emit-ir-format at all.
+//
+// What this row buys is the run: that a call naming no format is one the CLI
+// accepts and completes, and that it agrees with the hand-typed spelling of the
+// same thing on the day docs/cli/SPEC.md changes which encoding that is. A
+// module that had restated the old default would fail this row then, which is
+// exactly when somebody needs to be told.
 //
 // The vectors are written out rather than assembled from the module's
 // internal/argv, for [exampleInitVector]'s reason: two statements of one run
@@ -943,6 +962,24 @@ func (m *Cpybkc) checkInit(ctx context.Context, platform dagger.Platform) error 
 // What the descriptor *contains* is checked where it is decided: internal/emit's
 // tests, cmd/cpybkc's, and [Cpybkc.IrArtifacts]. A second expectation here would
 // be this pipeline's own reading of docs/ir/SPEC.md, and the two would drift.
+//
+// # Why comparing two runs is legitimate rather than lucky
+//
+// This compares the bytes of two *separate executions* of cpybkc, which is a
+// stronger thing to require than "the module did not re-encode on the way out",
+// and it is not a property the Go protobuf stack gives for free: proto.Marshal
+// is documented as unstable across runs, and protojson deliberately varies its
+// insignificant whitespace so that nobody depends on its exact output. Both are
+// pinned in internal/emit rather than hoped for — Marshal sets
+// proto.MarshalOptions{Deterministic: true}, and MarshalJSON re-indents
+// protojson's rendering through encoding/json, which is the step that makes the
+// bytes a function of the descriptor rather than of the build that produced it.
+//
+// So this check rests on those two, and it would flake rather than fail if
+// either were removed. That is the right way round: the same guarantees are what
+// docs/ir/SPEC.md's reproducibility requirement rests on, and a run of this
+// check disagreeing with itself would be a real finding about the encoder rather
+// than noise about the module.
 //
 // # No generator, deliberately
 //

--- a/.dagger/dagger.gen.go
+++ b/.dagger/dagger.gen.go
@@ -248,6 +248,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Cpybkc).CompanionModule(&parent, ctx)
+		case "ConformanceArtifact":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Cpybkc).ConformanceArtifact(&parent, ctx)
+		case "ConformanceBundle":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Cpybkc).ConformanceBundle(&parent), nil
 		case "EngineLock":
 			var parent Cpybkc
 			err = json.Unmarshal(parentJSON, &parent)

--- a/.dagger/internal/coverage/exception_test.go
+++ b/.dagger/internal/coverage/exception_test.go
@@ -29,8 +29,9 @@ func TestCheckAcceptsTheTwoShapesOfException(t *testing.T) {
 		},
 		{
 			// A curated function is coming and the story writing it is named, so a
-			// reader can tell this from a flag nobody thought about. --emit-ir is
-			// this shape.
+			// reader can tell this from a flag nobody thought about. --emit-ir was
+			// this shape until #251 curated it, and no flag is today — which is why
+			// the shape is pinned here rather than only in the pipeline's table.
 			name:      "tracked, with a reason and an issue",
 			exception: Exception{Reason: "a Directory return cannot express a stream", Tracking: "#251"},
 		},

--- a/.dagger/internal/dagger/companion.gen.go
+++ b/.dagger/internal/dagger/companion.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Companion
-func (r *Binding) AsCompanion() *Companion { // companion (../../../daggerverse/cpybkc/main.go:259:6)
+func (r *Binding) AsCompanion() *Companion { // companion (../../../daggerverse/cpybkc/main.go:327:6)
 	q := r.query.Select("asCompanion")
 
 	return &Companion{
@@ -24,7 +24,7 @@ func (r *Binding) AsCompanion() *Companion { // companion (../../../daggerverse/
 // A function on it is a builder returning a new Cpybkc, a terminal that runs
 // something, or an accessor handing back what was resolved, so a call chain
 // reads as the image being assembled and then used; nothing here mutates.
-type Companion struct { // companion (../../../daggerverse/cpybkc/main.go:259:6)
+type Companion struct { // companion (../../../daggerverse/cpybkc/main.go:327:6)
 	query *querybuilder.Selection
 
 	id *ID
@@ -40,6 +40,101 @@ func (r *Companion) With(f WithCompanionFunc) *Companion {
 
 func (r *Companion) WithGraphQLQuery(q *querybuilder.Selection) *Companion {
 	return &Companion{
+		query: q,
+	}
+}
+
+// CompanionEmitIrOpts contains options for Companion.EmitIr
+type CompanionEmitIrOpts struct {
+	//
+	// The project manifest to read, relative to the root of source.
+	//
+	// It is taken the way Generate takes it, and it is not a convenience: a run
+	// resolves one descriptor, from the layout the manifest names and the
+	// copybooks that layout names (docs/cli/SPEC.md, "Which descriptor is
+	// emitted"), so *which* descriptor is emitted is exactly which manifest was
+	// read. A project keeping its manifest somewhere else would otherwise be able
+	// to generate through this module and not to emit what it generated from.
+	//
+	// It defaults to nothing, which leaves cpybkc reading `cpybkc.json` at the
+	// root of the mounted project — the CLI's own default, applied by the CLI. A
+	// relative path resolves against that project root, and it cannot be "-",
+	// because a manifest's own paths are relative to the directory holding it and
+	// a manifest arriving on a stream is in no directory.
+	//
+	Manifest string // companion (../../../daggerverse/cpybkc/main.go:861:2)
+	//
+	// The encoding the descriptor is written in: `binary`, the canonical protobuf
+	// wire encoding a generator is handed, or `json`, the normalized rendering a
+	// person reads and pastes into an issue.
+	//
+	// It defaults to nothing, which is not a third encoding: an unnamed format
+	// reaches the CLI as no --emit-ir-format at all, so what arrives is whatever
+	// docs/cli/SPEC.md's default is — `binary` today — decided there rather than
+	// restated here where the two could drift.
+	//
+	// A value that is neither spelling is passed through and refused by the CLI,
+	// which names the spellings there are from the parser that decides them. That
+	// is deliberate for the reason Run validates nothing: a second reading of that
+	// contract out here is one that drifts, and this one would drift the day a
+	// third encoding landed.
+	//
+	Format string // companion (../../../daggerverse/cpybkc/main.go:877:2)
+}
+
+// EmitIr writes the run's resolved descriptor and hands back the file:
+//
+//	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+//	  emit-ir --source . --format json export --path descriptor.json
+//
+// It is `cpybkc --emit-ir`, and the name is that flag rather than a word of this
+// module's own for the reason Init's is the CLI's verb: somebody who read
+// docs/cli/SPEC.md should find what they read about here, under the name they
+// read it under.
+//
+// The descriptor is what to attach to a bug report, against cpybkc or against
+// any generator. It is exactly the bytes a plugin was handed — the equality the
+// plugin contract rests reproducibility on — so reading it settles in one step
+// whether a fault is the producer's or the consumer's. It is also available from
+// the run that is broken: an emission is terminal, so no generator is resolved,
+// nothing is merged into the project's tree and nothing is pruned from it
+// (docs/cli/SPEC.md, "Emitting replaces generation"), which is why a project
+// whose `generate` fails inside a generator can still emit the descriptor that
+// generator was given.
+//
+// Nothing is written to the host, exactly as with Init: the File that comes back
+// is a value, and exporting it is the caller's separate step. This module writes
+// it to a path of its own inside the container ([descriptorPath]) that nothing
+// was mounted into, so the run cannot land on something the caller already has.
+//
+// The one spelling this does not offer is `--emit-ir -`, which stays Run's for
+// the reason `--out -` does — a File-returning function has no stream to hand
+// back — and which is a spelling rather than a flag:
+//
+//	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+//	  run --source . --args=--emit-ir,- stdout
+//
+// The illegal pairing docs/cli/SPEC.md names — `--emit-ir-format` without
+// `--emit-ir` — is unstateable here rather than enforced. This function *is* the
+// emission and the format is its argument, so there is no call that names a
+// format without asking for one, and there is nothing left for the module to
+// check.
+func (r *Companion) EmitIr(source *Directory, opts ...CompanionEmitIrOpts) *File { // companion (../../../daggerverse/cpybkc/main.go:836:1)
+	assertNotNil("source", source)
+	q := r.query.Select("emitIr")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `manifest` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Manifest) {
+			q = q.Arg("manifest", opts[i].Manifest)
+		}
+		// `format` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Format) {
+			q = q.Arg("format", opts[i].Format)
+		}
+	}
+	q = q.Arg("source", source)
+
+	return &File{
 		query: q,
 	}
 }
@@ -60,7 +155,7 @@ type CompanionGenerateOpts struct {
 	// cannot be "-": a manifest's own paths are relative to the directory holding
 	// it, and a manifest arriving on a stream is in no directory.
 	//
-	Manifest string // companion (../../../daggerverse/cpybkc/main.go:622:2)
+	Manifest string // companion (../../../daggerverse/cpybkc/main.go:690:2)
 }
 
 // Generate runs cpybkc over a project and hands back the project as it should
@@ -83,7 +178,7 @@ type CompanionGenerateOpts struct {
 // express half of what a run did. `generate --source . export --path .` is
 // therefore the ordinary use, and it is a full statement of the run rather than
 // an overlay that leaves deletions behind.
-func (r *Companion) Generate(source *Directory, opts ...CompanionGenerateOpts) *Directory { // companion (../../../daggerverse/cpybkc/main.go:599:1)
+func (r *Companion) Generate(source *Directory, opts ...CompanionGenerateOpts) *Directory { // companion (../../../daggerverse/cpybkc/main.go:667:1)
 	assertNotNil("source", source)
 	q := r.query.Select("generate")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -166,7 +261,7 @@ func (r *Companion) UnmarshalJSON(bs []byte) error {
 // none of the signatures or attestations one does (docs/container/SPEC.md, "What
 // a tag carries besides the image"), because those are attached to the digest
 // this project published and not to the bytes.
-func (r *Companion) Image() *Container { // companion (../../../daggerverse/cpybkc/main.go:575:1)
+func (r *Companion) Image() *Container { // companion (../../../daggerverse/cpybkc/main.go:643:1)
 	q := r.query.Select("image")
 
 	return &Container{
@@ -180,9 +275,10 @@ func (r *Companion) Image() *Container { // companion (../../../daggerverse/cpyb
 //	  init --source . --copybook posting.cpy export --path ledger.sexpr
 //
 // It is the first thing an adopter runs, before there is a manifest, a layout or
-// a generator to speak of, and it is curated for that reason: the one invocation
-// somebody has nothing to copy from is a poor place to make them assemble an
-// argument vector by hand.
+// a generator to speak of, and it is the run that made the case for mapping
+// cpybkc's commands by name at all (#228): the one invocation somebody has
+// nothing to copy from is a poor place to make them assemble an argument vector
+// by hand.
 //
 // What comes back is **not a valid layout** and is not meant to be. `init`
 // writes what the copybooks decide — a record per 01-level, an alternative per
@@ -214,7 +310,7 @@ func (r *Companion) Image() *Container { // companion (../../../daggerverse/cpyb
 //
 //	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
 //	  run --source . --args=init,--copybook,posting.cpy,--out,- stdout
-func (r *Companion) Init(source *Directory, copybook []string) *File { // companion (../../../daggerverse/cpybkc/main.go:679:1)
+func (r *Companion) Init(source *Directory, copybook []string) *File { // companion (../../../daggerverse/cpybkc/main.go:748:1)
 	assertNotNil("source", source)
 	q := r.query.Select("init")
 	q = q.Arg("source", source)
@@ -235,11 +331,11 @@ type CompanionRunOpts struct {
 	// contact nothing. With no source the container is the image as it was
 	// resolved, and cpybkc runs in whatever directory the image left it in.
 	//
-	Source *Directory // companion (../../../daggerverse/cpybkc/main.go:795:2)
+	Source *Directory // companion (../../../daggerverse/cpybkc/main.go:976:2)
 }
 
-// Run is the escape hatch: cpybkc invoked with an argument vector this module
-// has no opinion about, in a container handed back whole.
+// Run is the fallback: cpybkc invoked with an argument vector this module has no
+// opinion about, in a container handed back whole.
 //
 //	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
 //	  run --source . --args=--emit-ir,- stdout
@@ -247,13 +343,22 @@ type CompanionRunOpts struct {
 //	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
 //	  run --args=--help stdout
 //
-// It exists so that Generate does not have to grow an argument every time
-// docs/cli/SPEC.md's flag table does. A flag that replaces the action rather
-// than configuring it (--emit-ir is terminal: no generator runs and nothing is
-// merged or pruned), one that may only appear beside another (--emit-ir-format
-// without --emit-ir is a usage error), and one that answers a question about the
-// program rather than about a project (--version, --help) are all things a
-// command line states plainly and a set of Dagger arguments states badly.
+// It is not the intended route for anything. This module mirrors the CLI, so a
+// capability's ordinary answer is an argument on the function named for the
+// command it belongs to (#253), and three kinds of thing are left over for this
+// function. A flag this module has not caught up with is reachable through it in
+// the meantime, which is what keeps a gap an inconvenience rather than a wall. A
+// spelling no Dagger type can express is reachable through it permanently: a
+// destination that is a stream rather than a file — `--out -`, `--emit-ir -` —
+// which a File-returning function cannot hand back. And a flag whose question
+// has a Dagger-native answer that is not a function here stays on purpose, which
+// is --version, --help and -h and is meant to be the whole of that class.
+//
+// Which flags arrive here today is stated in this module's package comment and
+// recorded where a check can fail on it, in the root pipeline's
+// companionRunExceptions: `dagger call cli-surface` fails when the CLI grows a
+// flag that neither a named function nor an argued exception covers, so a flag
+// landing on this function quietly is the one thing that cannot happen.
 //
 // A container rather than a directory, because the uncurated invocations are the
 // ones whose answer is not a tree. --emit-ir may write to standard output, and
@@ -272,7 +377,7 @@ type CompanionRunOpts struct {
 // unrecognised flag is, whether a flag may repeat and what a usage error exits
 // with are all docs/cli/SPEC.md's, and the exec's failure carries them back
 // verbatim.
-func (r *Companion) Run(args []string, opts ...CompanionRunOpts) *Container { // companion (../../../daggerverse/cpybkc/main.go:782:1)
+func (r *Companion) Run(args []string, opts ...CompanionRunOpts) *Container { // companion (../../../daggerverse/cpybkc/main.go:963:1)
 	q := r.query.Select("run")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `source` optional argument
@@ -298,7 +403,7 @@ type CompanionWithGeneratorOpts struct {
 	// image being composed into, which is checked, because a mismatch here is
 	// checkable and its exec-time failure is not legible.
 	//
-	Image *Container // companion (../../../daggerverse/cpybkc/main.go:457:2)
+	Image *Container // companion (../../../daggerverse/cpybkc/main.go:525:2)
 }
 
 // WithGenerator adds one generator to the image by copying its executable out of
@@ -326,7 +431,7 @@ type CompanionWithGeneratorOpts struct {
 // about multi-platform: composing an amd64 generator into an arm64 image produces
 // an image that builds and pushes and then fails at exec with the kernel's
 // message rather than cpybkc's, which is a long way from the call that caused it.
-func (r *Companion) WithGenerator(name string, opts ...CompanionWithGeneratorOpts) *Companion { // companion (../../../daggerverse/cpybkc/main.go:444:1)
+func (r *Companion) WithGenerator(name string, opts ...CompanionWithGeneratorOpts) *Companion { // companion (../../../daggerverse/cpybkc/main.go:512:1)
 	q := r.query.Select("withGenerator")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `image` optional argument
@@ -363,7 +468,7 @@ func (r *Companion) WithGenerator(name string, opts ...CompanionWithGeneratorOpt
 // or foreign-architecture generator fails at exec time with the kernel's message
 // rather than cpybkc's. WithGenerator can check the platform half of that because
 // a container states one; here there is nothing to read.
-func (r *Companion) WithGeneratorExecutable(name string, executable *File) *Companion { // companion (../../../daggerverse/cpybkc/main.go:529:1)
+func (r *Companion) WithGeneratorExecutable(name string, executable *File) *Companion { // companion (../../../daggerverse/cpybkc/main.go:597:1)
 	assertNotNil("executable", executable)
 	q := r.query.Select("withGeneratorExecutable")
 	q = q.Arg("name", name)
@@ -383,7 +488,7 @@ func (r *Companion) AsNode() Node {
 }
 
 // Create or update a binding of type Companion in the environment
-func (r *Env) WithCompanionInput(name string, value *Companion, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:259:6)
+func (r *Env) WithCompanionInput(name string, value *Companion, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:327:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withCompanionInput")
 	q = q.Arg("name", name)
@@ -396,7 +501,7 @@ func (r *Env) WithCompanionInput(name string, value *Companion, description stri
 }
 
 // Declare a desired Companion output to be assigned in the environment
-func (r *Env) WithCompanionOutput(name string, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:259:6)
+func (r *Env) WithCompanionOutput(name string, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:327:6)
 	q := r.query.Select("withCompanionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -420,7 +525,7 @@ type CompanionOpts struct {
 	//
 	//
 	// Default: "v0"
-	Version string // companion (../../../daggerverse/cpybkc/main.go:330:2)
+	Version string // companion (../../../daggerverse/cpybkc/main.go:398:2)
 	//
 	// The registry repository the image is pulled from, as `<host>/<path>` with no
 	// tag.
@@ -435,7 +540,7 @@ type CompanionOpts struct {
 	//
 	//
 	// Default: "ghcr.io/zaba505/cpybkc"
-	Repository string // companion (../../../daggerverse/cpybkc/main.go:343:2)
+	Repository string // companion (../../../daggerverse/cpybkc/main.go:411:2)
 	//
 	// Run in this container instead of pulling one, replacing it entirely.
 	//
@@ -455,7 +560,7 @@ type CompanionOpts struct {
 	// does not track whatever was pinned here, so a build that pins the CLI by
 	// digest and wants the pairing to hold still passes --version beside it.
 	//
-	Image *Container // companion (../../../daggerverse/cpybkc/main.go:362:2)
+	Image *Container // companion (../../../daggerverse/cpybkc/main.go:430:2)
 	//
 	// Pull the image for this platform, as `GOOS/GOARCH`, instead of for the
 	// engine's own.
@@ -474,7 +579,7 @@ type CompanionOpts struct {
 	// Empty is the engine's own platform, which is what makes an ordinary
 	// `dagger call` from a checkout do the obvious thing.
 	//
-	Platform string // companion (../../../daggerverse/cpybkc/main.go:380:2)
+	Platform string // companion (../../../daggerverse/cpybkc/main.go:448:2)
 }
 
 // New selects the cpybkc release to run:
@@ -495,7 +600,7 @@ type CompanionOpts struct {
 // resolves companion images against, which is why an air-gapped caller passing a
 // container from their own registry should pass --repository beside it rather
 // than instead of it.
-func (r *Query) Companion(opts ...CompanionOpts) *Companion { // companion (../../../daggerverse/cpybkc/main.go:319:1)
+func (r *Query) Companion(opts ...CompanionOpts) *Companion { // companion (../../../daggerverse/cpybkc/main.go:387:1)
 	q := r.query.Select("companion")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `version` optional argument

--- a/.dagger/internal/dagger/companion.gen.go
+++ b/.dagger/internal/dagger/companion.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Companion
-func (r *Binding) AsCompanion() *Companion { // companion (../../../daggerverse/cpybkc/main.go:327:6)
+func (r *Binding) AsCompanion() *Companion { // companion (../../../daggerverse/cpybkc/main.go:328:6)
 	q := r.query.Select("asCompanion")
 
 	return &Companion{
@@ -24,7 +24,7 @@ func (r *Binding) AsCompanion() *Companion { // companion (../../../daggerverse/
 // A function on it is a builder returning a new Cpybkc, a terminal that runs
 // something, or an accessor handing back what was resolved, so a call chain
 // reads as the image being assembled and then used; nothing here mutates.
-type Companion struct { // companion (../../../daggerverse/cpybkc/main.go:327:6)
+type Companion struct { // companion (../../../daggerverse/cpybkc/main.go:328:6)
 	query *querybuilder.Selection
 
 	id *ID
@@ -62,7 +62,7 @@ type CompanionEmitIrOpts struct {
 	// because a manifest's own paths are relative to the directory holding it and
 	// a manifest arriving on a stream is in no directory.
 	//
-	Manifest string // companion (../../../daggerverse/cpybkc/main.go:861:2)
+	Manifest string // companion (../../../daggerverse/cpybkc/main.go:871:2)
 	//
 	// The encoding the descriptor is written in: `binary`, the canonical protobuf
 	// wire encoding a generator is handed, or `json`, the normalized rendering a
@@ -79,13 +79,13 @@ type CompanionEmitIrOpts struct {
 	// contract out here is one that drifts, and this one would drift the day a
 	// third encoding landed.
 	//
-	Format string // companion (../../../daggerverse/cpybkc/main.go:877:2)
+	Format string // companion (../../../daggerverse/cpybkc/main.go:887:2)
 }
 
 // EmitIr writes the run's resolved descriptor and hands back the file:
 //
 //	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
-//	  emit-ir --source . --format json export --path descriptor.json
+//	  emit-ir --source . export --path descriptor.binpb
 //
 // It is `cpybkc --emit-ir`, and the name is that flag rather than a word of this
 // module's own for the reason Init's is the CLI's verb: somebody who read
@@ -93,9 +93,12 @@ type CompanionEmitIrOpts struct {
 // read it under.
 //
 // The descriptor is what to attach to a bug report, against cpybkc or against
-// any generator. It is exactly the bytes a plugin was handed — the equality the
-// plugin contract rests reproducibility on — so reading it settles in one step
-// whether a fault is the producer's or the consumer's. It is also available from
+// any generator, and the call above is the one that produces it: in the default
+// encoding it is exactly the bytes a plugin was handed — the equality the plugin
+// contract rests reproducibility on — so reading it settles in one step whether
+// a fault is the producer's or the consumer's. The JSON is a rendering of that
+// same descriptor rather than the bytes themselves, so it belongs beside the
+// binary file in an issue rather than instead of it. It is also available from
 // the run that is broken: an emission is terminal, so no generator is resolved,
 // nothing is merged into the project's tree and nothing is pruned from it
 // (docs/cli/SPEC.md, "Emitting replaces generation"), which is why a project
@@ -104,8 +107,9 @@ type CompanionEmitIrOpts struct {
 //
 // Nothing is written to the host, exactly as with Init: the File that comes back
 // is a value, and exporting it is the caller's separate step. This module writes
-// it to a path of its own inside the container ([descriptorPath]) that nothing
-// was mounted into, so the run cannot land on something the caller already has.
+// it to a path of its own inside the container, outside the mounted project and
+// where nothing was mounted, so the run cannot land on something the caller
+// already has.
 //
 // The one spelling this does not offer is `--emit-ir -`, which stays Run's for
 // the reason `--out -` does — a File-returning function has no stream to hand
@@ -119,7 +123,7 @@ type CompanionEmitIrOpts struct {
 // emission and the format is its argument, so there is no call that names a
 // format without asking for one, and there is nothing left for the module to
 // check.
-func (r *Companion) EmitIr(source *Directory, opts ...CompanionEmitIrOpts) *File { // companion (../../../daggerverse/cpybkc/main.go:836:1)
+func (r *Companion) EmitIr(source *Directory, opts ...CompanionEmitIrOpts) *File { // companion (../../../daggerverse/cpybkc/main.go:846:1)
 	assertNotNil("source", source)
 	q := r.query.Select("emitIr")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -155,7 +159,7 @@ type CompanionGenerateOpts struct {
 	// cannot be "-": a manifest's own paths are relative to the directory holding
 	// it, and a manifest arriving on a stream is in no directory.
 	//
-	Manifest string // companion (../../../daggerverse/cpybkc/main.go:690:2)
+	Manifest string // companion (../../../daggerverse/cpybkc/main.go:691:2)
 }
 
 // Generate runs cpybkc over a project and hands back the project as it should
@@ -178,7 +182,7 @@ type CompanionGenerateOpts struct {
 // express half of what a run did. `generate --source . export --path .` is
 // therefore the ordinary use, and it is a full statement of the run rather than
 // an overlay that leaves deletions behind.
-func (r *Companion) Generate(source *Directory, opts ...CompanionGenerateOpts) *Directory { // companion (../../../daggerverse/cpybkc/main.go:667:1)
+func (r *Companion) Generate(source *Directory, opts ...CompanionGenerateOpts) *Directory { // companion (../../../daggerverse/cpybkc/main.go:668:1)
 	assertNotNil("source", source)
 	q := r.query.Select("generate")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -261,7 +265,7 @@ func (r *Companion) UnmarshalJSON(bs []byte) error {
 // none of the signatures or attestations one does (docs/container/SPEC.md, "What
 // a tag carries besides the image"), because those are attached to the digest
 // this project published and not to the bytes.
-func (r *Companion) Image() *Container { // companion (../../../daggerverse/cpybkc/main.go:643:1)
+func (r *Companion) Image() *Container { // companion (../../../daggerverse/cpybkc/main.go:644:1)
 	q := r.query.Select("image")
 
 	return &Container{
@@ -290,9 +294,9 @@ func (r *Companion) Image() *Container { // companion (../../../daggerverse/cpyb
 // Nothing is written to the host, exactly as with Generate: the File that comes
 // back is a value, and exporting it is the caller's separate step. What it is
 // called is theirs — this module writes the scaffold to a path of its own inside
-// the container ([scaffoldPath]) that nothing was mounted into, so the run cannot
-// land on something the caller already has, and the name it takes in their tree
-// is the one they give `export`.
+// the container, outside the mounted project and where nothing was mounted, so
+// the run cannot land on something the caller already has, and the name it takes
+// in their tree is the one they give `export`.
 //
 // *Where* it goes is theirs within one constraint, and it is the one thing here
 // a caller cannot infer from the signature. The scaffold names each copybook by
@@ -310,7 +314,7 @@ func (r *Companion) Image() *Container { // companion (../../../daggerverse/cpyb
 //
 //	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
 //	  run --source . --args=init,--copybook,posting.cpy,--out,- stdout
-func (r *Companion) Init(source *Directory, copybook []string) *File { // companion (../../../daggerverse/cpybkc/main.go:748:1)
+func (r *Companion) Init(source *Directory, copybook []string) *File { // companion (../../../daggerverse/cpybkc/main.go:749:1)
 	assertNotNil("source", source)
 	q := r.query.Select("init")
 	q = q.Arg("source", source)
@@ -331,7 +335,7 @@ type CompanionRunOpts struct {
 	// contact nothing. With no source the container is the image as it was
 	// resolved, and cpybkc runs in whatever directory the image left it in.
 	//
-	Source *Directory // companion (../../../daggerverse/cpybkc/main.go:976:2)
+	Source *Directory // companion (../../../daggerverse/cpybkc/main.go:1008:2)
 }
 
 // Run is the fallback: cpybkc invoked with an argument vector this module has no
@@ -377,7 +381,7 @@ type CompanionRunOpts struct {
 // unrecognised flag is, whether a flag may repeat and what a usage error exits
 // with are all docs/cli/SPEC.md's, and the exec's failure carries them back
 // verbatim.
-func (r *Companion) Run(args []string, opts ...CompanionRunOpts) *Container { // companion (../../../daggerverse/cpybkc/main.go:963:1)
+func (r *Companion) Run(args []string, opts ...CompanionRunOpts) *Container { // companion (../../../daggerverse/cpybkc/main.go:995:1)
 	q := r.query.Select("run")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `source` optional argument
@@ -403,7 +407,7 @@ type CompanionWithGeneratorOpts struct {
 	// image being composed into, which is checked, because a mismatch here is
 	// checkable and its exec-time failure is not legible.
 	//
-	Image *Container // companion (../../../daggerverse/cpybkc/main.go:525:2)
+	Image *Container // companion (../../../daggerverse/cpybkc/main.go:526:2)
 }
 
 // WithGenerator adds one generator to the image by copying its executable out of
@@ -431,7 +435,7 @@ type CompanionWithGeneratorOpts struct {
 // about multi-platform: composing an amd64 generator into an arm64 image produces
 // an image that builds and pushes and then fails at exec with the kernel's
 // message rather than cpybkc's, which is a long way from the call that caused it.
-func (r *Companion) WithGenerator(name string, opts ...CompanionWithGeneratorOpts) *Companion { // companion (../../../daggerverse/cpybkc/main.go:512:1)
+func (r *Companion) WithGenerator(name string, opts ...CompanionWithGeneratorOpts) *Companion { // companion (../../../daggerverse/cpybkc/main.go:513:1)
 	q := r.query.Select("withGenerator")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `image` optional argument
@@ -468,7 +472,7 @@ func (r *Companion) WithGenerator(name string, opts ...CompanionWithGeneratorOpt
 // or foreign-architecture generator fails at exec time with the kernel's message
 // rather than cpybkc's. WithGenerator can check the platform half of that because
 // a container states one; here there is nothing to read.
-func (r *Companion) WithGeneratorExecutable(name string, executable *File) *Companion { // companion (../../../daggerverse/cpybkc/main.go:597:1)
+func (r *Companion) WithGeneratorExecutable(name string, executable *File) *Companion { // companion (../../../daggerverse/cpybkc/main.go:598:1)
 	assertNotNil("executable", executable)
 	q := r.query.Select("withGeneratorExecutable")
 	q = q.Arg("name", name)
@@ -488,7 +492,7 @@ func (r *Companion) AsNode() Node {
 }
 
 // Create or update a binding of type Companion in the environment
-func (r *Env) WithCompanionInput(name string, value *Companion, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:327:6)
+func (r *Env) WithCompanionInput(name string, value *Companion, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:328:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withCompanionInput")
 	q = q.Arg("name", name)
@@ -501,7 +505,7 @@ func (r *Env) WithCompanionInput(name string, value *Companion, description stri
 }
 
 // Declare a desired Companion output to be assigned in the environment
-func (r *Env) WithCompanionOutput(name string, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:327:6)
+func (r *Env) WithCompanionOutput(name string, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:328:6)
 	q := r.query.Select("withCompanionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -525,7 +529,7 @@ type CompanionOpts struct {
 	//
 	//
 	// Default: "v0"
-	Version string // companion (../../../daggerverse/cpybkc/main.go:398:2)
+	Version string // companion (../../../daggerverse/cpybkc/main.go:399:2)
 	//
 	// The registry repository the image is pulled from, as `<host>/<path>` with no
 	// tag.
@@ -540,7 +544,7 @@ type CompanionOpts struct {
 	//
 	//
 	// Default: "ghcr.io/zaba505/cpybkc"
-	Repository string // companion (../../../daggerverse/cpybkc/main.go:411:2)
+	Repository string // companion (../../../daggerverse/cpybkc/main.go:412:2)
 	//
 	// Run in this container instead of pulling one, replacing it entirely.
 	//
@@ -560,7 +564,7 @@ type CompanionOpts struct {
 	// does not track whatever was pinned here, so a build that pins the CLI by
 	// digest and wants the pairing to hold still passes --version beside it.
 	//
-	Image *Container // companion (../../../daggerverse/cpybkc/main.go:430:2)
+	Image *Container // companion (../../../daggerverse/cpybkc/main.go:431:2)
 	//
 	// Pull the image for this platform, as `GOOS/GOARCH`, instead of for the
 	// engine's own.
@@ -579,7 +583,7 @@ type CompanionOpts struct {
 	// Empty is the engine's own platform, which is what makes an ordinary
 	// `dagger call` from a checkout do the obvious thing.
 	//
-	Platform string // companion (../../../daggerverse/cpybkc/main.go:448:2)
+	Platform string // companion (../../../daggerverse/cpybkc/main.go:449:2)
 }
 
 // New selects the cpybkc release to run:
@@ -600,7 +604,7 @@ type CompanionOpts struct {
 // resolves companion images against, which is why an air-gapped caller passing a
 // container from their own registry should pass --repository beside it rather
 // than instead of it.
-func (r *Query) Companion(opts ...CompanionOpts) *Companion { // companion (../../../daggerverse/cpybkc/main.go:387:1)
+func (r *Query) Companion(opts ...CompanionOpts) *Companion { // companion (../../../daggerverse/cpybkc/main.go:388:1)
 	q := r.query.Select("companion")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `version` optional argument

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -824,12 +824,16 @@ is the stance (#253), and everything else in this section follows from it.
 
 `Generate` takes a source directory and a manifest and hands back a
 `Directory`; `Init` takes a source directory and copybook paths and hands back
-the layout scaffold as a `File`; `Run` takes an argument vector verbatim and
-hands back a `Container`. The first two are the two commands cpybkc has, under
-the CLI's own names — a second name for one command would be this module's
-vocabulary rather than cpybkc's, and a module mirroring the CLI has the least
-business growing one. The third is the fallback, and the rest of this section is
-about what that means.
+the layout scaffold as a `File`; `EmitIr` takes a source directory, a manifest
+and a format and hands back the run's resolved descriptor as a `File`; `Run`
+takes an argument vector verbatim and hands back a `Container`. The first two
+are the two commands cpybkc has, under the CLI's own names — a second name for
+one command would be this module's vocabulary rather than cpybkc's, and a module
+mirroring the CLI has the least business growing one. The third is named for a
+flag, on the same grounds and for the same reason: `--emit-ir` replaces the
+default action outright, so it is not an argument on `Generate`, and the name it
+takes is the one `docs/cli/SPEC.md` already gave it. The fourth is the fallback,
+and the rest of this section is about what that means.
 
 `Init` is `cpybkc init` (#228), and it is the run that made the case for
 mapping the commands by name at all: it is the run an adopter reaches **first**,
@@ -842,6 +846,19 @@ was typed and a layout's own paths are relative to the layout; and it supplies
 is ever replaced* holds without the module reasoning about the caller's tree at
 all. Where the file goes in that tree is what they name at `export`, which is
 the one thing the adopter knows and cpybkc does not.
+
+`EmitIr` is `cpybkc --emit-ir` (#251), and it is the run somebody reaches for
+when they are already having a bad time: the resolved descriptor is what to
+attach to a bug report, because it is exactly the bytes every generator in the
+run was handed, and an emitting run is **terminal**, so the project whose
+`generate` fails inside a generator still produces one. It takes the manifest
+`Generate` takes, since which descriptor is emitted follows from which manifest
+was read; it supplies the destination itself, outside the mounted project, on
+`Init`'s grounds; and the format is its one optional argument, which is what
+makes the pairing `docs/cli/SPEC.md` calls a usage error — `--emit-ir-format`
+without `--emit-ir` — **unstateable** here rather than enforced. An unrecognised
+format is passed through and refused by the CLI, which names the spellings there
+are from the parser that decides them.
 
 #### What this stance replaced, and what it costs
 
@@ -860,10 +877,10 @@ and a forgotten one read identically from outside, so a caller could not tell
 "not offered, on purpose" from "nobody has got to it yet" — and neither could a
 contributor, because the argument above was written in four places and read as
 settled. Every gap was therefore argued twice, once by whoever found it and once
-by whoever fixed it: #228 had to argue past it to curate `init`, and #251 has to
-argue past it again for `--emit-ir`. Two arguments per gap is a worse price than
+by whoever fixed it. Two arguments per gap is a worse price than
 a permanent argument per flag, because it is paid by whoever is *least* able to
-pay it — somebody who wanted a feature, not a stance.
+pay it — somebody who wanted a feature, not a stance. #228 had to argue past it
+to curate `init`, and #251 had to argue past it again for `--emit-ir`.
 
 The judgment underneath is that the flag table moves slowly. `docs/cli/SPEC.md`
 is a specification with its own review, not a place flags accumulate; if that
@@ -883,11 +900,13 @@ recorded as **settled**, which is the class `Exception.Settled` exists to name.
 That second one is why a named function may still decline one spelling of a
 flag without declining the flag, and the sentence is kept deliberately because
 #228 and #251 both lean on it. `Init` does not offer `--out -`, which a
-`File`-returning function cannot express; `--emit-ir` will be the same when it
-is curated. A destination that is a stream rather than a file is the whole of
-that class today, and the scaffold on standard output is
-`run --source . --args=init,--copybook,posting.cpy,--out,-`, exactly as it was
-before there was an `Init`.
+`File`-returning function cannot express, and `EmitIr` does not offer
+`--emit-ir -` for the same reason. A destination that is a stream rather than a
+file is the whole of that class today, and each command is still spellable
+through the escape hatch —
+`run --source . --args=init,--copybook,posting.cpy,--out,-` and
+`run --source . --args=--emit-ir,-` — exactly as it was before either function
+existed.
 
 It returns a container rather than a directory for the same reason: the
 invocations that arrive here are the ones whose answer is not a tree —
@@ -954,8 +973,11 @@ What the check buys is that the assertion has to be **made**, and re-made
 whenever the CLI's surface moves, which is exactly when it stops being true by
 accident.
 
-Today's exceptions are `--emit-ir` and `--emit-ir-format`, tracked to #251, and
-`--version`, `--help` and `-h`, settled: `dagger call --help` and the
+Today's exceptions are `--version`, `--help` and `-h`, all **settled**, and
+there are no tracked ones: #251 curated the last of those — `--emit-ir` and
+`--emit-ir-format` — onto `emit-ir`, and moved both entries into
+`companionCoverage` in the same commit, which is what an entry naming an issue
+is for. The settled three are settled because `dagger call --help` and the
 per-function documentation are the Dagger-native form of that question, and
 which release runs is something a caller states at `New`'s `--version` rather
 than asks the CLI afterwards. That last reason does not cover everything, which
@@ -1167,9 +1189,9 @@ which is what makes the two
 rather than merely both present (#63). Both start from the base image, which
 carries the CLI and **no** generator — so a generation that succeeded did so with
 the generators these calls installed and not with something lying around in the
-image. `image`, `run` and `init` are checked too, since a check that exercised
-only what it needed would leave the rest of the module's surface covered by
-nothing.
+image. `image`, `run`, `init` and `emit-ir` are checked too, since a check that
+exercised only what it needed would leave the rest of the module's surface
+covered by nothing.
 
 **`init` is checked against the escape hatch, not against a second expectation.**
 The curated scaffolding function has to hand back the scaffold
@@ -1184,6 +1206,20 @@ that the run it replaces is still spellable through `run` and still produces the
 same bytes. It runs against the base
 image with nothing composed into it, because `init` resolves no layout and runs
 no generator, which is also the state an adopter is in when they run it.
+
+**`emit-ir` is checked the same way, in every encoding** (#251). The curated
+function has to hand back the descriptor `run --args=--emit-ir,…` writes over
+[`example/`](example/), byte for byte, once naming no format — which is what
+says the module left the default encoding to the CLI rather than spelling one
+out here — and once for each of `binary` and `json`. Equality is not incidental
+to this flag the way it is to `init`: the plugin contract rests reproducibility
+on the bytes `--emit-ir` writes being the bytes a generator was handed, and it
+holds that by there being **one encoder** rather than by two agreeing. A curated
+function that re-encoded or re-indented on the way out would break that for
+everybody who reached this module first. Both sides come back as *files* rather
+than through standard output, unlike `init`'s: a descriptor is not text, and
+comparing the binary encoding through a string would compare two decodings
+instead of the bytes.
 
 **Two generators, because the example runs two.** Since #191 the committed
 example names `go` *and* `graph`, so each composition installs both and the

--- a/README.md
+++ b/README.md
@@ -228,13 +228,15 @@ still hands one back:
 
 ```sh
 dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
-  emit-ir --source . --format json export --path descriptor.json
+  emit-ir --source . export --path descriptor.binpb
 ```
 
-`--format json` is the rendering a person reads and pastes; leaving it off gives
-the canonical protobuf encoding, which is the one a generator was actually
-handed. `cpybkc --emit-ir descriptor.json --emit-ir-format json` is the same run
-without Dagger.
+That is the canonical protobuf encoding, and it is the artifact to attach: it is
+the bytes a generator received, byte for byte. `--format json` renders the same
+descriptor as the normalized JSON a person reads — useful for quoting a field in
+the issue text, but a rendering rather than the thing itself, so send it *beside*
+the binary file rather than instead of it. `cpybkc --emit-ir descriptor.binpb` is
+the same run without Dagger.
 
 It still has no `SPEC.md`, and not because there is nothing to specify — it is
 public API, and a function or an argument here lasts as long as the published

--- a/README.md
+++ b/README.md
@@ -213,10 +213,28 @@ dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
 
 It is the cpybkc CLI daggerized: what `cpybkc` can do, this module aims to do by
 name, with the CLI's commands as functions and their flags as arguments.
-`generate` and `init` are the two commands there are; `run` is the fallback for
-what has not been mapped yet and for the spellings a Dagger type cannot express,
-such as a destination that is a stream. Where the two disagree, that is a gap to
-file rather than a decision to work around.
+`generate` and `init` are the two commands there are, and `emit-ir` is the flag
+that replaces generating outright, so it gets a function under the flag's own
+name; `run` is the fallback for what has not been mapped yet and for the
+spellings a Dagger type cannot express, such as a destination that is a stream.
+Where the two disagree, that is a gap to file rather than a decision to work
+around.
+
+**Filing a bug against cpybkc or against a generator? Attach the descriptor.**
+It is exactly the bytes cpybkc handed every generator in the run, so reading it
+settles in one step whether a fault is the producer's or the consumer's — and an
+emitting run is terminal, so a project whose `generate` fails inside a generator
+still hands one back:
+
+```sh
+dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+  emit-ir --source . --format json export --path descriptor.json
+```
+
+`--format json` is the rendering a person reads and pastes; leaving it off gives
+the canonical protobuf encoding, which is the one a generator was actually
+handed. `cpybkc --emit-ir descriptor.json --emit-ir-format json` is the same run
+without Dagger.
 
 It still has no `SPEC.md`, and not because there is nothing to specify — it is
 public API, and a function or an argument here lasts as long as the published

--- a/daggerverse/cpybkc/dagger.gen.go
+++ b/daggerverse/cpybkc/dagger.gen.go
@@ -206,6 +206,34 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 	switch parentName {
 	case "Cpybkc":
 		switch fnName {
+		case "EmitIr":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var source *dagger.Directory
+			if inputArgs["source"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["source"]), &source)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg source", err))
+				}
+			}
+			var manifest string
+			if inputArgs["manifest"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["manifest"]), &manifest)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg manifest", err))
+				}
+			}
+			var format string
+			if inputArgs["format"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["format"]), &format)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg format", err))
+				}
+			}
+			return (*Cpybkc).EmitIr(&parent, ctx, source, manifest, format)
 		case "Generate":
 			var parent Cpybkc
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/cpybkc/internal/argv/argv.go
+++ b/daggerverse/cpybkc/internal/argv/argv.go
@@ -39,6 +39,17 @@ const copybookFlag = "--copybook"
 // not of the vector.
 const outFlag = "--out"
 
+// emitIRFlag names where the run's resolved descriptor goes, and it is what
+// makes a run an emitting one: docs/cli/SPEC.md has it replace generation
+// outright, so this flag being in the vector is the whole of what [EmitIR]
+// asks for.
+const emitIRFlag = "--emit-ir"
+
+// emitIRFormatFlag selects the encoding of that descriptor. It is a usage error
+// without [emitIRFlag], which is a rule this package cannot break rather than
+// one it enforces: it is only ever written beside it, three lines from here.
+const emitIRFormatFlag = "--emit-ir-format"
+
 // standardOutput is the dash cpybkc reads as "a stream" wherever it accepts
 // one. --manifest is the one flag that refuses it.
 const standardOutput = "-"
@@ -137,4 +148,51 @@ func Init(copybooks []string, out string) ([]string, error) {
 	}
 
 	return append(args, outFlag, out), nil
+}
+
+// EmitIR is the vector for an emitting run over a project mounted at the
+// container's working directory, with the resolved descriptor written to dest.
+//
+// It is a generating run's vector plus the flag that replaces the generating,
+// which is why [Generate] builds the front of it rather than this function
+// restating the manifest rule. Which descriptor is emitted follows from which
+// manifest was read (docs/cli/SPEC.md, "Which descriptor is emitted"), so a
+// project keeping its manifest somewhere else says so here exactly as it does
+// for a generating run — and the dash is refused here for the same reason and
+// with the same message, because it is the same argument.
+//
+// dest is the caller's rather than a constant here, for the reason [Init]'s out
+// is: where the descriptor lands inside the container is a property of how the
+// module mounts things. It is not examined. The one value that would be worth
+// refusing is the dash, and no caller of this package can pass it — a
+// File-returning function has no stream to hand back, so `--emit-ir -` stays
+// the escape hatch's spelling and never reaches here.
+//
+// An empty format is no --emit-ir-format at all, which leaves the CLI applying
+// its own default. That is the [Generate] treatment of an empty manifest and it
+// is chosen for the same reason: the default encoding is docs/cli/SPEC.md's to
+// name, and a vector spelling it out here would be this module's second reading
+// of it, drifting the moment that document changed.
+//
+// A format that is not one of the spellings that document fixes is passed
+// through unexamined, and the refusal is the CLI's. It has one to give —
+// `"xml" is not a format; write "binary" or "json"` — and it names the
+// alternatives from the parser that decides them, which is a better answer than
+// this package could assemble from out here. The two refusals above are
+// different in the way [Generate] gives: a stream is wrong for every state of
+// every filesystem, and paying for a pull and an exec to be told so buys
+// nothing, whereas the set of formats is a thing the CLI is entitled to grow.
+func EmitIR(manifest, dest, format string) ([]string, error) {
+	args, err := Generate(manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	args = append(args, emitIRFlag, dest)
+
+	if format == "" {
+		return args, nil
+	}
+
+	return append(args, emitIRFormatFlag, format), nil
 }

--- a/daggerverse/cpybkc/internal/argv/argv_test.go
+++ b/daggerverse/cpybkc/internal/argv/argv_test.go
@@ -7,6 +7,10 @@
 // leads, and that the copybooks reach cpybkc in the order they were given, which
 // is the order the scaffold then holds their records in. Pinning the vectors here
 // turns a later accidental flag, or a quietly reordered list, into a red build.
+// An emitting run's vector carries one more: that a caller who names no format
+// gets no --emit-ir-format at all, so the encoding a descriptor arrives in is
+// the CLI's default rather than a spelling this module would have to keep in
+// step with it.
 //
 // What is not tested here is anything needing an engine: whether the exec
 // succeeds, whether the project mounted at the working directory has a manifest
@@ -183,6 +187,98 @@ func TestInitRefusesTheDashAmongTheCopybooks(t *testing.T) {
 			if !strings.Contains(err.Error(), "has none to state") {
 				t.Errorf("Init(%q, …) error = %q, want it to say why a copybook cannot arrive on a stream",
 					tc.copybooks, err)
+			}
+		})
+	}
+}
+
+func TestEmitIRAssemblesTheVector(t *testing.T) {
+	const dest = "/ir/descriptor"
+
+	for _, tc := range []struct {
+		name     string
+		manifest string
+		format   string
+		want     []string
+	}{
+		{
+			// The ordinary case, and the one a bug report is built out of: the
+			// project's own cpybkc.json, the CLI's own default encoding, and one
+			// flag saying the run emits rather than generates.
+			name: "no manifest and no format",
+			want: []string{"--emit-ir", dest},
+		},
+		{
+			// No --emit-ir-format naming the default, for the reason
+			// [TestGenerateWithNoManifest] gives about --manifest: which encoding
+			// a run writes when nobody says is docs/cli/SPEC.md's, and a second
+			// statement of it here would drift.
+			name:   "the format named by name",
+			format: "binary",
+			want:   []string{"--emit-ir", dest, "--emit-ir-format", "binary"},
+		},
+		{
+			name:   "the JSON a person pastes into an issue",
+			format: "json",
+			want:   []string{"--emit-ir", dest, "--emit-ir-format", "json"},
+		},
+		{
+			// Passed through rather than refused, so the diagnostic is the CLI's:
+			// it names the spellings there are, from the parser that decides them.
+			name:   "a format this package does not recognise",
+			format: "xml",
+			want:   []string{"--emit-ir", dest, "--emit-ir-format", "xml"},
+		},
+		{
+			// Which descriptor is emitted follows from which manifest was read,
+			// so a project keeping its manifest below its root can still emit one.
+			name:     "a manifest below the project root",
+			manifest: "build/cpybkc.json",
+			want:     []string{"--manifest", "build/cpybkc.json", "--emit-ir", dest},
+		},
+		{
+			// The manifest leads, exactly as it does for a generating run: this is
+			// that vector plus the flag that replaces the generating.
+			name:     "a manifest and a format together",
+			manifest: "build/cpybkc.json",
+			format:   "json",
+			want: []string{
+				"--manifest", "build/cpybkc.json",
+				"--emit-ir", dest,
+				"--emit-ir-format", "json",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := EmitIR(tc.manifest, dest, tc.format)
+			if err != nil {
+				t.Fatalf("EmitIR(%q, %q, %q): unexpected error: %v", tc.manifest, dest, tc.format, err)
+			}
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("EmitIR(%q, %q, %q) = %q, want %q", tc.manifest, dest, tc.format, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEmitIRRefusesTheDashAsAManifest(t *testing.T) {
+	// Every format, because the refusal is about the manifest and a vector that
+	// escaped it for one spelling of an unrelated argument would be exactly the
+	// kind of hole a table stops.
+	for _, format := range []string{"", "binary", "json"} {
+		t.Run("format "+format, func(t *testing.T) {
+			got, err := EmitIR("-", "/ir/descriptor", format)
+			if err == nil {
+				t.Fatalf("EmitIR(\"-\", …, %q) = %q, want an error", format, got)
+			}
+			if got != nil {
+				t.Errorf("EmitIR(\"-\", …, %q) returned %q beside its error, want no vector", format, got)
+			}
+			// The same reason [TestGenerateRefusesTheDash] checks for, because it
+			// is the same rule read once rather than a second copy of it here.
+			if !strings.Contains(err.Error(), "in no directory") {
+				t.Errorf("EmitIR(\"-\", …, %q) error = %q, want it to say why a manifest cannot arrive on a stream",
+					format, err)
 			}
 		})
 	}

--- a/daggerverse/cpybkc/main.go
+++ b/daggerverse/cpybkc/main.go
@@ -165,6 +165,17 @@
 // CLI's rather than this module's: somebody who read docs/cli/SPEC.md should
 // find what they read about here, under the name they read it under.
 //
+// A flag that replaces the default action outright gets a function of its own
+// under the flag's own name, on the same grounds. EmitIr is `--emit-ir`: it
+// takes the project and the manifest Generate takes, plus the encoding, and
+// hands back the resolved descriptor rather than a generated tree. That is not a
+// third command and it is not this module inventing a verb — it is where the
+// mapping puts a flag whose whole meaning is that no generating happens
+// (docs/cli/SPEC.md, "Emitting replaces generation"), and it is the same move
+// #228 made for `init`. It also makes an illegal pairing unstateable rather than
+// enforced: --emit-ir-format is a usage error without --emit-ir, and as this
+// function's argument there is no call that names one without the other.
+//
 // That is a stance rather than an observation, and it replaced a good argument
 // (#62, #253). This module used to curate deliberately — two functions, an
 // escape hatch, and the reasoning that a module argument is public API for as
@@ -183,21 +194,24 @@
 // flag. A flag that reaches a caller through Run is recorded as an exception in
 // this repository's pipeline, with the argument for it and, where it is a gap
 // rather than a decision, the issue curating it — and `dagger call cli-surface`
-// fails on one that is neither. Today that is --emit-ir and --emit-ir-format,
-// which #251 is curating, and --version, --help and -h, which stay: `dagger call
-// --help` and the per-function documentation are the Dagger-native form of that
-// question, and which release runs is something a caller states at New's
-// --version rather than asks the CLI afterwards.
+// fails on one that is neither. Today that is --version, --help and -h, and all
+// three stay: `dagger call --help` and the per-function documentation are the
+// Dagger-native form of that question, and which release runs is something a
+// caller states at New's --version rather than asks the CLI afterwards. No flag
+// is on this function today for want of somebody curating it, which is the
+// state that table is kept in order to be able to say.
 //
 // A function is still allowed to decline one *spelling* of a flag without
 // declining the flag, and that stays deliberately. Init supplies --out itself,
 // at a path inside the container the caller never types, and hands back the
 // File; `--out -` is not offered, because a File-returning function cannot
-// express a stream. A stream destination is the whole of that class — --emit-ir
-// will have the same one when it is curated — and the spelling stays Run's,
-// which is the command being reachable rather than out of reach:
+// express a stream. EmitIr supplies --emit-ir's destination on the same terms
+// and declines `--emit-ir -` for the same reason. A stream destination is the
+// whole of that class, and both spellings stay Run's, which is the command being
+// reachable rather than out of reach:
 //
 //	dagger call run --source . --args=init,--copybook,posting.cpy,--out,- stdout
+//	dagger call run --source . --args=--emit-ir,- stdout
 //
 // One thing the flag table cannot say, and this comment therefore should. cpybkc
 // passes its whole environment through to a generator, which is how
@@ -270,6 +284,29 @@ const projectDir = "/src"
 const (
 	scaffoldDir  = "/scaffold"
 	scaffoldPath = scaffoldDir + "/layout.sexpr"
+)
+
+// descriptorDir is where EmitIr has cpybkc write the run's resolved descriptor,
+// and descriptorPath is the file inside it.
+//
+// Outside [projectDir] on [scaffoldDir]'s grounds, and the argument is the same
+// one twice: a destination inside the mounted project is a path this module
+// would have to reason about the caller's tree to choose safely, and an emitting
+// run over a project that already holds a file at the chosen path is not a run
+// anybody asked about. Nothing in the caller's tree is written either way — an
+// emission is terminal, so nothing is merged or pruned (docs/cli/SPEC.md,
+// "Emitting replaces generation") — and writing into a directory nothing was
+// mounted into is what keeps that true of the emission as well.
+//
+// The name carries no extension, deliberately. Which encoding is in the file is
+// the format argument's to say and both encodings land at this one path, so a
+// name claiming one of them would be wrong for the other run. It is only what
+// the file is called on the way out in any case: what it is called in the
+// caller's tree is what they name at export, which is the same arrangement the
+// scaffold has.
+const (
+	descriptorDir  = "/ir"
+	descriptorPath = descriptorDir + "/descriptor"
 )
 
 // contractUser is the UID:GID docs/container/SPEC.md pins the image to, used to
@@ -754,27 +791,130 @@ func (m *Cpybkc) Init(
 		return nil, err
 	}
 
-	project := m.mount(user, source)
-
-	// Emptied first, then an empty directory owned by whoever the container runs
-	// as.
-	//
-	// Emptied because WithDirectory *merges*: whatever the image already had
-	// here would survive it, and a caller may have passed --image, which this
-	// module is not entitled to have an opinion about the contents of. Without
-	// the removal, such a container carrying anything at [scaffoldPath] would
-	// fail the run on a destination its caller never named and cannot see in the
-	// call — which is the one failure this path is arranged to make impossible.
-	//
-	// Owned, because the scaffold is written through a temporary file created
-	// beside its destination and linked into place — the write is atomic or it
-	// does not happen — so the process needs a directory it can create in, not
-	// merely a path nothing occupies.
-	return project.
-		WithoutDirectory(scaffoldDir).
-		WithDirectory(scaffoldDir, dag.Directory(), dagger.ContainerWithDirectoryOpts{Owner: user}).
+	return m.writable(m.mount(user, source), user, scaffoldDir).
 		WithExec(args, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
 		File(scaffoldPath), nil
+}
+
+// EmitIr writes the run's resolved descriptor and hands back the file:
+//
+//	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+//	  emit-ir --source . --format json export --path descriptor.json
+//
+// It is `cpybkc --emit-ir`, and the name is that flag rather than a word of this
+// module's own for the reason Init's is the CLI's verb: somebody who read
+// docs/cli/SPEC.md should find what they read about here, under the name they
+// read it under.
+//
+// The descriptor is what to attach to a bug report, against cpybkc or against
+// any generator. It is exactly the bytes a plugin was handed — the equality the
+// plugin contract rests reproducibility on — so reading it settles in one step
+// whether a fault is the producer's or the consumer's. It is also available from
+// the run that is broken: an emission is terminal, so no generator is resolved,
+// nothing is merged into the project's tree and nothing is pruned from it
+// (docs/cli/SPEC.md, "Emitting replaces generation"), which is why a project
+// whose `generate` fails inside a generator can still emit the descriptor that
+// generator was given.
+//
+// Nothing is written to the host, exactly as with Init: the File that comes back
+// is a value, and exporting it is the caller's separate step. This module writes
+// it to a path of its own inside the container ([descriptorPath]) that nothing
+// was mounted into, so the run cannot land on something the caller already has.
+//
+// The one spelling this does not offer is `--emit-ir -`, which stays Run's for
+// the reason `--out -` does — a File-returning function has no stream to hand
+// back — and which is a spelling rather than a flag:
+//
+//	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+//	  run --source . --args=--emit-ir,- stdout
+//
+// The illegal pairing docs/cli/SPEC.md names — `--emit-ir-format` without
+// `--emit-ir` — is unstateable here rather than enforced. This function *is* the
+// emission and the format is its argument, so there is no call that names a
+// format without asking for one, and there is nothing left for the module to
+// check.
+func (m *Cpybkc) EmitIr(
+	ctx context.Context,
+	// The project to emit the descriptor of: the directory holding the manifest,
+	// the layout it names and the copybooks that layout names.
+	//
+	// It is mounted whole rather than filtered down to what the run reads, for
+	// Generate's reason: which copybooks are read is a property of the layout, and
+	// a module guessing at that set would be a second, weaker answer to a question
+	// docs/cli/SPEC.md answers exactly.
+	source *dagger.Directory,
+	// The project manifest to read, relative to the root of source.
+	//
+	// It is taken the way Generate takes it, and it is not a convenience: a run
+	// resolves one descriptor, from the layout the manifest names and the
+	// copybooks that layout names (docs/cli/SPEC.md, "Which descriptor is
+	// emitted"), so *which* descriptor is emitted is exactly which manifest was
+	// read. A project keeping its manifest somewhere else would otherwise be able
+	// to generate through this module and not to emit what it generated from.
+	//
+	// It defaults to nothing, which leaves cpybkc reading `cpybkc.json` at the
+	// root of the mounted project — the CLI's own default, applied by the CLI. A
+	// relative path resolves against that project root, and it cannot be "-",
+	// because a manifest's own paths are relative to the directory holding it and
+	// a manifest arriving on a stream is in no directory.
+	// +optional
+	manifest string,
+	// The encoding the descriptor is written in: `binary`, the canonical protobuf
+	// wire encoding a generator is handed, or `json`, the normalized rendering a
+	// person reads and pastes into an issue.
+	//
+	// It defaults to nothing, which is not a third encoding: an unnamed format
+	// reaches the CLI as no --emit-ir-format at all, so what arrives is whatever
+	// docs/cli/SPEC.md's default is — `binary` today — decided there rather than
+	// restated here where the two could drift.
+	//
+	// A value that is neither spelling is passed through and refused by the CLI,
+	// which names the spellings there are from the parser that decides them. That
+	// is deliberate for the reason Run validates nothing: a second reading of that
+	// contract out here is one that drifts, and this one would drift the day a
+	// third encoding landed.
+	// +optional
+	format string,
+) (*dagger.File, error) {
+	args, err := argv.EmitIR(manifest, descriptorPath, format)
+	if err != nil {
+		return nil, err
+	}
+
+	user, err := m.user(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return m.writable(m.mount(user, source), user, descriptorDir).
+		WithExec(args, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
+		File(descriptorPath), nil
+}
+
+// writable hands back container with dir emptied and owned by user, which is
+// what a curated function supplies the CLI when it chooses the destination
+// itself.
+//
+// Emptied because WithDirectory *merges*: whatever the image already had there
+// would survive it, and a caller may have passed --image, which this module is
+// not entitled to have an opinion about the contents of. Without the removal,
+// such a container carrying anything at the destination would fail the run on a
+// path its caller never named and cannot see in the call — which for `init` is
+// the one failure this path is arranged to make impossible, since a destination
+// that is occupied fails a scaffolding run whatever is in it.
+//
+// Owned, because both files are written through a temporary file created beside
+// the destination and linked into place — the write is atomic or it does not
+// happen — so the process needs a directory it can create in, not merely a path
+// nothing occupies.
+//
+// It is one function rather than two copies for the reason [Cpybkc.user] is:
+// Init and EmitIr are making the same arrangement for the same reasons, and two
+// statements of it would be two things to keep in step.
+func (m *Cpybkc) writable(container *dagger.Container, user, dir string) *dagger.Container {
+	return container.
+		WithoutDirectory(dir).
+		WithDirectory(dir, dag.Directory(), dagger.ContainerWithDirectoryOpts{Owner: user})
 }
 
 // Run is the fallback: cpybkc invoked with an argument vector this module has no

--- a/daggerverse/cpybkc/main.go
+++ b/daggerverse/cpybkc/main.go
@@ -226,6 +226,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"dagger/cpybkc/internal/argv"
 	"dagger/cpybkc/internal/dagger"
@@ -725,9 +726,9 @@ func (m *Cpybkc) Generate(
 // Nothing is written to the host, exactly as with Generate: the File that comes
 // back is a value, and exporting it is the caller's separate step. What it is
 // called is theirs — this module writes the scaffold to a path of its own inside
-// the container ([scaffoldPath]) that nothing was mounted into, so the run cannot
-// land on something the caller already has, and the name it takes in their tree
-// is the one they give `export`.
+// the container, outside the mounted project and where nothing was mounted, so
+// the run cannot land on something the caller already has, and the name it takes
+// in their tree is the one they give `export`.
 //
 // *Where* it goes is theirs within one constraint, and it is the one thing here
 // a caller cannot infer from the signature. The scaffold names each copybook by
@@ -791,7 +792,12 @@ func (m *Cpybkc) Init(
 		return nil, err
 	}
 
-	return m.writable(m.mount(user, source), user, scaffoldDir).
+	scaffold, err := m.writable(m.mount(user, source), user, scaffoldDir)
+	if err != nil {
+		return nil, err
+	}
+
+	return scaffold.
 		WithExec(args, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
 		File(scaffoldPath), nil
 }
@@ -799,7 +805,7 @@ func (m *Cpybkc) Init(
 // EmitIr writes the run's resolved descriptor and hands back the file:
 //
 //	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
-//	  emit-ir --source . --format json export --path descriptor.json
+//	  emit-ir --source . export --path descriptor.binpb
 //
 // It is `cpybkc --emit-ir`, and the name is that flag rather than a word of this
 // module's own for the reason Init's is the CLI's verb: somebody who read
@@ -807,9 +813,12 @@ func (m *Cpybkc) Init(
 // read it under.
 //
 // The descriptor is what to attach to a bug report, against cpybkc or against
-// any generator. It is exactly the bytes a plugin was handed — the equality the
-// plugin contract rests reproducibility on — so reading it settles in one step
-// whether a fault is the producer's or the consumer's. It is also available from
+// any generator, and the call above is the one that produces it: in the default
+// encoding it is exactly the bytes a plugin was handed — the equality the plugin
+// contract rests reproducibility on — so reading it settles in one step whether
+// a fault is the producer's or the consumer's. The JSON is a rendering of that
+// same descriptor rather than the bytes themselves, so it belongs beside the
+// binary file in an issue rather than instead of it. It is also available from
 // the run that is broken: an emission is terminal, so no generator is resolved,
 // nothing is merged into the project's tree and nothing is pruned from it
 // (docs/cli/SPEC.md, "Emitting replaces generation"), which is why a project
@@ -818,8 +827,9 @@ func (m *Cpybkc) Init(
 //
 // Nothing is written to the host, exactly as with Init: the File that comes back
 // is a value, and exporting it is the caller's separate step. This module writes
-// it to a path of its own inside the container ([descriptorPath]) that nothing
-// was mounted into, so the run cannot land on something the caller already has.
+// it to a path of its own inside the container, outside the mounted project and
+// where nothing was mounted, so the run cannot land on something the caller
+// already has.
 //
 // The one spelling this does not offer is `--emit-ir -`, which stays Run's for
 // the reason `--out -` does — a File-returning function has no stream to hand
@@ -886,7 +896,12 @@ func (m *Cpybkc) EmitIr(
 		return nil, err
 	}
 
-	return m.writable(m.mount(user, source), user, descriptorDir).
+	emitting, err := m.writable(m.mount(user, source), user, descriptorDir)
+	if err != nil {
+		return nil, err
+	}
+
+	return emitting.
 		WithExec(args, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
 		File(descriptorPath), nil
 }
@@ -894,6 +909,17 @@ func (m *Cpybkc) EmitIr(
 // writable hands back container with dir emptied and owned by user, which is
 // what a curated function supplies the CLI when it chooses the destination
 // itself.
+//
+// A dir inside [projectDir] is refused, and that is the whole reason this takes
+// a path rather than closing over one. Emptying is destructive, and as an
+// inlined block in one function it was safe by construction — the constant
+// beside it was outside the mount, and could be read in the same screenful. As a
+// helper taking a path it would empty whatever it was handed, so a later
+// destination written one directory further up would delete part of the caller's
+// project before the run, which is the one thing every comment around here says
+// cannot happen. It is checked rather than asserted for that reason: *the
+// destination is outside the mounted project* is a promise to a caller, and a
+// promise held by nobody editing a constant is held by nothing.
 //
 // Emptied because WithDirectory *merges*: whatever the image already had there
 // would survive it, and a caller may have passed --image, which this module is
@@ -911,10 +937,16 @@ func (m *Cpybkc) EmitIr(
 // It is one function rather than two copies for the reason [Cpybkc.user] is:
 // Init and EmitIr are making the same arrangement for the same reasons, and two
 // statements of it would be two things to keep in step.
-func (m *Cpybkc) writable(container *dagger.Container, user, dir string) *dagger.Container {
+func (m *Cpybkc) writable(container *dagger.Container, user, dir string) (*dagger.Container, error) {
+	if dir == projectDir || strings.HasPrefix(dir, projectDir+"/") {
+		return nil, fmt.Errorf(
+			"a destination this module supplies has to be outside the mounted project, and %q is inside %q: "+
+				"emptying it would delete part of the caller's tree before the run", dir, projectDir)
+	}
+
 	return container.
 		WithoutDirectory(dir).
-		WithDirectory(dir, dag.Directory(), dagger.ContainerWithDirectoryOpts{Owner: user})
+		WithDirectory(dir, dag.Directory(), dagger.ContainerWithDirectoryOpts{Owner: user}), nil
 }
 
 // Run is the fallback: cpybkc invoked with an argument vector this module has no


### PR DESCRIPTION
Closes #251

`--emit-ir` is what somebody attaches to a bug report — exactly the bytes every
generator in the run was handed, and available from the run that is broken,
because an emitting run is terminal. Until now it was reachable from the
companion module only as
`run --source . --args=--emit-ir,-,--emit-ir-format,json stdout`, which is a
clumsy thing to ask of somebody already having a bad time. This does for it what
#228 did for `init`.

## Acceptance criteria

- [x] **A curated function returning `*dagger.File`** — `EmitIr(source, manifest, format)` on `daggerverse/cpybkc`, both optional arguments optional.
- [x] **The name is the CLI's flag** — `emit-ir`, not a word of this module's own, exactly as `Init` is the CLI's verb.
- [x] **The format takes `docs/cli/SPEC.md`'s spellings and defaults to the CLI's default** — an unnamed format reaches the CLI as *no* `--emit-ir-format` at all, so the default encoding stays that document's to name; an unrecognised value is passed through and refused by the CLI, which names the spellings from the parser that decides them.
- [x] **The manifest is taken the way `Generate` takes it** — which descriptor is emitted follows from which manifest was read, and the dash is refused with `Generate`'s own message, by calling `Generate`.
- [x] **The destination is outside the mounted project** — `/ir/descriptor`, on #228's grounds for `init --out`: nothing in the caller's tree is written and the module never reasons about what is already there.
- [x] **The vector is assembled in `internal/argv`** — `argv.EmitIR`, beside `Generate` and `Init`, pinned by a table test there (both formats, an unrecognised one, a manifest, and the manifest-on-a-stream refusal).
- [x] **`companionCoverage` moves both flags off `Run` in the same commit** — with the comment reasoning them onto `Run` rewritten to what is now true; `companionRunExceptions` is now `--version`, `--help` and `-h`, all settled, and no tracked exceptions remain.
- [x] **The package comment states the curation split as it now stands** — a flag replacing the default action gets a function under the flag's own name; `--emit-ir -` stays `Run`'s alongside `--out -`.
- [x] **`CompanionModule` calls it against `example/`** — `checkEmitIR` requires the curated call and the hand-typed `run --args=--emit-ir,…` to produce a byte-identical descriptor over the same project.
- [x] **Both formats are exercised** — three comparisons: naming no format (which is what says the module left the default to the CLI without this pipeline restating it), `binary`, and `json`.
- [x] **`README.md` says the descriptor is what to attach to a bug report**, and gives the one call that produces it.

## Judgment calls

- **`EmitIr`, not `EmitIR`.** The Go name has to survive Dagger's kebab-casing into `emit-ir` and be spelled the same in `companionCoverage`, which `cli-surface` checks against the module's declared methods. `CliSurface` in the pipeline is the same choice. `internal/argv` is plain Go and spells it `EmitIR`.
- **The destination carries no extension.** Both encodings land at one container path, so a name claiming either would be wrong for the other run; it is only what the file is called on the way out, and the caller names it at `export`.
- **`checkEmitIR` compares files, not standard output.** `checkInit` takes the scaffold through `Stdout` because a scaffold is text. A descriptor is not: comparing the binary encoding through a GraphQL string compares two decodings rather than the bytes, and the bytes being the same ones is the whole promise. So the hand-typed side writes into the mounted project and the container is read back from there.
- **`Init` and `EmitIr` now share `writable`** — one statement of "empty the destination directory, own it to the container's user", rather than two to keep in step.
- **Two unrelated dispatch cases appear in `.dagger/dagger.gen.go`.** `dagger develop` picked up `ConformanceArtifact` and `ConformanceBundle`, which an earlier commit did not regenerate. Committing what `develop` produced is what CONTRIBUTING.md asks for.

## Verified

`dagger call ci` from an ordinary clone of this branch (a worktree cannot run it — CONTRIBUTING.md, "The pipeline does not run from a git worktree"), over the exact tree this commit holds: green, including `cli-surface` against the moved table and `companion-module` driving `emit-ir` over the image this pipeline builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)