### PR TITLE
story(layout): a second worked example — the converted file the spec calls most common

### DIFF
--- a/docs/layout/SPEC.md
+++ b/docs/layout/SPEC.md
@@ -1969,16 +1969,17 @@ Nothing in it states a size that anything else states. `lrecl` and `blksize`
 come from the dataset; every offset, extent and width is the copybook's and is
 computed once by `resolve`.
 
-The same file after an EBCDIC-to-ASCII conversion is [A converted file, end to
-end](#appendix-a-converted-file-end-to-end). The copybooks, the framing and the
-sequence are the same statements there; the four encoding lines are not, and
-neither is what a reader shows an adopter who gets them wrong.
+A second file of the same shop's, delivered through an EBCDIC-to-ASCII
+conversion rather than as the dataset it was written to, is [A converted file,
+end to end](#appendix-a-converted-file-end-to-end). It is a different file with
+its own copybooks and its own records — what carries across is the vocabulary,
+and the four encoding lines are where the two disagree.
 
 ## Appendix: A converted file, end to end
 
-A settlement file the same shop's mainframe wrote, delivered as a converted
-extract rather than as the dataset it was written to: a header, a counted run of
-details, and a trailer.
+A settlement file — a different file from the one above, from the same shop —
+delivered as a converted extract rather than as the dataset it was written to: a
+header, a counted run of details, and a trailer.
 
 It is here because of what an adopter holding one arrives with. A copybook says
 `PIC S9(5)`, and a reader shows them `1234E` — or `1234{` for a value ending in
@@ -2015,9 +2016,9 @@ at all because the four axes are stated separately.
   (charset cp037)
   (sign-convention ebcdic))
 
-;; The dataset the extract came off, out of the JCL that allocated it. A binary
-;; transfer keeps the record descriptor words, so this is unchanged by the
-;; conversion.
+;; The dataset the extract came off, out of the JCL that allocated it. The
+;; conversion rewrote character data inside each record and moved no record
+;; boundary, so these three numbers are the dataset's and are what they were.
 (framing
   (recfm VB)
   (lrecl 512)
@@ -2076,19 +2077,31 @@ byte for byte what the mainframe wrote.
 
 ### What differs from the native layout
 
-Against [A layout, end to end](#appendix-a-layout-end-to-end), which is the same
-shop's file as the dataset holds it, the difference is the `encoding` form and
-the overrides under it and nothing else. The framing came off the same JCL, the
-copybooks are the same copybooks, and the discriminators and the sequence are
-the same statements about the same records.
+[A layout, end to end](#appendix-a-layout-end-to-end) is a different file — an
+order file, its own copybooks, its own record names — and it is worth saying so
+rather than leaving a reader to diff the two and find it. What the two share is
+the *shape*: a header, a counted run of details, an optional trailer, told apart
+by a type item, sequenced by the same operators, and framed by the same
+`recfm`/`lrecl`/`blksize` vocabulary out of the JCL that allocated each dataset.
+Neither layout says anything about the other's records, and nothing here is a
+statement that carries between them.
 
-The two overrides are the mirror of that layout's one. There, a native EBCDIC
-file carries a single field that arrived from a partner in ASCII and was never
-converted. Here, a converted ASCII file carries the fields the conversion did
-*not* reach: one whose bytes are a payload and have no charset at all, and one
-the transfer was told to pass through, which is still EBCDIC characters with
-EBCDIC signs. In both directions the exception is per item, both are stated with
-the same form, and neither is a second profile.
+What differs is the `encoding` form and the overrides under it, and that
+difference does not follow from anything else either layout writes. Both files
+came off the same kind of dataset and both are described with the same forms;
+one arrived as the mainframe holds it and one arrived through a conversion, and
+the only place a layout can say which is those four lines. That is the claim
+[All four, always, with no default for
+any](#all-four-always-with-no-default-for-any) makes — the four axes are
+independent and are not a dialect flag — shown twice rather than argued once.
+
+The overrides are the mirror of each other. There, a native EBCDIC file carries
+a single field that arrived from a partner in ASCII and was never converted.
+Here, a converted ASCII file carries the two the conversion did *not* reach: one
+whose bytes are a payload and have no charset at all, and one the transfer was
+told to pass through, which is still EBCDIC characters with EBCDIC signs. In
+both directions the exception is per item, both are stated with the same form,
+and neither is a second profile.
 
 ## Appendix: Mapping to Stories
 

--- a/docs/layout/SPEC.md
+++ b/docs/layout/SPEC.md
@@ -1969,12 +1969,133 @@ Nothing in it states a size that anything else states. `lrecl` and `blksize`
 come from the dataset; every offset, extent and width is the copybook's and is
 computed once by `resolve`.
 
+The same file after an EBCDIC-to-ASCII conversion is [A converted file, end to
+end](#appendix-a-converted-file-end-to-end). The copybooks, the framing and the
+sequence are the same statements there; the four encoding lines are not, and
+neither is what a reader shows an adopter who gets them wrong.
+
+## Appendix: A converted file, end to end
+
+A settlement file the same shop's mainframe wrote, delivered as a converted
+extract rather than as the dataset it was written to: a header, a counted run of
+details, and a trailer.
+
+It is here because of what an adopter holding one arrives with. A copybook says
+`PIC S9(5)`, and a reader shows them `1234E` — or `1234{` for a value ending in
+a positive zero and `1234}` for a negative one. A field that should be a number
+reads as a letter or as punctuation. Nothing is corrupt, nothing is misaligned,
+and the character is not a delimiter: it is the sign, and the four lines at the
+top of this layout are what say so.
+
+This is also the combination [All four, always, with no default for
+any](#all-four-always-with-no-default-for-any) calls the one real files hit most
+often. No compiler produces it — ASCII characters, EBCDIC signs and mainframe
+byte order arrive together only by way of a conversion — and it is expressible
+at all because the four axes are stated separately.
+
+```
+;; The encoding profile — a property of this *file*, not of the mainframe that
+;; wrote it. The transfer rewrote the characters and left everything else as it
+;; found it, and each of the four lines below records one half of that.
+(encoding
+  (charset ascii)
+  (sign-convention translated-ebcdic)
+  (byte-order big-endian)
+  (float-format hfp))
+
+;; The conversion was copybook-aware and skipped this item, which holds a
+;; region code — one byte of any of 256 — rather than characters.
+(encoding-override (item SETTLE-DETAIL SD-REGION)
+  (charset none))
+
+;; A block the sending system reads back as it wrote it, so the transfer was
+;; told to leave it alone. It is the only EBCDIC left in the file, characters
+;; and signs both.
+(encoding-override (item SETTLE-HEADER SH-PASSTHROUGH)
+  (charset cp037)
+  (sign-convention ebcdic))
+
+;; The dataset the extract came off, out of the JCL that allocated it. A binary
+;; transfer keeps the record descriptor words, so this is unchanged by the
+;; conversion.
+(framing
+  (recfm VB)
+  (lrecl 512)
+  (blksize 27998))
+
+;; The compiler that wrote it.
+(copybook-reading
+  (occurs-depending-on odoslide))
+
+;; The record types.
+(record SETTLE-HEADER  (copybook "cpy/settle.cpy" SETTLE-HEADER-REC))
+(record SETTLE-DETAIL  (copybook "cpy/settle.cpy" SETTLE-DETAIL-REC))
+(record SETTLE-TRAILER (copybook "cpy/settle.cpy" SETTLE-TRAILER-REC))
+
+(rename (item SETTLE-DETAIL SD-AMT) "SettlementAmount")
+
+;; How to tell them apart. The type byte is a character, so it is ASCII here
+;; and would have been EBCDIC in the dataset — the literal is written as the
+;; file spells it and the charset axis is what resolves it.
+(discriminate SETTLE-HEADER  (equals (item SETTLE-HEADER SH-REC-TYPE) "H"))
+(discriminate SETTLE-DETAIL  (equals (item SETTLE-DETAIL SD-REC-TYPE) "D"))
+(discriminate SETTLE-TRAILER (equals (item SETTLE-TRAILER ST-REC-TYPE) "T"))
+
+;; The order they may appear in.
+(sequence
+  (seq SETTLE-HEADER
+       (times SETTLE-DETAIL (item SETTLE-HEADER SH-DETAIL-COUNT))
+       (? SETTLE-TRAILER)))
+```
+
+### Why the field reads as punctuation
+
+An EBCDIC signed zoned decimal carries its sign in the zone nibble of its last
+byte: `0xC5` is a positive 5 and `0xD5` a negative one, and `0xC0` and `0xD0`
+are a positive and a negative zero. A text conversion rewrites those bytes along
+with every other byte of character data, and cp037 and cp1047 both send `0xC5`
+to `E`, `0xD5` to `N`, `0xC0` to `{` and `0xD0` to `}`. The digits come through
+unharmed, because `0xF0`–`0xF9` are `0`–`9` on the other side; the sign does
+not, because there was no ASCII character for it to become.
+
+`translated-ebcdic` is that outcome named, and it is why the sign convention is
+an axis of its own rather than something the charset implies. `ascii` on its own
+would say the digits are ASCII and leave the sign byte to be read as the letter
+it now looks like; `ebcdic` on its own would say the file was never converted.
+The file in hand is neither, and only two axes stated separately can say so.
+
+A `"` where a number was expected is a different finding and a worse one. `0x7F`
+is an ordinary byte in a `COMP` item holding 127 and in a `COMP-3` item ending
+in an unsigned 7, and it is `"` in both cp037 and cp1047 — so punctuation
+appearing inside a *binary* or *packed* field is the fingerprint of a conversion
+that rewrote bytes which were never characters. No setting of these four axes
+describes that file, and [Undoing a character-set
+conversion](#undoing-a-character-set-conversion) is why. The extract above came
+off a copybook-aware conversion, which is what makes its packed and binary items
+byte for byte what the mainframe wrote.
+
+### What differs from the native layout
+
+Against [A layout, end to end](#appendix-a-layout-end-to-end), which is the same
+shop's file as the dataset holds it, the difference is the `encoding` form and
+the overrides under it and nothing else. The framing came off the same JCL, the
+copybooks are the same copybooks, and the discriminators and the sequence are
+the same statements about the same records.
+
+The two overrides are the mirror of that layout's one. There, a native EBCDIC
+file carries a single field that arrived from a partner in ASCII and was never
+converted. Here, a converted ASCII file carries the fields the conversion did
+*not* reach: one whose bytes are a payload and have no charset at all, and one
+the transfer was told to pass through, which is still EBCDIC characters with
+EBCDIC signs. In both directions the exception is per item, both are stated with
+the same form, and neither is a second profile.
+
 ## Appendix: Mapping to Stories
 
 | Section | Implemented by |
 |---|---|
 | [The surface syntax](#the-surface-syntax) | #22 `layout` |
-| [The encoding profile](#the-encoding-profile) | #25 `layout`; an item that carries bytes rather than text, and the conversion residue left out beside it, by #275 |
+| [The encoding profile](#the-encoding-profile) | #25 `layout`; an item that carries bytes rather than text, and the conversion residue left out beside it, by #275; a worked example of the converted file the section calls the most common, by #273 |
 | [Physical framing](#physical-framing) | #26 `layout` |
 | [Record definitions](#record-definitions) | #27, #30 `layout`; `copybook-reading` by #35 `resolve`; which alternative a `record` form is, a rename naming a record, and a rename being per record, settled by #164 |
 | [Discrimination](#discrimination) | #28 `layout`; the strategies lowered into IR predicates, the literals resolved to bytes, and the rules on a target that need a copybook, by #37 `resolve` |

--- a/internal/layout/parse_test.go
+++ b/internal/layout/parse_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 
 	sexpr "github.com/z5labs/sexpr-go"
+
+	"github.com/Zaba505/cpybkc/internal/layoutdoc"
 )
 
 // TestParseBuildsAPositionedAST is the criterion this package exists for, and
@@ -116,7 +118,7 @@ func TestParseBuildsAPositionedAST(t *testing.T) {
 func TestEveryNodeCarriesTheFileItWasReadFrom(t *testing.T) {
 	t.Parallel()
 
-	file, err := Parse("orders.sexpr", strings.NewReader(specExample(t)))
+	file, err := Parse("orders.sexpr", strings.NewReader(specExample(t, layoutdoc.NativeExample)))
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -144,15 +146,15 @@ func TestEveryNodeCarriesTheFileItWasReadFrom(t *testing.T) {
 // TestTheSpecsWorkedExampleParses is the staleness gate over the notation.
 //
 // docs/layout/SPEC.md's "A layout, end to end" appendix is the layout the
-// document shows an adopter, and it is the one layout in this repository nobody
-// wrote against this reader. Reading it out of the document rather than copying
-// it here is the point: a change to the notation the appendix followed and the
-// reader did not would otherwise be invisible until an adopter pasted the
-// example into a file.
+// document shows an adopter, and it is one of the two layouts in this
+// repository nobody wrote against this reader. Reading it out of the document
+// rather than copying it here is the point: a change to the notation the
+// appendix followed and the reader did not would otherwise be invisible until
+// an adopter pasted the example into a file.
 func TestTheSpecsWorkedExampleParses(t *testing.T) {
 	t.Parallel()
 
-	file, err := Parse("orders.sexpr", strings.NewReader(specExample(t)))
+	file, err := Parse("orders.sexpr", strings.NewReader(specExample(t, layoutdoc.NativeExample)))
 	if err != nil {
 		t.Fatalf("the reader rejects SPEC.md's own worked example: %v", err)
 	}
@@ -162,6 +164,43 @@ func TestTheSpecsWorkedExampleParses(t *testing.T) {
 	// than something the walk above absorbs.
 	if len(file.Forms) != 14 {
 		t.Errorf("read %d top-level forms out of the appendix, want 14: %s", len(file.Forms), strings.Join(tags(file), ", "))
+	}
+}
+
+// TestTheSpecsConvertedExampleParses is the same gate over the second layout the
+// document shows an adopter.
+//
+// It is a second appendix rather than a second block under the first one, and
+// so a second heading here rather than a position among the first section's
+// blocks — [github.com/Zaba505/cpybkc/internal/layoutdoc] is where that is
+// argued. What it earns over [TestTheSpecsWorkedExampleParses] is the notation
+// the native example has no reason to write: two overrides on one layout, one
+// of them setting the charset axis to `none`.
+func TestTheSpecsConvertedExampleParses(t *testing.T) {
+	t.Parallel()
+
+	file, err := Parse("settlement.sexpr", strings.NewReader(specExample(t, layoutdoc.ConvertedExample)))
+	if err != nil {
+		t.Fatalf("the reader rejects SPEC.md's own converted example: %v", err)
+	}
+
+	// Stated for [TestTheSpecsWorkedExampleParses]'s reason, and it is a
+	// different number from that example's on purpose: a heading that came back
+	// with the wrong section's layout would pass a count shared between them.
+	if len(file.Forms) != 13 {
+		t.Errorf("read %d top-level forms out of the converted appendix, want 13: %s", len(file.Forms), strings.Join(tags(file), ", "))
+	}
+
+	var overrides int
+
+	for _, form := range file.Forms {
+		if form.Tag == "encoding-override" {
+			overrides++
+		}
+	}
+
+	if overrides != 2 {
+		t.Errorf("the converted appendix carries %d encoding-override forms, want 2: %s", overrides, strings.Join(tags(file), ", "))
 	}
 }
 
@@ -798,113 +837,19 @@ func tags(file *File) []string {
 	return names
 }
 
-// specExample returns docs/layout/SPEC.md's worked example.
-func specExample(t *testing.T) string {
+// specExample returns docs/layout/SPEC.md's worked example under heading.
+//
+// The document carries two of them and each is located by its own heading; the
+// reasoning is [github.com/Zaba505/cpybkc/internal/layoutdoc]'s, and so is the
+// one reading of the document that this package, layoutschema and layoutmodel
+// now share.
+func specExample(t *testing.T, heading string) string {
 	t.Helper()
 
-	return fencedBlock(t, section(t, "## Appendix: A layout, end to end"))
-}
-
-// fencedBlock returns the first fenced code block in body.
-func fencedBlock(t *testing.T, body string) string {
-	t.Helper()
-
-	var (
-		block []string
-		open  bool
-	)
-
-	for line := range strings.SplitSeq(body, "\n") {
-		if strings.HasPrefix(strings.TrimSpace(line), "```") {
-			if open {
-				return strings.Join(block, "\n")
-			}
-
-			open = true
-
-			continue
-		}
-
-		if open {
-			block = append(block, line)
-		}
-	}
-
-	t.Fatal("no fenced code block found")
-
-	return ""
-}
-
-// section returns the text of SPEC.md under heading, up to the next heading at
-// the same level or above.
-func section(t *testing.T, heading string) string {
-	t.Helper()
-
-	level := strings.IndexFunc(heading, func(r rune) bool { return r != '#' })
-
-	var (
-		body  []string
-		found bool
-	)
-
-	for line := range strings.SplitSeq(specText(t), "\n") {
-		if line == heading {
-			found = true
-
-			continue
-		}
-
-		if !found {
-			continue
-		}
-
-		if strings.HasPrefix(line, "#") && strings.IndexFunc(line, func(r rune) bool { return r != '#' }) <= level {
-			break
-		}
-
-		body = append(body, line)
-	}
-
-	if !found {
-		t.Fatalf("the layout SPEC has no %q section", heading)
-	}
-
-	return strings.Join(body, "\n")
-}
-
-// specText reads docs/layout/SPEC.md.
-func specText(t *testing.T) string {
-	t.Helper()
-
-	b, err := os.ReadFile(filepath.Join(repoRoot(t), "docs", "layout", "SPEC.md"))
+	example, err := layoutdoc.Example(heading)
 	if err != nil {
-		t.Fatalf("read the layout SPEC: %v", err)
+		t.Fatalf("read the layout SPEC's worked example: %v", err)
 	}
 
-	return string(b)
-}
-
-// repoRoot walks up from the test's working directory to the directory holding
-// go.mod, which for this module is the repository root and so the directory
-// docs/ sits in.
-func repoRoot(t *testing.T) string {
-	t.Helper()
-
-	dir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("working directory: %v", err)
-	}
-
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatal("no go.mod above the test's working directory")
-		}
-
-		dir = parent
-	}
+	return example
 }

--- a/internal/layoutdoc/doc.go
+++ b/internal/layoutdoc/doc.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Package layoutdoc reads docs/layout/SPEC.md's worked examples out of the
+// document itself.
+//
+// Three packages check the layouts that document shows an adopter —
+// [github.com/Zaba505/cpybkc/internal/layout] parses them,
+// [github.com/Zaba505/cpybkc/internal/layoutschema] validates them against the
+// published schema, and [github.com/Zaba505/cpybkc/internal/layoutmodel] reads
+// every layer out of them — and each of them reads the example rather than
+// carrying a copy of it. A copy is a second thing to keep right, and the one
+// that is wrong is always the one nobody runs: an adopter runs the document.
+//
+// # A heading per example
+//
+// A worked example is located by the heading of the section it sits under, and
+// is the first fenced block there. The alternative was an anchor of some kind
+// inside one section holding both, and the reason against it is what happens
+// when a third example is added: with one section per example the new heading
+// terminates the previous section, so what an existing heading extracts cannot
+// move, while under a shared section the identity of every block is its
+// position among the others and an example inserted above the first silently
+// retargets every package that reads it.
+//
+// It is also the answer this repository already gave. .dagger/worked_example.go
+// reads docs/container/SPEC.md's two worked examples by heading, one constant
+// each, for the same reason — so a second convention here would be a second
+// convention and not a decision.
+//
+// # Why this is a package and not a helper per test
+//
+// It was a helper per test for as long as two packages wanted one, with
+// [github.com/Zaba505/cpybkc/internal/layoutmodel] carrying a note saying that
+// two copies were worth leaving until a third package wanted one. Two examples
+// read by three packages is that arrival: what they share is one reading of the
+// document, and three readings of it are three chances to disagree about which
+// block is which.
+//
+// The functions here return errors rather than taking a [testing.TB], so that
+// nothing outside a test's own file decides what a missing section means, and
+// so that a package whose only consumers are tests does not put the testing
+// flags into every binary that links it.
+package layoutdoc

--- a/internal/layoutdoc/layoutdoc.go
+++ b/internal/layoutdoc/layoutdoc.go
@@ -25,13 +25,16 @@ const (
 	// partner in ASCII and was never converted.
 	NativeExample = "## Appendix: A layout, end to end"
 
-	// ConvertedExample is the layout for the same shop's file after an
-	// EBCDIC-to-ASCII conversion: ASCII characters, translated-EBCDIC signs,
-	// big-endian binary, and the items the conversion did not reach. It is the
-	// combination "All four, always, with no default for any" calls the one
-	// real files hit most often.
+	// ConvertedExample is the layout for a file of the same shop's that an
+	// EBCDIC-to-ASCII conversion delivered: ASCII characters,
+	// translated-EBCDIC signs, big-endian binary, and the items the conversion
+	// did not reach. It is the combination "All four, always, with no default
+	// for any" calls the one real files hit most often.
 	ConvertedExample = "## Appendix: A converted file, end to end"
 )
+
+// fence opens and closes a Markdown code block in this document.
+const fence = "```"
 
 // specPath is the document, relative to the repository root.
 var specPath = filepath.Join("docs", "layout", "SPEC.md")
@@ -39,29 +42,47 @@ var specPath = filepath.Join("docs", "layout", "SPEC.md")
 // Example returns the layout under heading: the first fenced block in that
 // section.
 //
-// First rather than only, because a section is prose as well as a layout and
-// may illustrate a form beside it. What every caller here wants is the layout
-// the section is about, and it opens the section for exactly that reason.
+// A worked example's section carries exactly one fenced block and that block is
+// the layout — which is a rule about how the document is written, and is
+// asserted rather than assumed by this package's own tests. First rather than
+// only because [Blocks] serves the sections that illustrate a form and then
+// show it used, and one function that means "the layout here" is easier to read
+// at a call site than an index.
 func Example(heading string) (string, error) {
 	blocks, err := Blocks(heading)
 	if err != nil {
 		return "", err
 	}
 
+	// Blocks already refuses an empty result, and this says so at the point a
+	// reader would otherwise have to go and confirm it — a later relaxation of
+	// that guard is then an error here rather than a panic.
+	if len(blocks) == 0 {
+		return "", fmt.Errorf("layoutdoc: %q carries no fenced code block", heading)
+	}
+
 	return blocks[0], nil
 }
 
 // Blocks returns every fenced code block under heading, in the order the
-// document writes them, and fails where there are none — a section that was
-// meant to carry a layout and carries none is the staleness these readings
-// exist to catch, and an empty result handed back would be a check that passed
-// over nothing.
+// document writes them.
+//
+// A section with no block, a block that is empty and a fence that is never
+// closed are each an error rather than a result. All three are the same hazard:
+// an empty layout parses, validates and reads as nothing at all, so a check
+// resting on one passes over nothing and says so nowhere.
 func Blocks(heading string) ([]string, error) {
 	body, err := Section(heading)
 	if err != nil {
 		return nil, err
 	}
 
+	return blocksIn(body, heading)
+}
+
+// blocksIn is [Blocks] over a body already read, which is what makes its
+// failures reachable from a test.
+func blocksIn(body, where string) ([]string, error) {
 	var (
 		blocks []string
 		block  []string
@@ -69,8 +90,12 @@ func Blocks(heading string) ([]string, error) {
 	)
 
 	for line := range strings.SplitSeq(body, "\n") {
-		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+		if strings.HasPrefix(strings.TrimSpace(line), fence) {
 			if open {
+				if strings.TrimSpace(strings.Join(block, "\n")) == "" {
+					return nil, fmt.Errorf("layoutdoc: a fenced code block under %q is empty", where)
+				}
+
 				blocks = append(blocks, strings.Join(block, "\n"))
 				block = nil
 			}
@@ -86,11 +111,11 @@ func Blocks(heading string) ([]string, error) {
 	}
 
 	if open {
-		return nil, fmt.Errorf("layoutdoc: a fenced code block under %q is not closed", heading)
+		return nil, fmt.Errorf("layoutdoc: a fenced code block under %q is not closed", where)
 	}
 
 	if len(blocks) == 0 {
-		return nil, fmt.Errorf("layoutdoc: %q carries no fenced code block", heading)
+		return nil, fmt.Errorf("layoutdoc: %q carries no fenced code block", where)
 	}
 
 	return blocks, nil
@@ -103,11 +128,17 @@ func Blocks(heading string) ([]string, error) {
 // example added after another one ends the section before it, so what an
 // existing heading extracts does not move.
 func Section(heading string) (string, error) {
-	text, err := Text()
+	text, err := specText()
 	if err != nil {
 		return "", err
 	}
 
+	return sectionIn(text, heading)
+}
+
+// sectionIn is [Section] over a document already read, which is what makes its
+// failures reachable from a test.
+func sectionIn(text, heading string) (string, error) {
 	level := headingLevel(heading)
 	if level == 0 {
 		return "", fmt.Errorf("layoutdoc: %q is not a Markdown heading", heading)
@@ -116,10 +147,23 @@ func Section(heading string) (string, error) {
 	var (
 		body  []string
 		found bool
+		open  bool
 	)
 
 	for line := range strings.SplitSeq(text, "\n") {
-		if line == heading {
+		// Fenced text is not the document's structure. A section bounded
+		// without tracking this ends on the first `# ` comment in a shell or
+		// YAML snippet, which is the same silently-truncated section
+		// [headingLevel] exists to prevent, reached by another road.
+		if strings.HasPrefix(strings.TrimSpace(line), fence) {
+			open = !open
+		}
+
+		if !open && line == heading {
+			if found {
+				return "", fmt.Errorf("layoutdoc: %s carries the heading %q more than once", specPath, heading)
+			}
+
 			found = true
 
 			continue
@@ -129,8 +173,10 @@ func Section(heading string) (string, error) {
 			continue
 		}
 
-		if next := headingLevel(line); next > 0 && next <= level {
-			break
+		if !open {
+			if next := headingLevel(line); next > 0 && next <= level {
+				break
+			}
 		}
 
 		body = append(body, line)
@@ -166,8 +212,12 @@ func headingLevel(line string) int {
 	return level
 }
 
-// Text returns the whole of docs/layout/SPEC.md.
-func Text() (string, error) {
+// specText returns the whole of docs/layout/SPEC.md.
+//
+// Unexported, because a caller handed the document reads it however it likes,
+// and three packages reading it however they liked is what this package was
+// made to end.
+func specText() (string, error) {
 	root, err := repoRoot()
 	if err != nil {
 		return "", err

--- a/internal/layoutdoc/layoutdoc.go
+++ b/internal/layoutdoc/layoutdoc.go
@@ -1,0 +1,206 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layoutdoc
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// The headings of the worked examples in docs/layout/SPEC.md, each matched as a
+// whole line.
+//
+// One constant per example, because the heading is what locates it: a package
+// naming the example it wants names one of these and never a position among the
+// document's fenced blocks.
+const (
+	// NativeExample is the layout for a file as the mainframe holds it —
+	// cp037 characters, EBCDIC signs, and a single field that arrived from a
+	// partner in ASCII and was never converted.
+	NativeExample = "## Appendix: A layout, end to end"
+
+	// ConvertedExample is the layout for the same shop's file after an
+	// EBCDIC-to-ASCII conversion: ASCII characters, translated-EBCDIC signs,
+	// big-endian binary, and the items the conversion did not reach. It is the
+	// combination "All four, always, with no default for any" calls the one
+	// real files hit most often.
+	ConvertedExample = "## Appendix: A converted file, end to end"
+)
+
+// specPath is the document, relative to the repository root.
+var specPath = filepath.Join("docs", "layout", "SPEC.md")
+
+// Example returns the layout under heading: the first fenced block in that
+// section.
+//
+// First rather than only, because a section is prose as well as a layout and
+// may illustrate a form beside it. What every caller here wants is the layout
+// the section is about, and it opens the section for exactly that reason.
+func Example(heading string) (string, error) {
+	blocks, err := Blocks(heading)
+	if err != nil {
+		return "", err
+	}
+
+	return blocks[0], nil
+}
+
+// Blocks returns every fenced code block under heading, in the order the
+// document writes them, and fails where there are none — a section that was
+// meant to carry a layout and carries none is the staleness these readings
+// exist to catch, and an empty result handed back would be a check that passed
+// over nothing.
+func Blocks(heading string) ([]string, error) {
+	body, err := Section(heading)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		blocks []string
+		block  []string
+		open   bool
+	)
+
+	for line := range strings.SplitSeq(body, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+			if open {
+				blocks = append(blocks, strings.Join(block, "\n"))
+				block = nil
+			}
+
+			open = !open
+
+			continue
+		}
+
+		if open {
+			block = append(block, line)
+		}
+	}
+
+	if open {
+		return nil, fmt.Errorf("layoutdoc: a fenced code block under %q is not closed", heading)
+	}
+
+	if len(blocks) == 0 {
+		return nil, fmt.Errorf("layoutdoc: %q carries no fenced code block", heading)
+	}
+
+	return blocks, nil
+}
+
+// Section returns the text of the document under heading, up to the next
+// heading at the same level or above.
+//
+// Stopping at the same level is what makes one heading per example safe: an
+// example added after another one ends the section before it, so what an
+// existing heading extracts does not move.
+func Section(heading string) (string, error) {
+	text, err := Text()
+	if err != nil {
+		return "", err
+	}
+
+	level := headingLevel(heading)
+	if level == 0 {
+		return "", fmt.Errorf("layoutdoc: %q is not a Markdown heading", heading)
+	}
+
+	var (
+		body  []string
+		found bool
+	)
+
+	for line := range strings.SplitSeq(text, "\n") {
+		if line == heading {
+			found = true
+
+			continue
+		}
+
+		if !found {
+			continue
+		}
+
+		if next := headingLevel(line); next > 0 && next <= level {
+			break
+		}
+
+		body = append(body, line)
+	}
+
+	if !found {
+		return "", fmt.Errorf("layoutdoc: %s carries no heading %q", specPath, heading)
+	}
+
+	return strings.Join(body, "\n"), nil
+}
+
+// headingLevel is the number of leading number signs on an ATX heading, and 0
+// for a line that is not one.
+//
+// The space matters and is not pedantry. This document wraps its prose, and a
+// sentence closing a parenthesis on an issue reference begins a line with
+// "#35); what is written here is the choice." — which a rule reading only the
+// leading number signs takes for a level-one heading and ends the section on,
+// several paragraphs before the layout it was asked for. Markdown requires the
+// space, and requiring it here is what tells a heading from a sentence that
+// happens to start with an issue number.
+func headingLevel(line string) int {
+	level := strings.IndexFunc(line, func(r rune) bool { return r != '#' })
+	if level <= 0 {
+		return 0
+	}
+
+	if rest := line[level:]; rest != "" && !strings.HasPrefix(rest, " ") {
+		return 0
+	}
+
+	return level
+}
+
+// Text returns the whole of docs/layout/SPEC.md.
+func Text() (string, error) {
+	root, err := repoRoot()
+	if err != nil {
+		return "", err
+	}
+
+	b, err := os.ReadFile(filepath.Join(root, specPath))
+	if err != nil {
+		return "", fmt.Errorf("layoutdoc: read %s: %w", specPath, err)
+	}
+
+	return string(b), nil
+}
+
+// repoRoot walks up from the working directory to the directory holding go.mod,
+// which for this module is the repository root and so the directory docs/ sits
+// in. A test's working directory is its own package directory, which is what
+// makes this the right answer from any of them.
+func repoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("layoutdoc: working directory: %w", err)
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", errors.New("layoutdoc: no go.mod above the working directory")
+		}
+
+		dir = parent
+	}
+}

--- a/internal/layoutdoc/layoutdoc_test.go
+++ b/internal/layoutdoc/layoutdoc_test.go
@@ -60,13 +60,31 @@ func TestOneExamplePerSectionKeepsTheOthersWhereTheyAre(t *testing.T) {
 		t.Errorf("the native example's section carries %d fenced blocks, want the one layout it is about", len(blocks))
 	}
 
-	converted, err := Example(ConvertedExample)
+	// The mirror of both checks above, on the second example. Without them only
+	// the native example's layout is pinned to position 0 of its section, and
+	// the converted one carries two subsections after its layout — which is
+	// exactly where an illustrative snippet would land, and one landing above
+	// the layout would be handed silently to every package that reads it.
+	converted, err := Section(ConvertedExample)
 	if err != nil {
-		t.Fatalf("the converted example: %v", err)
+		t.Fatalf("the converted example's section: %v", err)
 	}
 
-	if strings.Contains(native, converted) || strings.Contains(converted, blocks[0]) {
-		t.Error("the two examples extract to overlapping text, so one heading is reaching the other's layout")
+	if strings.Contains(converted, NativeExample) {
+		t.Error("the converted example's section reaches back over the native one's heading")
+	}
+
+	if strings.Contains(converted, blocks[0]) {
+		t.Error("the converted example's section carries the native example's layout, so one heading is reaching the other's")
+	}
+
+	convertedBlocks, err := Blocks(ConvertedExample)
+	if err != nil {
+		t.Fatalf("the converted example's blocks: %v", err)
+	}
+
+	if len(convertedBlocks) != 1 {
+		t.Errorf("the converted example's section carries %d fenced blocks, want the one layout it is about", len(convertedBlocks))
 	}
 }
 
@@ -127,5 +145,116 @@ func TestASentenceStartingWithAnIssueNumberIsNotAHeading(t *testing.T) {
 
 	if got := headingLevel("## Appendix: A layout, end to end"); got != 2 {
 		t.Errorf("headingLevel of a level-two heading is %d, want 2", got)
+	}
+}
+
+// TestSectionIsBoundedByHeadingsAndNotByFencedText covers the failures the
+// document does not currently produce, which is the only place they can be
+// covered: [Section] and [Blocks] read one file that is checked into this
+// repository, so every one of these would otherwise be an error path with no
+// test and a document edit away from being live.
+func TestSectionIsBoundedByHeadingsAndNotByFencedText(t *testing.T) {
+	t.Parallel()
+
+	const doc = "# Title\n" +
+		"\n" +
+		"## Wanted\n" +
+		"\n" +
+		"```\n" +
+		"# not a heading, it is a comment in a snippet\n" +
+		"(encoding (charset ascii))\n" +
+		"```\n" +
+		"\n" +
+		"### Still inside\n" +
+		"\n" +
+		"tail\n" +
+		"\n" +
+		"## Next\n" +
+		"\n" +
+		"not wanted\n"
+
+	body, err := sectionIn(doc, "## Wanted")
+	if err != nil {
+		t.Fatalf("sectionIn: %v", err)
+	}
+
+	if strings.Contains(body, "not wanted") {
+		t.Error("the section ran on past the next heading of its own level")
+	}
+
+	if !strings.Contains(body, "### Still inside") || !strings.Contains(body, "tail") {
+		t.Errorf("the section stopped before a deeper heading:\n%s", body)
+	}
+
+	blocks, err := blocksIn(body, "## Wanted")
+	if err != nil {
+		t.Fatalf("blocksIn: %v", err)
+	}
+
+	if len(blocks) != 1 {
+		t.Fatalf("read %d fenced blocks, want 1: %q", len(blocks), blocks)
+	}
+
+	// The whole point of the fence tracking: the comment line is part of the
+	// layout rather than the heading that ended the section before it.
+	if !strings.Contains(blocks[0], "# not a heading") || !strings.Contains(blocks[0], "(encoding (charset ascii))") {
+		t.Errorf("the fenced block lost its comment line or its layout:\n%s", blocks[0])
+	}
+}
+
+// TestADocumentThatCannotBeReadUnambiguouslyIsAnError keeps every one of these
+// an error rather than a plausible-looking answer. Each of them yields an empty
+// or a merged layout, and an empty layout parses, validates and reads as
+// nothing at all — so the check resting on it passes over nothing.
+func TestADocumentThatCannotBeReadUnambiguouslyIsAnError(t *testing.T) {
+	t.Parallel()
+
+	sections := map[string]struct {
+		doc     string
+		heading string
+	}{
+		"a heading the document does not carry": {
+			doc:     "## Elsewhere\n\nbody\n",
+			heading: "## Wanted",
+		},
+		"a string that is not a heading": {
+			doc:     "## Wanted\n\nbody\n",
+			heading: "Wanted",
+		},
+		"number signs with no space after them": {
+			doc:     "## Wanted\n\nbody\n",
+			heading: "##Wanted",
+		},
+		"the same heading twice": {
+			doc:     "## Wanted\n\nfirst\n\n### Other\n\n## Wanted\n\nsecond\n",
+			heading: "## Wanted",
+		},
+	}
+
+	for name, tc := range sections {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if body, err := sectionIn(tc.doc, tc.heading); err == nil {
+				t.Errorf("sectionIn accepted %s and returned %q", name, body)
+			}
+		})
+	}
+
+	blocks := map[string]string{
+		"no fenced block at all":            "prose and nothing else\n",
+		"a fence that never closes":         "```\n(encoding)\n",
+		"a fenced block with nothing in it": "```\n```\n",
+		"a fenced block of whitespace":      "```\n   \n```\n",
+	}
+
+	for name, body := range blocks {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got, err := blocksIn(body, "## Wanted"); err == nil {
+				t.Errorf("blocksIn accepted %s and returned %q", name, got)
+			}
+		})
 	}
 }

--- a/internal/layoutdoc/layoutdoc_test.go
+++ b/internal/layoutdoc/layoutdoc_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package layoutdoc
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestEveryWorkedExampleIsFound is the check the three reading packages rest
+// on. Each of them names a heading and expects a layout; a heading the document
+// no longer carries is a rename nobody noticed, and it is a failure here rather
+// than three identical failures further out.
+func TestEveryWorkedExampleIsFound(t *testing.T) {
+	t.Parallel()
+
+	for _, heading := range []string{NativeExample, ConvertedExample} {
+		example, err := Example(heading)
+		if err != nil {
+			t.Errorf("%q: %v", heading, err)
+
+			continue
+		}
+
+		if !strings.Contains(example, "(encoding\n") {
+			t.Errorf("the example under %q states no encoding profile:\n%s", heading, example)
+		}
+	}
+}
+
+// TestOneExamplePerSectionKeepsTheOthersWhereTheyAre is the property that makes
+// a heading per example the right answer, asserted rather than assumed: an
+// example added to the document ends the section before it, so what an existing
+// heading extracts cannot move.
+//
+// The failure this rules out is silent. A second layout placed inside the first
+// one's section would be found by no heading of its own, and one placed above it
+// would be handed to every package that asked for the first.
+func TestOneExamplePerSectionKeepsTheOthersWhereTheyAre(t *testing.T) {
+	t.Parallel()
+
+	native, err := Section(NativeExample)
+	if err != nil {
+		t.Fatalf("the native example's section: %v", err)
+	}
+
+	if strings.Contains(native, ConvertedExample) {
+		t.Error("the native example's section runs on into the converted one, so the two are not separated by their headings")
+	}
+
+	blocks, err := Blocks(NativeExample)
+	if err != nil {
+		t.Fatalf("the native example's blocks: %v", err)
+	}
+
+	if len(blocks) != 1 {
+		t.Errorf("the native example's section carries %d fenced blocks, want the one layout it is about", len(blocks))
+	}
+
+	converted, err := Example(ConvertedExample)
+	if err != nil {
+		t.Fatalf("the converted example: %v", err)
+	}
+
+	if strings.Contains(native, converted) || strings.Contains(converted, blocks[0]) {
+		t.Error("the two examples extract to overlapping text, so one heading is reaching the other's layout")
+	}
+}
+
+// TestAHeadingTheDocumentDoesNotCarryIsAnError keeps a missing section an error
+// rather than an empty string. An empty layout parses, validates and reads as
+// nothing at all, so a reading that returned one would turn every check resting
+// on it into a check of nothing.
+func TestAHeadingTheDocumentDoesNotCarryIsAnError(t *testing.T) {
+	t.Parallel()
+
+	if _, err := Section("## Appendix: A heading nobody wrote"); err == nil {
+		t.Error("Section accepted a heading the document does not carry")
+	}
+
+	if _, err := Example("not a heading at all"); err == nil {
+		t.Error("Example accepted a string that is not a Markdown heading")
+	}
+}
+
+// TestASentenceStartingWithAnIssueNumberIsNotAHeading is a regression, and the
+// reason a section is bounded by [headingLevel] rather than by a leading number
+// sign.
+//
+// docs/layout/SPEC.md wraps its prose at the same width everywhere, and one
+// wrapped line under "A discriminator for a redefine inside a table" begins
+// "#35); what is written here is the choice." A rule counting only the number
+// signs reads that as a level-one heading and hands back a section ending
+// several paragraphs before the layout it was asked for — which is a fenced
+// block that silently is not there rather than an error.
+func TestASentenceStartingWithAnIssueNumberIsNotAHeading(t *testing.T) {
+	t.Parallel()
+
+	const heading = "### A discriminator for a redefine inside a table"
+
+	body, err := Section(heading)
+	if err != nil {
+		t.Fatalf("%q: %v", heading, err)
+	}
+
+	if !strings.Contains(body, "#35); what is written here is the choice.") {
+		t.Fatalf("the wrapped line this test is about is no longer in %q; the regression it guards has moved", heading)
+	}
+
+	blocks, err := Blocks(heading)
+	if err != nil {
+		t.Fatalf("%q: %v", heading, err)
+	}
+
+	if len(blocks) != 2 {
+		t.Errorf("%q carries %d fenced blocks, want the skeleton and the layout after it", heading, len(blocks))
+	}
+
+	for _, line := range []string{"#", "#not a heading", "###nospace"} {
+		if got := headingLevel(line); got != 0 {
+			t.Errorf("headingLevel(%q) is %d, want 0 — it is not an ATX heading", line, got)
+		}
+	}
+
+	if got := headingLevel("## Appendix: A layout, end to end"); got != 2 {
+		t.Errorf("headingLevel of a level-two heading is %d, want 2", got)
+	}
+}

--- a/internal/layoutmodel/discriminate_test.go
+++ b/internal/layoutmodel/discriminate_test.go
@@ -8,12 +8,11 @@ package layoutmodel
 import (
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/Zaba505/cpybkc/internal/layout"
+	"github.com/Zaba505/cpybkc/internal/layoutdoc"
 )
 
 // discriminationOf is the whole pipeline a caller runs: parse the source, then
@@ -627,7 +626,7 @@ func TestDiscriminationFaultsAreAssertable(t *testing.T) {
 func TestTheSpecsWorkedExampleDiscriminates(t *testing.T) {
 	t.Parallel()
 
-	read, err := discriminationOf(t, specExample(t))
+	read, err := discriminationOf(t, specExample(t, layoutdoc.NativeExample))
 	if err != nil {
 		t.Fatalf("the reader rejects SPEC.md's own worked example: %v", err)
 	}
@@ -687,31 +686,25 @@ func TestTheSpecsVariantExampleDiscriminates(t *testing.T) {
 // a redefine inside a table", which is the last one in that subsection: the
 // first is the form's skeleton, and a skeleton is placeholders rather than a
 // layout.
+//
+// The last rather than the first, so this reads
+// [github.com/Zaba505/cpybkc/internal/layoutdoc.Blocks] where the worked
+// examples read Example. That a subsection may carry more than one block is
+// exactly why a worked example gets a heading to itself rather than a position
+// among a section's blocks.
 func specVariantExample(t *testing.T) string {
 	t.Helper()
 
 	const heading = "### A discriminator for a redefine inside a table"
 
-	spec, err := os.ReadFile(filepath.Join(repoRoot(t), "docs", "layout", "SPEC.md"))
+	blocks, err := layoutdoc.Blocks(heading)
 	if err != nil {
 		t.Fatalf("read the layout SPEC: %v", err)
 	}
 
-	_, subsection, found := strings.Cut(string(spec), heading+"\n")
-	if !found {
-		t.Fatalf("the layout SPEC has no %q subsection", heading)
+	if len(blocks) < 2 {
+		t.Fatalf("the %q subsection carries %d fenced blocks, want the skeleton and a layout", heading, len(blocks))
 	}
 
-	if next := strings.Index(subsection, "\n### "); next >= 0 {
-		subsection = subsection[:next]
-	}
-
-	blocks := strings.Split(subsection, "```")
-	if len(blocks) < 5 {
-		t.Fatalf("the %q subsection carries fewer than two fenced blocks", heading)
-	}
-
-	// The fences split the text into alternating prose and blocks, so the last
-	// block is the second-to-last field.
-	return blocks[len(blocks)-2]
+	return blocks[len(blocks)-1]
 }

--- a/internal/layoutmodel/discriminate_test.go
+++ b/internal/layoutmodel/discriminate_test.go
@@ -692,6 +692,13 @@ func TestTheSpecsVariantExampleDiscriminates(t *testing.T) {
 // examples read Example. That a subsection may carry more than one block is
 // exactly why a worked example gets a heading to itself rather than a position
 // among a section's blocks.
+//
+// The bound moved when this converged on that package, and in the safe
+// direction. The reading it replaced ended the subsection at the next "### "
+// and at nothing else, so a "## " or "# " heading in between left the
+// subsection running on and the last block could have belonged to a later
+// section; Blocks ends it at any heading of level three or above. The two agree
+// on the document as it stands, which is what the block count below asserts.
 func specVariantExample(t *testing.T) string {
 	t.Helper()
 

--- a/internal/layoutmodel/framing_test.go
+++ b/internal/layoutmodel/framing_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/Zaba505/cpybkc/internal/layout"
+	"github.com/Zaba505/cpybkc/internal/layoutdoc"
 )
 
 // framingOf is the whole pipeline a caller runs: parse the source, then read the
@@ -841,7 +842,7 @@ func TestFramingFaultsAreAssertable(t *testing.T) {
 func TestTheSpecsWorkedExampleFrames(t *testing.T) {
 	t.Parallel()
 
-	read, err := framingOf(t, specExample(t))
+	read, err := framingOf(t, specExample(t, layoutdoc.NativeExample))
 	if err != nil {
 		t.Fatalf("the reader rejects SPEC.md's own worked example: %v", err)
 	}

--- a/internal/layoutmodel/profile_test.go
+++ b/internal/layoutmodel/profile_test.go
@@ -8,12 +8,11 @@ package layoutmodel
 import (
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/Zaba505/cpybkc/internal/layout"
+	"github.com/Zaba505/cpybkc/internal/layoutdoc"
 )
 
 // profile is the whole pipeline a caller runs: parse the source, then read the
@@ -605,9 +604,9 @@ func TestFaultsAreAssertable(t *testing.T) {
 
 // TestTheSpecsWorkedExampleReads is the staleness gate over the layer.
 //
-// docs/layout/SPEC.md's "A layout, end to end" appendix is the layout the
-// document shows an adopter, and it is read out of the document rather than
-// copied here for the reason
+// docs/layout/SPEC.md's "A layout, end to end" appendix is one of the two
+// layouts the document shows an adopter, and it is read out of the document
+// rather than copied here for the reason
 // [github.com/Zaba505/cpybkc/internal/layout]'s tests read it: an encoding form
 // the example writes and this reader does not read would otherwise be invisible
 // until somebody pasted the example into a file.
@@ -617,7 +616,7 @@ func TestFaultsAreAssertable(t *testing.T) {
 func TestTheSpecsWorkedExampleReads(t *testing.T) {
 	t.Parallel()
 
-	read, err := profile(t, specExample(t))
+	read, err := profile(t, specExample(t, layoutdoc.NativeExample))
 	if err != nil {
 		t.Fatalf("the reader rejects SPEC.md's own worked example: %v", err)
 	}
@@ -652,60 +651,91 @@ func TestTheSpecsWorkedExampleReads(t *testing.T) {
 	}
 }
 
-// specExample returns the layout in docs/layout/SPEC.md's "A layout, end to end"
-// appendix: the first fenced block under that heading.
+// TestTheSpecsConvertedExampleReads is the same gate over the second layout, and
+// over the claim the layer exists to make.
 //
-// [github.com/Zaba505/cpybkc/internal/layout]'s tests read the same block, with
-// their own copy of this. Two are a duplication worth leaving until a third
-// package wants one, at which point what they share is a helper and not three
-// readings of a document.
-func specExample(t *testing.T) string {
+// "All four, always, with no default for any" says the combination real files
+// hit most often is one no compiler produces — ASCII characters, EBCDIC signs
+// and mainframe byte order — and that it is expressible only because the four
+// axes are stated separately. Until the second appendix that claim was made in
+// prose and shown nowhere, so nothing here read it. This is the layout that
+// makes it, read back one axis at a time.
+//
+// It earns two things the native example cannot. Two overrides on one profile,
+// which is what makes "an override is per item" a rule the reader is held to
+// rather than a sentence; and `none` on the charset axis of one of them, which
+// is the only value an override admits that a profile does not.
+func TestTheSpecsConvertedExampleReads(t *testing.T) {
+	t.Parallel()
+
+	read, err := profile(t, specExample(t, layoutdoc.ConvertedExample))
+	if err != nil {
+		t.Fatalf("the reader rejects SPEC.md's own converted example: %v", err)
+	}
+
+	want := Axes{
+		Charset:        ASCII,
+		SignConvention: SignTranslatedEBCDIC,
+		ByteOrder:      BigEndian,
+		FloatFormat:    HFP,
+	}
+
+	if read.Axes != want {
+		t.Errorf("the profile reads as %+v, want %+v", read.Axes, want)
+	}
+
+	// The two overrides, in the order the layout writes them, and what each one
+	// leaves the profile saying. The payload item moves one axis and the
+	// passed-through block moves two, which is the whole of "an override
+	// replaces the profile's value axis by axis, for that item alone".
+	payload := want
+	payload.Charset = None
+
+	passthrough := want
+	passthrough.Charset = CP037
+	passthrough.SignConvention = SignEBCDIC
+
+	wantOverrides := []struct {
+		item    string
+		applied Axes
+	}{
+		{item: "(item SETTLE-DETAIL SD-REGION)", applied: payload},
+		{item: "(item SETTLE-HEADER SH-PASSTHROUGH)", applied: passthrough},
+	}
+
+	if len(read.Overrides) != len(wantOverrides) {
+		t.Fatalf("read %d overrides out of the converted appendix, want %d", len(read.Overrides), len(wantOverrides))
+	}
+
+	for i, want := range wantOverrides {
+		override := read.Overrides[i]
+
+		if got := override.Item.String(); got != want.item {
+			t.Errorf("override %d is on %s, want %s", i, got, want.item)
+		}
+
+		if got := read.Applied(override); got != want.applied {
+			t.Errorf("override %d applies as %+v, want %+v", i, got, want.applied)
+		}
+	}
+}
+
+// specExample returns the worked example under heading in docs/layout/SPEC.md.
+//
+// This package, [github.com/Zaba505/cpybkc/internal/layout] and
+// [github.com/Zaba505/cpybkc/internal/layoutschema] now share one reading of
+// the document, which is what the note that used to sit here asked for: two
+// copies were worth leaving until a third package wanted one. Two examples read
+// by three packages is that arrival, and
+// [github.com/Zaba505/cpybkc/internal/layoutdoc] is the helper it became — see
+// there for why an example is located by a heading of its own.
+func specExample(t *testing.T, heading string) string {
 	t.Helper()
 
-	spec, err := os.ReadFile(filepath.Join(repoRoot(t), "docs", "layout", "SPEC.md"))
+	example, err := layoutdoc.Example(heading)
 	if err != nil {
-		t.Fatalf("read the layout SPEC: %v", err)
-	}
-
-	_, appendix, found := strings.Cut(string(spec), "## Appendix: A layout, end to end")
-	if !found {
-		t.Fatal("the layout SPEC has no \"A layout, end to end\" appendix")
-	}
-
-	_, block, found := strings.Cut(appendix, "```\n")
-	if !found {
-		t.Fatal("the appendix carries no fenced code block")
-	}
-
-	example, _, found := strings.Cut(block, "```")
-	if !found {
-		t.Fatal("the appendix's fenced code block is not closed")
+		t.Fatalf("read the layout SPEC's worked example: %v", err)
 	}
 
 	return example
-}
-
-// repoRoot walks up from the test's working directory to the directory holding
-// go.mod, which for this module is the repository root and so the directory
-// docs/ sits in.
-func repoRoot(t *testing.T) string {
-	t.Helper()
-
-	dir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("working directory: %v", err)
-	}
-
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatal("no go.mod above the test's working directory")
-		}
-
-		dir = parent
-	}
 }

--- a/internal/layoutmodel/rename_test.go
+++ b/internal/layoutmodel/rename_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/Zaba505/cpybkc/internal/layout"
+	"github.com/Zaba505/cpybkc/internal/layoutdoc"
 )
 
 // renamesOf is the whole pipeline a caller runs: parse the source, then read the
@@ -569,7 +570,7 @@ func TestRenameFaultsAreAssertable(t *testing.T) {
 func TestTheSpecsWorkedExampleRenames(t *testing.T) {
 	t.Parallel()
 
-	read, err := renamesOf(t, specExample(t))
+	read, err := renamesOf(t, specExample(t, layoutdoc.NativeExample))
 	if err != nil {
 		t.Fatalf("the reader rejects SPEC.md's own worked example: %v", err)
 	}

--- a/internal/layoutmodel/sequence_test.go
+++ b/internal/layoutmodel/sequence_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/Zaba505/cpybkc/internal/layout"
+	"github.com/Zaba505/cpybkc/internal/layoutdoc"
 )
 
 // sequenceOf is the whole pipeline a caller runs: parse the source, then read
@@ -724,7 +725,7 @@ func TestSequenceFaultsAreAssertable(t *testing.T) {
 func TestTheSpecsWorkedExampleSequences(t *testing.T) {
 	t.Parallel()
 
-	read, err := sequenceOf(t, specExample(t))
+	read, err := sequenceOf(t, specExample(t, layoutdoc.NativeExample))
 	if err != nil {
 		t.Fatalf("the reader rejects SPEC.md's own worked example: %v", err)
 	}
@@ -735,5 +736,31 @@ func TestTheSpecsWorkedExampleSequences(t *testing.T) {
 
 	if got := read.String(); got != want {
 		t.Errorf("the example sequences as\n%s\nwant\n%s", got, want)
+	}
+}
+
+// TestTheSpecsConvertedExampleSequences is the same gate over the second layout
+// the document shows an adopter.
+//
+// The converted example is about the encoding profile and its sequence is
+// ordinary, which is exactly why it is read here: a form the example writes and
+// no reader reads is the failure this gate exists to prevent, and "the
+// interesting part is elsewhere" is how a second example stops being read at
+// all. It writes one shape the native example does not — a `?` beside a
+// `times`, an optional trailer rather than a flagged one.
+func TestTheSpecsConvertedExampleSequences(t *testing.T) {
+	t.Parallel()
+
+	read, err := sequenceOf(t, specExample(t, layoutdoc.ConvertedExample))
+	if err != nil {
+		t.Fatalf("the reader rejects SPEC.md's own converted example: %v", err)
+	}
+
+	want := "(sequence (seq SETTLE-HEADER " +
+		"(times SETTLE-DETAIL (item SETTLE-HEADER SH-DETAIL-COUNT)) " +
+		"(? SETTLE-TRAILER)))"
+
+	if got := read.String(); got != want {
+		t.Errorf("the converted example sequences as\n%s\nwant\n%s", got, want)
 	}
 }

--- a/internal/layoutschema/schema_test.go
+++ b/internal/layoutschema/schema_test.go
@@ -11,6 +11,8 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/layoutdoc"
 )
 
 // TestThePublishedSchemaLoads is the floor under everything else here: the file
@@ -223,7 +225,7 @@ func specTopLevelForms(t *testing.T) map[string]specTopLevelForm {
 
 	rows := make(map[string]specTopLevelForm)
 
-	for line := range strings.SplitSeq(section(t, "### The top-level forms"), "\n") {
+	for line := range strings.SplitSeq(specSection(t, "### The top-level forms"), "\n") {
 		cells := tableRow(line)
 		if len(cells) != 3 || !strings.HasPrefix(cells[0], "`") {
 			continue
@@ -255,53 +257,20 @@ func tableRow(line string) []string {
 	return cells
 }
 
-// section returns the text of SPEC.md under heading, up to the next heading at
-// the same level or above.
-func section(t *testing.T, heading string) string {
+// specSection returns the text of docs/layout/SPEC.md under heading.
+//
+// One reading of the document for this package, internal/layout and
+// internal/layoutmodel — see [github.com/Zaba505/cpybkc/internal/layoutdoc] for
+// why they share one and why a worked example is located by its own heading.
+func specSection(t *testing.T, heading string) string {
 	t.Helper()
 
-	level := strings.IndexFunc(heading, func(r rune) bool { return r != '#' })
-
-	var (
-		body  []string
-		found bool
-	)
-
-	for line := range strings.SplitSeq(specText(t), "\n") {
-		if line == heading {
-			found = true
-
-			continue
-		}
-
-		if !found {
-			continue
-		}
-
-		if strings.HasPrefix(line, "#") && strings.IndexFunc(line, func(r rune) bool { return r != '#' }) <= level {
-			break
-		}
-
-		body = append(body, line)
-	}
-
-	if !found {
-		t.Fatalf("SPEC.md carries no heading %q", heading)
-	}
-
-	return strings.Join(body, "\n")
-}
-
-// specText reads docs/layout/SPEC.md.
-func specText(t *testing.T) string {
-	t.Helper()
-
-	b, err := os.ReadFile(filepath.Join(repoRoot(t), "docs", "layout", "SPEC.md"))
+	body, err := layoutdoc.Section(heading)
 	if err != nil {
 		t.Fatalf("read the layout SPEC: %v", err)
 	}
 
-	return string(b)
+	return body
 }
 
 // publishedSchema loads schema/layout.sexpr — the file a release publishes and

--- a/internal/layoutschema/validate_test.go
+++ b/internal/layoutschema/validate_test.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Zaba505/cpybkc/internal/layoutdoc"
 )
 
 // TestValidLayoutsValidate is half of the acceptance criterion the corpus
@@ -95,13 +97,13 @@ func TestInvalidLayoutsAreRejected(t *testing.T) {
 // itself.
 //
 // docs/layout/SPEC.md's "A layout, end to end" appendix is the layout the
-// document shows an adopter, and it is the one layout in this repository nobody
-// wrote to satisfy the schema. Reading it out of the document rather than
+// document shows an adopter, and it is one of the two layouts in this
+// repository nobody wrote to satisfy the schema. Reading it out of the document rather than
 // copying it here is the point: a change to the notation that the appendix
 // followed and the schema did not would otherwise be invisible until an adopter
 // pasted the example into a file.
 func TestTheSpecsWorkedExampleValidates(t *testing.T) {
-	example := fencedBlock(t, section(t, "## Appendix: A layout, end to end"))
+	example := specExample(t, layoutdoc.NativeExample)
 
 	diagnostics, err := publishedSchema(t).Validate("SPEC.md", strings.NewReader(example))
 	if err != nil {
@@ -110,6 +112,27 @@ func TestTheSpecsWorkedExampleValidates(t *testing.T) {
 
 	for _, diagnostic := range diagnostics {
 		t.Errorf("the schema rejects SPEC.md's own worked example: %s", diagnostic)
+	}
+}
+
+// TestTheSpecsConvertedExampleValidates is the same gate over the second layout
+// the document shows an adopter.
+//
+// A second appendix and so a second heading, for the reason
+// [github.com/Zaba505/cpybkc/internal/layoutdoc] gives. What the schema earns
+// over the native example is the forms that example has no reason to write: two
+// overrides on one layout, `none` on the charset axis of one of them, and a
+// `?` where the native example writes a `when`.
+func TestTheSpecsConvertedExampleValidates(t *testing.T) {
+	example := specExample(t, layoutdoc.ConvertedExample)
+
+	diagnostics, err := publishedSchema(t).Validate("SPEC.md", strings.NewReader(example))
+	if err != nil {
+		t.Fatalf("validate the SPEC's converted example: %v", err)
+	}
+
+	for _, diagnostic := range diagnostics {
+		t.Errorf("the schema rejects SPEC.md's own converted example: %s", diagnostic)
 	}
 }
 
@@ -225,34 +248,16 @@ func TestValidateFailsOnSourceThatIsNotSExpressions(t *testing.T) {
 	}
 }
 
-// fencedBlock returns the first fenced code block in body.
-func fencedBlock(t *testing.T, body string) string {
+// specExample returns the worked example under heading in docs/layout/SPEC.md.
+func specExample(t *testing.T, heading string) string {
 	t.Helper()
 
-	var (
-		block []string
-		open  bool
-	)
-
-	for line := range strings.SplitSeq(body, "\n") {
-		if strings.HasPrefix(strings.TrimSpace(line), "```") {
-			if open {
-				return strings.Join(block, "\n")
-			}
-
-			open = true
-
-			continue
-		}
-
-		if open {
-			block = append(block, line)
-		}
+	example, err := layoutdoc.Example(heading)
+	if err != nil {
+		t.Fatalf("read the layout SPEC's worked example: %v", err)
 	}
 
-	t.Fatal("no fenced code block found")
-
-	return ""
+	return example
 }
 
 // layouts returns the names of every layout in one of the corpus directories.


### PR DESCRIPTION
Closes #273.

`docs/layout/SPEC.md` gains a second worked example — a mainframe-written file
converted to ASCII, which is the combination the document itself calls "the one
real files hit most often" and the one an adopter could previously read off no
example at all.

## The decision the story left open

**Extraction takes a heading per example.** The new example is an appendix of
its own, `## Appendix: A converted file, end to end`, placed *after* the
existing one. `section` already stops at the next heading of the same level or
above, so a new example ends the section before it and what an existing heading
extracts cannot move. The alternative — a second block under one heading,
addressed by position — is the failure the story names: an example inserted
above the first silently retargets every package reading it.

It is also the answer this repository already gave. `.dagger/worked_example.go`
reads `docs/container/SPEC.md`'s two worked examples by heading, one constant
each. A second convention here would have been a second convention rather than
a decision.

**The third copy converged, into `internal/layoutdoc`.** `profile_test.go`
carried a standing note that two hand-rolled readings were "worth leaving until
a third package wants one, at which point what they share is a helper and not
three readings of a document". Two examples read by three packages is that
arrival. The new package exports `Section`, `Blocks`, `Example` and one constant
per example; `internal/layout`, `internal/layoutschema` and `internal/layoutmodel`
now all read the document through it, and the `strings.Cut` copy in
`layoutmodel` is gone. It returns errors rather than taking a `testing.TB`, so
nothing outside a test decides what a missing section means and no binary
linking it picks up the testing flags.

## A latent bug the convergence surfaced

The old `section` helpers took the leading run of `#` as a heading level without
requiring the space Markdown requires. `docs/layout/SPEC.md` wraps its prose,
and one wrapped line under "A discriminator for a redefine inside a table"
begins `#35); what is written here is the choice.` — read as a level-one
heading, it ended that section several paragraphs before the layout it was asked
for. It never bit, because the two callers of `section` asked for headings whose
sections carry no such line; `layoutmodel`'s hand-rolled reader used a different
rule and so did not hit it either. `layoutdoc.headingLevel` requires the space,
and `TestASentenceStartingWithAnIssueNumberIsNotAHeading` pins it.

## Acceptance criteria

- [x] **A second worked example, beside the first and not replacing it** — a
      converted file stating `ascii` / `translated-ebcdic` / `big-endian` /
      `hfp`, with two `encoding-override` forms doing work the profile cannot:
      `(charset none)` on a payload item, and `(charset cp037)` +
      `(sign-convention ebcdic)` on a block the transfer passed through.
- [x] **The prose names the symptom, not only the axes** — the appendix opens on
      a `PIC S9(5)` field that reads `1234E`, `1234{` or `1234}`, and "Why the
      field reads as punctuation" derives it from the zone nibble. The `"` of
      `0x7F` is named too, as the *different* finding it is: punctuation inside
      a binary or packed field is a conversion that rewrote bytes which were
      never characters, and it points at "Undoing a character-set conversion"
      rather than at an axis. Every byte mapping stated was checked with `iconv`
      against IBM037 and IBM1047. The two appendices cross-reference, and "What
      differs from the native layout" states the difference rather than leaving
      it to be diffed.
- [x] **The new example is parsed by tests, on the same ground the first one is**
      — `TestTheSpecsConvertedExampleParses` (`internal/layout`),
      `TestTheSpecsConvertedExampleValidates` (`internal/layoutschema`),
      `TestTheSpecsConvertedExampleReads` and
      `TestTheSpecsConvertedExampleSequences` (`internal/layoutmodel`).
- [x] **How the extraction addresses two examples is decided, with the reason
      written down** — in `internal/layoutdoc/doc.go`, and all three packages
      agree on it because all three now call the same functions.
- [x] **The existing example still reads as itself** — every assertion about
      `cp037` / `ebcdic` / `big-endian` / `hfp` and the single override on
      `(item ORDER-HEADER OH-PARTNER-REF)` is untouched, including the 14
      top-level forms. Only two doc comments moved, where "the one layout in
      this repository" had become false.
- [x] **No normative text changes.** No new form, value or axis. The diff to
      `SPEC.md` is the new appendix, one cross-reference sentence closing the
      old one, and the `Mapping to Stories` row this document keeps for every
      story.

## Judgment calls

- **`(charset none)` in a converted file.** "Undoing a character-set conversion"
  says a byte item a conversion *reached* is unfixable in a layout. The example
  therefore states its extract came off a copybook-aware conversion, which is
  what makes its packed and binary items byte for byte what the mainframe wrote
  — the same claim `testdata/conformance/mixed-record-converted` already makes —
  and says so both in the layout's comment and in the prose.
- **The `Mapping to Stories` row.** Strictly this is neither the appendix nor
  test wiring. It is added anyway, because that table is how this document
  records which story implemented what, and a story missing from it is the
  staleness the table exists against.
- **Two overrides rather than one.** The story asked for at least one. Two are
  the mirror of the native example's one, and they make "an override is per
  item" something the reader is held to rather than a sentence.

## Verified

- `dagger call ci` — green, from an ordinary clone of this branch (a worktree's
  `.git` is a file, which every `dagger call` refuses).
- `go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l .` — all clean.
- The EBCDIC-to-ASCII mappings quoted in the new prose (`0xC0`→`{`, `0xC5`→`E`,
  `0xD0`→`}`, `0xD5`→`N`, `0x7F`→`"`) checked with
  `printf '\xNN' | iconv -f IBM037 -t ISO8859-1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
