### PR TITLE
story(dagger): let a caller state the environment a generation runs with, so SOURCE_DATE_EPOCH reaches generators

### DIFF
--- a/.dagger/companion.go
+++ b/.dagger/companion.go
@@ -687,7 +687,7 @@ const (
 // failure mode "one of three generators disagreed" for a question none of them
 // can answer.
 const envProbeManifestBody = `{
-  "layout": "ledger.sexpr",
+  "layout": "` + exampleLayout + `",
   "generators": [
     {
       "name": "` + envProbeGenerator + `",
@@ -713,6 +713,20 @@ const envProbeManifestBody = `{
 // decision about what this check covers, and it should fail here loudly rather
 // than widen silently.
 var exampleCopybooks = []string{"header.cpy", "posting.cpy", "trailer.cpy"}
+
+// exampleLayout is the layout example/cpybkc.json names, and the one
+// [envProbeManifestBody] names beside it.
+//
+// It is a constant rather than a literal inside that manifest for
+// [exampleCopybooks]'s reason: it is a path that has to agree with a directory
+// this file does not own, and a rename over there should be one edit here rather
+// than a string somebody greps for. What it does *not* buy is a legible failure
+// — a layout this manifest cannot find fails the generation, which
+// [Cpybkc.checkEnvVariable] reports as the variable most likely not having
+// reached the generator. That misattribution is worth knowing about and is not
+// worth a check of its own: the run beside it, over the committed manifest,
+// fails on the same rename and says so plainly.
+const exampleLayout = "ledger.sexpr"
 
 // exampleInitVector is the hand-typed escape-hatch spelling of the same
 // scaffolding run, `--out -` and all.
@@ -1220,22 +1234,55 @@ func (m *Cpybkc) checkEnvVariable(ctx context.Context, platform dagger.Platform)
 			envProbeVariable, got, envProbeValue))
 	}
 
-	// The same run without the builder. It has to fail, and what fails is the
-	// generator: anything else passing here would mean this check's positive
-	// case was reading a variable the engine supplied rather than one the module
-	// did.
+	// The same run without the builder. It has to fail, and it has to fail *in
+	// the generator*: this is the half whose job is to falsify the half above,
+	// so "it failed" is not the fact this needs and "the generator refused it"
+	// is. A run that failed because the manifest name was wrong, the probe would
+	// not build or the example's layout moved satisfies "an error came back"
+	// exactly as well — and it would do so in the same pull request that made
+	// the positive case fail for that reason, reporting it as the variable not
+	// having arrived. The probe's refusal names the variable, which is what makes
+	// the two distinguishable from out here.
 	_, err = composed.
 		Generate(project, dagger.CompanionGenerateOpts{Manifest: envProbeManifest}).
 		Entries(ctx)
-	if err == nil {
+
+	switch {
+	case err == nil:
 		errs = append(errs, fmt.Errorf(
 			"generate without with-env-variable succeeded, and it must not: the generator refuses a run in which "+
 				"%s is unset, so a run that succeeded was started with that variable from somewhere other than the "+
 				"module — which would leave the case above passing on a builder that did nothing",
 			envProbeVariable))
+	case !strings.Contains(failure(err), envProbeVariable):
+		errs = append(errs, fmt.Errorf(
+			"generate without with-env-variable failed without the generator's refusal of %s in what came back, so "+
+				"this run did not get as far as a generator and falsified nothing — what it said was: %s: %w",
+			envProbeVariable, failure(err), err))
 	}
 
 	return errors.Join(errs...)
+}
+
+// failure is everything a failed call said, including the standard streams of
+// the exec that failed.
+//
+// It exists because a [dagger.ExecError]'s message is not what a reader of it
+// expects: Error() reports that the command exited non-zero and the process's
+// own output is carried in fields beside it. So a check asking *what did the
+// program say* has to look there, and one that matched on the message alone
+// would find nothing — which is not a difference between "it did not say that"
+// and "it said nothing", and reads as the first while being the second.
+//
+// Measured rather than assumed: [Cpybkc.checkEnvVariable]'s falsification of its
+// own negative case failed exactly this way before this function existed.
+func failure(err error) string {
+	var exec *dagger.ExecError
+	if errors.As(err, &exec) {
+		return strings.Join([]string{err.Error(), exec.Stdout, exec.Stderr}, "\n")
+	}
+
+	return err.Error()
 }
 
 // envProbeBinary builds the generator [Cpybkc.checkEnvVariable] composes, for

--- a/.dagger/companion.go
+++ b/.dagger/companion.go
@@ -36,6 +36,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path"
 	"slices"
 	"strings"
 
@@ -380,11 +381,12 @@ const runFunction = "Run"
 //
 // It is not the CLI's surface, and the mirroring stance is what makes the
 // difference matter. This check reads flag *constants*, so a capability the CLI
-// has that is not spelled as a flag is invisible to it by construction — and
-// there is one today: cpybkc passes its whole environment through to a generator,
-// which is how docs/plugin/SPEC.md propagates SOURCE_DATE_EPOCH, and the
-// companion module has no way to state an environment at all (#252). No check in
-// this repository noticed, and none could have.
+// has that is not spelled as a flag is invisible to it by construction — and one
+// was missing for exactly that reason: cpybkc passes its whole environment
+// through to a generator, which is how docs/plugin/SPEC.md propagates
+// SOURCE_DATE_EPOCH, and the companion module had no way to state an environment
+// at all until #252 added with-env-variable. No check in this repository
+// noticed, and none could have.
 //
 // So the honest answer to how a non-flag capability is caught is that it is
 // caught by a person, at the document that promises it: a change to
@@ -392,6 +394,16 @@ const runFunction = "Run"
 // flag is answered in the companion module in the same review, and CONTRIBUTING.md
 // says so where the stance is argued. That is a weaker guarantee than this check
 // and it is stated as one rather than dressed up.
+//
+// What #252 adds to that answer is the second half, and it is the half a
+// mechanical check would not have given either: a capability that arrives this
+// way is covered afterwards by a *run* rather than by a reading.
+// [Cpybkc.checkEnvVariable] drives with-env-variable end to end and requires the
+// value to come back out of a generator process, so the module losing it again
+// fails CI even though nothing here can see it. The rule that follows is the one
+// worth writing down: a person answers the document, and what they add to this
+// pipeline is a call in CompanionModule, because the table below can only ever
+// hold flags.
 //
 // The mechanical version was considered and is not worth having. Anything that
 // could notice "docs/cli/SPEC.md changed" is a check comparing a document against
@@ -591,7 +603,102 @@ const (
 	// way round: that path is documented behaviour of the escape hatch, and this
 	// is the only place in this repository that depends on it.
 	emitIRDescriptorPath = "/src/.cpybkc-descriptor-check"
+
+	// envProbePackage builds the generator [Cpybkc.checkEnvVariable] composes,
+	// and envProbeExecutable is what the build calls it.
+	//
+	// It is internal/tools/ rather than cmd/, because it is a fixture rather
+	// than something a release publishes: it generates nothing anybody wants and
+	// exists to report the environment it was started with. Its own package
+	// comment carries the rest of the argument, including why the two-line shell
+	// generator internal/plugin's tests use cannot be composed into a scratch
+	// image.
+	//
+	// The name it is *installed* under is not this constant. with-generator-executable
+	// renames whatever it is handed to cpybkc-gen-<name>, which is the mechanism
+	// rather than a liberty, so what matters here is only what the build
+	// artifact is called on the way through.
+	envProbePackage    = "./internal/tools/cpybkc-gen-env"
+	envProbeExecutable = "cpybkc-gen-env"
+
+	// envProbeGenerator is the name example's stand-in manifest asks the probe
+	// for, and envProbeOut is the directory that manifest has it write into.
+	envProbeGenerator = "env"
+	envProbeOut       = "env"
+
+	// envProbeValueFile is what the probe writes under its output directory, and
+	// this is the second spelling of that filename.
+	//
+	// The first is internal/tools/cpybkc-gen-env's valueFile, and the two are in
+	// Go modules that cannot import each other — the same arrangement
+	// generatorRepository and daggerverse/cpybkc's generator.Repository are in.
+	// It is pinned at the other end by that package's tests, and a disagreement
+	// here fails this check on a file that is not there rather than passing
+	// quietly.
+	envProbeValueFile = "value"
+
+	// envProbeManifest is the manifest [Cpybkc.checkEnvVariable] adds to the
+	// worked example, and it is added rather than substituted for cpybkc.json so
+	// that the committed manifest keeps saying what the rest of this check
+	// asserts about it.
+	envProbeManifest = "cpybkc-env-probe.json"
+
+	// envProbeVariable and envProbeValue are what the check states through
+	// with-env-variable and requires to come back out of the generator.
+	//
+	// SOURCE_DATE_EPOCH rather than a variable of this check's own, because it is
+	// the one docs/plugin/SPEC.md says legitimately reaches a generator and
+	// changes its output, and the promise #252 was about is the one made for it.
+	// The builder takes any name, and that this one is not special to it is
+	// asserted where the rule is — daggerverse/cpybkc's internal/env tests.
+	//
+	// The value is a plausible epoch rather than a nonsense string, so that a
+	// person reading a failure is reading the thing a build would really set.
+	envProbeVariable = "SOURCE_DATE_EPOCH"
+	envProbeValue    = "1700000000"
+
+	// exampleRecordName is the record of what the last run generated, which
+	// [Cpybkc.checkEnvVariable] drops before generating with a manifest of its
+	// own.
+	//
+	// A literal rather than internal/generate's RecordName: this is a separate
+	// Go module and that package is internal to the other one, so the constant
+	// cannot be imported however much both would like it to be. It is the same
+	// arrangement generatorRepository is in, and it is safe in the same weak way
+	// — a name that disagreed would leave the record in place, which prunes the
+	// example's generated trees inside a Directory nothing exports rather than
+	// changing what this check asserts.
+	exampleRecordName = "cpybkc.gen.json"
 )
+
+// envProbeManifestBody is the stand-in manifest: the worked example's layout,
+// and the probe as its only generator.
+//
+// The example's own layout rather than one written here, because the point of
+// running against example/ is that the inputs are real — three copybooks, a
+// discriminated union and a redefine — and a manifest naming a layout of this
+// check's own would be a smaller project that happened to run a generator. The
+// probe reports the environment whatever it was handed, so what this run
+// resolves is not what is being asserted; that it is a real resolution is what
+// keeps the assertion about a generation rather than about an exec.
+//
+// One generator rather than three. The two the example publishes are covered by
+// the tree comparisons above, and adding them here would make this check's
+// failure mode "one of three generators disagreed" for a question none of them
+// can answer.
+const envProbeManifestBody = `{
+  "layout": "ledger.sexpr",
+  "generators": [
+    {
+      "name": "` + envProbeGenerator + `",
+      "out": "` + envProbeOut + `",
+      "options": {
+        "variable": "` + envProbeVariable + `"
+      }
+    }
+  ]
+}
+`
 
 // exampleCopybooks are the copybooks in [companionExampleDir], as the paths a
 // person would type them, and they are all three of them.
