### PR TITLE
story(setup): enforce the modernize analyzer and clear the 53 findings it raises

### DIFF
--- a/.dagger/image.go
+++ b/.dagger/image.go
@@ -1381,7 +1381,7 @@ func (m *Cpybkc) checkShippedIr(ctx context.Context, image *dagger.Container) []
 func buildSettings(out string) map[string]string {
 	settings := map[string]string{}
 
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		fields := strings.Fields(line)
 		if len(fields) != 2 || fields[0] != "build" {
 			continue
@@ -1599,7 +1599,7 @@ func (m *Cpybkc) checkImageContents(
 	var errs []error
 
 	got := make(map[string]imageEntry, len(want))
-	for _, line := range strings.Split(strings.TrimSpace(listing), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(listing), "\n") {
 		if line == "" {
 			continue
 		}

--- a/.dagger/release.go
+++ b/.dagger/release.go
@@ -1228,7 +1228,7 @@ func releaseNotesBlock(version string, irVersion int, reference string) string {
 // prerelease and a release say *different* things about the moving tags, and a
 // keyword search is how two different sentences come to look identical.
 func movingTagsSentence(block string) string {
-	for _, line := range strings.Split(block, "\n") {
+	for line := range strings.SplitSeq(block, "\n") {
 		if strings.Contains(line, "moving tags") || strings.Contains(line, "moves none") {
 			return strings.TrimSpace(line)
 		}
@@ -1296,7 +1296,7 @@ func headRefs(ctx context.Context, source, gitDir *dagger.Directory) ([]string, 
 
 	var refs []string
 
-	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
 		if ref := strings.TrimSpace(line); ref != "" {
 			refs = append(refs, ref)
 		}

--- a/.dagger/worked_example.go
+++ b/.dagger/worked_example.go
@@ -517,8 +517,8 @@ func instructions(lines []string) []string {
 		if current == "" && (trimmed == "" || strings.HasPrefix(trimmed, "#")) {
 			continue
 		}
-		if strings.HasSuffix(trimmed, `\`) {
-			current += strings.TrimSuffix(trimmed, `\`) + " "
+		if before, ok := strings.CutSuffix(trimmed, `\`); ok {
+			current += before + " "
 			continue
 		}
 		out = append(out, current+trimmed)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,7 +32,8 @@
 # makes each suggestion a decision — taken, or declined at the site with a
 # `//nolint:modernize` saying why. Declining belongs in the file and not here:
 # an exclusion rule in this config would silence an analyzer across the whole
-# repository, which is the state this paragraph is the end of.
+# repository, which is the repository-wide silence this paragraph exists to
+# prevent.
 #
 # It has a cost worth stating rather than discovering. `modernize`'s suggestions
 # track the Go release and the golangci-lint pin, so a version bump can turn CI

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,13 +16,29 @@
 # github.com/z5labs/devex/daggerverse/go, which is where a bump belongs, and
 # nothing here restates it.
 #
-# The enabled set is v2's own "standard" set, spelled out rather than inherited
-# so that a change to golangci-lint's defaults is a change this repository has to
-# make deliberately.
+# The enabled set is v2's own "standard" set plus `modernize`, spelled out rather
+# than inherited so that a change to golangci-lint's defaults is a change this
+# repository has to make deliberately — and so that the one addition to the
+# standard set is visible as an addition rather than lost in an inherited list.
 #
 # Unlike cobol-go, `unused` is left enabled: this repository starts from an
 # empty package tree rather than a pre-seeded set of building-block helpers,
 # so there is nothing legitimately unused to exempt.
+#
+# `modernize` is enforced because the alternative is not "no rule" but "a rule
+# only some readers see": a gopls-backed editor raises its suggestions whether
+# this file enables it or not, so leaving it out made every one of them noise to
+# whoever had the file open and a finding nothing ever cleared. Enforcing it
+# makes each suggestion a decision — taken, or declined at the site with a
+# `//nolint:modernize` saying why. Declining belongs in the file and not here:
+# an exclusion rule in this config would silence an analyzer across the whole
+# repository, which is the state this paragraph is the end of.
+#
+# It has a cost worth stating rather than discovering. `modernize`'s suggestions
+# track the Go release and the golangci-lint pin, so a version bump can turn CI
+# red on code nobody touched. Renovate raises those bumps automatically (#245),
+# so the first such pull request is where this shows up, and the fix there is to
+# clear or decline the new findings in the same pull request.
 version: "2"
 
 run:
@@ -34,5 +50,6 @@ linters:
     - errcheck
     - govet
     - ineffassign
+    - modernize
     - staticcheck
     - unused

--- a/cmd/cpybkc-gen-go/diagnostic.go
+++ b/cmd/cpybkc-gen-go/diagnostic.go
@@ -66,7 +66,7 @@ func report(w io.Writer, err error) {
 	var carrier noted
 	if errors.As(err, &carrier) {
 		for _, note := range carrier.Notes() {
-			for _, line := range strings.Split(note, "\n") {
+			for line := range strings.SplitSeq(note, "\n") {
 				diagnostic(w, severityNote, line)
 			}
 		}

--- a/cmd/cpybkc-gen-go/machine_test.go
+++ b/cmd/cpybkc-gen-go/machine_test.go
@@ -293,11 +293,19 @@ func edge(id, record, next uint64, predicate *uint64, guards, bindings []uint64)
 // predicateOn is a transition's predicate reference, which is the one reference
 // in the schema absence is a meaning for.
 //
-// Kept rather than inlined to `new(expr)`: every call site passes an untyped
-// constant, so inlining spells each one `new(uint64(50))` — which is the naming
-// of the pointer traded for a conversion, in the one place a reader is checking
-// that a present reference and an absent one are told apart.
-func predicateOn(id uint64) *uint64 { return &id } //nolint:modernize // named on purpose; see above
+// Kept rather than inlined to `new(expr)`, on the rule this repository applies
+// to every `newexpr` finding: a one-line shim earns its name when it is called
+// repeatedly *and* says something the call site does not. Both hold here.
+// [edge] takes four identifier-shaped arguments in a row, so at the call site
+// `predicateOn(50)` is the only thing marking which of them is the reference
+// absence is a meaning for — and there are five of them.
+//
+// Where either half fails, the shim goes: `grammarString("XX")` in
+// internal/conformance/grammar_test.go had one call site and sat beside a field
+// already named `Text`, and was inlined to `new("XX")` for exactly that reason.
+// The conversion an untyped constant costs — `new(uint64(50))` — is the price
+// of the rule and not the reason for it.
+func predicateOn(id uint64) *uint64 { return &id } //nolint:modernize // see above
 
 // counter is an integer register and flag is a bytes one.
 func counter(id uint64) *irpb.Node {

--- a/cmd/cpybkc-gen-go/machine_test.go
+++ b/cmd/cpybkc-gen-go/machine_test.go
@@ -292,7 +292,12 @@ func edge(id, record, next uint64, predicate *uint64, guards, bindings []uint64)
 
 // predicateOn is a transition's predicate reference, which is the one reference
 // in the schema absence is a meaning for.
-func predicateOn(id uint64) *uint64 { return &id }
+//
+// Kept rather than inlined to `new(expr)`: every call site passes an untyped
+// constant, so inlining spells each one `new(uint64(50))` — which is the naming
+// of the pointer traded for a conversion, in the one place a reader is checking
+// that a present reference and an absent one are told apart.
+func predicateOn(id uint64) *uint64 { return &id } //nolint:modernize // named on purpose; see above
 
 // counter is an integer register and flag is a bytes one.
 func counter(id uint64) *irpb.Node {

--- a/cmd/cpybkc-gen-go/record.go
+++ b/cmd/cpybkc-gen-go/record.go
@@ -1070,7 +1070,7 @@ func comment(name string, names *irpb.Names, summary string) string {
 func commentLines(text string) string {
 	var b strings.Builder
 
-	for _, line := range strings.Split(text, "\n") {
+	for line := range strings.SplitSeq(text, "\n") {
 		b.WriteString("// ")
 		b.WriteString(line)
 		b.WriteString("\n")

--- a/cmd/cpybkc-gen-go/record_test.go
+++ b/cmd/cpybkc-gen-go/record_test.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"testing"
 
-	"google.golang.org/protobuf/proto"
-
 	"github.com/Zaba505/cpybkc/irpb"
 )
 
@@ -1271,7 +1269,7 @@ func ordersDescriptor() *irpb.Descriptor {
 			// a framing stating a record's length has a predicate to bound:
 			// a target outside the record the framing bounds does not match.
 			{Id: 92, Kind: &irpb.Node_Transition{Transition: &irpb.Transition{
-				RecordId: 40, NextStateId: 5, PredicateId: proto.Uint64(95),
+				RecordId: 40, NextStateId: 5, PredicateId: new(uint64(95)),
 			}}},
 			equals(95, 42, "\xe8"),
 
@@ -1377,7 +1375,7 @@ func ordersDescriptor() *irpb.Descriptor {
 // renamed is a node the layout gave a substitute name for, which is the name
 // this generator munges into an identifier.
 func renamed(node *irpb.Node, override string) *irpb.Node {
-	namesOf(node).OverrideName = proto.String(override)
+	namesOf(node).OverrideName = new(override)
 
 	return node
 }

--- a/cmd/cpybkc-gen-graph/args.go
+++ b/cmd/cpybkc-gen-graph/args.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -269,12 +270,10 @@ func assign(field *string, key, value string, admitted ...string) error {
 		return fmt.Errorf("%s %s was passed more than once", optFlag, key)
 	}
 
-	for _, one := range admitted {
-		if value == one {
-			*field = value
+	if slices.Contains(admitted, value) {
+		*field = value
 
-			return nil
-		}
+		return nil
 	}
 
 	return fmt.Errorf("%s=%q is not a value this generator takes; it takes %s",

--- a/cmd/cpybkc-gen-graph/automaton_test.go
+++ b/cmd/cpybkc-gen-graph/automaton_test.go
@@ -517,7 +517,7 @@ func TestARecordNameInTheRegisterTableIsEscapedAsMarkdown(t *testing.T) {
 
 	// The row is still one row: an unescaped `|` would have made it three
 	// columns of something else.
-	for _, line := range strings.Split(written, "\n") {
+	for line := range strings.SplitSeq(written, "\n") {
 		if !strings.HasPrefix(line, "| r20 ") {
 			continue
 		}
@@ -944,7 +944,12 @@ func edgeNode(id, admits, to uint64, predicate *uint64, guards, bindings []uint6
 // predicateAt is a transition's predicate reference, which is the one reference
 // in the schema absence is a meaning for — so it is a pointer and never a
 // sentinel, because zero is an ordinary identifier.
-func predicateAt(id uint64) *uint64 { return &id }
+//
+// Kept rather than inlined to `new(expr)`: all twenty-odd call sites pass an
+// untyped constant, so inlining spells each one `new(uint64(50))` — twenty
+// conversions bought with the name that says which of a transition's several
+// identifiers this one is.
+func predicateAt(id uint64) *uint64 { return &id } //nolint:modernize // named on purpose; see above
 
 // equalPredicate and oneOfPredicate are the two members of the predicate set.
 func equalPredicate(id, field uint64, value string) *irpb.Node {

--- a/cmd/cpybkc-gen-graph/automaton_test.go
+++ b/cmd/cpybkc-gen-graph/automaton_test.go
@@ -945,11 +945,19 @@ func edgeNode(id, admits, to uint64, predicate *uint64, guards, bindings []uint6
 // in the schema absence is a meaning for — so it is a pointer and never a
 // sentinel, because zero is an ordinary identifier.
 //
-// Kept rather than inlined to `new(expr)`: all twenty-odd call sites pass an
-// untyped constant, so inlining spells each one `new(uint64(50))` — twenty
-// conversions bought with the name that says which of a transition's several
-// identifiers this one is.
-func predicateAt(id uint64) *uint64 { return &id } //nolint:modernize // named on purpose; see above
+// Kept rather than inlined to `new(expr)`, on the rule this repository applies
+// to every `newexpr` finding: a one-line shim earns its name when it is called
+// repeatedly *and* says something the call site does not. Both hold here, and
+// the first emphatically — [edgeNode] takes three bare identifiers before this
+// one, across twenty-odd call sites in four files, and `predicateAt(50)` is
+// what tells a reader which of them is the reference absence is a meaning for.
+//
+// Where either half fails, the shim goes: `grammarString("XX")` in
+// internal/conformance/grammar_test.go had one call site and sat beside a field
+// already named `Text`, and was inlined to `new("XX")` for exactly that reason.
+// The conversion an untyped constant costs — `new(uint64(50))` — is the price
+// of the rule and not the reason for it.
+func predicateAt(id uint64) *uint64 { return &id } //nolint:modernize // see above
 
 // equalPredicate and oneOfPredicate are the two members of the predicate set.
 func equalPredicate(id, field uint64, value string) *irpb.Node {

--- a/cmd/cpybkc-gen-graph/diagnostic.go
+++ b/cmd/cpybkc-gen-graph/diagnostic.go
@@ -89,7 +89,7 @@ func report(w io.Writer, err error) {
 	var carrier noted
 	if errors.As(err, &carrier) {
 		for _, note := range carrier.Notes() {
-			for _, line := range strings.Split(note, "\n") {
+			for line := range strings.SplitSeq(note, "\n") {
 				diagnostic(w, severityNote, line)
 			}
 		}

--- a/cmd/cpybkc-gen-graph/dot.go
+++ b/cmd/cpybkc-gen-graph/dot.go
@@ -563,7 +563,7 @@ func wrapped(text string, at int) []string {
 		wide  int
 	)
 
-	for _, word := range strings.Fields(text) {
+	for word := range strings.FieldsSeq(text) {
 		runes := utf8.RuneCountInString(word)
 
 		switch {

--- a/cmd/cpybkc-gen-graph/dot_test.go
+++ b/cmd/cpybkc-gen-graph/dot_test.go
@@ -100,7 +100,7 @@ func TestAnEdgeLabelIsOneLeftJustifiedLinePerSection(t *testing.T) {
 	// `\n` centres the line it ends and `\l` left-justifies it, so a label that
 	// broke its lines the other way would draw a ragged sentence with no left
 	// edge — which is the shape being avoided.
-	for _, line := range strings.Split(written, "\n") {
+	for line := range strings.SplitSeq(written, "\n") {
 		if strings.Contains(line, "[label=") && strings.Contains(line, `\n`) {
 			t.Errorf("the label %q breaks a line with a centring escape", line)
 		}
@@ -199,7 +199,7 @@ func TestTheRecordTablesAreClusteredAndNothingRunsIntoThem(t *testing.T) {
 	// it was written; a cell naming one is the register table's third column,
 	// which says the edges in words and is the whole reason there is no need to
 	// draw them.
-	for _, line := range strings.Split(written, "\n") {
+	for line := range strings.SplitSeq(written, "\n") {
 		if !strings.Contains(line, " -> ") || strings.Contains(line, "<TD>") {
 			continue
 		}

--- a/cmd/cpybkc-gen-graph/graph.go
+++ b/cmd/cpybkc-gen-graph/graph.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -488,9 +489,9 @@ func (g *graph) walk(nodes nodeSet, id uint64, seen map[uint64]bool) ([]uint64, 
 		// Pushed in reverse so that the first transition the state carries is
 		// the first one popped, which is what makes this a pre-order walk in
 		// the order a consumer evaluates transitions.
-		for i := len(s.edges) - 1; i >= 0; i-- {
-			if !seen[s.edges[i].to] {
-				stack = append(stack, s.edges[i].to)
+		for _, edge := range slices.Backward(s.edges) {
+			if !seen[edge.to] {
+				stack = append(stack, edge.to)
 			}
 		}
 	}

--- a/cmd/cpybkc-gen-graph/graph_test.go
+++ b/cmd/cpybkc-gen-graph/graph_test.go
@@ -686,7 +686,7 @@ func transitionNode(id, admits, to uint64) *irpb.Node {
 func recordNode(id uint64, original, override string) *irpb.Node {
 	names := &irpb.Names{Original: original}
 	if override != "" {
-		names.OverrideName = proto.String(override)
+		names.OverrideName = new(override)
 	}
 
 	return &irpb.Node{Id: id, Kind: &irpb.Node_Record{Record: &irpb.Record{

--- a/cmd/cpybkc-gen-graph/main_test.go
+++ b/cmd/cpybkc-gen-graph/main_test.go
@@ -146,7 +146,7 @@ func TestEveryDiagnosticThisProgramWritesOpensWithASeverity(t *testing.T) {
 			var stderr bytes.Buffer
 			report(&stderr, err)
 
-			for _, line := range strings.Split(strings.TrimSuffix(stderr.String(), "\n"), "\n") {
+			for line := range strings.SplitSeq(strings.TrimSuffix(stderr.String(), "\n"), "\n") {
 				severity, message, separated := strings.Cut(line, severitySeparator)
 				if !separated || message == "" {
 					t.Errorf("the diagnostic %q is not `<severity>%s<message>`", line, severitySeparator)

--- a/cmd/cpybkc/diagnostic.go
+++ b/cmd/cpybkc/diagnostic.go
@@ -142,7 +142,7 @@ func continuation(w io.Writer, span diag.Span) {
 		}
 	}
 
-	for _, line := range strings.Split(text, "\n") {
+	for line := range strings.SplitSeq(text, "\n") {
 		line = strings.TrimRight(line, " \t")
 		if line == "" {
 			continue

--- a/cmd/cpybkc/diagnostic_test.go
+++ b/cmd/cpybkc/diagnostic_test.go
@@ -144,7 +144,7 @@ func TestAContinuationLineIsNotADiagnostic(t *testing.T) {
 
 	stderr := reported(crossFile)
 
-	for _, line := range strings.Split(strings.TrimRight(stderr, "\n"), "\n") {
+	for line := range strings.SplitSeq(strings.TrimRight(stderr, "\n"), "\n") {
 		if strings.HasPrefix(line, continuationIndent) {
 			for _, severity := range []string{severityError, severityWarning, severityNote} {
 				if strings.HasPrefix(strings.TrimLeft(line, " "), severity+severitySeparator) {

--- a/cmd/cpybkc/main_test.go
+++ b/cmd/cpybkc/main_test.go
@@ -446,7 +446,7 @@ func TestEveryDiagnosticLineCarriesASeverity(t *testing.T) {
 
 	diagnostics, _, _ := strings.Cut(stderr, "\n\n")
 
-	for _, line := range strings.Split(strings.TrimRight(diagnostics, "\n"), "\n") {
+	for line := range strings.SplitSeq(strings.TrimRight(diagnostics, "\n"), "\n") {
 		switch {
 		case strings.HasPrefix(line, continuationIndent):
 			// A continuation line carries no severity of its own, and the

--- a/cmd/cpybkc/relay.go
+++ b/cmd/cpybkc/relay.go
@@ -105,7 +105,7 @@ func (r *relay) Handle(_ context.Context, record slog.Record) error {
 	// diagnostic has none. Either way every piece of it is written at the
 	// severity the whole arrived at, because the alternative is a line on this
 	// stream that no severity opens.
-	for _, line := range strings.Split(record.Message, "\n") {
+	for line := range strings.SplitSeq(record.Message, "\n") {
 		relayed(r.w, severity, name, line)
 	}
 

--- a/internal/assemble/assemble.go
+++ b/internal/assemble/assemble.go
@@ -9,7 +9,6 @@ import (
 	"math"
 
 	"github.com/Zaba505/cobol-go/copybook"
-	"google.golang.org/protobuf/proto"
 
 	"github.com/Zaba505/cpybkc/internal/diag"
 	"github.com/Zaba505/cpybkc/internal/layoutmodel"
@@ -379,7 +378,7 @@ func (a *assembler) recordName(record Record) *irpb.Names {
 
 	names := &irpb.Names{Original: field.Name}
 	if substitute, renamed := a.recordSubstitutes[record.Name]; renamed {
-		names.OverrideName = proto.String(substitute)
+		names.OverrideName = new(substitute)
 	}
 
 	return names
@@ -524,7 +523,7 @@ func (a *assembler) names(s *scope, field *copybook.Field) *irpb.Names {
 
 	names := &irpb.Names{Original: field.Name}
 	if substitute, renamed := a.renames[renameKey{record: s.name, item: field}]; renamed {
-		names.OverrideName = proto.String(substitute)
+		names.OverrideName = new(substitute)
 	}
 
 	return names

--- a/internal/assemble/automaton.go
+++ b/internal/assemble/automaton.go
@@ -8,8 +8,6 @@ package assemble
 import (
 	"strconv"
 
-	"google.golang.org/protobuf/proto"
-
 	"github.com/Zaba505/cpybkc/internal/resolve"
 	"github.com/Zaba505/cpybkc/irpb"
 )
@@ -100,7 +98,7 @@ func (a *assembler) transition(transition *resolve.Transition) uint64 {
 	// and why nothing here writes a sentinel (docs/ir/SPEC.md, "A transition
 	// may carry no predicate").
 	if transition.Predicate != nil {
-		built.PredicateId = proto.Uint64(a.allocatePredicate(scope, transition.Predicate))
+		built.PredicateId = new(a.allocatePredicate(scope, transition.Predicate))
 	}
 
 	for _, guard := range transition.Guards {

--- a/internal/assemble/validate_test.go
+++ b/internal/assemble/validate_test.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"google.golang.org/protobuf/proto"
-
 	"github.com/Zaba505/cpybkc/internal/diag"
 	"github.com/Zaba505/cpybkc/irpb"
 )
@@ -321,7 +319,7 @@ func TestASignedComp6FieldIsRefused(t *testing.T) {
 // copybook it came from.
 func TestAnOverrideWithNoOriginalIsRefused(t *testing.T) {
 	d := valid()
-	node(t, d, 3).GetField().Names = &irpb.Names{OverrideName: proto.String("kind")}
+	node(t, d, 3).GetField().Names = &irpb.Names{OverrideName: new("kind")}
 
 	refused(t, d, "carries an override and no original name")
 }
@@ -422,7 +420,7 @@ func TestAPredicateCarriesATestOverBytes(t *testing.T) {
 		t.Helper()
 
 		d := valid()
-		node(t, d, 5).GetTransition().PredicateId = proto.Uint64(6)
+		node(t, d, 5).GetTransition().PredicateId = new(uint64(6))
 		d.Nodes = append(d.GetNodes(), &irpb.Node{Id: 6, Kind: &irpb.Node_Predicate{Predicate: test}})
 
 		return d

--- a/internal/conformance/engine/engine_test.go
+++ b/internal/conformance/engine/engine_test.go
@@ -704,7 +704,7 @@ func frames(t *testing.T, path string) []string {
 
 	var sent []string
 
-	for _, line := range strings.Split(transcript(t, path), "\n") {
+	for line := range strings.SplitSeq(transcript(t, path), "\n") {
 		if line != "" {
 			sent = append(sent, line)
 		}

--- a/internal/conformance/engine/image_test.go
+++ b/internal/conformance/engine/image_test.go
@@ -398,8 +398,8 @@ func assertRemoved(t *testing.T, record string) {
 	var name string
 
 	for _, arg := range run {
-		if strings.HasPrefix(arg, "--name=") {
-			name = strings.TrimPrefix(arg, "--name=")
+		if after, ok := strings.CutPrefix(arg, "--name="); ok {
+			name = after
 		}
 	}
 

--- a/internal/conformance/engine/position.go
+++ b/internal/conformance/engine/position.go
@@ -104,17 +104,20 @@ func (p position) bytes(input []byte) (string, bool) {
 	}
 
 	run := input[p.FileOffset:end]
-	said := fmt.Sprintf("%s 0x%04x..0x%04x:", conformance.InputName, p.FileOffset, end-1)
+
+	var said strings.Builder
+
+	fmt.Fprintf(&said, "%s 0x%04x..0x%04x:", conformance.InputName, p.FileOffset, end-1)
 
 	for _, b := range run[:min(len(run), bytesLimit)] {
-		said += fmt.Sprintf(" %02x", b)
+		fmt.Fprintf(&said, " %02x", b)
 	}
 
 	if len(run) > bytesLimit {
-		said += fmt.Sprintf(" (and %d more)", len(run)-bytesLimit)
+		fmt.Fprintf(&said, " (and %d more)", len(run)-bytesLimit)
 	}
 
-	return said, true
+	return said.String(), true
 }
 
 // positions is where the descriptor puts every value the entry states, keyed by

--- a/internal/conformance/grammar_test.go
+++ b/internal/conformance/grammar_test.go
@@ -211,8 +211,8 @@ var grammarValues = map[string]grammarValue{
 	"table-none":      {node: 155, value: []string{}},
 	"table-of-groups": {node: 157, value: []grammarLine{{LineSKU: "SK1"}, {LineSKU: "SK2"}}},
 
-	"variant-arm-held":   {node: 159, value: grammarRecord{Before: 1, Num: grammarNum(2), After: 3}},
-	"variant-arm-absent": {node: 159, value: grammarRecord{Before: 1, Text: grammarString("XX"), After: 3}},
+	"variant-arm-held":   {node: 159, value: grammarRecord{Before: 1, Num: new(int32(2)), After: 3}},
+	"variant-arm-absent": {node: 159, value: grammarRecord{Before: 1, Text: new("XX"), After: 3}},
 }
 
 // grammarDocuments is what every row of GRAMMAR.md's "A record and a document"
@@ -279,10 +279,6 @@ var grammarRefusals = map[string]bool{
 	"bytes-not-canonical":      true,
 	"text-trailing-space-kept": true,
 }
-
-func grammarNum(n int32) *int32 { return &n }
-
-func grammarString(s string) *string { return &s }
 
 // TestTheWriterWritesEveryGrammarRow holds this repository's writer to
 // docs/conformance/GRAMMAR.md: for every row of every value table, the value
@@ -680,7 +676,7 @@ func grammarWritten(t *testing.T) map[string]string {
 
 	rows := map[string]string{}
 
-	for _, line := range strings.Split(grammarText(t), "\n") {
+	for line := range strings.SplitSeq(grammarText(t), "\n") {
 		cells := grammarCells(line)
 		if len(cells) != 3 || !grammarRowID.MatchString(cells[0]) {
 			continue
@@ -709,7 +705,7 @@ func grammarNotAdmissible(t *testing.T) map[string]grammarNotAdmissibleRow {
 
 	rows := map[string]grammarNotAdmissibleRow{}
 
-	for _, line := range strings.Split(grammarText(t), "\n") {
+	for line := range strings.SplitSeq(grammarText(t), "\n") {
 		cells := grammarCells(line)
 		if len(cells) != 4 || !grammarRowID.MatchString(cells[0]) {
 			continue
@@ -734,7 +730,7 @@ func grammarCells(line string) []string {
 	}
 
 	var cells []string
-	for _, cell := range strings.Split(strings.Trim(line, "|"), "|") {
+	for cell := range strings.SplitSeq(strings.Trim(line, "|"), "|") {
 		cells = append(cells, strings.TrimSpace(cell))
 	}
 

--- a/internal/generate/merge_test.go
+++ b/internal/generate/merge_test.go
@@ -51,7 +51,11 @@ func owner(t *testing.T, path string) Owner {
 // umask is a mask to hand a [Runner], stated rather than read: the process's own
 // is a process-wide setting, and a test that moved it would move it for every
 // other test running beside it.
-func umask(mask fs.FileMode) *fs.FileMode { return &mask }
+//
+// Kept rather than inlined to `new(expr)`: its other call site passes an untyped
+// constant, which `new` cannot take without a conversion, so inlining would
+// leave `new(test.mask)` beside `new(fs.FileMode(0o022))` for the same idea.
+func umask(mask fs.FileMode) *fs.FileMode { return &mask } //nolint:modernize // named on purpose; see above
 
 // tight is a generator that writes under a umask of its own, so that what lands
 // in the project's tree is visibly not what the plugin created.
@@ -98,7 +102,7 @@ func TestTheModesAreThisRunsRatherThanThePlugins(t *testing.T) {
 			t.Parallel()
 
 			r := runner(t)
-			r.Umask = umask(test.mask)
+			r.Umask = umask(test.mask) //nolint:modernize // [umask] is kept, so its call sites are too
 
 			out := filepath.Join(t.TempDir(), "project", "gen")
 

--- a/internal/generate/merge_test.go
+++ b/internal/generate/merge_test.go
@@ -52,10 +52,15 @@ func owner(t *testing.T, path string) Owner {
 // is a process-wide setting, and a test that moved it would move it for every
 // other test running beside it.
 //
-// Kept rather than inlined to `new(expr)`: its other call site passes an untyped
-// constant, which `new` cannot take without a conversion, so inlining would
-// leave `new(test.mask)` beside `new(fs.FileMode(0o022))` for the same idea.
-func umask(mask fs.FileMode) *fs.FileMode { return &mask } //nolint:modernize // named on purpose; see above
+// Kept rather than inlined to `new(expr)`, on the rule this repository applies
+// to every `newexpr` finding: a one-line shim earns its name when it is called
+// repeatedly *and* says something the call site does not. Both hold — two call
+// sites, and the paragraph above is the thing the name carries to each of them.
+//
+// Inlining would also split one idea in two, since the call site below passes an
+// untyped constant `new` cannot take without a conversion: `new(test.mask)` on
+// one line and `new(fs.FileMode(0o022))` on another, for the same idea.
+func umask(mask fs.FileMode) *fs.FileMode { return &mask } //nolint:modernize // see above
 
 // tight is a generator that writes under a umask of its own, so that what lands
 // in the project's tree is visibly not what the plugin created.
@@ -102,7 +107,7 @@ func TestTheModesAreThisRunsRatherThanThePlugins(t *testing.T) {
 			t.Parallel()
 
 			r := runner(t)
-			r.Umask = umask(test.mask) //nolint:modernize // [umask] is kept, so its call sites are too
+			r.Umask = umask(test.mask) //nolint:modernize // [umask] is kept, so this call site is too
 
 			out := filepath.Join(t.TempDir(), "project", "gen")
 

--- a/internal/layout/parse_test.go
+++ b/internal/layout/parse_test.go
@@ -814,7 +814,7 @@ func fencedBlock(t *testing.T, body string) string {
 		open  bool
 	)
 
-	for _, line := range strings.Split(body, "\n") {
+	for line := range strings.SplitSeq(body, "\n") {
 		if strings.HasPrefix(strings.TrimSpace(line), "```") {
 			if open {
 				return strings.Join(block, "\n")
@@ -847,7 +847,7 @@ func section(t *testing.T, heading string) string {
 		found bool
 	)
 
-	for _, line := range strings.Split(specText(t), "\n") {
+	for line := range strings.SplitSeq(specText(t), "\n") {
 		if line == heading {
 			found = true
 

--- a/internal/layoutmodel/axes.go
+++ b/internal/layoutmodel/axes.go
@@ -94,13 +94,7 @@ func (a Axis) Values() []string {
 
 // admits reports whether value is one the axis takes.
 func (a Axis) admits(value string) bool {
-	for _, admitted := range a.Values() {
-		if admitted == value {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(a.Values(), value)
 }
 
 // Charset is a character set the charset axis admits.

--- a/internal/layoutschema/schema_test.go
+++ b/internal/layoutschema/schema_test.go
@@ -223,7 +223,7 @@ func specTopLevelForms(t *testing.T) map[string]specTopLevelForm {
 
 	rows := make(map[string]specTopLevelForm)
 
-	for _, line := range strings.Split(section(t, "### The top-level forms"), "\n") {
+	for line := range strings.SplitSeq(section(t, "### The top-level forms"), "\n") {
 		cells := tableRow(line)
 		if len(cells) != 3 || !strings.HasPrefix(cells[0], "`") {
 			continue
@@ -248,7 +248,7 @@ func tableRow(line string) []string {
 	}
 
 	var cells []string
-	for _, cell := range strings.Split(strings.Trim(line, "|"), "|") {
+	for cell := range strings.SplitSeq(strings.Trim(line, "|"), "|") {
 		cells = append(cells, strings.TrimSpace(cell))
 	}
 
@@ -267,7 +267,7 @@ func section(t *testing.T, heading string) string {
 		found bool
 	)
 
-	for _, line := range strings.Split(specText(t), "\n") {
+	for line := range strings.SplitSeq(specText(t), "\n") {
 		if line == heading {
 			found = true
 

--- a/internal/layoutschema/validate_test.go
+++ b/internal/layoutschema/validate_test.go
@@ -234,7 +234,7 @@ func fencedBlock(t *testing.T, body string) string {
 		open  bool
 	)
 
-	for _, line := range strings.Split(body, "\n") {
+	for line := range strings.SplitSeq(body, "\n") {
 		if strings.HasPrefix(strings.TrimSpace(line), "```") {
 			if open {
 				return strings.Join(block, "\n")

--- a/internal/plugin/invoke.go
+++ b/internal/plugin/invoke.go
@@ -209,13 +209,9 @@ func (r *Runner) Run(ctx context.Context, d *irpb.Descriptor, invocations []Invo
 	var running sync.WaitGroup
 
 	for i, invocation := range invocations {
-		running.Add(1)
-
-		go func() {
-			defer running.Done()
-
+		running.Go(func() {
 			faults[i] = r.invoke(ctx, invocation, descriptor)
-		}()
+		})
 	}
 
 	running.Wait()

--- a/internal/project/errors.go
+++ b/internal/project/errors.go
@@ -405,11 +405,8 @@ func and(items []string) string {
 	default:
 		last := len(items) - 1
 
-		joined := ""
-		for _, item := range items[:last] {
-			joined += item + ", "
-		}
-
-		return joined + "and " + items[last]
+		// The serial comma is deliberate: "a, b, and c" rather than "a, b and
+		// c", so that a two-word item cannot read as two items.
+		return strings.Join(items[:last], ", ") + ", and " + items[last]
 	}
 }

--- a/internal/project/errors_test.go
+++ b/internal/project/errors_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package project
+
+import "testing"
+
+// TestAndJoinsAListTheWayASentenceDoes pins every arm of [and], which is the one
+// place in this package where a diagnostic's wording is assembled rather than
+// formatted.
+//
+// It is here because [and] was rewritten when `modernize` was enforced (#257):
+// the `default` arm was a `+=` loop and is now a [strings.Join], and the two
+// spellings agree on every length the arm can see but disagree at one it cannot
+// — a single item, where the loop contributed a trailing `", "` and the join
+// contributes none. That length is unreachable, because `case 1` is above the
+// `default`. This test is what makes the unreachability a fact the package
+// states rather than one a reader has to re-derive from the switch.
+func TestAndJoinsAListTheWayASentenceDoes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		about string
+		items []string
+		want  string
+	}{
+		{
+			about: "nothing at all is a word and not an empty string, because it is read in a sentence",
+			items: nil,
+			want:  "nothing",
+		},
+		{
+			about: "one item is the item, with nothing joining it to anything",
+			items: []string{"A"},
+			want:  "A",
+		},
+		{
+			about: "two items take no comma, which is what English does",
+			items: []string{"A", "B"},
+			want:  "A and B",
+		},
+		{
+			about: "three items take the serial comma",
+			items: []string{"A", "B", "C"},
+			want:  "A, B, and C",
+		},
+		{
+			about: "four items put a comma between every pair and before the last",
+			items: []string{"A", "B", "C", "D"},
+			want:  "A, B, C, and D",
+		},
+		{
+			about: "an item that is two words is still one item, which is what the serial comma is for",
+			items: []string{"A", "B", "C D"},
+			want:  "A, B, and C D",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.about, func(t *testing.T) {
+			t.Parallel()
+
+			if got := and(test.items); got != test.want {
+				t.Errorf("and(%q) is %q, want %q", test.items, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/resolve/sequence.go
+++ b/internal/resolve/sequence.go
@@ -525,6 +525,12 @@ func (c *compiler) boundOnEntry(a *Automaton) map[int]map[int]bool {
 // It is not named `maps`, as it once was, because a package-level identifier by
 // that name shadows the standard library's `maps` package for every file in this
 // one — including this function, which is now a single call into it.
+//
+// It is `make` plus [maps.Copy] and **not** [maps.Clone], which is what a reader
+// of a two-line body wrapping `maps.Copy` will reach for next. `maps.Clone`
+// returns nil for a nil argument, where this returns an empty map; a state whose
+// entry set is nil is ordinary here, and [compiler.boundOnEntry] writes into
+// what this returns, so the nil would be a panic and not a smaller allocation.
 func copyOf(of map[int]bool) map[int]bool {
 	out := make(map[int]bool, len(of))
 	maps.Copy(out, of)

--- a/internal/resolve/sequence.go
+++ b/internal/resolve/sequence.go
@@ -6,6 +6,7 @@
 package resolve
 
 import (
+	"maps"
 	"slices"
 	"strconv"
 
@@ -487,7 +488,7 @@ func (c *compiler) boundOnEntry(a *Automaton) map[int]map[int]bool {
 			continue
 		}
 
-		bound[state.ID] = maps(all)
+		bound[state.ID] = copyOf(all)
 	}
 
 	for settled := false; !settled; {
@@ -499,7 +500,7 @@ func (c *compiler) boundOnEntry(a *Automaton) map[int]map[int]bool {
 					continue
 				}
 
-				after := maps(bound[state.ID])
+				after := copyOf(bound[state.ID])
 				for _, binding := range transition.Bindings {
 					after[binding.Register.ID] = true
 				}
@@ -518,13 +519,16 @@ func (c *compiler) boundOnEntry(a *Automaton) map[int]map[int]bool {
 	return bound
 }
 
-// maps copies a set, so that a state's own answer is never the one being
+// copyOf copies a set, so that a state's own answer is never the one being
 // narrowed.
-func maps(of map[int]bool) map[int]bool {
+//
+// It is not named `maps`, as it once was, because a package-level identifier by
+// that name shadows the standard library's `maps` package for every file in this
+// one — including this function, which is now a single call into it.
+func copyOf(of map[int]bool) map[int]bool {
 	out := make(map[int]bool, len(of))
-	for key, value := range of {
-		out[key] = value
-	}
+	maps.Copy(out, of)
+
 	return out
 }
 

--- a/internal/scaffold/write_test.go
+++ b/internal/scaffold/write_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -60,22 +61,12 @@ func leftovers(t *testing.T, dir string, expected ...string) []string {
 	var found []string
 
 	for _, entry := range entries {
-		if !contains(expected, entry.Name()) {
+		if !slices.Contains(expected, entry.Name()) {
 			found = append(found, entry.Name())
 		}
 	}
 
 	return found
-}
-
-func contains(names []string, name string) bool {
-	for _, each := range names {
-		if each == name {
-			return true
-		}
-	}
-
-	return false
 }
 
 func TestAFreeDestinationIsWrittenInFull(t *testing.T) {

--- a/ir_module_test.go
+++ b/ir_module_test.go
@@ -37,7 +37,7 @@ const irModulePath = "github.com/Zaba505/cpybkc/irpb"
 func TestTheCLIConsumesThePublishedIRModule(t *testing.T) {
 	d := &irpb.Descriptor{Version: irpb.IrVersion_IR_VERSION_1}
 
-	if got := reflect.TypeOf(d).Elem().PkgPath(); got != irModulePath {
+	if got := reflect.TypeFor[irpb.Descriptor]().PkgPath(); got != irModulePath {
 		t.Errorf("IR types resolve to %q, want %q: the IR a plugin author imports and the IR this module builds against must be the same package", got, irModulePath)
 	}
 

--- a/irpb/importable_test.go
+++ b/irpb/importable_test.go
@@ -21,9 +21,9 @@ import (
 // single path element named "internal" anywhere in it puts the IR out of reach
 // of the third-party generators it exists for.
 func TestImportPathHasNoInternalElement(t *testing.T) {
-	pkgPath := reflect.TypeOf((*irpb.Descriptor)(nil)).Elem().PkgPath()
+	pkgPath := reflect.TypeFor[irpb.Descriptor]().PkgPath()
 
-	for _, elem := range strings.Split(pkgPath, "/") {
+	for elem := range strings.SplitSeq(pkgPath, "/") {
 		if elem == "internal" {
 			t.Fatalf("IR package %q is unimportable from outside this module: no element of its import path may be %q", pkgPath, "internal")
 		}

--- a/irpb/module_test.go
+++ b/irpb/module_test.go
@@ -85,7 +85,7 @@ func parseGoMod(t *testing.T, path string) goMod {
 	mod := goMod{requires: make(map[string]string)}
 
 	block := ""
-	for _, raw := range strings.Split(string(b), "\n") {
+	for raw := range strings.SplitSeq(string(b), "\n") {
 		line := raw
 		if i := strings.Index(line, "//"); i >= 0 {
 			line = line[:i]


### PR DESCRIPTION
Closes #257

`modernize` joins `.golangci.yml`'s enabled set, and the 53 findings enabling it raises are each decided rather than swept — 49 taken, 4 declined at the site with a reason.

## The measurement held

Re-measured with golangci-lint v2.12.2 — the pin `github.com/z5labs/devex/daggerverse/go` installs — under `default: none`, `modernize` alone, and `max-issues-per-linter: 0` / `max-same-issues: 0`:

| module | before | after |
| --- | --- | --- |
| `.` (root) | 45 | 0 |
| `irpb` | 3 | 0 |
| `.dagger` | 5 | 0 |
| `daggerverse/cpybkc` | 0 | 0 |
| **total** | **53** | **0** |

The issue's caveat is real and was needed: with golangci-lint's default `max-same-issues: 3` the same tree reports 32, because `stringsseq` alone is capped from 28 to 3 per module. The committed config does not carry the lift — the clearing pass was verified with it, so the count reaches zero rather than three.

## The behavioural ones

These are the findings that are not style, and they are the reason the pass is worth having:

- **`internal/conformance/engine/position.go`** — string `+=` in a loop over a byte run, in production code. Now a `strings.Builder` written with `fmt.Fprintf`, which is how the rest of this repository writes into one (`cmd/cpybkc-gen-graph/mermaid.go`, `.dagger/release.go`).
- **`internal/project/errors.go`** — string `+=` in a loop building a serial list. Rewritten as `strings.Join(items[:last], ", ") + ", and " + items[last]`, which removes the loop rather than rehousing it. Byte-identical output for every `n ≥ 3`, the only case that branch takes; the serial comma is now stated in a comment so it does not read as an accident.
- **`internal/plugin/invoke.go`** — reviewed as a concurrency change, not a style one, per the acceptance criteria. `sync.WaitGroup.Go` is exactly equivalent to what it replaces: it performs the `Add(1)` before the goroutine starts, and its `Done` is deferred, so the ordering guarantee and the panic path are both unchanged. The indexed-`faults` comment above it still holds — nothing about fault ordering moves.
- **`internal/resolve/sequence.go`** — `mapsloop` could not be taken as written, because a package-level `func maps(...)` shadowed the standard library's `maps` package for every file in `resolve`. Renamed to `copyOf` (2 call sites), and the doc comment now says why the old name was a problem.

## The `newexpr` judgment

All 13 are decided individually, as the acceptance criteria ask.

**Taken (9).** The six `proto.String`/`proto.Uint64` calls become `new(...)`, which drops the `google.golang.org/protobuf/proto` import from `internal/assemble/assemble.go` and `internal/assemble/automaton.go` entirely. `internal/conformance/grammar_test.go`'s `grammarNum` and `grammarString` were undocumented one-line shims with exactly one call site each; both are inlined and deleted.

**One deliberate extra edit.** `modernize` can only flag a `proto.Uint64(x)` whose argument is already typed, so taking its six suggestions would have left `record_test.go:1274` and `validate_test.go:425` spelling the same idea the old way, two lines from the new one. Those two are converted as well — `new(uint64(95))`, `new(uint64(6))` — so the root module speaks one spelling. `irpb` keeps `proto.String` and is not touched: it is pinned at `go 1.24.0` for the third-party generator authors it exists for, and `new(expr)` is a Go 1.26 feature it cannot use. The split is per-module and has a visible reason in each `go.mod`.

**Declined (4),** each with a `//nolint:modernize` and the reason at the site:

| site | reason |
| --- | --- |
| `cmd/cpybkc-gen-go/machine_test.go` `predicateOn` | every call site passes an untyped constant, so inlining spells each `new(uint64(50))` — a conversion bought with the name that says a present reference from an absent one |
| `cmd/cpybkc-gen-graph/automaton_test.go` `predicateAt` | same, across twenty-odd call sites in four files |
| `internal/generate/merge_test.go` `umask` | its other call site passes an untyped constant, so inlining leaves `new(test.mask)` beside `new(fs.FileMode(0o022))` for one idea |
| `internal/generate/merge_test.go:101` | the helper is kept, so its call site is too |

No finding is silenced by an exclusion rule in `.golangci.yml`. Every decline is at the site, in the file, where the next reader can disagree with it.

## The config comment

The paragraph claiming the enabled set is "v2's own standard set" would have become false, so it now says what the set is — the standard set plus one deliberate addition. Two things are written down beside it: why `modernize` is enforced (a gopls-backed editor raises it whether CI does or not, so leaving it out made every suggestion noise nobody could clear), and the cost — its suggestions track the Go release and the tool pin, so a Renovate bump (#245) can turn CI red on code nobody touched, and the fix belongs in that pull request.

## Acceptance criteria

- [x] `modernize` is added to `linters.enable` in `.golangci.yml`
- [x] The header comment's argument for the enabled set is rewritten to describe what the set then is
- [x] The reason `modernize` is enforced is written in that comment, alongside the existing note about `unused`
- [x] All four modules are clean under the new configuration: `.`, `irpb`, `.dagger`, `daggerverse/cpybkc`
- [x] Every declined suggestion carries a `//nolint:modernize` with the reason at the site, and no finding is silenced by an exclusion rule
- [x] The `newexpr` findings in test helpers are each decided rather than swept — 9 inlined, 4 declined with reasons
- [x] The two `stringsbuilder` findings are treated as the behavioural ones they are
- [x] The single `waitgroupgo` finding is reviewed as a concurrency change, not a style one
- [x] `dagger call ci` is green from a real clone
- [x] The clearing pass is verified with the reporting caps lifted, so the count reaches zero rather than three

## How it was verified

- `golangci-lint run` v2.12.2 against all four modules with the committed config plus `max-issues-per-linter: 0` and `max-same-issues: 0` — **0 issues** in each.
- `go build ./...`, `go vet ./...`, `go test ./...` on the root module and on `irpb`; `go build ./...` on `.dagger` and `daggerverse/cpybkc`.
- `go test -race` on every package with a behavioural change, `internal/plugin` included.
- `dagger call ci` — **green**, run from a fresh `git clone` of this branch rather than from a worktree, since a worktree's `.git` is a file and every `dagger call` fails there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
