### PR TITLE
story(gen-go): reuse one codec.Reader per record and per occurrence rather than constructing one

### DIFF
--- a/cmd/cpybkc-gen-go/codec.go
+++ b/cmd/cpybkc-gen-go/codec.go
@@ -77,9 +77,27 @@ type coder struct {
 	// counter is what makes a generated temporary unique inside one method.
 	counter int
 
+	// subs is, for the record being decoded, every sub-reader the walk rewinds
+	// onto an occurrence, in the order the walk reaches them. Each is declared
+	// and built once at the top of the method rather than once per occurrence;
+	// see [coder.subReaders].
+	subs []subReader
+
 	// record is the COBOL name of the record being walked, for a diagnostic
 	// composed away from the walk.
 	record string
+}
+
+// subReader is one decoder a record's decode method builds over the bytes of
+// one occurrence: the identifier it is declared under, and the table whose
+// occurrences it reads.
+type subReader struct {
+	// name is the Go identifier, unique inside the method that declares it.
+	name string
+
+	// item is the repeating group one occurrence of which it reads, as the
+	// copybook names it, for the diagnostic its construction makes.
+	item string
 }
 
 // countUse is one repeating item naming a count field: where its occurrences
@@ -290,6 +308,7 @@ func codecMethods(d *irpb.Descriptor, opts options) (string, error) {
 func (c *coder) unmarshal(name string, record *irpb.Record) (string, error) {
 	c.valueOf = make(map[uint64]string)
 	c.counter = 0
+	c.subs = nil
 	c.record = record.GetNames().GetOriginal()
 
 	s := scope{record: c.record, rw: "r", dir: decoding}
@@ -309,7 +328,37 @@ of the file in hand, and %s is what this descriptor resolved.`,
 		record.GetNames().GetOriginal(), encodingFunc))
 
 	return doc + fmt.Sprintf("func (%s *%s) UnmarshalCOBOL(r *codec.Reader) error {\n%s\nreturn nil\n}",
-		c.receiver, name, c.prologue(body.String())), nil
+		c.receiver, name, c.prologue(c.subReaders()+body.String())), nil
+}
+
+// subReaders declares and builds every sub-reader the record being decoded
+// rewinds onto an occurrence, ahead of the walk that rewinds them.
+//
+// One per buffered table rather than one per occurrence of one, which is the
+// whole of what this saves: codec.Reader.Reset keeps everything the Encoding
+// derives — the zoned decimal byte tables, the alphanumeric translation table
+// and both scratch buffers — and swaps only the bytes, so a table of a hundred
+// occurrences carrying a variant costs one construction rather than a hundred,
+// and none of the allocations that stood beside them.
+//
+// It is the decode direction only. An encoder's sub-writer fills a buffer of
+// its own per occurrence and hands those bytes back to the writer above it, so
+// there is nothing there for one built once to be rewound onto.
+func (c *coder) subReaders() string {
+	var b strings.Builder
+
+	for _, sub := range c.subs {
+		line(&b, "// %s reads one occurrence of %s, which carries a variant and so is read", sub.name, sub.item)
+		line(&b, "// whole before it is walked. It is built here rather than inside the loop")
+		line(&b, "// over those occurrences, and rewound onto each occurrence's bytes there.")
+		line(&b, "var %s *codec.Reader", sub.name)
+		line(&b, "if %s, err = codec.NewBytesReader(nil, r.Encoding()); err != nil {", sub.name)
+		line(&b, "return fmt.Errorf(%s, err)", strconv.Quote(c.record+": reading over the bytes of "+sub.item+": %w"))
+		line(&b, "}")
+		line(&b, "")
+	}
+
+	return b.String()
 }
 
 // marshal is one record's encode method.
@@ -473,17 +522,28 @@ func (c *coder) decodeMembers(b *strings.Builder, id uint64, expr string, s scop
 		return c.decodeGroup(b, id, expr, s)
 	}
 
-	c.imports["bytes"] = struct{}{}
-
 	width, err := c.sumWidth(id, expr, s.dir)
 	if err != nil {
 		return err
 	}
 
-	var (
-		buf = fmt.Sprintf("occurrence%d", s.depth)
-		sub = fmt.Sprintf("entry%d", s.depth)
-	)
+	group, err := c.group(id)
+	if err != nil {
+		return err
+	}
+
+	buf := fmt.Sprintf("occurrence%d", s.depth)
+
+	// The sub-reader is declared and built once for the record, by
+	// [coder.prologue], and rewound onto each occurrence here. So its name is
+	// unique across the whole method rather than to this depth: two tables
+	// nested one inside the other are two names because their depths differ,
+	// and two standing side by side would otherwise be one name declared twice.
+	c.counter++
+
+	sub := fmt.Sprintf("entry%d", c.counter)
+
+	c.subs = append(c.subs, subReader{name: sub, item: group.GetNames().GetOriginal()})
 
 	// Assigned rather than declared, so that the one `err` the method declares
 	// is the one every statement of it uses: a `:=` here would shadow it, and a
@@ -493,10 +553,7 @@ func (c *coder) decodeMembers(b *strings.Builder, id uint64, expr string, s scop
 	line(b, "if %s, err = %s.ReadBytes(%s); err != nil {", buf, s.rw, width)
 	line(b, "%s", wrapf(s, "reading its bytes"))
 	line(b, "}")
-	line(b, "var %s *codec.Reader", sub)
-	line(b, "if %s, err = codec.NewReader(bytes.NewReader(%s), %s.Encoding()); err != nil {", sub, buf, s.rw)
-	line(b, "%s", wrapf(s, "reading over its bytes"))
-	line(b, "}")
+	line(b, "%s.Reset(%s)", sub, buf)
 
 	inner := s
 	inner.rw = sub

--- a/cmd/cpybkc-gen-go/codec.go
+++ b/cmd/cpybkc-gen-go/codec.go
@@ -344,6 +344,20 @@ of the file in hand, and %s is what this descriptor resolved.`,
 // It is the decode direction only. An encoder's sub-writer fills a buffer of
 // its own per occurrence and hands those bytes back to the writer above it, so
 // there is nothing there for one built once to be rewound onto.
+//
+// # Built for the record rather than at the first occurrence that needs one
+//
+// A record therefore pays one construction for a table whose loop runs no
+// times — an OCCURS DEPENDING ON that decoded to zero — and one for a
+// variant-carrying table inside an arm the record did not take. The lazy
+// alternative, a nil check at each Reset site, removes both and was declined:
+// what it charges instead is five lines of generated Go at every buffered
+// table, in a package whose output is what an adopter reads, and what it saves
+// is bounded by the record's *shape* — the handful of tables it declares —
+// rather than by its *data*, which is the unbounded per-occurrence tax this
+// whole method exists to remove. If a descriptor ever makes the shape half of
+// that cost matter, the nil check is the change and this paragraph is the
+// reason it was not made first.
 func (c *coder) subReaders() string {
 	var b strings.Builder
 
@@ -353,7 +367,7 @@ func (c *coder) subReaders() string {
 		line(&b, "// over those occurrences, and rewound onto each occurrence's bytes there.")
 		line(&b, "var %s *codec.Reader", sub.name)
 		line(&b, "if %s, err = codec.NewBytesReader(nil, r.Encoding()); err != nil {", sub.name)
-		line(&b, "return fmt.Errorf(%s, err)", strconv.Quote(c.record+": reading over the bytes of "+sub.item+": %w"))
+		line(&b, "return fmt.Errorf(%s, err)", strconv.Quote(c.record+": building the decoder the occurrences of "+sub.item+" are read through: %w"))
 		line(&b, "}")
 		line(&b, "")
 	}
@@ -534,11 +548,14 @@ func (c *coder) decodeMembers(b *strings.Builder, id uint64, expr string, s scop
 
 	buf := fmt.Sprintf("occurrence%d", s.depth)
 
-	// The sub-reader is declared and built once for the record, by
-	// [coder.prologue], and rewound onto each occurrence here. So its name is
-	// unique across the whole method rather than to this depth: two tables
-	// nested one inside the other are two names because their depths differ,
-	// and two standing side by side would otherwise be one name declared twice.
+	// The sub-reader is declared and built once for the record by
+	// [coder.subReaders], and rewound onto each occurrence here. That
+	// declaration stands at the top of the method rather than inside this
+	// loop's block, which is what its name now has to be unique against: a
+	// suffix telling this table apart from the ones it is nested inside was
+	// enough while each declaration had a block of its own, and two tables
+	// standing side by side are at one depth and would now be one identifier
+	// declared twice.
 	c.counter++
 
 	sub := fmt.Sprintf("entry%d", c.counter)

--- a/cmd/cpybkc-gen-go/internal/README.md
+++ b/cmd/cpybkc-gen-go/internal/README.md
@@ -21,15 +21,24 @@ DO NOT EDIT.` header is what tells them apart. `records_test.go` and
 `file_test.go` are **output**: the first is one case per record and per variant
 arm, the second one case per path through the automaton, each carrying the bytes
 it reads as a literal, and `written` pins both byte for byte like every other
-generated file. Everything else — `file_roundtrip_test.go` in all six, and
-`record_roundtrip_test.go` in `orders` — is hand-written and is skipped, because
-those assertions live *inside* each package for a reason the generated ones do
-not have: the bytes retained for a slack node are unexported, so a run of the
-wrong length is something only code in the package can hand a writer.
+generated file. Everything else — `file_roundtrip_test.go` in all six,
+`record_roundtrip_test.go` in `orders`, and the two `file_reuse_test.go` — is
+hand-written and is skipped, because those assertions live *inside* each package
+for a reason the generated ones do not have: the bytes retained for a slack node
+are unexported, so a run of the wrong length is something only code in the
+package can hand a writer.
 
 The hand-written names carry `roundtrip` because `file_test.go` is the name
 `cpybkc-gen-go` itself writes, for the file tier; see [the names, and which
 side moves](../README.md#the-names-and-which-side-moves).
+
+`file_reuse_test.go` in [`chunks`](chunks) and [`orders`](orders) is the pair
+that is not a round trip. They hold what a reader may *cost*: `chunks` that one
+more record of a file does not cost one more decoder, and `orders` that one
+sub-decoder serves every occurrence of a table holding a variant. Both assert in
+allocations rather than in nanoseconds, because an allocation count is the same
+on every machine and a duration is not, and both carry a benchmark beside the
+assertion for the nanoseconds somebody reading a regression will want.
 
 ## Why there is more than one
 

--- a/cmd/cpybkc-gen-go/internal/chunks/file.go
+++ b/cmd/cpybkc-gen-go/internal/chunks/file.go
@@ -45,7 +45,17 @@ const readAhead = 4096
 // register file the automaton remembers in, whatever the file's size.
 type Reader struct {
 	src *bufio.Reader
-	enc codec.Encoding
+
+	// cr decodes the record in hand, and is the only one this reader builds:
+	// the framing states a record's length, so the bytes are held before
+	// anything decodes them and [Reader.admit] rewinds this onto each record
+	// rather than constructing one over it. Everything the encoding derives —
+	// the zoned decimal byte tables, the alphanumeric translation table and the
+	// scratch buffers every field is read into — is built once for the file and
+	// survives every rewind, which is why the encoding is not kept beside it:
+	// codec.Reader carries it, and one that could be swapped under a half-read
+	// record is what codec refuses to allow.
+	cr *codec.Reader
 
 	// state is where in the automaton the read is, as a position in the switch
 	// [Reader.Next] walks. The descriptor's state nodes are numbered by ascending
@@ -77,13 +87,18 @@ func NewReader(r io.Reader, enc codec.Encoding) (*Reader, error) {
 		return nil, codec.ErrNilReader
 	}
 
-	if err := enc.Validate(); err != nil {
+	// The one decoder this reader builds, over no bytes until a record is in
+	// hand. Construction is what validates the encoding, and it reports the
+	// same error for the same axis that enc.Validate does, so nothing is
+	// checked twice here.
+	cr, err := codec.NewBytesReader(nil, enc)
+	if err != nil {
 		return nil, err
 	}
 
 	return &Reader{
 		src:   bufio.NewReaderSize(r, readAhead),
-		enc:   enc,
+		cr:    cr,
 		state: 0,
 	}, nil
 }
@@ -216,14 +231,15 @@ func (r *Reader) leading() error {
 // are line delimiters on some mainframe code page. A reader counting the extent
 // never reads those bytes as anything but the number they are.
 func (r *Reader) admit(rec Record) error {
-	src := bytes.NewReader(r.data)
+	// The record's bytes are in hand, so the decoder is rewound onto them rather
+	// than built over them. A rewind keeps everything the encoding derives and
+	// swaps only the bytes, which is a construction and an allocation this
+	// reader does not make per record — and it puts the offset back to zero, so
+	// every offset codec reports is counted from the start of this record
+	// rather than from the start of the file.
+	r.cr.Reset(r.data)
 
-	cr, err := codec.NewReader(src, r.enc)
-	if err != nil {
-		return fmt.Errorf("reading record %d: %w", r.ordinal, err)
-	}
-
-	if err := rec.UnmarshalCOBOL(cr); err != nil {
+	if err := rec.UnmarshalCOBOL(r.cr); err != nil {
 		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 			return fmt.Errorf("the framing states record %d is %d bytes and the extent of the record it admits is longer than that: %v", r.ordinal, len(r.data), err)
 		}
@@ -233,9 +249,11 @@ func (r *Reader) admit(rec Record) error {
 
 	// The framing checked against the extent, which is what a framed file buys
 	// over an unframed one: a wrong width or a mis-selected transition is an
-	// error at the record it happened on rather than silence.
-	if src.Len() != 0 {
-		return fmt.Errorf("the framing states record %d is %d bytes and the extent of the record it admits is %d", r.ordinal, len(r.data), len(r.data)-src.Len())
+	// error at the record it happened on rather than silence. The extent is what
+	// the decoder consumed, which is its offset: the rewind above is what makes
+	// that a count of this record rather than of the file.
+	if r.cr.Offset() != int64(len(r.data)) {
+		return fmt.Errorf("the framing states record %d is %d bytes and the extent of the record it admits is %d", r.ordinal, len(r.data), r.cr.Offset())
 	}
 
 	return nil

--- a/cmd/cpybkc-gen-go/internal/chunks/file_reuse_test.go
+++ b/cmd/cpybkc-gen-go/internal/chunks/file_reuse_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// The assertion that a reader under a framing that states a record's length
+// builds one decoder for the file rather than one per record.
+//
+// It is stated as a *marginal* cost, in allocations, because that is the one
+// form of it a machine cannot disagree with: what one more record of this file
+// costs is what its own values cost, and a decoder built for it would stand out
+// as two more — the decoder, and the reader over bytes this one already held.
+// Nanoseconds are orientation and belong in the benchmark below; the allocation
+// count is the assertion, which is the lesson Zaba505/cobol-go#108 closed on.
+package chunks
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strconv"
+	"testing"
+)
+
+// perRecordAllocations is what one more record of this file may cost.
+//
+// Four, and every one of them is this file's own rather than the decoder's: the
+// CHUNK-RECORD the reader hands back, the two strings its items decode into,
+// and the segment descriptor word this framing reads in front of the one
+// segment each of these records is laid into. Before one decoder served the
+// whole file it was six — a codec.Reader built for the record, and a
+// bytes.Reader wrapping bytes the reader already held.
+//
+// An upper bound rather than an equality, so that codec allocating less for a
+// field than it does today passes rather than failing on an improvement. What
+// it catches is the regression: a decoder back on the margin takes this to six
+// whatever else changes.
+const perRecordAllocations = 4
+
+// tolerance is the slack the bound is read with, which is what makes the
+// comparison one of whole allocations rather than of floating point.
+const tolerance = 0.5
+
+// chunkFile is n CHUNK-RECORDs, each laid into one segment.
+func chunkFile(tb testing.TB, n int) []byte {
+	tb.Helper()
+
+	var b bytes.Buffer
+
+	for i := range n {
+		b.Write(segmented(chunkBytes(tb, "C"+strconv.Itoa(i%10), "body"), 24))
+	}
+
+	return b.Bytes()
+}
+
+// drain reads every record of in and keeps none of them.
+func drain(tb testing.TB, in []byte) {
+	tb.Helper()
+
+	r, err := NewReader(bytes.NewReader(in), Encoding())
+	if err != nil {
+		tb.Fatalf("NewReader: %v", err)
+	}
+
+	for {
+		switch _, err := r.Next(); {
+		case errors.Is(err, io.EOF):
+			return
+		case err != nil:
+			tb.Fatalf("Next: %v", err)
+		}
+	}
+}
+
+// TestOneMoreRecordDoesNotCostOneMoreDecoder is what a framing that states a
+// record's length buys beyond the check against the extent: the record's bytes
+// are in hand before anything decodes them, so one decoder is rewound onto each
+// record rather than built over it.
+//
+// The difference between two files of the same records is what isolates that. A
+// reader's fixed costs — the buffered input, the one decoder, the run a record
+// is reassembled into — are the same for both files and cancel, so what is left
+// is what a record costs, and a decoder on that margin is what this fails on.
+//
+// Not parallel, and deliberately: [testing.AllocsPerRun] counts the whole
+// process's allocations, so a test measuring them cannot run beside one making
+// them.
+func TestOneMoreRecordDoesNotCostOneMoreDecoder(t *testing.T) {
+	const few, many = 4, 20
+
+	short, long := chunkFile(t, few), chunkFile(t, many)
+
+	fewer := testing.AllocsPerRun(20, func() { drain(t, short) })
+	more := testing.AllocsPerRun(20, func() { drain(t, long) })
+
+	marginal := (more - fewer) / float64(many-few)
+
+	if marginal > perRecordAllocations+tolerance {
+		t.Errorf("one more record of this file allocates %.2f times, and a record of it accounts for %d of them",
+			marginal, perRecordAllocations)
+	}
+}
+
+// BenchmarkReadingAFile is the orientation the assertion above deliberately is
+// not: what a record of this file costs in nanoseconds on the machine in front
+// of you.
+func BenchmarkReadingAFile(b *testing.B) {
+	in := chunkFile(b, 100)
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		drain(b, in)
+	}
+}

--- a/cmd/cpybkc-gen-go/internal/chunks/file_roundtrip_test.go
+++ b/cmd/cpybkc-gen-go/internal/chunks/file_roundtrip_test.go
@@ -23,22 +23,22 @@ import (
 )
 
 // chunkBytes is one CHUNK-RECORD, with no framing around it.
-func chunkBytes(t *testing.T, id, body string) []byte {
-	t.Helper()
+func chunkBytes(tb testing.TB, id, body string) []byte {
+	tb.Helper()
 
 	var b bytes.Buffer
 
 	w, err := codec.NewWriter(&b, Encoding())
 	if err != nil {
-		t.Fatalf("codec.NewWriter: %v", err)
+		tb.Fatalf("codec.NewWriter: %v", err)
 	}
 
 	if err := w.WriteAlphanumeric(id, 4); err != nil {
-		t.Fatalf("CHUNK-ID: %v", err)
+		tb.Fatalf("CHUNK-ID: %v", err)
 	}
 
 	if err := w.WriteAlphanumeric(body, 20); err != nil {
-		t.Fatalf("CHUNK-BODY: %v", err)
+		tb.Fatalf("CHUNK-BODY: %v", err)
 	}
 
 	return b.Bytes()

--- a/cmd/cpybkc-gen-go/internal/counted/file.go
+++ b/cmd/cpybkc-gen-go/internal/counted/file.go
@@ -487,6 +487,11 @@ func (r *Reader) leading() error {
 func (r *Reader) admit(rec Record) error {
 	r.raw = r.raw[:0]
 
+	// One decoder per record, which is what this framing costs and the two that
+	// state a record's length do not pay: the framing says nothing about where
+	// this record ends, so the record's bytes are drawn off the same input the
+	// framing came off and are never held. A decoder is rewound onto bytes, and
+	// there are none to rewind this one onto, so it is built over the stream.
 	cr, err := codec.NewReader(&recording{src: r.src, into: &r.raw}, r.enc)
 	if err != nil {
 		return fmt.Errorf("reading record %d: %w", r.ordinal, err)

--- a/cmd/cpybkc-gen-go/internal/fixed/codec.go
+++ b/cmd/cpybkc-gen-go/internal/fixed/codec.go
@@ -102,7 +102,7 @@ func (x *LedgerRecord) UnmarshalCOBOL(r *codec.Reader) error {
 	// over those occurrences, and rewound onto each occurrence's bytes there.
 	var entry1 *codec.Reader
 	if entry1, err = codec.NewBytesReader(nil, r.Encoding()); err != nil {
-		return fmt.Errorf("LEDGER-RECORD: reading over the bytes of ENTRY: %w", err)
+		return fmt.Errorf("LEDGER-RECORD: building the decoder the occurrences of ENTRY are read through: %w", err)
 	}
 
 	if x.LedgerId, err = r.ReadAlphanumeric(4); err != nil {

--- a/cmd/cpybkc-gen-go/internal/fixed/codec.go
+++ b/cmd/cpybkc-gen-go/internal/fixed/codec.go
@@ -97,6 +97,14 @@ func fresh[T any](p *T) *T {
 func (x *LedgerRecord) UnmarshalCOBOL(r *codec.Reader) error {
 	var err error
 
+	// entry1 reads one occurrence of ENTRY, which carries a variant and so is read
+	// whole before it is walked. It is built here rather than inside the loop
+	// over those occurrences, and rewound onto each occurrence's bytes there.
+	var entry1 *codec.Reader
+	if entry1, err = codec.NewBytesReader(nil, r.Encoding()); err != nil {
+		return fmt.Errorf("LEDGER-RECORD: reading over the bytes of ENTRY: %w", err)
+	}
+
 	if x.LedgerId, err = r.ReadAlphanumeric(4); err != nil {
 		return fmt.Errorf("LEDGER-RECORD: reading LEDGER-ID: %w", err)
 	}
@@ -106,10 +114,7 @@ func (x *LedgerRecord) UnmarshalCOBOL(r *codec.Reader) error {
 		if occurrence1, err = r.ReadBytes(7); err != nil {
 			return fmt.Errorf("LEDGER-RECORD: reading its bytes in occurrence %d of ENTRY: %w", i0, err)
 		}
-		var entry1 *codec.Reader
-		if entry1, err = codec.NewReader(bytes.NewReader(occurrence1), r.Encoding()); err != nil {
-			return fmt.Errorf("LEDGER-RECORD: reading over its bytes in occurrence %d of ENTRY: %w", i0, err)
-		}
+		entry1.Reset(occurrence1)
 		if x.Entry[i0].EntryType, err = entry1.ReadAlphanumeric(1); err != nil {
 			return fmt.Errorf("LEDGER-RECORD: reading ENTRY-TYPE in occurrence %d of ENTRY: %w", i0, err)
 		}

--- a/cmd/cpybkc-gen-go/internal/fixed/file.go
+++ b/cmd/cpybkc-gen-go/internal/fixed/file.go
@@ -176,6 +176,11 @@ func (r *Reader) leading() error {
 // are line delimiters on some mainframe code page. A reader counting the extent
 // never reads those bytes as anything but the number they are.
 func (r *Reader) admit(rec Record) error {
+	// One decoder per record, which is what this framing costs and the two that
+	// state a record's length do not pay: the framing says nothing about where
+	// this record ends, so the record's bytes are drawn off the same input the
+	// framing came off and are never held. A decoder is rewound onto bytes, and
+	// there are none to rewind this one onto, so it is built over the stream.
 	cr, err := codec.NewReader(r.src, r.enc)
 	if err != nil {
 		return fmt.Errorf("reading record %d: %w", r.ordinal, err)

--- a/cmd/cpybkc-gen-go/internal/opt/file.go
+++ b/cmd/cpybkc-gen-go/internal/opt/file.go
@@ -190,6 +190,11 @@ func (r *Reader) leading() error {
 // are line delimiters on some mainframe code page. A reader counting the extent
 // never reads those bytes as anything but the number they are.
 func (r *Reader) admit(rec Record) error {
+	// One decoder per record, which is what this framing costs and the two that
+	// state a record's length do not pay: the framing says nothing about where
+	// this record ends, so the record's bytes are drawn off the same input the
+	// framing came off and are never held. A decoder is rewound onto bytes, and
+	// there are none to rewind this one onto, so it is built over the stream.
 	cr, err := codec.NewReader(r.src, r.enc)
 	if err != nil {
 		return fmt.Errorf("reading record %d: %w", r.ordinal, err)

--- a/cmd/cpybkc-gen-go/internal/orders/codec.go
+++ b/cmd/cpybkc-gen-go/internal/orders/codec.go
@@ -596,15 +596,20 @@ func (x *TableRecord) MarshalCOBOL(w *codec.Writer) error {
 func (x *EntryRecord) UnmarshalCOBOL(r *codec.Reader) error {
 	var err error
 
+	// entry1 reads one occurrence of ENTRY, which carries a variant and so is read
+	// whole before it is walked. It is built here rather than inside the loop
+	// over those occurrences, and rewound onto each occurrence's bytes there.
+	var entry1 *codec.Reader
+	if entry1, err = codec.NewBytesReader(nil, r.Encoding()); err != nil {
+		return fmt.Errorf("ENTRY-RECORD: reading over the bytes of ENTRY: %w", err)
+	}
+
 	for i0 := range x.Entry {
 		var occurrence1 []byte
 		if occurrence1, err = r.ReadBytes(7); err != nil {
 			return fmt.Errorf("ENTRY-RECORD: reading its bytes in occurrence %d of ENTRY: %w", i0, err)
 		}
-		var entry1 *codec.Reader
-		if entry1, err = codec.NewReader(bytes.NewReader(occurrence1), r.Encoding()); err != nil {
-			return fmt.Errorf("ENTRY-RECORD: reading over its bytes in occurrence %d of ENTRY: %w", i0, err)
-		}
+		entry1.Reset(occurrence1)
 		if x.Entry[i0].EntryType, err = entry1.ReadAlphanumeric(1); err != nil {
 			return fmt.Errorf("ENTRY-RECORD: reading ENTRY-TYPE in occurrence %d of ENTRY: %w", i0, err)
 		}

--- a/cmd/cpybkc-gen-go/internal/orders/codec.go
+++ b/cmd/cpybkc-gen-go/internal/orders/codec.go
@@ -601,7 +601,7 @@ func (x *EntryRecord) UnmarshalCOBOL(r *codec.Reader) error {
 	// over those occurrences, and rewound onto each occurrence's bytes there.
 	var entry1 *codec.Reader
 	if entry1, err = codec.NewBytesReader(nil, r.Encoding()); err != nil {
-		return fmt.Errorf("ENTRY-RECORD: reading over the bytes of ENTRY: %w", err)
+		return fmt.Errorf("ENTRY-RECORD: building the decoder the occurrences of ENTRY are read through: %w", err)
 	}
 
 	for i0 := range x.Entry {

--- a/cmd/cpybkc-gen-go/internal/orders/file.go
+++ b/cmd/cpybkc-gen-go/internal/orders/file.go
@@ -46,7 +46,17 @@ const readAhead = 4096
 // register file the automaton remembers in, whatever the file's size.
 type Reader struct {
 	src *bufio.Reader
-	enc codec.Encoding
+
+	// cr decodes the record in hand, and is the only one this reader builds:
+	// the framing states a record's length, so the bytes are held before
+	// anything decodes them and [Reader.admit] rewinds this onto each record
+	// rather than constructing one over it. Everything the encoding derives —
+	// the zoned decimal byte tables, the alphanumeric translation table and the
+	// scratch buffers every field is read into — is built once for the file and
+	// survives every rewind, which is why the encoding is not kept beside it:
+	// codec.Reader carries it, and one that could be swapped under a half-read
+	// record is what codec refuses to allow.
+	cr *codec.Reader
 
 	// state is where in the automaton the read is, as a position in the switch
 	// [Reader.Next] walks. The descriptor's state nodes are numbered by ascending
@@ -81,13 +91,18 @@ func NewReader(r io.Reader, enc codec.Encoding) (*Reader, error) {
 		return nil, codec.ErrNilReader
 	}
 
-	if err := enc.Validate(); err != nil {
+	// The one decoder this reader builds, over no bytes until a record is in
+	// hand. Construction is what validates the encoding, and it reports the
+	// same error for the same axis that enc.Validate does, so nothing is
+	// checked twice here.
+	cr, err := codec.NewBytesReader(nil, enc)
+	if err != nil {
 		return nil, err
 	}
 
 	return &Reader{
 		src:   bufio.NewReaderSize(r, readAhead),
-		enc:   enc,
+		cr:    cr,
 		state: 0,
 	}, nil
 }
@@ -279,14 +294,15 @@ func (r *Reader) leading() error {
 // are line delimiters on some mainframe code page. A reader counting the extent
 // never reads those bytes as anything but the number they are.
 func (r *Reader) admit(rec Record) error {
-	src := bytes.NewReader(r.data)
+	// The record's bytes are in hand, so the decoder is rewound onto them rather
+	// than built over them. A rewind keeps everything the encoding derives and
+	// swaps only the bytes, which is a construction and an allocation this
+	// reader does not make per record — and it puts the offset back to zero, so
+	// every offset codec reports is counted from the start of this record
+	// rather than from the start of the file.
+	r.cr.Reset(r.data)
 
-	cr, err := codec.NewReader(src, r.enc)
-	if err != nil {
-		return fmt.Errorf("reading record %d: %w", r.ordinal, err)
-	}
-
-	if err := rec.UnmarshalCOBOL(cr); err != nil {
+	if err := rec.UnmarshalCOBOL(r.cr); err != nil {
 		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 			return fmt.Errorf("the framing states record %d is %d bytes and the extent of the record it admits is longer than that: %v", r.ordinal, len(r.data), err)
 		}
@@ -296,9 +312,11 @@ func (r *Reader) admit(rec Record) error {
 
 	// The framing checked against the extent, which is what a framed file buys
 	// over an unframed one: a wrong width or a mis-selected transition is an
-	// error at the record it happened on rather than silence.
-	if src.Len() != 0 {
-		return fmt.Errorf("the framing states record %d is %d bytes and the extent of the record it admits is %d", r.ordinal, len(r.data), len(r.data)-src.Len())
+	// error at the record it happened on rather than silence. The extent is what
+	// the decoder consumed, which is its offset: the rewind above is what makes
+	// that a count of this record rather than of the file.
+	if r.cr.Offset() != int64(len(r.data)) {
+		return fmt.Errorf("the framing states record %d is %d bytes and the extent of the record it admits is %d", r.ordinal, len(r.data), r.cr.Offset())
 	}
 
 	return nil

--- a/cmd/cpybkc-gen-go/internal/orders/file_reuse_test.go
+++ b/cmd/cpybkc-gen-go/internal/orders/file_reuse_test.go
@@ -1,0 +1,196 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// The assertions over decoders that are rewound rather than rebuilt: what the
+// framing check counts in once the reader holds one decoder for the whole file,
+// and what a table of variants costs once one sub-decoder serves every
+// occurrence of it.
+//
+// They live inside the golden package for the reason the round-trip assertions
+// beside them do, and they are here rather than in `chunks` because this
+// descriptor is the one carrying a table that holds a variant — the call site
+// with a multiplier on it, since an OCCURS 100 group holding a REDEFINES paid
+// the per-occurrence price a hundred times per record.
+package orders
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cobol-go/codec"
+)
+
+// TestTheExtentOfARecordIsCountedFromTheStartOfIt is the framing check as it is
+// now expressed: the extent is what the decoder consumed, which is its offset,
+// and the offset counts from the last rewind.
+//
+// The record is the *second* of the file, and that is the whole point of it. A
+// reader that built a decoder per record got record-relative offsets by
+// accident, because each decoder began at zero; one that rewinds a single
+// decoder gets them because a rewind sets the offset back to zero. Asserting
+// the number on the second record is what tells those two apart from a reader
+// that had simply stopped resetting anything — there, this would read as the
+// extent of the file so far.
+func TestTheExtentOfARecordIsCountedFromTheStartOfIt(t *testing.T) {
+	t.Parallel()
+
+	table := tableBytes(t, Encoding(), 3)
+
+	// Three bytes of framing the record does not describe. The record decodes
+	// whole and stops short of what the descriptor word states, which is the
+	// disagreement this reports.
+	stated := append(append([]byte{}, table...), 0x00, 0x00, 0x00)
+
+	in := append(framed(orderBytes(t, Encoding(), 2)), framed(stated)...)
+
+	r, err := NewReader(bytes.NewReader(in), Encoding())
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+
+	if _, err := r.Next(); err != nil {
+		t.Fatalf("the first record: %v", err)
+	}
+
+	_, err = r.Next()
+	if err == nil {
+		t.Fatal("a descriptor word longer than the record it states the length of was read as a record")
+	}
+
+	want := fmt.Sprintf("the framing states record 2 is %d bytes and the extent of the record it admits is %d",
+		len(stated), len(table))
+
+	if err.Error() != want {
+		t.Errorf("the report reads\n %q\nand the record's own lengths are\n %q", err, want)
+	}
+}
+
+// TestACodecFaultInASecondRecordReportsAnOffsetWithinThatRecord is the same
+// property one layer down, where it is not this generator's message but codec's
+// own.
+//
+// codec stamps every read error with the offset it happened at, counted from
+// the last rewind. A reader rewinding one decoder per record therefore reports
+// where in *this record* the fault is, which is what somebody holding a copybook
+// can act on; a reader that had stopped rewinding would report a position in the
+// file, and the numbers would be indistinguishable from correct until a record
+// went missing.
+func TestACodecFaultInASecondRecordReportsAnOffsetWithinThatRecord(t *testing.T) {
+	t.Parallel()
+
+	first := framed(orderBytes(t, Encoding(), 2))
+
+	// A TABLE-RECORD three bytes short of the record its own count describes.
+	// Its tail is a table of one-byte items, so every byte the framing does
+	// state is consumed before the read that runs out — the offset codec
+	// reports is the whole of what is there.
+	table := tableBytes(t, Encoding(), 3)
+	short := table[:len(table)-3]
+
+	r, err := NewReader(bytes.NewReader(append(first, framed(short)...)), Encoding())
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+
+	if _, err := r.Next(); err != nil {
+		t.Fatalf("the first record: %v", err)
+	}
+
+	_, err = r.Next()
+	if err == nil {
+		t.Fatal("a record cut short by its own framing was read as a record")
+	}
+
+	if within := fmt.Sprintf("offset %d", len(short)); !strings.Contains(err.Error(), within) {
+		t.Errorf("the report reads %q and does not put the fault at %q, within the record it is in", err, within)
+	}
+
+	// What the same fault would read as if the offset counted from the start of
+	// the file rather than from the start of this record.
+	if absolute := fmt.Sprintf("offset %d", len(first)+len(short)); strings.Contains(err.Error(), absolute) {
+		t.Errorf("the report reads %q and puts the fault at %q, which is a position in the file", err, absolute)
+	}
+}
+
+// tolerance is the slack the bound below is read with, which is what makes the
+// comparison one of whole allocations rather than of floating point.
+const tolerance = 0.5
+
+// recordAllocations is what decoding one ENTRY-RECORD may cost.
+//
+// Eleven, of which exactly **one** is a decoder: the sub-decoder this record's
+// method builds and rewinds onto each of its three occurrences. The other ten
+// hold something the record hands back — each occurrence's own bytes, which an
+// arm's predicate is evaluated against, the string ENTRY-TYPE decodes into, the
+// alternative chosen for the occurrence and the values inside it.
+//
+// Before one sub-decoder served every occurrence it was sixteen: three
+// decoders, and the three bytes.Readers wrapping bytes the record already held,
+// one pair per occurrence. That is the multiplier this story removed, and on a
+// real copybook's OCCURS 100 holding a REDEFINES it is two hundred allocations
+// per record rather than six.
+//
+// An upper bound rather than an equality, so that codec allocating less for a
+// field than it does today passes rather than failing on an improvement. What
+// it catches is the regression: a decoder back inside the loop over occurrences
+// costs two an occurrence whatever else changes.
+const recordAllocations = 11
+
+// TestATableOfVariantsBuildsOneDecoderForTheRecord is the call site the whole
+// story turns on: a group that repeats and holds a variant is read one
+// occurrence at a time, and the decoder over an occurrence's bytes was built
+// once per occurrence rather than once per record.
+//
+// Not parallel, and deliberately: [testing.AllocsPerRun] counts the whole
+// process's allocations, so a test measuring them cannot run beside one making
+// them.
+func TestATableOfVariantsBuildsOneDecoderForTheRecord(t *testing.T) {
+	raw := entryBytes(t, "DSD")
+
+	cr, err := codec.NewBytesReader(nil, Encoding())
+	if err != nil {
+		t.Fatalf("codec.NewBytesReader: %v", err)
+	}
+
+	allocs := testing.AllocsPerRun(20, func() {
+		cr.Reset(raw)
+
+		var x EntryRecord
+
+		if err := x.UnmarshalCOBOL(cr); err != nil {
+			t.Fatalf("UnmarshalCOBOL: %v", err)
+		}
+	})
+
+	if allocs > recordAllocations+tolerance {
+		t.Errorf("decoding an ENTRY-RECORD allocates %.2f times, and its three occurrences and the one decoder over them account for %d",
+			allocs, recordAllocations)
+	}
+}
+
+// BenchmarkDecodingATableOfVariants is the orientation the assertion above
+// deliberately is not.
+func BenchmarkDecodingATableOfVariants(b *testing.B) {
+	raw := entryBytes(b, "DSD")
+
+	cr, err := codec.NewBytesReader(nil, Encoding())
+	if err != nil {
+		b.Fatalf("codec.NewBytesReader: %v", err)
+	}
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		cr.Reset(raw)
+
+		var x EntryRecord
+
+		if err := x.UnmarshalCOBOL(cr); err != nil {
+			b.Fatalf("UnmarshalCOBOL: %v", err)
+		}
+	}
+}

--- a/cmd/cpybkc-gen-go/internal/orders/file_reuse_test.go
+++ b/cmd/cpybkc-gen-go/internal/orders/file_reuse_test.go
@@ -105,14 +105,82 @@ func TestACodecFaultInASecondRecordReportsAnOffsetWithinThatRecord(t *testing.T)
 		t.Fatal("a record cut short by its own framing was read as a record")
 	}
 
-	if within := fmt.Sprintf("offset %d", len(short)); !strings.Contains(err.Error(), within) {
+	// Anchored on the whole of codec's phrase, colon and all, rather than on the
+	// digits: a substring ending at a digit matches every longer number that
+	// begins with it, so "offset 23" is in "offset 231" and both assertions
+	// below could report a result they had not earned.
+	if within := fmt.Sprintf("at byte offset %d:", len(short)); !strings.Contains(err.Error(), within) {
 		t.Errorf("the report reads %q and does not put the fault at %q, within the record it is in", err, within)
 	}
 
 	// What the same fault would read as if the offset counted from the start of
 	// the file rather than from the start of this record.
-	if absolute := fmt.Sprintf("offset %d", len(first)+len(short)); strings.Contains(err.Error(), absolute) {
+	if absolute := fmt.Sprintf("at byte offset %d:", len(first)+len(short)); strings.Contains(err.Error(), absolute) {
 		t.Errorf("the report reads %q and puts the fault at %q, which is a position in the file", err, absolute)
+	}
+}
+
+// TestARecordThatFailedLeavesNothingBehindInTheDecoder is the question one
+// decoder for the whole file raises and one decoder per record could not: a
+// record that failed part-way through leaves the decoder holding an offset, a
+// slice and whatever its scratch buffers last held, and the next record is
+// decoded through that same decoder.
+//
+// It is answered by where the rewind stands. [Reader.admit] resets before it
+// decodes rather than after, so what a failed record left behind is dropped by
+// the record after it whatever the failure was — which is the property this
+// reads back, by failing the first record of a file and then reading the same
+// record, well framed, through the reader that failed.
+//
+// The automaton is what makes that file legal: a transition is taken when a
+// record is admitted, so a record that failed leaves the walk in the state it
+// was in, and the state that admits an ORDER-RECORD admits the next one too.
+func TestARecordThatFailedLeavesNothingBehindInTheDecoder(t *testing.T) {
+	t.Parallel()
+
+	order := orderBytes(t, Encoding(), 2)
+
+	// The first record, cut short by three bytes of its own framing, so that it
+	// fails inside codec with bytes consumed and an offset stopped part-way.
+	cut := order[:len(order)-3]
+
+	in := append(framed(cut), framed(order)...)
+
+	r, err := NewReader(bytes.NewReader(in), Encoding())
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+
+	if _, err := r.Next(); err == nil {
+		t.Fatal("a record cut short by its own framing was read as a record")
+	}
+
+	rec, err := r.Next()
+	if err != nil {
+		t.Fatalf("the record after a failed one: %v", err)
+	}
+
+	got, ok := rec.(*OrderRecord)
+	if !ok {
+		t.Fatalf("the record after a failed one came back as a %T", rec)
+	}
+
+	// Written back rather than compared field by field, because the bytes are
+	// what a decoder carrying something over would get wrong: an offset the
+	// rewind did not clear moves every item behind it.
+	var out bytes.Buffer
+
+	w, err := codec.NewWriter(&out, Encoding())
+	if err != nil {
+		t.Fatalf("codec.NewWriter: %v", err)
+	}
+
+	if err := got.MarshalCOBOL(w); err != nil {
+		t.Fatalf("MarshalCOBOL: %v", err)
+	}
+
+	if !bytes.Equal(out.Bytes(), order) {
+		t.Errorf("the record read after a failed one is\n % x\nand the record in the file is\n % x", out.Bytes(), order)
 	}
 }
 
@@ -130,9 +198,18 @@ const tolerance = 0.5
 //
 // Before one sub-decoder served every occurrence it was sixteen: three
 // decoders, and the three bytes.Readers wrapping bytes the record already held,
-// one pair per occurrence. That is the multiplier this story removed, and on a
-// real copybook's OCCURS 100 holding a REDEFINES it is two hundred allocations
-// per record rather than six.
+// one pair per occurrence. Six of the sixteen were the multiplier, and it is
+// the multiplier this story removed — on a real copybook's OCCURS 100 holding a
+// REDEFINES those same six are two hundred, and they become the one decoder
+// this record now builds whatever the count is.
+//
+// It is a cost and not a correctness criterion. That an occurrence decodes to
+// the right values, and that no occurrence's bytes bleed into the next through
+// the scratch buffers they now share, is
+// [TestATableOfVariantsWritesBackTheBytesItWasReadFrom] in
+// record_roundtrip_test.go: it round-trips this exact input byte for byte, over
+// four arm patterns, and each occurrence's retained slack is a different byte
+// so that one standing in for another fails it.
 //
 // An upper bound rather than an equality, so that codec allocating less for a
 // field than it does today passes rather than failing on an improvement. What

--- a/cmd/cpybkc-gen-go/internal/orders/record_roundtrip_test.go
+++ b/cmd/cpybkc-gen-go/internal/orders/record_roundtrip_test.go
@@ -62,18 +62,18 @@ func ascii() codec.Encoding {
 }
 
 // laidOut is a record's bytes, written item by item.
-func laidOut(t *testing.T, enc codec.Encoding, items func(*codec.Writer) error) []byte {
-	t.Helper()
+func laidOut(tb testing.TB, enc codec.Encoding, items func(*codec.Writer) error) []byte {
+	tb.Helper()
 
 	var b bytes.Buffer
 
 	w, err := codec.NewWriter(&b, enc)
 	if err != nil {
-		t.Fatalf("codec.NewWriter: %v", err)
+		tb.Fatalf("codec.NewWriter: %v", err)
 	}
 
 	if err := items(w); err != nil {
-		t.Fatalf("laying the record out: %v", err)
+		tb.Fatalf("laying the record out: %v", err)
 	}
 
 	return b.Bytes()
@@ -501,10 +501,10 @@ func TestACountOutsideItsDeclaredBoundsIsReported(t *testing.T) {
 // Reading these records under an ASCII encoding is reading a file that is not
 // the file the descriptor describes, which is the axis that has no default for
 // exactly this reason.
-func entryBytes(t *testing.T, arms string) []byte {
-	t.Helper()
+func entryBytes(tb testing.TB, arms string) []byte {
+	tb.Helper()
 
-	return laidOut(t, Encoding(), func(w *codec.Writer) error {
+	return laidOut(tb, Encoding(), func(w *codec.Writer) error {
 		for i, code := range arms {
 			if err := w.WriteAlphanumeric(string(code), 1); err != nil {
 				return err

--- a/cmd/cpybkc-gen-go/internal/sep/file.go
+++ b/cmd/cpybkc-gen-go/internal/sep/file.go
@@ -205,6 +205,11 @@ func (r *Reader) leading() error {
 // are line delimiters on some mainframe code page. A reader counting the extent
 // never reads those bytes as anything but the number they are.
 func (r *Reader) admit(rec Record) error {
+	// One decoder per record, which is what this framing costs and the two that
+	// state a record's length do not pay: the framing says nothing about where
+	// this record ends, so the record's bytes are drawn off the same input the
+	// framing came off and are never held. A decoder is rewound onto bytes, and
+	// there are none to rewind this one onto, so it is built over the stream.
 	cr, err := codec.NewReader(r.src, r.enc)
 	if err != nil {
 		return fmt.Errorf("reading record %d: %w", r.ordinal, err)

--- a/cmd/cpybkc-gen-go/reader.go
+++ b/cmd/cpybkc-gen-go/reader.go
@@ -43,7 +43,23 @@ func (f *filer) emitReader(b *strings.Builder, walks [][]transition) error {
 	line(b, "// register file the automaton remembers in, whatever the file's size.")
 	line(b, "type %s struct {", readerType)
 	line(b, "src *bufio.Reader")
-	line(b, "enc codec.Encoding")
+
+	if f.how.bounded() {
+		line(b, "")
+		line(b, "// cr decodes the record in hand, and is the only one this reader builds:")
+		line(b, "// the framing states a record's length, so the bytes are held before")
+		line(b, "// anything decodes them and [%s.admit] rewinds this onto each record", readerType)
+		line(b, "// rather than constructing one over it. Everything the encoding derives —")
+		line(b, "// the zoned decimal byte tables, the alphanumeric translation table and the")
+		line(b, "// scratch buffers every field is read into — is built once for the file and")
+		line(b, "// survives every rewind, which is why the encoding is not kept beside it:")
+		line(b, "// codec.Reader carries it, and one that could be swapped under a half-read")
+		line(b, "// record is what codec refuses to allow.")
+		line(b, "cr *codec.Reader")
+	} else {
+		line(b, "enc codec.Encoding")
+	}
+
 	line(b, "")
 	line(b, "// state is where in the automaton the read is, as a position in the switch")
 	line(b, "// [%s.Next] walks. The descriptor's state nodes are numbered by ascending", readerType)
@@ -132,13 +148,32 @@ func (f *filer) emitNewReader(b *strings.Builder) {
 	line(b, "return nil, codec.ErrNilReader")
 	line(b, "}")
 	line(b, "")
-	line(b, "if err := enc.Validate(); err != nil {")
-	line(b, "return nil, err")
-	line(b, "}")
+
+	if f.how.bounded() {
+		line(b, "// The one decoder this reader builds, over no bytes until a record is in")
+		line(b, "// hand. Construction is what validates the encoding, and it reports the")
+		line(b, "// same error for the same axis that enc.Validate does, so nothing is")
+		line(b, "// checked twice here.")
+		line(b, "cr, err := codec.NewBytesReader(nil, enc)")
+		line(b, "if err != nil {")
+		line(b, "return nil, err")
+		line(b, "}")
+	} else {
+		line(b, "if err := enc.Validate(); err != nil {")
+		line(b, "return nil, err")
+		line(b, "}")
+	}
+
 	line(b, "")
 	line(b, "return &%s{", readerType)
 	line(b, "src: bufio.NewReaderSize(r, %s),", readAheadConst)
-	line(b, "enc: enc,")
+
+	if f.how.bounded() {
+		line(b, "cr: cr,")
+	} else {
+		line(b, "enc: enc,")
+	}
+
 	line(b, "state: %d,", f.index[f.file.GetStartStateId()])
 
 	if f.how == delimited && f.placement == irpb.DelimiterPlacement_DELIMITER_PLACEMENT_SEPARATOR {
@@ -916,14 +951,15 @@ func (f *filer) emitAdmit(b *strings.Builder) {
 	line(b, "func (r *%s) admit(rec %s) error {", readerType, recordInterface)
 
 	if f.how.bounded() {
-		line(b, "src := bytes.NewReader(r.data)")
+		line(b, "// The record's bytes are in hand, so the decoder is rewound onto them rather")
+		line(b, "// than built over them. A rewind keeps everything the encoding derives and")
+		line(b, "// swaps only the bytes, which is a construction and an allocation this")
+		line(b, "// reader does not make per record — and it puts the offset back to zero, so")
+		line(b, "// every offset codec reports is counted from the start of this record")
+		line(b, "// rather than from the start of the file.")
+		line(b, "r.cr.Reset(r.data)")
 		line(b, "")
-		line(b, "cr, err := codec.NewReader(src, r.enc)")
-		line(b, "if err != nil {")
-		line(b, "return fmt.Errorf(\"reading record %%d: %%w\", r.ordinal, err)")
-		line(b, "}")
-		line(b, "")
-		line(b, "if err := rec.UnmarshalCOBOL(cr); err != nil {")
+		line(b, "if err := rec.UnmarshalCOBOL(r.cr); err != nil {")
 		line(b, "if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {")
 		line(b, "return fmt.Errorf(\"the framing states record %%d is %%d bytes and the extent of the record it admits is longer than that: %%v\", r.ordinal, len(r.data), err)")
 		line(b, "}")
@@ -933,9 +969,11 @@ func (f *filer) emitAdmit(b *strings.Builder) {
 		line(b, "")
 		line(b, "// The framing checked against the extent, which is what a framed file buys")
 		line(b, "// over an unframed one: a wrong width or a mis-selected transition is an")
-		line(b, "// error at the record it happened on rather than silence.")
-		line(b, "if src.Len() != 0 {")
-		line(b, "return fmt.Errorf(\"the framing states record %%d is %%d bytes and the extent of the record it admits is %%d\", r.ordinal, len(r.data), len(r.data)-src.Len())")
+		line(b, "// error at the record it happened on rather than silence. The extent is what")
+		line(b, "// the decoder consumed, which is its offset: the rewind above is what makes")
+		line(b, "// that a count of this record rather than of the file.")
+		line(b, "if r.cr.Offset() != int64(len(r.data)) {")
+		line(b, "return fmt.Errorf(\"the framing states record %%d is %%d bytes and the extent of the record it admits is %%d\", r.ordinal, len(r.data), r.cr.Offset())")
 		line(b, "}")
 		line(b, "")
 		line(b, "return nil")
@@ -949,6 +987,15 @@ func (f *filer) emitAdmit(b *strings.Builder) {
 	if f.keepsBytes {
 		line(b, "r.raw = r.raw[:0]")
 		line(b, "")
+	}
+
+	line(b, "// One decoder per record, which is what this framing costs and the two that")
+	line(b, "// state a record's length do not pay: the framing says nothing about where")
+	line(b, "// this record ends, so the record's bytes are drawn off the same input the")
+	line(b, "// framing came off and are never held. A decoder is rewound onto bytes, and")
+	line(b, "// there are none to rewind this one onto, so it is built over the stream.")
+
+	if f.keepsBytes {
 		line(b, "cr, err := codec.NewReader(&%s{src: r.src, into: &r.raw}, r.enc)", recordingType)
 	} else {
 		line(b, "cr, err := codec.NewReader(r.src, r.enc)")

--- a/example/ledger/file.go
+++ b/example/ledger/file.go
@@ -46,7 +46,17 @@ const readAhead = 4096
 // register file the automaton remembers in, whatever the file's size.
 type Reader struct {
 	src *bufio.Reader
-	enc codec.Encoding
+
+	// cr decodes the record in hand, and is the only one this reader builds:
+	// the framing states a record's length, so the bytes are held before
+	// anything decodes them and [Reader.admit] rewinds this onto each record
+	// rather than constructing one over it. Everything the encoding derives —
+	// the zoned decimal byte tables, the alphanumeric translation table and the
+	// scratch buffers every field is read into — is built once for the file and
+	// survives every rewind, which is why the encoding is not kept beside it:
+	// codec.Reader carries it, and one that could be swapped under a half-read
+	// record is what codec refuses to allow.
+	cr *codec.Reader
 
 	// state is where in the automaton the read is, as a position in the switch
 	// [Reader.Next] walks. The descriptor's state nodes are numbered by ascending
@@ -93,13 +103,18 @@ func NewReader(r io.Reader, enc codec.Encoding) (*Reader, error) {
 		return nil, codec.ErrNilReader
 	}
 
-	if err := enc.Validate(); err != nil {
+	// The one decoder this reader builds, over no bytes until a record is in
+	// hand. Construction is what validates the encoding, and it reports the
+	// same error for the same axis that enc.Validate does, so nothing is
+	// checked twice here.
+	cr, err := codec.NewBytesReader(nil, enc)
+	if err != nil {
 		return nil, err
 	}
 
 	return &Reader{
 		src:   bufio.NewReaderSize(r, readAhead),
-		enc:   enc,
+		cr:    cr,
 		state: 0,
 	}, nil
 }
@@ -1793,14 +1808,15 @@ func (r *Reader) leading() error {
 // are line delimiters on some mainframe code page. A reader counting the extent
 // never reads those bytes as anything but the number they are.
 func (r *Reader) admit(rec Record) error {
-	src := bytes.NewReader(r.data)
+	// The record's bytes are in hand, so the decoder is rewound onto them rather
+	// than built over them. A rewind keeps everything the encoding derives and
+	// swaps only the bytes, which is a construction and an allocation this
+	// reader does not make per record — and it puts the offset back to zero, so
+	// every offset codec reports is counted from the start of this record
+	// rather than from the start of the file.
+	r.cr.Reset(r.data)
 
-	cr, err := codec.NewReader(src, r.enc)
-	if err != nil {
-		return fmt.Errorf("reading record %d: %w", r.ordinal, err)
-	}
-
-	if err := rec.UnmarshalCOBOL(cr); err != nil {
+	if err := rec.UnmarshalCOBOL(r.cr); err != nil {
 		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 			return fmt.Errorf("the framing states record %d is %d bytes and the extent of the record it admits is longer than that: %v", r.ordinal, len(r.data), err)
 		}
@@ -1810,9 +1826,11 @@ func (r *Reader) admit(rec Record) error {
 
 	// The framing checked against the extent, which is what a framed file buys
 	// over an unframed one: a wrong width or a mis-selected transition is an
-	// error at the record it happened on rather than silence.
-	if src.Len() != 0 {
-		return fmt.Errorf("the framing states record %d is %d bytes and the extent of the record it admits is %d", r.ordinal, len(r.data), len(r.data)-src.Len())
+	// error at the record it happened on rather than silence. The extent is what
+	// the decoder consumed, which is its offset: the rewind above is what makes
+	// that a count of this record rather than of the file.
+	if r.cr.Offset() != int64(len(r.data)) {
+		return fmt.Errorf("the framing states record %d is %d bytes and the extent of the record it admits is %d", r.ordinal, len(r.data), r.cr.Offset())
 	}
 
 	return nil


### PR DESCRIPTION
Closes #290

The generated reader built a `codec.Reader` on a schedule: one per record in
`admit`, and one more **per occurrence** wherever an `OCCURS` group carries a
variant. Both are now rewound rather than rebuilt, which is what
`Reader.Reset` and `NewBytesReader` (Zaba505/cobol-go#115) landed for.

## What changed in the emitter

**`reader.go`, the bounded framings.** The reader holds one `cr *codec.Reader`,
built in `NewReader` over no bytes, and `admit` does `r.cr.Reset(r.data)`. The
encoding is no longer kept beside it — `codec.Reader` carries it, and nothing
else in the emitted reader read `r.enc` — so the field is emitted only for the
unbounded framings, which still use it. Construction validates the encoding and
returns the same `EncodingError` for the same axis that `enc.Validate` did, so
the constructor checks it once rather than twice.

**`reader.go`, the framing check.** `src.Len() != 0` was a property of the
`bytes.Reader` this deletes. It is now `r.cr.Offset() != int64(len(r.data))`,
and `len(r.data) - src.Len()` is `r.cr.Offset()`. The message is unchanged, to
the byte. That works because `Reset` puts the offset back to zero, which is also
what keeps every codec-level diagnostic record-relative.

**`codec.go`, the variant-occurrence sub-reader.** One sub-reader per buffered
table, declared and built in the method's prologue and `Reset` onto each
occurrence's bytes inside the loop. The `bytes.NewReader` beside it is gone.

**The unbounded framings are untouched**, and the emitted `admit` now says why:
the framing states nothing about where the record ends, so its bytes come off
the same stream the framing did and are never held, and there is nothing to
rewind a decoder onto. `ResetStream` (Zaba505/cobol-go#131) has since landed
upstream and makes that call site reusable too; it wants its own story, as #290
said it would.

## Judgment calls

- **The sub-reader's name is now unique to the method rather than to the loop
  depth.** Hoisting it to the method's prologue means two buffered tables
  standing side by side would otherwise declare one identifier twice; nesting
  was the only case the depth suffix ever distinguished.
- **The `enc` field is dropped from the bounded reader** rather than left
  written-and-never-read. `unused` is enabled here and generated code is linted
  like every other file, so a dead field is not a neutral choice.
- **`bytes` stays in the imports of both emitted files.** The reader no longer
  needs it, but the writer's own `raw bytes.Buffer` and an arm's `bytes.Equal`
  predicate do, so nothing else needed dropping.

## Acceptance criteria

- [x] The variant-occurrence sub-reader is constructed once per record rather
      than once per occurrence, and the `bytes.NewReader` beside it is gone
- [x] The bounded framings decode through bytes they already hold rather than
      wrapping them; the `bytes` import stays only because the writer and the
      arm predicates still need it, which is recorded above
- [x] The framing-against-extent check is expressed in terms of the codec's
      offset, and its error message is unchanged — pinned to the byte by
      `TestTheExtentOfARecordIsCountedFromTheStartOfIt`
- [x] Codec-level diagnostics stay record-relative, asserted rather than
      assumed: `TestACodecFaultInASecondRecordReportsAnOffsetWithinThatRecord`
      cuts the **second** record of a file short and asserts both that the
      offset is inside that record and that it is not the position in the file
- [x] The unbounded framings are untouched, and why is recorded in the emitted
      `admit` where a reader of the generated code will find it
- [x] Golden packages, the example tree and the determinism tests are
      regenerated and green
- [x] Benchmarked before and after, with allocs/op as the assertion and ns/op as
      orientation
- [x] A record with a variant-carrying `OCCURS` is covered — `orders`, whose
      `ENTRY` occurs three times and holds a variant

## Measured

`internal/chunks`, a segmented file, per record:

| | allocs/record | ns/record |
|---|---|---|
| before | 6 | 467 |
| after | **4** | **131** |

`internal/orders`, one `ENTRY-RECORD` whose table of three occurrences carries a
variant:

| | allocs/op | ns/op |
|---|---|---|
| before | 16 | 1345 |
| after | **11** | **597** |

The two assertions are upper bounds on the allocation count, so codec allocating
*less* for a field later passes rather than failing on an improvement; both were
run against the pre-change generated output and fail there, which is what makes
them assertions rather than descriptions.

## Verified

`dagger call ci` — green. It cannot run inside a per-issue worktree (a
worktree's `.git` is a file, Zaba505/cpybkc#185), so it was run from a clone of
this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