@@ -748,6 +855,12 @@ var exampleEmitIRRuns = []struct {
 // escape hatch writes over the same project, in every encoding — see
 // [Cpybkc.checkEmitIR].
 //
+// And with-env-variable (#252), which is the one function here whose subject is
+// not a flag: CliSurface reads flag constants and cannot see a capability that
+// is not spelled as one, so this is where the module's obligation to mirror the
+// CLI's environment pass-through is held to anything at all — see
+// [Cpybkc.checkEnvVariable].
+//
 // Both compositions start from the base image this pipeline built, which carries
 // the CLI and no generator — so a generation that succeeded did so with the
 // generators these calls installed and not with something that was lying around
@@ -853,6 +966,10 @@ func (m *Cpybkc) CompanionModule(ctx context.Context) error {
 	}
 
 	if err := m.checkEmitIR(ctx, platform); err != nil {
+		errs = append(errs, err)
+	}
+
+	if err := m.checkEnvVariable(ctx, platform); err != nil {
 		errs = append(errs, err)
 	}
 
@@ -1030,6 +1147,114 @@ func (m *Cpybkc) checkEmitIR(ctx context.Context, platform dagger.Platform) erro
 	}
 
 	return errors.Join(errs...)
+}
+
+// checkEnvVariable requires a variable stated through with-env-variable to reach
+// the generator process, over [companionExampleDir]'s inputs (#252).
+//
+// # Why the generator has to be the one to say so
+//
+// This is a pass-through with three hops in it — the module sets the variable on
+// a container, the container starts cpybkc with it, and cpybkc hands its own
+// environment to each generator unchanged (docs/plugin/SPEC.md, "The
+// environment") — and only the last one is what the promise is about. Reading the
+// variable back off the composed container would assert the first hop and look
+// like a check; a module that set it on a container it then did not run cpybkc
+// in, or a CLI that scrubbed its environment before an exec, would pass it. So
+// the assertion is made by the process at the far end: the generator writes what
+// it was started with, and this compares that file.
+//
+// # Both directions, because one of them is not evidence
+//
+// The negative case is the half that makes the positive one mean anything. A
+// Dagger engine's containers carry an environment of their own, so a check that
+// only ran *with* with-env-variable would pass on a module whose builder did
+// nothing if the variable happened to be set somewhere upstream. The same
+// generation without the builder therefore has to **fail**, and it fails in the
+// generator rather than in this check: the probe refuses a variable it was not
+// started with, which is a diagnostic and a non-zero exit, which is a failed run.
+//
+// # Against the worked example, and with a manifest of its own
+//
+// The example's copybooks and layout, because that is the tree the rest of this
+// check drives and a smaller project of this check's own would be a second, less
+// real answer to what a generation is. What is not the example's is the manifest:
+// this run generates with the probe and nothing else, so it names a manifest
+// added beside the committed one rather than replacing it — the committed
+// cpybkc.json is what every other comparison here rests on, and a check that
+// edited it would be checking a project no adopter has.
+//
+// [exampleRecordName] is dropped from the tree for the same reason: the record
+// of what the last run generated belongs to the committed manifest's generators,
+// and leaving it would have this run prune the example's generated trees on its
+// way past. Nothing of the caller's is at risk either way — a Directory is a
+// value and nothing is exported — but a run that pruned would make the failure
+// of a later comparison depend on the order these checks happened to run in.
+func (m *Cpybkc) checkEnvVariable(ctx context.Context, platform dagger.Platform) error {
+	project := m.Source.Directory(companionExampleDir).
+		WithoutFile(exampleRecordName).
+		WithNewFile(envProbeManifest, envProbeManifestBody)
+
+	// One composition, built once and used for both runs, so that the two differ
+	// in exactly the thing being asserted and not in how the generator arrived.
+	composed := m.companion(platform).
+		WithGeneratorExecutable(envProbeGenerator, m.envProbeBinary(platform))
+
+	stated := composed.
+		WithEnvVariable(envProbeVariable, envProbeValue).
+		Generate(project, dagger.CompanionGenerateOpts{Manifest: envProbeManifest})
+
+	var errs []error
+
+	got, err := stated.File(path.Join(envProbeOut, envProbeValueFile)).Contents(ctx)
+	if err != nil {
+		errs = append(errs, fmt.Errorf(
+			"generate with %s stated through with-env-variable did not hand back what the generator wrote at %s: "+
+				"the generator refuses a variable it was not started with, so this is most likely the variable not "+
+				"having reached it: %w",
+			envProbeVariable, path.Join(envProbeOut, envProbeValueFile), err))
+	} else if got != envProbeValue {
+		errs = append(errs, fmt.Errorf(
+			"the generator was started with %s=%q where with-env-variable stated %q: the value reaches a generator "+
+				"as cpybkc's own environment does, unchanged",
+			envProbeVariable, got, envProbeValue))
+	}
+
+	// The same run without the builder. It has to fail, and what fails is the
+	// generator: anything else passing here would mean this check's positive
+	// case was reading a variable the engine supplied rather than one the module
+	// did.
+	_, err = composed.
+		Generate(project, dagger.CompanionGenerateOpts{Manifest: envProbeManifest}).
+		Entries(ctx)
+	if err == nil {
+		errs = append(errs, fmt.Errorf(
+			"generate without with-env-variable succeeded, and it must not: the generator refuses a run in which "+
+				"%s is unset, so a run that succeeded was started with that variable from somewhere other than the "+
+				"module — which would leave the case above passing on a builder that did nothing",
+			envProbeVariable))
+	}
+
+	return errors.Join(errs...)
+}
+
+// envProbeBinary builds the generator [Cpybkc.checkEnvVariable] composes, for
+// the platform the composition is for.
+//
+// No version stamp, unlike [Cpybkc.generatorBinary]: nothing asks this generator
+// which build it is, and a -X naming a variable that does not exist is silently
+// dropped, so passing one would be a line in this recipe that does nothing and
+// read as though it did.
+func (m *Cpybkc) envProbeBinary(platform dagger.Platform) *dagger.File {
+	return dag.Go().
+		Build(m.appSource(), dagger.GoBuildOpts{
+			Pkg:          envProbePackage,
+			ArtifactName: envProbeExecutable,
+			Trimpath:     true,
+			DisableCgo:   true,
+			Platform:     string(platform),
+		}).
+		File(envProbeExecutable)
 }
 
 // companion is the module bound to the image this pipeline built, and it is the

--- a/.dagger/internal/dagger/companion.gen.go
+++ b/.dagger/internal/dagger/companion.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Companion
-func (r *Binding) AsCompanion() *Companion { // companion (../../../daggerverse/cpybkc/main.go:328:6)
+func (r *Binding) AsCompanion() *Companion { // companion (../../../daggerverse/cpybkc/main.go:336:6)
 	q := r.query.Select("asCompanion")
 
 	return &Companion{
@@ -24,7 +24,7 @@ func (r *Binding) AsCompanion() *Companion { // companion (../../../daggerverse/
 // A function on it is a builder returning a new Cpybkc, a terminal that runs
 // something, or an accessor handing back what was resolved, so a call chain
 // reads as the image being assembled and then used; nothing here mutates.
-type Companion struct { // companion (../../../daggerverse/cpybkc/main.go:328:6)
+type Companion struct { // companion (../../../daggerverse/cpybkc/main.go:336:6)
 	query *querybuilder.Selection
 
 	id *ID
@@ -62,7 +62,7 @@ type CompanionEmitIrOpts struct {
 	// because a manifest's own paths are relative to the directory holding it and
 	// a manifest arriving on a stream is in no directory.
 	//
-	Manifest string // companion (../../../daggerverse/cpybkc/main.go:871:2)
+	Manifest string // companion (../../../daggerverse/cpybkc/main.go:973:2)
 	//
 	// The encoding the descriptor is written in: `binary`, the canonical protobuf
 	// wire encoding a generator is handed, or `json`, the normalized rendering a
@@ -79,7 +79,7 @@ type CompanionEmitIrOpts struct {
 	// contract out here is one that drifts, and this one would drift the day a
 	// third encoding landed.
 	//
-	Format string // companion (../../../daggerverse/cpybkc/main.go:887:2)
+	Format string // companion (../../../daggerverse/cpybkc/main.go:989:2)
 }
 
 // EmitIr writes the run's resolved descriptor and hands back the file:
@@ -123,7 +123,7 @@ type CompanionEmitIrOpts struct {
 // emission and the format is its argument, so there is no call that names a
 // format without asking for one, and there is nothing left for the module to
 // check.
-func (r *Companion) EmitIr(source *Directory, opts ...CompanionEmitIrOpts) *File { // companion (../../../daggerverse/cpybkc/main.go:846:1)
+func (r *Companion) EmitIr(source *Directory, opts ...CompanionEmitIrOpts) *File { // companion (../../../daggerverse/cpybkc/main.go:948:1)
 	assertNotNil("source", source)
 	q := r.query.Select("emitIr")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -159,7 +159,7 @@ type CompanionGenerateOpts struct {
 	// cannot be "-": a manifest's own paths are relative to the directory holding
 	// it, and a manifest arriving on a stream is in no directory.
 	//
-	Manifest string // companion (../../../daggerverse/cpybkc/main.go:691:2)
+	Manifest string // companion (../../../daggerverse/cpybkc/main.go:793:2)
 }
 
 // Generate runs cpybkc over a project and hands back the project as it should
@@ -182,7 +182,7 @@ type CompanionGenerateOpts struct {
 // express half of what a run did. `generate --source . export --path .` is
 // therefore the ordinary use, and it is a full statement of the run rather than
 // an overlay that leaves deletions behind.
-func (r *Companion) Generate(source *Directory, opts ...CompanionGenerateOpts) *Directory { // companion (../../../daggerverse/cpybkc/main.go:668:1)
+func (r *Companion) Generate(source *Directory, opts ...CompanionGenerateOpts) *Directory { // companion (../../../daggerverse/cpybkc/main.go:770:1)
 	assertNotNil("source", source)
 	q := r.query.Select("generate")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -265,7 +265,7 @@ func (r *Companion) UnmarshalJSON(bs []byte) error {
 // none of the signatures or attestations one does (docs/container/SPEC.md, "What
 // a tag carries besides the image"), because those are attached to the digest
 // this project published and not to the bytes.
-func (r *Companion) Image() *Container { // companion (../../../daggerverse/cpybkc/main.go:644:1)
+func (r *Companion) Image() *Container { // companion (../../../daggerverse/cpybkc/main.go:746:1)
 	q := r.query.Select("image")
 
 	return &Container{
@@ -314,7 +314,7 @@ func (r *Companion) Image() *Container { // companion (../../../daggerverse/cpyb
 //
 //	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
 //	  run --source . --args=init,--copybook,posting.cpy,--out,- stdout
-func (r *Companion) Init(source *Directory, copybook []string) *File { // companion (../../../daggerverse/cpybkc/main.go:749:1)
+func (r *Companion) Init(source *Directory, copybook []string) *File { // companion (../../../daggerverse/cpybkc/main.go:851:1)
 	assertNotNil("source", source)
 	q := r.query.Select("init")
 	q = q.Arg("source", source)
@@ -335,7 +335,7 @@ type CompanionRunOpts struct {
 	// contact nothing. With no source the container is the image as it was
 	// resolved, and cpybkc runs in whatever directory the image left it in.
 	//
-	Source *Directory // companion (../../../daggerverse/cpybkc/main.go:1008:2)
+	Source *Directory // companion (../../../daggerverse/cpybkc/main.go:1110:2)
 }
 
 // Run is the fallback: cpybkc invoked with an argument vector this module has no
@@ -381,7 +381,7 @@ type CompanionRunOpts struct {
 // unrecognised flag is, whether a flag may repeat and what a usage error exits
 // with are all docs/cli/SPEC.md's, and the exec's failure carries them back
 // verbatim.
-func (r *Companion) Run(args []string, opts ...CompanionRunOpts) *Container { // companion (../../../daggerverse/cpybkc/main.go:995:1)
+func (r *Companion) Run(args []string, opts ...CompanionRunOpts) *Container { // companion (../../../daggerverse/cpybkc/main.go:1097:1)
 	q := r.query.Select("run")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `source` optional argument
@@ -392,6 +392,90 @@ func (r *Companion) Run(args []string, opts ...CompanionRunOpts) *Container { //
 	q = q.Arg("args", args)
 
 	return &Container{
+		query: q,
+	}
+}
+
+// WithEnvVariable states one environment variable every run through this module
+// is started with, and therefore one every generator it starts is handed:
+//
+//	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+//	  with-env-variable --name SOURCE_DATE_EPOCH --value "$SOURCE_DATE_EPOCH" \
+//	  with-generator --name hello --image ghcr.io/example/cpybkc-gen-hello:v1 \
+//	  generate --source . export --path .
+//
+// # The variable this exists for
+//
+// SOURCE_DATE_EPOCH, and the reason is a promise made elsewhere. cpybkc passes
+// its own environment through to a generator unchanged — it adds no variable,
+// removes none and names none — and that pass-through *is* how
+// docs/plugin/SPEC.md propagates the timestamp its determinism requirement rests
+// on (#47). A generator honouring it produces the same bytes on every run; a
+// build that has already set it for its other tools has set it for every
+// generator cpybkc runs. Until this function existed that sentence was false for
+// a build going through this module, and there was no way to make it true
+// without dropping out of the module to edit a container (#252) — which is not a
+// chain `dagger call` can express, so it meant an SDK program or nothing.
+//
+// # Any variable, rather than that one
+//
+// This takes a name and a value instead of a typed --source-date-epoch, which is
+// the wider of the two shapes #252 put up and the one the mirroring stance
+// settles on. The CLI has no flag for this: it reads its whole environment and
+// hands it on, so *the* capability to mirror is an environment and not a
+// timestamp (#253). A single typed argument would have been this module deciding
+// which variables may reach a generator, which is a reading of
+// docs/plugin/SPEC.md kept out here where it would drift — the same reason the
+// format argument passes an unknown encoding through to be refused by the parser
+// that decides them rather than screening it first.
+//
+// It also would not have been the narrower thing it looks like. A caller who
+// wants any other variable still has `image` and a container of their own; what
+// a typed argument buys is not that the door is shut but that the ordinary route
+// through it is missing, which is how a promise ends up kept for one variable and
+// broken for the build that needed a second.
+//
+// What the wide shape does *not* do is make the environment a place to configure
+// a generator. docs/cli/SPEC.md and docs/plugin/SPEC.md both forbid a plugin to
+// require a variable for its normal work — everything that configures its output
+// arrives as --opt, because the manifest is the reviewable record of how a
+// project's code was generated and a setting living in the environment is absent
+// from it. That prohibition binds generator authors and is unaffected by this
+// function: cpybkc has always passed the whole environment through, so the door
+// this opens is one the CLI already had, and a module refusing it would make a
+// generator no more compliant while making the mirror less honest.
+//
+// # Which runs it reaches, and which of them start a generator
+//
+// Every function on this module, because the variable is set on the container
+// they all run in rather than passed to one of them. That is the CLI's own
+// arrangement — cpybkc is started with an environment, not a command — and it is
+// stated here rather than left to fall out of the implementation.
+//
+// Generate is the one where it matters, because it is the one that starts a
+// generator. Init runs none at all (docs/cli/SPEC.md, "`init` reads no
+// manifest"), and EmitIr resolves none either, since an emission is terminal
+// ("Emitting replaces generation"); Run starts one exactly when the vector it was
+// handed asks for a generation. So on three of the four the variable reaches
+// cpybkc and stops there, which is what "the environment cpybkc was started with"
+// means and is why they are not carved out: a builder that refused to set a
+// variable for a run that would not have read it would be inventing a rule the
+// CLI does not have, and the caller would have to know which functions resolve
+// generators to predict it.
+//
+// Repeated calls compose, in the order they are written, and a name given twice
+// takes the second value — a container's environment is a mapping, and the last
+// write to a key wins.
+//
+// The name is checked for the two shapes that are not a name in any environment
+// (empty, or carrying `=` or NUL); nothing else about it is this module's
+// business, and the value is not examined at all. See internal/env.
+func (r *Companion) WithEnvVariable(name string, value string) *Companion { // companion (../../../daggerverse/cpybkc/main.go:708:1)
+	q := r.query.Select("withEnvVariable")
+	q = q.Arg("name", name)
+	q = q.Arg("value", value)
+
+	return &Companion{
 		query: q,
 	}
 }
@@ -407,7 +491,7 @@ type CompanionWithGeneratorOpts struct {
 	// image being composed into, which is checked, because a mismatch here is
 	// checkable and its exec-time failure is not legible.
 	//
-	Image *Container // companion (../../../daggerverse/cpybkc/main.go:526:2)
+	Image *Container // companion (../../../daggerverse/cpybkc/main.go:534:2)
 }
 
 // WithGenerator adds one generator to the image by copying its executable out of
@@ -435,7 +519,7 @@ type CompanionWithGeneratorOpts struct {
 // about multi-platform: composing an amd64 generator into an arm64 image produces
 // an image that builds and pushes and then fails at exec with the kernel's
 // message rather than cpybkc's, which is a long way from the call that caused it.
-func (r *Companion) WithGenerator(name string, opts ...CompanionWithGeneratorOpts) *Companion { // companion (../../../daggerverse/cpybkc/main.go:513:1)
+func (r *Companion) WithGenerator(name string, opts ...CompanionWithGeneratorOpts) *Companion { // companion (../../../daggerverse/cpybkc/main.go:521:1)
 	q := r.query.Select("withGenerator")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `image` optional argument
@@ -472,7 +556,7 @@ func (r *Companion) WithGenerator(name string, opts ...CompanionWithGeneratorOpt
 // or foreign-architecture generator fails at exec time with the kernel's message
 // rather than cpybkc's. WithGenerator can check the platform half of that because
 // a container states one; here there is nothing to read.
-func (r *Companion) WithGeneratorExecutable(name string, executable *File) *Companion { // companion (../../../daggerverse/cpybkc/main.go:598:1)
+func (r *Companion) WithGeneratorExecutable(name string, executable *File) *Companion { // companion (../../../daggerverse/cpybkc/main.go:606:1)
 	assertNotNil("executable", executable)
 	q := r.query.Select("withGeneratorExecutable")
 	q = q.Arg("name", name)
@@ -492,7 +576,7 @@ func (r *Companion) AsNode() Node {
 }
 
 // Create or update a binding of type Companion in the environment
-func (r *Env) WithCompanionInput(name string, value *Companion, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:328:6)
+func (r *Env) WithCompanionInput(name string, value *Companion, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:336:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withCompanionInput")
 	q = q.Arg("name", name)
@@ -505,7 +589,7 @@ func (r *Env) WithCompanionInput(name string, value *Companion, description stri
 }
 
 // Declare a desired Companion output to be assigned in the environment
-func (r *Env) WithCompanionOutput(name string, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:328:6)
+func (r *Env) WithCompanionOutput(name string, description string) *Env { // companion (../../../daggerverse/cpybkc/main.go:336:6)
 	q := r.query.Select("withCompanionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -529,7 +613,7 @@ type CompanionOpts struct {
 	//
 	//
 	// Default: "v0"
-	Version string // companion (../../../daggerverse/cpybkc/main.go:399:2)
+	Version string // companion (../../../daggerverse/cpybkc/main.go:407:2)
 	//
 	// The registry repository the image is pulled from, as `<host>/<path>` with no
 	// tag.
@@ -544,7 +628,7 @@ type CompanionOpts struct {
 	//
 	//
 	// Default: "ghcr.io/zaba505/cpybkc"
-	Repository string // companion (../../../daggerverse/cpybkc/main.go:412:2)
+	Repository string // companion (../../../daggerverse/cpybkc/main.go:420:2)
 	//
 	// Run in this container instead of pulling one, replacing it entirely.
 	//
@@ -564,7 +648,7 @@ type CompanionOpts struct {
 	// does not track whatever was pinned here, so a build that pins the CLI by
 	// digest and wants the pairing to hold still passes --version beside it.
 	//
-	Image *Container // companion (../../../daggerverse/cpybkc/main.go:431:2)
+	Image *Container // companion (../../../daggerverse/cpybkc/main.go:439:2)
 	//
 	// Pull the image for this platform, as `GOOS/GOARCH`, instead of for the
 	// engine's own.
@@ -583,7 +667,7 @@ type CompanionOpts struct {
 	// Empty is the engine's own platform, which is what makes an ordinary
 	// `dagger call` from a checkout do the obvious thing.
 	//
-	Platform string // companion (../../../daggerverse/cpybkc/main.go:449:2)
+	Platform string // companion (../../../daggerverse/cpybkc/main.go:457:2)
 }
 
 // New selects the cpybkc release to run:
@@ -604,7 +688,7 @@ type CompanionOpts struct {
 // resolves companion images against, which is why an air-gapped caller passing a
 // container from their own registry should pass --repository beside it rather
 // than instead of it.
-func (r *Query) Companion(opts ...CompanionOpts) *Companion { // companion (../../../daggerverse/cpybkc/main.go:388:1)
+func (r *Query) Companion(opts ...CompanionOpts) *Companion { // companion (../../../daggerverse/cpybkc/main.go:396:1)
 	q := r.query.Select("companion")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `version` optional argument

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1025,12 +1025,14 @@ plugged; it is the boundary of what a check reading Go source can see, and under
 the mirroring stance it matters, because the module's obligation is every
 capability rather than every flag.
 
-There is one such capability today and it is the worked case. cpybkc passes its
+There has been one such capability and it is the worked case. cpybkc passes its
 whole environment through to a generator — that pass-through **is** how
 [`docs/plugin/SPEC.md`](docs/plugin/SPEC.md) propagates `SOURCE_DATE_EPOCH` —
-and the companion module offers no way to state an environment at all, so a
-promise that document makes to every generator author does not reach a Dagger
-caller (#252). No check here noticed, and none could have.
+and the companion module offered no way to state an environment at all, so a
+promise that document makes to every generator author did not reach a Dagger
+caller (#252). No check here noticed, and none could have. `with-env-variable`
+is the answer, and [The environment a generation runs
+with](#the-environment-a-generation-runs-with) is what it decided.
 
 So the answer to how the next one is caught is a person, at the document that
 promises it: **a change to
@@ -1040,12 +1042,23 @@ in the same review.** That is a weaker guarantee than `cli-surface`, and saying
 so plainly is the point — a reader who believes the check covers the whole
 surface will not go looking.
 
-The mechanical version was considered and is not worth having. Anything that
-could notice "`docs/cli/SPEC.md` changed" is a check comparing a document
-against a copy of itself, which is precisely [the shape #65 was closed for
-being](#65-is-closed-rather-than-left-open): it fails on every edit to that
-document and on nothing else, so it is answered by updating the copy, and a
-check whose remedy is *tell it what happened* has taught nobody anything.
+What #252 adds is the other half of the answer, and it is the half that is
+mechanical after all: **a capability that arrives this way is covered afterwards
+by a run rather than by a reading.** `companion-module` drives
+`with-env-variable` end to end and requires the value to come back out of a
+generator *process*, so the module losing the capability again fails CI even
+though nothing can read it out of the source. The rule to follow when the next
+one lands is therefore two-part — answer the document in the same review, and
+add a call to `CompanionModule`, because the coverage table can only ever hold
+flags.
+
+The mechanical version of the *first* half was considered and is not worth
+having. Anything that could notice "`docs/cli/SPEC.md` changed" is a check
+comparing a document against a copy of itself, which is precisely [the shape #65
+was closed for being](#65-is-closed-rather-than-left-open): it fails on every
+edit to that document and on nothing else, so it is answered by updating the
+copy, and a check whose remedy is *tell it what happened* has taught nobody
+anything.
 
 ### Composing a generator is `COPY --from`, split across two methods
 
@@ -1102,6 +1115,74 @@ it, and a dynamically linked generator fails at exec time with the kernel's
 message rather than cpybkc's. That is the same requirement the worked example
 states as `CGO_ENABLED=0`, and it is said in both methods' documentation rather
 than enforced in either.
+
+### The environment a generation runs with
+
+`WithEnvVariable` states one variable every run through the module is started
+with, and therefore one every generator it starts is handed:
+
+```sh
+dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+  with-env-variable --name SOURCE_DATE_EPOCH --value "$SOURCE_DATE_EPOCH" \
+  with-generator --name hello --image ghcr.io/example/cpybkc-gen-hello:v1 \
+  generate --source . export --path .
+```
+
+It exists for one variable and takes any. `SOURCE_DATE_EPOCH` is the reason:
+cpybkc passes its own environment through unchanged, and that pass-through **is**
+how [`docs/plugin/SPEC.md`](docs/plugin/SPEC.md) propagates the timestamp
+[determinism](docs/plugin/SPEC.md#determinism) rests on, so *"a build that sets
+`SOURCE_DATE_EPOCH` for its other tools has already set it for every generator
+cpybkc runs"* was a sentence that had been false for every build going through
+this module (#252). It was not reachable by composition either — `Image()` hands
+back a container, `WithEnvVariable` is on that container, and the only way back
+into the module is `New --image`, which is not a chain `dagger call` can express.
+
+**Any variable rather than that one**, and this is the decision #252 records.
+The narrow shape — a typed `--source-date-epoch` — was the recommendation the
+plugin contract suggested, on the grounds that it is the only variable that
+document says legitimately reaches a generator and changes its output, and that
+a plugin **MUST NOT** require another one to do its normal work. The wide shape
+is what [the mirroring stance](#the-module-mirrors-the-cli-and-the-check-that-holds-it-to-it)
+implies, and that is what settled it: the CLI has no flag here, it reads its
+*whole* environment and hands it on, so the capability to mirror is an
+environment and not a timestamp. A single typed argument would have been the
+module deciding which variables may reach a generator — a reading of
+`docs/plugin/SPEC.md` kept out here where it would drift, which is the same
+reason `emit-ir`'s `--format` passes an unknown encoding through to be refused by
+the parser that decides encodings rather than screening it first.
+
+It would not have been the narrower thing it looks like, either. A caller who
+wants a second variable still has `--image` and a container of their own; what
+the typed argument buys is not that the door is shut but that the ordinary route
+through it is missing. And the prohibition it appears to enforce is not the
+module's to enforce: *a plugin must not require an environment variable to do its
+normal work* binds generator authors, the manifest is the reviewable record, and
+cpybkc has passed the whole environment through since before this module existed
+— so refusing to offer the door makes no generator more compliant and the mirror
+less honest.
+
+**It reaches every function**, because it is set on the container they all run
+in, which is the CLI's own arrangement: cpybkc is started with an environment,
+not a command. `generate` is where it matters, since it is the one that starts a
+generator; `init` runs none, `emit-ir` resolves none because an emission is
+terminal, and `run` starts one exactly when its vector asks for a generation. The
+three where nothing reads it are not carved out — a builder that refused to set a
+variable for a run that would not have read it would be inventing a rule the CLI
+does not have, and a caller would have to know which functions resolve generators
+to predict it.
+
+**The check is a run, not a reading**, and it has to be. This is a pass-through
+with three hops in it — the module sets the variable on a container, the
+container starts cpybkc with it, cpybkc hands its environment to the generator —
+and only the last one is the promise. So `companion-module` composes a generator
+that reports what it was started with
+([`internal/tools/cpybkc-gen-env/`](internal/tools/cpybkc-gen-env/), a fixture
+rather than anything a release publishes) over the worked example's copybooks and
+layout, and requires the value back out of the generator's own output. The same
+generation **without** the builder has to fail, which is the half that makes the
+other half evidence: an engine's containers carry an environment of their own, so
+a check that only ran the positive case would pass on a builder that did nothing.
 
 ### Multi-platform is one composition per platform
 

--- a/README.md
+++ b/README.md
@@ -238,6 +238,27 @@ the issue text, but a rendering rather than the thing itself, so send it *beside
 the binary file rather than instead of it. `cpybkc --emit-ir descriptor.binpb` is
 the same run without Dagger.
 
+**Building reproducibly? State the environment.** cpybkc passes its whole
+environment through to every generator it runs, which is how [the plugin
+contract](docs/plugin/SPEC.md#the-environment) propagates `SOURCE_DATE_EPOCH`, so
+a build that sets it for its other tools sets it for generated output too —
+through this module, that is `with-env-variable`:
+
+```sh
+dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+  with-env-variable --name SOURCE_DATE_EPOCH --value "$SOURCE_DATE_EPOCH" \
+  with-generator --name hello --image ghcr.io/example/cpybkc-gen-hello:v1 \
+  generate --source . export --path .
+```
+
+It takes any variable, not that one: what the CLI hands a generator is an
+environment rather than a timestamp, and this module mirrors the CLI. What it is
+*for* is still that one — a generator's output is configured by the manifest, and
+[the plugin contract](docs/plugin/SPEC.md#the-environment) is explicit that a
+generator must not need a variable set to do its normal work, precisely so that
+two developers comparing generated output can see the difference between their
+machines.
+
 It still has no `SPEC.md`, and not because there is nothing to specify — it is
 public API, and a function or an argument here lasts as long as the published
 ref does. It is that everything there would be to specify is specified already:

--- a/daggerverse/cpybkc/dagger.gen.go
+++ b/daggerverse/cpybkc/dagger.gen.go
@@ -304,6 +304,27 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*Cpybkc).Run(&parent, ctx, args, source)
+		case "WithEnvVariable":
+			var parent Cpybkc
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var name string
+			if inputArgs["name"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["name"]), &name)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg name", err))
+				}
+			}
+			var value string
+			if inputArgs["value"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["value"]), &value)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg value", err))
+				}
+			}
+			return (*Cpybkc).WithEnvVariable(&parent, name, value)
 		case "WithGenerator":
 			var parent Cpybkc
 			err = json.Unmarshal(parentJSON, &parent)

--- a/daggerverse/cpybkc/internal/env/env.go
+++ b/daggerverse/cpybkc/internal/env/env.go
@@ -1,0 +1,68 @@
+// Package env refuses the environment variable names that could not be
+// environment variables at all, and refuses nothing else.
+//
+// It is a package of its own, rather than one function in package main, for the
+// reason internal/generator and internal/imageref are: the module's own package
+// main imports the generated Dagger client, whose init panics when no Dagger
+// session is present, so a test beside main cannot run under plain `go test`
+// and the rule below would be asserted by a comment instead of pinned by a
+// test. Nothing here imports Dagger, so `go test ./internal/...` runs anywhere.
+//
+// What is deliberately not here is any opinion about *which* variables a caller
+// may set. cpybkc passes its whole environment through to a generator unchanged
+// and names no variable of its own (docs/plugin/SPEC.md, "The environment"), so
+// a module mirroring the CLI (#253) has nothing to say about the difference
+// between SOURCE_DATE_EPOCH and anything else — and a module that did would be
+// making the contract smaller from the outside, which is the one thing the
+// mirroring stance rules out. The whole of this package is the two shapes that
+// are not a name in any environment.
+package env
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// CheckName refuses a name that cannot be an environment variable: the empty
+// one, and one carrying `=` or a NUL byte.
+//
+// Both refusals are about the representation rather than about taste. An
+// environment is a list of `NAME=VALUE` strings terminated by NUL, so a name
+// holding either character does not encode: `A=B` set to `c` is indistinguishable
+// from `A` set to `B=c`, and everything from a NUL onwards is not carried at
+// all. The failure from letting one through is silent rather than loud — the
+// generator sees a variable it was not told about, or does not see the one it
+// was — and the value would have travelled a long way from the argument that
+// named it.
+//
+// Those two and no more, which is less than a reader might expect. POSIX
+// reserves the names made of upper-case letters, digits and underscore for
+// utilities and says a portable *application*'s own variables should keep to
+// that shape, and this refuses neither a lowercase name nor one starting with a
+// digit. Both of those are variables the shell can export, cpybkc can be started
+// with and a generator can read, so a module refusing them would refuse a run
+// the CLI performs — and what a plugin may be handed is docs/plugin/SPEC.md's to
+// narrow, not this module's. It is the same boundary
+// [github.com/Zaba505/cpybkc/daggerverse/cpybkc/internal/generator.CheckName]
+// draws between that document's **MUST**s and its **SHOULD**s.
+func CheckName(name string) error {
+	switch {
+	case name == "":
+		return errors.New(
+			"an environment variable name is required: it is the NAME in the NAME=VALUE an environment is made of, " +
+				"and there is no run in which the empty one reaches a generator")
+	case strings.Contains(name, "="):
+		return fmt.Errorf(
+			"environment variable name %q contains a =: an environment is a list of NAME=VALUE strings split at the "+
+				"first =, so this name and this value cannot be told apart from a shorter name and a longer value",
+			name)
+	case strings.ContainsRune(name, 0):
+		return fmt.Errorf(
+			"environment variable name %q contains a NUL byte: an environment string ends at the first one, so "+
+				"everything from it onwards would not reach the generator at all",
+			name)
+	}
+
+	return nil
+}

--- a/daggerverse/cpybkc/internal/env/env.go
+++ b/daggerverse/cpybkc/internal/env/env.go
@@ -66,3 +66,33 @@ func CheckName(name string) error {
 
 	return nil
 }
+
+// CheckValue refuses a value carrying a NUL byte, and refuses nothing else.
+//
+// It is [CheckName]'s NUL rule on the other half of the pair, and it is here
+// because the argument for that rule was never about names: an environment
+// string ends at the first NUL, so a value holding one arrives at the generator
+// silently truncated, which is the same failure as a truncated name and just as
+// invisible in every diagnostic printed afterwards. Guarding one half and
+// documenting the other as unexamined would have been asymmetric by accident
+// rather than on purpose.
+//
+// It costs the mirroring stance nothing, which is what makes it safe to have: a
+// value carrying NUL is not a value cpybkc could have been started with either,
+// so this refuses no run the CLI performs. That is the whole test a check out
+// here has to pass.
+//
+// `=` is deliberately not refused. It is a name's problem and not a value's —
+// an environment string is split at the *first* one, so everything after that is
+// value by definition, and `LDFLAGS=-X main.version=v1` is an ordinary thing to
+// want to set.
+func CheckValue(name, value string) error {
+	if strings.ContainsRune(value, 0) {
+		return fmt.Errorf(
+			"the value given for %s contains a NUL byte: an environment string ends at the first one, so the "+
+				"generator would be handed %q rather than what was stated here",
+			name, value[:strings.IndexByte(value, 0)])
+	}
+
+	return nil
+}

--- a/daggerverse/cpybkc/internal/env/env_test.go
+++ b/daggerverse/cpybkc/internal/env/env_test.go
@@ -62,6 +62,65 @@ func TestCheckNameAcceptsWhatCanBeAName(t *testing.T) {
 	}
 }
 
+func TestCheckValue(t *testing.T) {
+	for _, tc := range []struct {
+		testName string
+		value    string
+		// want is a substring the refusal has to carry, and an empty one is a
+		// value that has to be accepted.
+		want string
+	}{
+		{
+			testName: "an epoch",
+			value:    "1700000000",
+		},
+		{
+			// A value may be empty, and an exported variable with no value is
+			// set: cpybkc would have carried it, so this does too.
+			testName: "empty",
+			value:    "",
+		},
+		{
+			// The one character that is a name's problem and not a value's. An
+			// environment string is split at the first =, so everything after
+			// it is value by definition.
+			testName: "carries equals signs",
+			value:    "-X main.version=v1 -X main.commit=abc",
+		},
+		{
+			testName: "carries a NUL byte",
+			value:    "1700000000\x00trailing",
+			want:     "NUL",
+		},
+	} {
+		t.Run(tc.testName, func(t *testing.T) {
+			err := CheckValue("SOURCE_DATE_EPOCH", tc.value)
+
+			if tc.want == "" {
+				if err != nil {
+					t.Errorf("CheckValue(%q) = %v, want no error", tc.value, err)
+				}
+
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("CheckValue(%q) = nil, want an error", tc.value)
+			}
+
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("CheckValue(%q) = %q, which does not mention %q", tc.value, err, tc.want)
+			}
+
+			// The name, because a refusal that does not say which variable was
+			// being set is one a caller with several has to bisect.
+			if !strings.Contains(err.Error(), "SOURCE_DATE_EPOCH") {
+				t.Errorf("CheckValue(%q) = %q, which does not name the variable it refused", tc.value, err)
+			}
+		})
+	}
+}
+
 func TestCheckNameRefusesWhatCannotBeAName(t *testing.T) {
 	for _, tc := range []struct {
 		testName string

--- a/daggerverse/cpybkc/internal/env/env_test.go
+++ b/daggerverse/cpybkc/internal/env/env_test.go
@@ -1,0 +1,106 @@
+// These tests cover the whole of what this module decides about an environment
+// variable name, which is deliberately two refusals. The accepted cases are here
+// in the same number as the refused ones, because the interesting claim is the
+// one a stricter rule would break: a module that grew a POSIX-shaped name check
+// would pass every refusal below and start refusing runs cpybkc performs.
+//
+// What is not tested here is that the variable reaches anything. That is three
+// hops — the module sets it on a container, the container starts cpybkc with it,
+// and cpybkc passes its whole environment through to the generator — and the
+// last one is the point, so it is asserted end to end where an engine is
+// available: the root pipeline's CompanionModule check runs a generator that
+// reports what it was started with (#252).
+
+package env
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheckNameAcceptsWhatCanBeAName(t *testing.T) {
+	for _, tc := range []struct {
+		testName string
+		name     string
+	}{
+		{
+			// The one variable docs/plugin/SPEC.md says legitimately reaches a
+			// generator and changes its output, and the reason this builder exists
+			// at all (#47).
+			testName: "SOURCE_DATE_EPOCH",
+			name:     "SOURCE_DATE_EPOCH",
+		},
+		{
+			// A variable of the caller's own. cpybkc names none of its own and
+			// removes none, so what else a build has already exported is not this
+			// module's business.
+			testName: "a caller's own variable",
+			name:     "ACME_BUILD_ID",
+		},
+		{
+			// Lowercase, which POSIX reserves *for applications* rather than
+			// forbids. The shell exports it, cpybkc is started with it and a
+			// generator reads it, so refusing it here would refuse a run the CLI
+			// performs.
+			testName: "lowercase",
+			name:     "http_proxy",
+		},
+		{
+			// Leading digit, which no shell's assignment syntax can write and
+			// `env 1PASSWORD=x` sets anyway. It is not a name this module has a
+			// reason to have an opinion about: what a plugin may be handed is the
+			// plugin contract's to narrow.
+			testName: "leading digit",
+			name:     "1PASSWORD_TOKEN",
+		},
+	} {
+		t.Run(tc.testName, func(t *testing.T) {
+			if err := CheckName(tc.name); err != nil {
+				t.Errorf("CheckName(%q) = %v, want no error", tc.name, err)
+			}
+		})
+	}
+}
+
+func TestCheckNameRefusesWhatCannotBeAName(t *testing.T) {
+	for _, tc := range []struct {
+		testName string
+		name     string
+		// wants are substrings the message has to carry. They are the fact the
+		// reader needs and not the wording: what was refused, and why it could
+		// never have arrived.
+		wants []string
+	}{
+		{
+			testName: "empty",
+			name:     "",
+			wants:    []string{"required", "NAME=VALUE"},
+		},
+		{
+			testName: "carries an equals sign",
+			name:     "SOURCE_DATE_EPOCH=1700000000",
+			wants:    []string{"SOURCE_DATE_EPOCH=1700000000", "first ="},
+		},
+		{
+			// The one that is easy to leave out and impossible to see: a name
+			// truncated at a NUL arrives as a shorter name that looks right in
+			// every diagnostic printed afterwards.
+			testName: "carries a NUL byte",
+			name:     "SOURCE_DATE\x00_EPOCH",
+			wants:    []string{"NUL"},
+		},
+	} {
+		t.Run(tc.testName, func(t *testing.T) {
+			err := CheckName(tc.name)
+			if err == nil {
+				t.Fatalf("CheckName(%q) = nil, want an error", tc.name)
+			}
+
+			for _, want := range tc.wants {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("CheckName(%q) = %q, which does not mention %q", tc.name, err, want)
+				}
+			}
+		})
+	}
+}

--- a/daggerverse/cpybkc/main.go
+++ b/daggerverse/cpybkc/main.go
@@ -215,12 +215,19 @@
 //
 // One thing the flag table cannot say, and this comment therefore should. cpybkc
 // passes its whole environment through to a generator, which is how
-// docs/plugin/SPEC.md propagates SOURCE_DATE_EPOCH — and this module offers no
-// way to state an environment, so that promise does not reach a Dagger caller
-// (#252). It is a capability with no flag behind it, so cli-surface cannot see
-// it and did not; it is named here because the flag table is a lower bound on
-// what mirroring the CLI means, and a reader deserves to know the one place it
-// is currently short.
+// docs/plugin/SPEC.md propagates SOURCE_DATE_EPOCH, and that capability has no
+// flag behind it — so cli-surface could not see that this module had no way to
+// state an environment, and did not (#252). WithEnvVariable is the answer, and
+// it takes any variable rather than that one, because what the CLI mirrors here
+// is an environment and not a timestamp.
+//
+// The gap is worth leaving written down now that it is closed, because the
+// lesson is about the check rather than about the variable: the flag table is a
+// lower bound on what mirroring the CLI means. A capability that is not spelled
+// as a flag is caught by a person, at the document that promises it — a change
+// to docs/cli/SPEC.md or docs/plugin/SPEC.md adding one is answered in this
+// module in the same review — and that is a weaker guarantee than cli-surface,
+// stated as one. This is the worked case of it working.
 package main
 
 import (
@@ -230,6 +237,7 @@ import (
 
 	"dagger/cpybkc/internal/argv"
 	"dagger/cpybkc/internal/dagger"
+	"dagger/cpybkc/internal/env"
 	"dagger/cpybkc/internal/generator"
 	"dagger/cpybkc/internal/imageref"
 )
@@ -619,6 +627,100 @@ func (m *Cpybkc) WithGeneratorExecutable(
 		executable,
 		dagger.ContainerWithFileOpts{Permissions: executableMode},
 	)
+
+	return &next, nil
+}
+
+// WithEnvVariable states one environment variable every run through this module
+// is started with, and therefore one every generator it starts is handed:
+//
+//	dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
+//	  with-env-variable --name SOURCE_DATE_EPOCH --value "$SOURCE_DATE_EPOCH" \
+//	  with-generator --name hello --image ghcr.io/example/cpybkc-gen-hello:v1 \
+//	  generate --source . export --path .
+//
+// # The variable this exists for
+//
+// SOURCE_DATE_EPOCH, and the reason is a promise made elsewhere. cpybkc passes
+// its own environment through to a generator unchanged — it adds no variable,
+// removes none and names none — and that pass-through *is* how
+// docs/plugin/SPEC.md propagates the timestamp its determinism requirement rests
+// on (#47). A generator honouring it produces the same bytes on every run; a
+// build that has already set it for its other tools has set it for every
+// generator cpybkc runs. Until this function existed that sentence was false for
+// a build going through this module, and there was no way to make it true
+// without dropping out of the module to edit a container (#252) — which is not a
+// chain `dagger call` can express, so it meant an SDK program or nothing.
+//
+// # Any variable, rather than that one
+//
+// This takes a name and a value instead of a typed --source-date-epoch, which is
+// the wider of the two shapes #252 put up and the one the mirroring stance
+// settles on. The CLI has no flag for this: it reads its whole environment and
+// hands it on, so *the* capability to mirror is an environment and not a
+// timestamp (#253). A single typed argument would have been this module deciding
+// which variables may reach a generator, which is a reading of
+// docs/plugin/SPEC.md kept out here where it would drift — the same reason the
+// format argument passes an unknown encoding through to be refused by the parser
+// that decides them rather than screening it first.
+//
+// It also would not have been the narrower thing it looks like. A caller who
+// wants any other variable still has `image` and a container of their own; what
+// a typed argument buys is not that the door is shut but that the ordinary route
+// through it is missing, which is how a promise ends up kept for one variable and
+// broken for the build that needed a second.
+//
+// What the wide shape does *not* do is make the environment a place to configure
+// a generator. docs/cli/SPEC.md and docs/plugin/SPEC.md both forbid a plugin to
+// require a variable for its normal work — everything that configures its output
+// arrives as --opt, because the manifest is the reviewable record of how a
+// project's code was generated and a setting living in the environment is absent
+// from it. That prohibition binds generator authors and is unaffected by this
+// function: cpybkc has always passed the whole environment through, so the door
+// this opens is one the CLI already had, and a module refusing it would make a
+// generator no more compliant while making the mirror less honest.
+//
+// # Which runs it reaches, and which of them start a generator
+//
+// Every function on this module, because the variable is set on the container
+// they all run in rather than passed to one of them. That is the CLI's own
+// arrangement — cpybkc is started with an environment, not a command — and it is
+// stated here rather than left to fall out of the implementation.
+//
+// Generate is the one where it matters, because it is the one that starts a
+// generator. Init runs none at all (docs/cli/SPEC.md, "`init` reads no
+// manifest"), and EmitIr resolves none either, since an emission is terminal
+// ("Emitting replaces generation"); Run starts one exactly when the vector it was
+// handed asks for a generation. So on three of the four the variable reaches
+// cpybkc and stops there, which is what "the environment cpybkc was started with"
+// means and is why they are not carved out: a builder that refused to set a
+// variable for a run that would not have read it would be inventing a rule the
+// CLI does not have, and the caller would have to know which functions resolve
+// generators to predict it.
+//
+// Repeated calls compose, in the order they are written, and a name given twice
+// takes the second value — a container's environment is a mapping, and the last
+// write to a key wins.
+//
+// The name is checked for the two shapes that are not a name in any environment
+// (empty, or carrying `=` or NUL); nothing else about it is this module's
+// business, and the value is not examined at all. See internal/env.
+func (m *Cpybkc) WithEnvVariable(
+	// The variable's name, as a generator would read it — SOURCE_DATE_EPOCH for
+	// the reproducible timestamp that is this function's reason to exist.
+	name string,
+	// The value it is set to. It is passed through as written and never
+	// interpreted here: what a variable means is the generator's, and even
+	// SOURCE_DATE_EPOCH is a count of seconds this module has no business
+	// parsing — a value cpybkc would have carried is one this module carries.
+	value string,
+) (*Cpybkc, error) {
+	if err := env.CheckName(name); err != nil {
+		return nil, err
+	}
+
+	next := *m
+	next.Container = m.Container.WithEnvVariable(name, value)
 
 	return &next, nil
 }

--- a/daggerverse/cpybkc/main.go
+++ b/daggerverse/cpybkc/main.go
@@ -702,9 +702,22 @@ func (m *Cpybkc) WithGeneratorExecutable(
 // takes the second value — a container's environment is a mapping, and the last
 // write to a key wins.
 //
-// The name is checked for the two shapes that are not a name in any environment
-// (empty, or carrying `=` or NUL); nothing else about it is this module's
-// business, and the value is not examined at all. See internal/env.
+// One variable is worth naming, because its failure lands a long way from the
+// call that caused it. PATH is how the CLI finds a generator, and in a composed
+// image it is the plugin directory WithGenerator installed into — so a caller
+// who states PATH here is overwriting an arrangement this module made, and the
+// symptom is a generation failing with cpybkc reporting that a generator the
+// manifest plainly names cannot be found. That is not a reason to refuse the
+// name: a module deciding which variables may reach a generator is what the
+// section above rejects, and the same is true of anything else the image's
+// entrypoint depends on. It is a reason to say so here, so that a caller who
+// does it can recognise what they did.
+//
+// The name is checked for the shapes that are not a name in any environment
+// (empty, or carrying `=` or NUL) and the value for the one shape that is not a
+// value in any environment (NUL, which truncates the string it is in). Nothing
+// else about either is this module's business — in particular a value may
+// contain `=`. See internal/env.
 func (m *Cpybkc) WithEnvVariable(
 	// The variable's name, as a generator would read it — SOURCE_DATE_EPOCH for
 	// the reproducible timestamp that is this function's reason to exist.
@@ -716,6 +729,10 @@ func (m *Cpybkc) WithEnvVariable(
 	value string,
 ) (*Cpybkc, error) {
 	if err := env.CheckName(name); err != nil {
+		return nil, err
+	}
+
+	if err := env.CheckValue(name, value); err != nil {
 		return nil, err
 	}
 

--- a/internal/tools/cpybkc-gen-env/main.go
+++ b/internal/tools/cpybkc-gen-env/main.go
@@ -150,6 +150,11 @@ func parse(args []string) (invocation, error) {
 		parsed     invocation
 		descriptor string
 		options    []string
+		// seen counts each flag, so that the arity below is enforced rather
+		// than claimed. A message saying a flag appears exactly once beside a
+		// loop that keeps the last of several is the fixture being wrong about
+		// the contract it exists to be right about.
+		seen = map[string]int{}
 	)
 
 	for i := 0; i < len(args); i++ {
@@ -168,6 +173,24 @@ func parse(args []string) (invocation, error) {
 			break
 		}
 
+		// Recognised before its value is counted, because the two failures have
+		// different messages and only one of them is true of an argument this
+		// program does not take: `--bogus` in final position is an unrecognised
+		// argument, not a flag missing its value, and the second message sends
+		// its reader looking for the value rather than for the typo.
+		switch arg {
+		case descriptorFlag, outFlag, optFlag:
+			seen[arg]++
+		default:
+			return invocation{}, fmt.Errorf("unrecognised argument %q: the invocation is `%s <path> %s <dir> "+
+				"[%s k=v ...]` and nothing else", arg, descriptorFlag, outFlag, optFlag)
+		}
+
+		if arg != optFlag && seen[arg] > 1 {
+			return invocation{}, fmt.Errorf("%s was passed %d times, and it appears exactly once in every "+
+				"invocation cpybkc emits", arg, seen[arg])
+		}
+
 		if i+1 >= len(args) {
 			return invocation{}, fmt.Errorf("%s was passed with no value after it", arg)
 		}
@@ -182,9 +205,6 @@ func parse(args []string) (invocation, error) {
 			parsed.out = value
 		case optFlag:
 			options = append(options, value)
-		default:
-			return invocation{}, fmt.Errorf("unrecognised argument %q: the invocation is `%s <path> %s <dir> "+
-				"[%s k=v ...]` and nothing else", arg, descriptorFlag, outFlag, optFlag)
 		}
 	}
 
@@ -213,7 +233,16 @@ func parse(args []string) (invocation, error) {
 // generator dropped is configuration a reviewer can read in the manifest and
 // nobody can observe in the output.
 func readOptions(options []string) (string, error) {
-	var variable string
+	var (
+		variable string
+		// named separately from the value, because an option that was not
+		// passed and one passed with an empty value are different mistakes and
+		// telling a caller their required option is missing when they wrote it
+		// is the diagnostic sending them to the wrong line of their manifest.
+		// A value MAY be empty as far as the contract is concerned; it is this
+		// generator that has no variable to read when it is.
+		named bool
+	)
 
 	for _, option := range options {
 		key, value, ok := strings.Cut(option, "=")
@@ -226,12 +255,16 @@ func readOptions(options []string) (string, error) {
 				key, variableOption)
 		}
 
-		variable = value
+		variable, named = value, true
 	}
 
-	if variable == "" {
+	switch {
+	case !named:
 		return "", errors.New("the `" + variableOption +
 			"` option is required, and names the environment variable this generator reports")
+	case variable == "":
+		return "", errors.New("the `" + variableOption +
+			"` option names no variable: it was passed with an empty value, and there is no variable to report")
 	}
 
 	return variable, nil

--- a/internal/tools/cpybkc-gen-env/main.go
+++ b/internal/tools/cpybkc-gen-env/main.go
@@ -1,0 +1,238 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Command cpybkc-gen-env is a generator that reports one environment variable it
+// was started with, and fails when it was not started with it.
+//
+//	cpybkc-gen-env --descriptor <path> --out <dir> --opt variable=SOURCE_DATE_EPOCH
+//
+// It generates nothing anybody would want. It exists so that *the environment
+// reached the generator process* is a thing a check can assert rather than
+// infer, which is what #252 turned out to need: the companion Dagger module's
+// with-env-variable is a pass-through with three hops in it — the module sets a
+// variable on a container, the container starts cpybkc with it, and cpybkc hands
+// its whole environment to each generator (docs/plugin/SPEC.md, "The
+// environment") — and the only one of those a check can see from outside is the
+// last. A composed image whose environment carries the variable and whose
+// generator does not see it is exactly the failure that would otherwise pass.
+//
+// # Why this is a program rather than a fixture
+//
+// The published image is a scratch image: it holds cpybkc, a generator, and no
+// shell, no coreutils and no interpreter (docs/container/SPEC.md). So the
+// two-line shell generator that answers this question in internal/plugin's tests
+// cannot be composed into it, and the thing that can is a statically linked
+// executable. That is this, built by the pipeline from this repository's own
+// module and installed through with-generator-executable, which is the path a
+// generator author takes before there is anything of theirs to pull.
+//
+// # Why it is not in cmd/ and is not published
+//
+// It is not a generator anybody should run over a real project, and the
+// directories a release publishes an image from are cmd/'s. Test infrastructure
+// is documented where it lives (docs/CONVENTIONS.md, "What belongs here"), and
+// this is test infrastructure with a `main` function: internal/tools/ is where
+// this repository already keeps the programs its pipeline runs and its releases
+// do not.
+//
+// # What it implements of the plugin contract, and what it does not
+//
+// The whole of the invocation: --descriptor and --out each exactly once, --opt
+// any number of times in the separated form, `--` ending the options, and a
+// refusal with an `error:` diagnostic and a non-zero exit for an option key it
+// does not recognise — which docs/plugin/SPEC.md requires of every plugin rather
+// than permitting, because an ignored option is a line in a checked-in manifest
+// that reads as configuration and does nothing.
+//
+// It reads no descriptor, which is a liberty this contract allows and this
+// program takes: it is required to be handed one and required to say so if it is
+// not, and nothing about the variable it reports depends on what is in it. A
+// generator with an opinion about the IR is cmd/cpybkc-gen-go's job.
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Flags of the invocation, spelled as docs/plugin/SPEC.md fixes them. They are
+// constants here for the reason they are constants in the CLI: a spelling
+// written twice is a spelling that can disagree with itself.
+const (
+	descriptorFlag = "--descriptor"
+	outFlag        = "--out"
+	optFlag        = "--opt"
+	endOfOptions   = "--"
+)
+
+// variableOption is the one option key this generator recognises, and it names
+// the environment variable to report.
+//
+// A key rather than a fixed SOURCE_DATE_EPOCH, so that the check driving this
+// can state which variable it set in the same place it states the value. An
+// option is the generator's own vocabulary and cpybkc neither interprets nor
+// validates one, so nothing outside this file has to agree about the spelling
+// beyond the manifest that names it.
+const variableOption = "variable"
+
+// valueFile is what this generator writes under --out, holding the value of the
+// variable it was asked about and nothing else — no trailing newline, so that a
+// check comparing bytes compares the value.
+const valueFile = "value"
+
+func main() {
+	if err := run(os.Args[1:], os.Stderr); err != nil {
+		// The diagnostic format: one line, `<severity>: <message>`, on standard
+		// error (docs/plugin/SPEC.md, "The diagnostic format"). The exit status
+		// is 1 because the contract attaches meaning to zero and non-zero and to
+		// nothing else.
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
+		os.Exit(1)
+	}
+}
+
+// run is main with its inputs and its diagnostic stream passed in, so that a
+// test can drive it.
+func run(args []string, stderr io.Writer) error {
+	invocation, err := parse(args)
+	if err != nil {
+		return err
+	}
+
+	value, ok := os.LookupEnv(invocation.variable)
+	if !ok {
+		// A refusal rather than an empty file, and it is the assertion this
+		// program is for: a variable that did not arrive is the failure #252's
+		// three hops exist to detect, and a run that quietly wrote nothing would
+		// leave the check comparing an empty file with an empty expectation.
+		return fmt.Errorf(
+			"%s is not set in the environment this generator was started with: cpybkc passes its own environment "+
+				"through unchanged, so a variable missing here is one that never reached cpybkc", invocation.variable)
+	}
+
+	// Standard error rather than standard output, where the contract says a
+	// generator's explanation goes and where cpybkc attributes it to the
+	// generator that wrote it. It makes a failing check readable without going
+	// looking for the file.
+	//
+	// The write is deliberately unchecked: a diagnostic that could not be
+	// written leaves nothing better to do than produce the file this generator
+	// was asked for, and what cpybkc reads is the exit status.
+	_, _ = fmt.Fprintf(stderr, "info: %s=%s\n", invocation.variable, value)
+
+	return os.WriteFile(filepath.Join(invocation.out, valueFile), []byte(value), 0o644)
+}
+
+// invocation is one run's arguments, after parsing.
+type invocation struct {
+	// out is the private scratch directory this run writes into.
+	out string
+	// variable is the environment variable to report, from the one option this
+	// generator takes.
+	variable string
+}
+
+// parse reads the argument vector docs/plugin/SPEC.md fixes, and refuses
+// everything it does not.
+//
+// The separated form only, which is the one form a plugin **MUST** accept and
+// the only one cpybkc emits. The joined `--out=<dir>` spelling is one a plugin
+// **MAY** additionally accept, and accepting it here would be this fixture
+// covering a spelling the thing it is checking never produces.
+func parse(args []string) (invocation, error) {
+	var (
+		parsed     invocation
+		descriptor string
+		options    []string
+	)
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+
+		if arg == endOfOptions {
+			// This contract defines no operands and cpybkc passes none, so
+			// anything after the delimiter is a caller doing something this
+			// generator has no meaning for.
+			if rest := args[i+1:]; len(rest) > 0 {
+				return invocation{}, fmt.Errorf(
+					"%d operands were passed after %s (%s): this contract defines no operands",
+					len(rest), endOfOptions, strings.Join(rest, " "))
+			}
+
+			break
+		}
+
+		if i+1 >= len(args) {
+			return invocation{}, fmt.Errorf("%s was passed with no value after it", arg)
+		}
+
+		value := args[i+1]
+		i++
+
+		switch arg {
+		case descriptorFlag:
+			descriptor = value
+		case outFlag:
+			parsed.out = value
+		case optFlag:
+			options = append(options, value)
+		default:
+			return invocation{}, fmt.Errorf("unrecognised argument %q: the invocation is `%s <path> %s <dir> "+
+				"[%s k=v ...]` and nothing else", arg, descriptorFlag, outFlag, optFlag)
+		}
+	}
+
+	switch {
+	case descriptor == "":
+		return invocation{}, fmt.Errorf("%s is required and appears exactly once in every invocation", descriptorFlag)
+	case parsed.out == "":
+		return invocation{}, fmt.Errorf("%s is required and appears exactly once in every invocation", outFlag)
+	}
+
+	variable, err := readOptions(options)
+	if err != nil {
+		return invocation{}, err
+	}
+
+	parsed.variable = variable
+
+	return parsed, nil
+}
+
+// readOptions takes the one option this generator recognises out of the `k=v`
+// values it was given, and refuses every other key.
+//
+// Refusing rather than ignoring is the contract's requirement on a plugin and
+// not this fixture's fastidiousness: an option cpybkc passed through and a
+// generator dropped is configuration a reviewer can read in the manifest and
+// nobody can observe in the output.
+func readOptions(options []string) (string, error) {
+	var variable string
+
+	for _, option := range options {
+		key, value, ok := strings.Cut(option, "=")
+		if !ok {
+			return "", fmt.Errorf("option %q is not `k=v`: everything before the first = is the key", option)
+		}
+
+		if key != variableOption {
+			return "", fmt.Errorf("unrecognised option %q: this generator takes %s and nothing else",
+				key, variableOption)
+		}
+
+		variable = value
+	}
+
+	if variable == "" {
+		return "", errors.New("the `" + variableOption +
+			"` option is required, and names the environment variable this generator reports")
+	}
+
+	return variable, nil
+}

--- a/internal/tools/cpybkc-gen-env/main_test.go
+++ b/internal/tools/cpybkc-gen-env/main_test.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// These tests hold this generator to the half of the plugin contract it
+// implements, because a fixture that is wrong about the contract fails the check
+// it exists for and blames the thing under test. The companion module's
+// with-env-variable is what that check is about (#252), and a run that failed
+// here would read as *the variable did not reach the generator* whichever of the
+// two was at fault.
+
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// vector is the invocation cpybkc emits, with the two paths filled in.
+func vector(descriptor, out string, options ...string) []string {
+	args := []string{descriptorFlag, descriptor, outFlag, out}
+	for _, option := range options {
+		args = append(args, optFlag, option)
+	}
+
+	return args
+}
+
+func TestRunWritesTheVariableItWasStartedWith(t *testing.T) {
+	const (
+		variable = "SOURCE_DATE_EPOCH"
+		want     = "1700000000"
+	)
+
+	t.Setenv(variable, want)
+
+	out := t.TempDir()
+
+	var diagnostics strings.Builder
+	if err := run(vector("/descriptor", out, variableOption+"="+variable), &diagnostics); err != nil {
+		t.Fatalf("run over a set %s = %v, want no error", variable, err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(out, valueFile))
+	if err != nil {
+		t.Fatalf("reading what the generator wrote: %v", err)
+	}
+
+	// Byte-exact, with no trailing newline: the check driving this compares the
+	// file against the value it set, and a newline nobody asked for would make
+	// that comparison a rule about this fixture rather than about the variable.
+	if string(got) != want {
+		t.Errorf("the generator wrote %q, want %q", got, want)
+	}
+
+	// The value on stderr as well, since that is where the contract puts a
+	// generator's explanation and where cpybkc surfaces it attributed. A failing
+	// end-to-end check should say what arrived without anybody exporting a
+	// directory.
+	if diagnostic := diagnostics.String(); !strings.Contains(diagnostic, variable+"="+want) {
+		t.Errorf("the generator's diagnostics were %q, which do not report %s=%s", diagnostic, variable, want)
+	}
+}
+
+func TestRunRefusesAVariableThatDidNotArrive(t *testing.T) {
+	const variable = "CPYBKC_GEN_ENV_UNSET_IN_THIS_TEST"
+
+	// Not merely unset: an empty value is a value, and this generator has to
+	// tell "set to nothing" from "not set at all" — the second is the failure
+	// the module's three hops are checked for.
+	if _, ok := os.LookupEnv(variable); ok {
+		t.Fatalf("%s is set in this test's environment, which is the one thing this case needs it not to be", variable)
+	}
+
+	err := run(vector("/descriptor", t.TempDir(), variableOption+"="+variable), io.Discard)
+	if err == nil {
+		t.Fatalf("run over an unset %s = nil, want an error", variable)
+	}
+
+	if !strings.Contains(err.Error(), variable) {
+		t.Errorf("the refusal is %q, which does not name the variable that was missing", err)
+	}
+}
+
+func TestRunAcceptsAVariableSetToNothing(t *testing.T) {
+	const variable = "CPYBKC_GEN_ENV_EMPTY"
+
+	t.Setenv(variable, "")
+
+	out := t.TempDir()
+	if err := run(vector("/descriptor", out, variableOption+"="+variable), io.Discard); err != nil {
+		t.Fatalf("run over an empty %s = %v, want no error: an exported variable with no value is set", variable, err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(out, valueFile))
+	if err != nil {
+		t.Fatalf("reading what the generator wrote: %v", err)
+	}
+
+	if len(got) != 0 {
+		t.Errorf("the generator wrote %q for a variable set to nothing, want an empty file", got)
+	}
+}
+
+func TestParseRefusesWhatTheContractDoesNotAllow(t *testing.T) {
+	for _, tc := range []struct {
+		testName string
+		args     []string
+		// want is a substring of the refusal, and it is the fact rather than the
+		// wording.
+		want string
+	}{
+		{
+			testName: "no descriptor",
+			args:     []string{outFlag, "/out", optFlag, variableOption + "=X"},
+			want:     descriptorFlag,
+		},
+		{
+			testName: "no out",
+			args:     []string{descriptorFlag, "/descriptor", optFlag, variableOption + "=X"},
+			want:     outFlag,
+		},
+		{
+			testName: "no variable option",
+			args:     vector("/descriptor", "/out"),
+			want:     variableOption,
+		},
+		{
+			// The contract's own requirement, and the one a fixture is most
+			// tempted to skip: a plugin MUST fail on a key it does not
+			// recognise rather than ignoring it.
+			testName: "an option key it does not recognise",
+			args:     vector("/descriptor", "/out", variableOption+"=X", "package_name=ledger"),
+			want:     "package_name",
+		},
+		{
+			testName: "an option that is not k=v",
+			args:     vector("/descriptor", "/out", "variable"),
+			want:     "k=v",
+		},
+		{
+			// The joined form, which a plugin MAY accept and cpybkc never
+			// emits. Refusing it keeps this fixture covering exactly the
+			// spelling the thing it checks produces.
+			testName: "the joined spelling",
+			args:     []string{outFlag + "=/out", descriptorFlag, "/descriptor"},
+			want:     "unrecognised argument",
+		},
+		{
+			testName: "a flag with no value after it",
+			args:     []string{descriptorFlag},
+			want:     descriptorFlag,
+		},
+		{
+			testName: "operands after the delimiter",
+			args:     append(vector("/descriptor", "/out", variableOption+"=X"), endOfOptions, "extra"),
+			want:     "operands",
+		},
+	} {
+		t.Run(tc.testName, func(t *testing.T) {
+			_, err := parse(tc.args)
+			if err == nil {
+				t.Fatalf("parse(%q) = nil, want an error", tc.args)
+			}
+
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("parse(%q) = %q, which does not mention %q", tc.args, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseAcceptsTheDelimiterWithNothingAfterIt(t *testing.T) {
+	// `--` ends the options and cpybkc passes no operands; a plugin has to treat
+	// it as the end rather than as an argument, so that one invoked by hand
+	// behaves the way its neighbours do.
+	args := append(vector("/descriptor", "/out", variableOption+"=SOURCE_DATE_EPOCH"), endOfOptions)
+
+	parsed, err := parse(args)
+	if err != nil {
+		t.Fatalf("parse(%q) = %v, want no error", args, err)
+	}
+
+	if parsed.out != "/out" || parsed.variable != "SOURCE_DATE_EPOCH" {
+		t.Errorf("parse(%q) = %+v, want the out directory and the variable it was given", args, parsed)
+	}
+}

--- a/internal/tools/cpybkc-gen-env/main_test.go
+++ b/internal/tools/cpybkc-gen-env/main_test.go
@@ -143,6 +143,37 @@ func TestParseRefusesWhatTheContractDoesNotAllow(t *testing.T) {
 			want:     "k=v",
 		},
 		{
+			// Distinct from the option being absent: it was written, and what
+			// it names is nothing. A message saying it is required would send
+			// its reader looking for a line that is in front of them.
+			testName: "the variable option with an empty value",
+			args:     vector("/descriptor", "/out", variableOption+"="),
+			want:     "names no variable",
+		},
+		{
+			// The arity the messages claim, now enforced. cpybkc emits each of
+			// these exactly once, and a fixture that quietly kept the last of
+			// several would be wrong about the contract it exists to be right
+			// about.
+			testName: "a repeated out",
+			args:     []string{descriptorFlag, "/descriptor", outFlag, "/a", outFlag, "/b"},
+			want:     "exactly once",
+		},
+		{
+			testName: "a repeated descriptor",
+			args:     []string{descriptorFlag, "/a", descriptorFlag, "/b", outFlag, "/out"},
+			want:     "exactly once",
+		},
+		{
+			// The one the arity check used to answer wrongly: an argument this
+			// program does not take, in final position, read as a flag missing
+			// its value. The message has to name the typo rather than send its
+			// reader looking for a value.
+			testName: "an unrecognised argument in final position",
+			args:     append(vector("/descriptor", "/out", variableOption+"=X"), "--bogus"),
+			want:     "unrecognised argument",
+		},
+		{
 			// The joined form, which a plugin MAY accept and cpybkc never
 			// emits. Refusing it keeps this fixture covering exactly the
 			// spelling the thing it checks produces.


### PR DESCRIPTION
Closes #252

`daggerverse/cpybkc` had no environment handling at all, so the plugin
contract's promise that *"a build that sets `SOURCE_DATE_EPOCH` for its other
tools has already set it for every generator cpybkc runs"* was false for every
build going through the module — and unreachable by composition, since
`Image()` hands back a container and the only way back in is `New --image`,
which is not a chain `dagger call` can express.

```sh
dagger call -m github.com/Zaba505/cpybkc/daggerverse/cpybkc \
  with-env-variable --name SOURCE_DATE_EPOCH --value "$SOURCE_DATE_EPOCH" \
  with-generator --name hello --image ghcr.io/example/cpybkc-gen-hello:v1 \
  generate --source . export --path .
```

## The judgment call: the wide shape, and why

#252 put up two shapes and left the choice to this story. **A general
`WithEnvVariable` builder lands**, not a typed `--source-date-epoch`.

The narrow one is what the plugin contract suggests — `SOURCE_DATE_EPOCH` is the
only variable that document says legitimately reaches a generator and changes
its output, and a plugin **MUST NOT** require another one to do its normal work.
What decided it the other way is #253: the module mirrors the CLI, the CLI has
no flag here, and what it hands a generator is its *whole* environment. A single
typed argument would have been this module deciding which variables may reach a
generator — a reading of `docs/plugin/SPEC.md` kept out here where it would
drift, which is the same reason `emit-ir`'s `--format` passes an unknown
encoding through to the parser that decides encodings rather than screening it
first.

It would not have been narrower in effect either: a caller wanting a second
variable still has `--image` and a container of their own, so what the typed
argument buys is not that the door is shut but that the ordinary route through
it is missing. And the prohibition it appears to enforce binds *generator
authors*; cpybkc has passed the whole environment through since before this
module existed, so refusing to offer the door makes no generator more compliant
and the mirror less honest.

## Acceptance criteria

- [x] **A caller can state the environment in a single `dagger call`, without
  dropping out of the module** — `with-env-variable` is a builder, so it chains
  with `with-generator` and `generate` the way the example above does.
- [x] **The shape is decided and argued, not assumed** — argued in
  `WithEnvVariable`'s own documentation (where `dagger call --help` puts it in
  front of a caller) and in CONTRIBUTING.md's new *The environment a generation
  runs with*, with both sides stated.
- [x] **It reaches the runs it has to reach, stated rather than left to fall
  out** — every function, because the variable is set on the container they all
  run in, which is the CLI's own arrangement. `generate` is where it matters;
  `init` runs no generator, `emit-ir` resolves none because an emission is
  terminal, and `run` starts one exactly when its vector asks for a generation.
  Those three are not carved out: a builder refusing to set a variable for a run
  that would not read it would invent a rule the CLI does not have.
- [x] **The value reaches the generator process, asserted by a test** —
  `CompanionModule` → `checkEnvVariable` composes
  `internal/tools/cpybkc-gen-env`, a fixture generator that writes the variable
  it was started with, and compares the file. Both directions were falsified
  locally: stating a different value fails with *"the generator was started with
  `SOURCE_DATE_EPOCH="17000000009"` where with-env-variable stated
  `"1700000000"`"*, and setting the variable on the base composition fails the
  negative case with *"generate without with-env-variable succeeded, and it must
  not"*.
- [x] **`CompanionModule` covers it against `example/`** — the example's
  copybooks and layout, with a manifest added beside the committed one (the
  committed `cpybkc.json` is what every other comparison here rests on) and
  `cpybkc.gen.json` dropped so the run prunes nothing.
- [x] **The determinism claim is made honest for consumers** — README.md gains
  *Building reproducibly? State the environment*, and CONTRIBUTING.md's *The
  flag table is not the CLI's surface* no longer records this as an open gap.
- [x] **How a non-flag capability gets caught next time is recorded** — the rule
  is now two-part, in `CliSurface`'s comment and in CONTRIBUTING.md: a person
  answers the document that promises it in the same review, **and** what they
  add to the pipeline is a call in `CompanionModule`, because the coverage table
  can only ever hold flags. `cli-surface` is unchanged — a capability with no
  flag behind it is invisible to it by construction, and that is stated rather
  than dressed up.

## Notes

- **A fixture generator, in `internal/tools/` rather than `cmd/`.** The
  published image is a scratch image, so the two-line shell generator
  `internal/plugin`'s tests use cannot be composed into it; the thing that can
  is a statically linked executable. It implements the whole invocation —
  including refusing an option key it does not recognise, which the contract
  requires of every plugin — and reads no descriptor, which the contract allows.
- **Name validation lives in `daggerverse/cpybkc/internal/env`** so `go test`
  can reach it without a Dagger session, like `internal/argv`,
  `internal/generator` and `internal/imageref`. It refuses the empty name and
  one carrying `=` or NUL — the two shapes that are not a name in any
  environment — and refuses nothing else: a lowercase or digit-leading name is
  one cpybkc can be started with, and narrowing what a plugin may be handed is
  `docs/plugin/SPEC.md`'s, not this module's.
- **Generated clients** (`.dagger/internal/dagger/companion.gen.go`,
  `daggerverse/cpybkc/dagger.gen.go`) are `dagger develop`'s output for the new
  function.

## Verified

`dagger call ci` — green, from an ordinary clone (a worktree's `.git` is a file,
so the image stages cannot run there). `companion-module` was additionally run
on its own, and both halves of the new check were falsified as described above.
