### PR TITLE
story(gen-go): reuse the codec.Reader on the framings that read from the stream

### DIFF
--- a/cmd/cpybkc-gen-go/internal/README.md
+++ b/cmd/cpybkc-gen-go/internal/README.md
@@ -22,7 +22,7 @@ DO NOT EDIT.` header is what tells them apart. `records_test.go` and
 arm, the second one case per path through the automaton, each carrying the bytes
 it reads as a literal, and `written` pins both byte for byte like every other
 generated file. Everything else — `file_roundtrip_test.go` in all six,
-`record_roundtrip_test.go` in `orders`, and the two `file_reuse_test.go` — is
+`record_roundtrip_test.go` in `orders`, and the four `file_reuse_test.go` — is
 hand-written and is skipped, because those assertions live *inside* each package
 for a reason the generated ones do not have: the bytes retained for a slack node
 are unexported, so a run of the wrong length is something only code in the
@@ -32,14 +32,26 @@ The hand-written names carry `roundtrip` because `file_test.go` is the name
 `cpybkc-gen-go` itself writes, for the file tier; see [the names, and which
 side moves](../README.md#the-names-and-which-side-moves).
 
-`file_reuse_test.go` in [`chunks`](chunks) and [`orders`](orders) is the pair
-that is not a round trip. They hold what a reader and a writer may *cost*, in
-both directions of each: `chunks` that one more record of a file costs neither
-one more decoder nor one more encoder, and `orders` that one sub-decoder and one
-sub-encoder serve every occurrence of a table holding a variant. Both assert in
-allocations rather than in nanoseconds, because an allocation count is the same
-on every machine and a duration is not, and both carry a benchmark beside each
+`file_reuse_test.go` in [`chunks`](chunks), [`orders`](orders),
+[`counted`](counted) and [`sep`](sep) is the set that is not a round trip. They
+hold what a reader and a writer may *cost*: `chunks` that one more record of a
+file costs neither one more decoder nor one more encoder, `orders` that one
+sub-decoder and one sub-encoder serve every occurrence of a table holding a
+variant, and `counted` and `sep` that a framing which does not state a record's
+length costs no decoder per record either. All of them assert in allocations
+rather than in nanoseconds, because an allocation count is the same on every
+machine and a duration is not, and all of them carry a benchmark beside each
 assertion for the nanoseconds somebody reading a regression will want.
+
+The last two are one claim on two arms of the emitter rather than the same
+assertion twice. A reader under an unbounded framing rewinds its decoder onto
+the *input* rather than onto bytes it holds, so those two also hold what the
+rewind must not disturb: that codec's offsets stay counted from the start of the
+record, and that a rewind reads nothing ahead of it, so the byte behind a
+record's extent is still the framing's to read. `counted` binds a bytes register
+and `sep` does not, which is the line of generated code that differs between
+them — and it is on the margin, because the tap a bytes register is read through
+escapes into the decoder.
 
 ## Why there is more than one
 

--- a/cmd/cpybkc-gen-go/internal/chunks/file.go
+++ b/cmd/cpybkc-gen-go/internal/chunks/file.go
@@ -87,9 +87,10 @@ func NewReader(r io.Reader, enc codec.Encoding) (*Reader, error) {
 	}
 
 	// The one decoder this reader builds, over no bytes until a record is in
-	// hand. Construction is what validates the encoding, and it reports the
-	// same error for the same axis that enc.Validate does, so nothing is
-	// checked twice here.
+	// hand.
+	//
+	// Construction is what validates the encoding, and it reports the same error
+	// for the same axis that enc.Validate does, so nothing is checked twice here.
 	cr, err := codec.NewBytesReader(nil, enc)
 	if err != nil {
 		return nil, err

--- a/cmd/cpybkc-gen-go/internal/counted/file.go
+++ b/cmd/cpybkc-gen-go/internal/counted/file.go
@@ -101,15 +101,17 @@ type Reader struct {
 	// reused between records, and a binding copies out of it.
 	raw []byte
 
-	// tap is what [Reader.cr] is rewound onto, and it is wired once in
-	// [NewReader] rather than built per record. Both of the things it holds are
-	// properties of this reader rather than of a record — the input every
-	// record is drawn off, and the address of the field above, which does not
-	// move when the slice it holds is regrown.
+	// tap is what [Reader.cr] is rewound onto, and it is a field of this reader
+	// rather than a value built per record. Neither of the things it holds is
+	// a record's — the input every record is drawn off, and the address of the
+	// field above, which does not move when the slice it holds is regrown.
 	//
 	// Hoisting it is the other half of hoisting the decoder rather than a
 	// detail of it: it escapes into the decoder, so one built per record
 	// would be exactly the allocation per record the rewind was for.
+	// [Reader.admit] points it at this reader before each rewind, which is two
+	// field stores and no allocation — and is why a Reader value copied out of
+	// one cannot go on writing into the original's bytes.
 	tap recording
 
 	// The register file. There is one for the whole read, a register holds what the
@@ -152,21 +154,11 @@ func NewReader(r io.Reader, enc codec.Encoding) (*Reader, error) {
 		return nil, err
 	}
 
-	rd := &Reader{
+	return &Reader{
 		src:   bufio.NewReaderSize(r, readAhead),
 		cr:    cr,
 		state: 0,
-	}
-
-	// The tap wired onto the reader that owns it, which is why there is a name
-	// for that reader here: it keeps the buffered input this constructor made
-	// and the address of a field of the reader, and neither exists until the
-	// reader does. It is wired once and never again — the address of a slice
-	// field does not move when the slice it holds is regrown.
-	rd.tap.src = rd.src
-	rd.tap.into = &rd.raw
-
-	return rd, nil
+	}, nil
 }
 
 // Next is the next record of the file, or io.EOF where the file is complete.
@@ -535,11 +527,19 @@ func (r *Reader) admit(rec Record) error {
 	// byte behind this record's extent is still there for whatever reads next:
 	// the framing behind the record, or the record behind it where this framing
 	// carries nothing.
+	//
 	// A rewind keeps everything the encoding derives and swaps only the source,
 	// which is a construction and an allocation this reader does not make per
 	// record — and it puts the offset back to zero, so every offset codec
 	// reports is counted from the start of this record rather than from the
 	// start of the file.
+	//
+	// The tap is pointed at this reader before every rewind rather than wired
+	// once, so that it follows the receiver that is decoding. It is two field
+	// stores into a [Reader] that is already on the heap and allocates nothing,
+	// which is the whole of what hoisting it out of here would have bought.
+	r.tap.src = r.src
+	r.tap.into = &r.raw
 	r.cr.ResetStream(&r.tap)
 
 	if err := rec.UnmarshalCOBOL(r.cr); err != nil {
@@ -582,10 +582,10 @@ func (r *Reader) trailing() error {
 // bytes register: it keeps what it hands on, so that the record's own bytes
 // are in hand once its values are.
 //
-// One of these serves the whole file — it is [Reader.tap], wired in [NewReader]
-// and rewound onto by every record. Neither field is a record's: the source
-// is the file's input, and into is the address of a field rather than of the
-// bytes in it, so what a record changes is the length of the slice there and
+// One of these serves the whole file — it is [Reader.tap], and every record
+// is rewound onto it. Neither field is a record's: the source is the file's
+// input, and into is the address of a field rather than of the bytes in it,
+// so what a record changes is the length of the slice there and
 // [Reader.admit] truncating it is the whole of the per-record reset.
 type recording struct {
 	src  io.Reader

--- a/cmd/cpybkc-gen-go/internal/counted/file.go
+++ b/cmd/cpybkc-gen-go/internal/counted/file.go
@@ -61,7 +61,21 @@ const (
 // register file the automaton remembers in, whatever the file's size.
 type Reader struct {
 	src *bufio.Reader
-	enc codec.Encoding
+
+	// cr decodes the record being read, and is the only one this reader
+	// builds: the framing says nothing about where a record ends, so the
+	// record's bytes come off the same input the framing does and are never
+	// held — and [Reader.admit] rewinds this onto that input for each record
+	// rather than constructing one over it. A rewind onto a stream reads
+	// nothing and discards nothing, which is what lets everything drawn off
+	// that input — this record, the framing around it, and the record behind
+	// it — go on sharing it across a rewind. Everything the encoding derives —
+	// the zoned decimal byte tables, the alphanumeric translation table and the
+	// scratch buffers every field is read into — is built once for the file and
+	// survives every rewind, which is why the encoding is not kept beside it:
+	// codec.Reader carries it, and one that could be swapped under a half-read
+	// record is what codec refuses to allow.
+	cr *codec.Reader
 
 	// state is where in the automaton the read is, as a position in the switch
 	// [Reader.Next] walks. The descriptor's state nodes are numbered by ascending
@@ -86,6 +100,17 @@ type Reader struct {
 	// holds its source field's bytes as they appear in the record. It is
 	// reused between records, and a binding copies out of it.
 	raw []byte
+
+	// tap is what [Reader.cr] is rewound onto, and it is wired once in
+	// [NewReader] rather than built per record. Both of the things it holds are
+	// properties of this reader rather than of a record — the input every
+	// record is drawn off, and the address of the field above, which does not
+	// move when the slice it holds is regrown.
+	//
+	// Hoisting it is the other half of hoisting the decoder rather than a
+	// detail of it: it escapes into the decoder, so one built per record
+	// would be exactly the allocation per record the rewind was for.
+	tap recording
 
 	// The register file. There is one for the whole read, a register holds what the
 	// most recent binding put in it, and nothing saves or restores one — so the
@@ -117,15 +142,31 @@ func NewReader(r io.Reader, enc codec.Encoding) (*Reader, error) {
 		return nil, codec.ErrNilReader
 	}
 
-	if err := enc.Validate(); err != nil {
+	// The one decoder this reader builds, over no bytes until [Reader.admit]
+	// rewinds it onto the input.
+	//
+	// Construction is what validates the encoding, and it reports the same error
+	// for the same axis that enc.Validate does, so nothing is checked twice here.
+	cr, err := codec.NewBytesReader(nil, enc)
+	if err != nil {
 		return nil, err
 	}
 
-	return &Reader{
+	rd := &Reader{
 		src:   bufio.NewReaderSize(r, readAhead),
-		enc:   enc,
+		cr:    cr,
 		state: 0,
-	}, nil
+	}
+
+	// The tap wired onto the reader that owns it, which is why there is a name
+	// for that reader here: it keeps the buffered input this constructor made
+	// and the address of a field of the reader, and neither exists until the
+	// reader does. It is wired once and never again — the address of a slice
+	// field does not move when the slice it holds is regrown.
+	rd.tap.src = rd.src
+	rd.tap.into = &rd.raw
+
+	return rd, nil
 }
 
 // Next is the next record of the file, or io.EOF where the file is complete.
@@ -487,17 +528,21 @@ func (r *Reader) leading() error {
 func (r *Reader) admit(rec Record) error {
 	r.raw = r.raw[:0]
 
-	// One decoder per record, which is what this framing costs and the two that
-	// state a record's length do not pay: the framing says nothing about where
-	// this record ends, so the record's bytes are drawn off the same input the
-	// framing came off and are never held. A decoder is rewound onto bytes, and
-	// there are none to rewind this one onto, so it is built over the stream.
-	cr, err := codec.NewReader(&recording{src: r.src, into: &r.raw}, r.enc)
-	if err != nil {
-		return fmt.Errorf("reading record %d: %w", r.ordinal, err)
-	}
+	// The decoder is rewound onto the input rather than built over it. The
+	// framing says nothing about where this record ends, so the record's bytes
+	// are drawn off the same input the framing came off and are never held —
+	// and a rewind onto a stream reads nothing and discards nothing, so the
+	// byte behind this record's extent is still there for whatever reads next:
+	// the framing behind the record, or the record behind it where this framing
+	// carries nothing.
+	// A rewind keeps everything the encoding derives and swaps only the source,
+	// which is a construction and an allocation this reader does not make per
+	// record — and it puts the offset back to zero, so every offset codec
+	// reports is counted from the start of this record rather than from the
+	// start of the file.
+	r.cr.ResetStream(&r.tap)
 
-	if err := rec.UnmarshalCOBOL(cr); err != nil {
+	if err := rec.UnmarshalCOBOL(r.cr); err != nil {
 		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 			return fmt.Errorf("the file ends part-way through record %d: %v", r.ordinal, err)
 		}
@@ -536,6 +581,12 @@ func (r *Reader) trailing() error {
 // recording is the reader a record is decoded through where a binding writes a
 // bytes register: it keeps what it hands on, so that the record's own bytes
 // are in hand once its values are.
+//
+// One of these serves the whole file — it is [Reader.tap], wired in [NewReader]
+// and rewound onto by every record. Neither field is a record's: the source
+// is the file's input, and into is the address of a field rather than of the
+// bytes in it, so what a record changes is the length of the slice there and
+// [Reader.admit] truncating it is the whole of the per-record reset.
 type recording struct {
 	src  io.Reader
 	into *[]byte

--- a/cmd/cpybkc-gen-go/internal/counted/file_reuse_test.go
+++ b/cmd/cpybkc-gen-go/internal/counted/file_reuse_test.go
@@ -1,0 +1,289 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// The assertions that a reader under a framing which does *not* state a
+// record's length builds one decoder for the file rather than one per record,
+// and that rewinding it onto the input leaves the input where building one over
+// it did.
+//
+// The reader in the chunks package makes the same claim under the other kind
+// of framing, and the two are not the same claim. There a record's bytes
+// are in hand before anything decodes them, so the decoder is rewound onto
+// bytes; here the framing says nothing about where a record ends, so the
+// decoder is rewound onto the input the framing itself is read from, and what
+// has to hold is that a rewind neither reads ahead nor drops what it has not
+// read. Three things below are that property, from three sides.
+//
+// This is also the arm that keeps a record's own bytes: a binding here writes a
+// bytes register, so the record is decoded through a tap that copies what it
+// hands on. The tap is hoisted onto the reader rather than built per record,
+// and the count below is why — it escapes into the decoder, so one per record
+// is one allocation per record however cheap the decoder became.
+package counted
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/Zaba505/cobol-go/codec"
+)
+
+// perRecordAllocations is what one more DETAIL-RECORD of this file may cost.
+//
+// Two, and neither is the decoder's: what is left on the margin is the record
+// the reader hands back and what codec decodes its items into. Before one
+// decoder served the whole file it was four — a codec.Reader built for the
+// record, and the recording tap that Reader read the record's bytes through,
+// which escaped into it and so could not be hoisted separately.
+//
+// An upper bound rather than an equality, so that codec allocating less for a
+// field than it does today passes rather than failing on an improvement. What
+// it catches is the regression: a decoder back on the margin takes this to four
+// whatever else changes.
+const perRecordAllocations = 2
+
+// tolerance is the slack the bound is read with, which is what makes the
+// comparison one of whole allocations rather than of floating point.
+const tolerance = 0.5
+
+// laid is a record's bytes, written item by item, with the delimiter behind it
+// — which is where a terminator stands.
+//
+// It is [laidOut] over a [testing.TB], because the assertions here have a
+// benchmark beside each of them and a benchmark is not a [testing.T].
+func laid(tb testing.TB, items func(*codec.Writer) error) []byte {
+	tb.Helper()
+
+	var b bytes.Buffer
+
+	w, err := codec.NewWriter(&b, Encoding())
+	if err != nil {
+		tb.Fatalf("codec.NewWriter: %v", err)
+	}
+
+	if err := items(w); err != nil {
+		tb.Fatalf("laying the record out: %v", err)
+	}
+
+	b.Write([]byte{0x15})
+
+	return b.Bytes()
+}
+
+// countedRun is one group: a header stating how many details follow it, and
+// those details. Its flag is N, so no summary record stands behind them and the
+// state the run ends in accepts.
+//
+// Each detail's amount is +152.50, which is the three bytes 15 25 0C — the
+// first of them this file's delimiter, so a reader that read one byte further
+// than a record's extent would find the wrong thing where the terminator is.
+func countedRun(tb testing.TB, details int) []byte {
+	tb.Helper()
+
+	parts := [][]byte{laid(tb, func(w *codec.Writer) error {
+		if err := w.WriteAlphanumeric("H", 1); err != nil {
+			return err
+		}
+
+		if err := w.WriteZonedInt32(int32(details), 2, codec.SignUnsigned); err != nil {
+			return err
+		}
+
+		if err := w.WriteAlphanumeric("N", 1); err != nil {
+			return err
+		}
+
+		return w.WriteZonedInt32(0, 2, codec.SignUnsigned)
+	})}
+
+	for range details {
+		parts = append(parts, laid(tb, func(w *codec.Writer) error {
+			if err := w.WriteAlphanumeric("D", 1); err != nil {
+				return err
+			}
+
+			return w.WritePackedInt32(15250, 5, codec.Signed)
+		}))
+	}
+
+	return bytes.Join(parts, nil)
+}
+
+// drain reads every record of in and keeps none of them.
+func drain(tb testing.TB, in []byte) {
+	tb.Helper()
+
+	r, err := NewReader(bytes.NewReader(in), Encoding())
+	if err != nil {
+		tb.Fatalf("NewReader: %v", err)
+	}
+
+	for {
+		switch _, err := r.Next(); {
+		case errors.Is(err, io.EOF):
+			return
+		case err != nil:
+			tb.Fatalf("Next: %v", err)
+		}
+	}
+}
+
+// TestOneMoreRecordDoesNotCostOneMoreDecoder is what a rewind onto a stream
+// buys this framing, which is what it could not have before codec had one: the
+// record's bytes are never held, so there is nothing to rewind a decoder onto
+// with [codec.Reader.Reset], and the decoder is rewound onto the input instead.
+//
+// The difference between two files of the same records is what isolates that. A
+// reader's fixed costs — the buffered input, the one decoder, the tap it reads
+// through — are the same for both files and cancel, so what is left is what a
+// record costs, and a decoder on that margin is what this fails on.
+//
+// Not parallel, and deliberately: [testing.AllocsPerRun] counts the whole
+// process's allocations, so a test measuring them cannot run beside one making
+// them.
+func TestOneMoreRecordDoesNotCostOneMoreDecoder(t *testing.T) {
+	const few, many = 4, 20
+
+	short, long := countedRun(t, few), countedRun(t, many)
+
+	fewer := testing.AllocsPerRun(20, func() { drain(t, short) })
+	more := testing.AllocsPerRun(20, func() { drain(t, long) })
+
+	marginal := (more - fewer) / float64(many-few)
+
+	if marginal > perRecordAllocations+tolerance {
+		t.Errorf("one more record of this file allocates %.2f times, and a record of it accounts for %d of them",
+			marginal, perRecordAllocations)
+	}
+}
+
+// BenchmarkReadingAFile is the orientation the assertion above deliberately is
+// not: what a record of this file costs in nanoseconds on the machine in front
+// of you.
+func BenchmarkReadingAFile(b *testing.B) {
+	in := countedRun(b, 99)
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		drain(b, in)
+	}
+}
+
+// TestCodecDiagnosticsStayRecordRelative is the property the rewind is worth
+// nothing without.
+//
+// A rewind puts [codec.Reader.Offset] back to zero, so an offset codec reports
+// is counted from the start of the record it is reading rather than from the
+// start of the file — which is the offset an adopter can find in a copybook.
+// One decoder for the whole file could have made every one of these a file
+// offset, and on a record that is not the first the two differ: this record
+// begins at byte 12 of the file and the fault is at byte 3 of the record.
+//
+// The message is held whole rather than searched for a number. What must not
+// change on this path is the diagnostic an adopter reads, and an assertion that
+// merely finds "3" somewhere in it would pass on a sentence rewritten around
+// it.
+func TestCodecDiagnosticsStayRecordRelative(t *testing.T) {
+	t.Parallel()
+
+	in := countedRun(t, 2)
+
+	// The sign nibble of the second DETAIL-RECORD, which is the third record of
+	// the file and the last byte in front of its terminator.
+	in[len(in)-2] = 0xff
+
+	_, err := read(t, in)
+	if err == nil {
+		t.Fatal("a record whose packed field holds a digit nibble of F was read")
+	}
+
+	const want = "reading record 3: DETAIL-RECORD: reading AMOUNT: at byte offset 3: " +
+		"invalid packed decimal digit nibble F: digit nibbles are 0-9"
+
+	if err.Error() != want {
+		t.Errorf("the diagnostic is\n got: %s\nwant: %s", err, want)
+	}
+}
+
+// TestAShortFileIsStillReportedAtTheRecordItRanOutIn is the other half of the
+// same property, and it carries the distinction the whole path turns on: a
+// record whose first byte is missing ends the field with io.EOF, and one cut
+// part-way through a field ends it with io.ErrUnexpectedEOF. Both are the file
+// being cut short rather than the file ending, and neither wraps io.EOF where a
+// caller can reach it.
+func TestAShortFileIsStillReportedAtTheRecordItRanOutIn(t *testing.T) {
+	t.Parallel()
+
+	whole := countedRun(t, 2)
+
+	for _, tc := range []struct {
+		name string
+		cut  int
+		want string
+	}{
+		{
+			name: "part-way through a field",
+			cut:  2,
+			want: "the file ends part-way through record 3: DETAIL-RECORD: reading AMOUNT: at byte offset 3: unexpected EOF",
+		},
+		{
+			name: "at a field boundary",
+			cut:  4,
+			want: "the file ends part-way through record 3: DETAIL-RECORD: reading AMOUNT: at byte offset 1: EOF",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := read(t, whole[:len(whole)-tc.cut])
+			if err == nil {
+				t.Fatal("a file cut short was read as complete")
+			}
+
+			if errors.Is(err, io.EOF) {
+				t.Error("a file cut short reports io.EOF, which is what a complete file reports")
+			}
+
+			if err.Error() != tc.want {
+				t.Errorf("the diagnostic is\n got: %s\nwant: %s", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestARewindReadsNothingAheadOfTheRecord is the property that lets the framing
+// and the record share one input across a rewind, asserted from the far side of
+// the last record.
+//
+// codec does not buffer, so a decoder rewound onto this reader's input has
+// never read further than the last field it was asked for — and the whole of
+// this framing depends on it, because the terminator behind a record is drawn
+// off the same input the record was. Bytes behind the last terminator are
+// therefore still there to be read as the record they are not, which is what
+// this holds: three records come back, and the fourth is reported as a record
+// the layout does not describe rather than never being seen at all.
+func TestARewindReadsNothingAheadOfTheRecord(t *testing.T) {
+	t.Parallel()
+
+	in := append(countedRun(t, 2), 0xc1, 0xc2, 0x15)
+
+	records, err := read(t, in)
+	if err == nil {
+		t.Fatal("the bytes behind the last record were read as the end of the file")
+	}
+
+	if len(records) != 3 {
+		t.Errorf("the file's three records came back as %d", len(records))
+	}
+
+	const want = "record 4 is a record the layout does not describe, and the automaton expected one of HEADER-RECORD"
+
+	if err.Error() != want {
+		t.Errorf("the diagnostic is\n got: %s\nwant: %s", err, want)
+	}
+}

--- a/cmd/cpybkc-gen-go/internal/counted/file_reuse_test.go
+++ b/cmd/cpybkc-gen-go/internal/counted/file_reuse_test.go
@@ -44,6 +44,15 @@ import (
 // field than it does today passes rather than failing on an improvement. What
 // it catches is the regression: a decoder back on the margin takes this to four
 // whatever else changes.
+//
+// It is a budget and not an attribution, and the difference matters when it
+// fires. Everything on the margin is summed — the decoder, the tap, the record
+// and whatever codec allocates for the items — so a tap back on the margin
+// beside a codec that shed one elsewhere lands at two and passes. Splitting
+// them is not something this can do: the allocations are indistinguishable from
+// outside the package that made them, and a two-sided bound would fail on the
+// improvement the paragraph above deliberately allows. The attribution is that
+// paragraph, checked by hand whenever the number moves.
 const perRecordAllocations = 2
 
 // tolerance is the slack the bound is read with, which is what makes the

--- a/cmd/cpybkc-gen-go/internal/fixed/file.go
+++ b/cmd/cpybkc-gen-go/internal/fixed/file.go
@@ -44,7 +44,21 @@ const readAhead = 4096
 // register file the automaton remembers in, whatever the file's size.
 type Reader struct {
 	src *bufio.Reader
-	enc codec.Encoding
+
+	// cr decodes the record being read, and is the only one this reader
+	// builds: the framing says nothing about where a record ends, so the
+	// record's bytes come off the same input the framing does and are never
+	// held — and [Reader.admit] rewinds this onto that input for each record
+	// rather than constructing one over it. A rewind onto a stream reads
+	// nothing and discards nothing, which is what lets everything drawn off
+	// that input — this record, the framing around it, and the record behind
+	// it — go on sharing it across a rewind. Everything the encoding derives —
+	// the zoned decimal byte tables, the alphanumeric translation table and the
+	// scratch buffers every field is read into — is built once for the file and
+	// survives every rewind, which is why the encoding is not kept beside it:
+	// codec.Reader carries it, and one that could be swapped under a half-read
+	// record is what codec refuses to allow.
+	cr *codec.Reader
 
 	// state is where in the automaton the read is, as a position in the switch
 	// [Reader.Next] walks. The descriptor's state nodes are numbered by ascending
@@ -72,13 +86,19 @@ func NewReader(r io.Reader, enc codec.Encoding) (*Reader, error) {
 		return nil, codec.ErrNilReader
 	}
 
-	if err := enc.Validate(); err != nil {
+	// The one decoder this reader builds, over no bytes until [Reader.admit]
+	// rewinds it onto the input.
+	//
+	// Construction is what validates the encoding, and it reports the same error
+	// for the same axis that enc.Validate does, so nothing is checked twice here.
+	cr, err := codec.NewBytesReader(nil, enc)
+	if err != nil {
 		return nil, err
 	}
 
 	return &Reader{
 		src:   bufio.NewReaderSize(r, readAhead),
-		enc:   enc,
+		cr:    cr,
 		state: 0,
 	}, nil
 }
@@ -175,17 +195,21 @@ func (r *Reader) leading() error {
 // are line delimiters on some mainframe code page. A reader counting the extent
 // never reads those bytes as anything but the number they are.
 func (r *Reader) admit(rec Record) error {
-	// One decoder per record, which is what this framing costs and the two that
-	// state a record's length do not pay: the framing says nothing about where
-	// this record ends, so the record's bytes are drawn off the same input the
-	// framing came off and are never held. A decoder is rewound onto bytes, and
-	// there are none to rewind this one onto, so it is built over the stream.
-	cr, err := codec.NewReader(r.src, r.enc)
-	if err != nil {
-		return fmt.Errorf("reading record %d: %w", r.ordinal, err)
-	}
+	// The decoder is rewound onto the input rather than built over it. The
+	// framing says nothing about where this record ends, so the record's bytes
+	// are drawn off the same input the framing came off and are never held —
+	// and a rewind onto a stream reads nothing and discards nothing, so the
+	// byte behind this record's extent is still there for whatever reads next:
+	// the framing behind the record, or the record behind it where this framing
+	// carries nothing.
+	// A rewind keeps everything the encoding derives and swaps only the source,
+	// which is a construction and an allocation this reader does not make per
+	// record — and it puts the offset back to zero, so every offset codec
+	// reports is counted from the start of this record rather than from the
+	// start of the file.
+	r.cr.ResetStream(r.src)
 
-	if err := rec.UnmarshalCOBOL(cr); err != nil {
+	if err := rec.UnmarshalCOBOL(r.cr); err != nil {
 		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 			return fmt.Errorf("the file ends part-way through record %d: %v", r.ordinal, err)
 		}

--- a/cmd/cpybkc-gen-go/internal/fixed/file.go
+++ b/cmd/cpybkc-gen-go/internal/fixed/file.go
@@ -202,6 +202,7 @@ func (r *Reader) admit(rec Record) error {
 	// byte behind this record's extent is still there for whatever reads next:
 	// the framing behind the record, or the record behind it where this framing
 	// carries nothing.
+	//
 	// A rewind keeps everything the encoding derives and swaps only the source,
 	// which is a construction and an allocation this reader does not make per
 	// record — and it puts the offset back to zero, so every offset codec

--- a/cmd/cpybkc-gen-go/internal/opt/file.go
+++ b/cmd/cpybkc-gen-go/internal/opt/file.go
@@ -217,6 +217,7 @@ func (r *Reader) admit(rec Record) error {
 	// byte behind this record's extent is still there for whatever reads next:
 	// the framing behind the record, or the record behind it where this framing
 	// carries nothing.
+	//
 	// A rewind keeps everything the encoding derives and swaps only the source,
 	// which is a construction and an allocation this reader does not make per
 	// record — and it puts the offset back to zero, so every offset codec

--- a/cmd/cpybkc-gen-go/internal/opt/file.go
+++ b/cmd/cpybkc-gen-go/internal/opt/file.go
@@ -55,7 +55,21 @@ const readAhead = 4096
 // register file the automaton remembers in, whatever the file's size.
 type Reader struct {
 	src *bufio.Reader
-	enc codec.Encoding
+
+	// cr decodes the record being read, and is the only one this reader
+	// builds: the framing says nothing about where a record ends, so the
+	// record's bytes come off the same input the framing does and are never
+	// held — and [Reader.admit] rewinds this onto that input for each record
+	// rather than constructing one over it. A rewind onto a stream reads
+	// nothing and discards nothing, which is what lets everything drawn off
+	// that input — this record, the framing around it, and the record behind
+	// it — go on sharing it across a rewind. Everything the encoding derives —
+	// the zoned decimal byte tables, the alphanumeric translation table and the
+	// scratch buffers every field is read into — is built once for the file and
+	// survives every rewind, which is why the encoding is not kept beside it:
+	// codec.Reader carries it, and one that could be swapped under a half-read
+	// record is what codec refuses to allow.
+	cr *codec.Reader
 
 	// state is where in the automaton the read is, as a position in the switch
 	// [Reader.Next] walks. The descriptor's state nodes are numbered by ascending
@@ -83,13 +97,19 @@ func NewReader(r io.Reader, enc codec.Encoding) (*Reader, error) {
 		return nil, codec.ErrNilReader
 	}
 
-	if err := enc.Validate(); err != nil {
+	// The one decoder this reader builds, over no bytes until [Reader.admit]
+	// rewinds it onto the input.
+	//
+	// Construction is what validates the encoding, and it reports the same error
+	// for the same axis that enc.Validate does, so nothing is checked twice here.
+	cr, err := codec.NewBytesReader(nil, enc)
+	if err != nil {
 		return nil, err
 	}
 
 	return &Reader{
 		src:   bufio.NewReaderSize(r, readAhead),
-		enc:   enc,
+		cr:    cr,
 		state: 0,
 	}, nil
 }
@@ -190,17 +210,21 @@ func (r *Reader) leading() error {
 // are line delimiters on some mainframe code page. A reader counting the extent
 // never reads those bytes as anything but the number they are.
 func (r *Reader) admit(rec Record) error {
-	// One decoder per record, which is what this framing costs and the two that
-	// state a record's length do not pay: the framing says nothing about where
-	// this record ends, so the record's bytes are drawn off the same input the
-	// framing came off and are never held. A decoder is rewound onto bytes, and
-	// there are none to rewind this one onto, so it is built over the stream.
-	cr, err := codec.NewReader(r.src, r.enc)
-	if err != nil {
-		return fmt.Errorf("reading record %d: %w", r.ordinal, err)
-	}
+	// The decoder is rewound onto the input rather than built over it. The
+	// framing says nothing about where this record ends, so the record's bytes
+	// are drawn off the same input the framing came off and are never held —
+	// and a rewind onto a stream reads nothing and discards nothing, so the
+	// byte behind this record's extent is still there for whatever reads next:
+	// the framing behind the record, or the record behind it where this framing
+	// carries nothing.
+	// A rewind keeps everything the encoding derives and swaps only the source,
+	// which is a construction and an allocation this reader does not make per
+	// record — and it puts the offset back to zero, so every offset codec
+	// reports is counted from the start of this record rather than from the
+	// start of the file.
+	r.cr.ResetStream(r.src)
 
-	if err := rec.UnmarshalCOBOL(cr); err != nil {
+	if err := rec.UnmarshalCOBOL(r.cr); err != nil {
 		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 			return fmt.Errorf("the file ends part-way through record %d: %v", r.ordinal, err)
 		}

--- a/cmd/cpybkc-gen-go/internal/orders/file.go
+++ b/cmd/cpybkc-gen-go/internal/orders/file.go
@@ -92,9 +92,10 @@ func NewReader(r io.Reader, enc codec.Encoding) (*Reader, error) {
 	}
 
 	// The one decoder this reader builds, over no bytes until a record is in
-	// hand. Construction is what validates the encoding, and it reports the
-	// same error for the same axis that enc.Validate does, so nothing is
-	// checked twice here.
+	// hand.
+	//
+	// Construction is what validates the encoding, and it reports the same error
+	// for the same axis that enc.Validate does, so nothing is checked twice here.
 	cr, err := codec.NewBytesReader(nil, enc)
 	if err != nil {
 		return nil, err

--- a/cmd/cpybkc-gen-go/internal/sep/file.go
+++ b/cmd/cpybkc-gen-go/internal/sep/file.go
@@ -232,6 +232,7 @@ func (r *Reader) admit(rec Record) error {
 	// byte behind this record's extent is still there for whatever reads next:
 	// the framing behind the record, or the record behind it where this framing
 	// carries nothing.
+	//
 	// A rewind keeps everything the encoding derives and swaps only the source,
 	// which is a construction and an allocation this reader does not make per
 	// record — and it puts the offset back to zero, so every offset codec

--- a/cmd/cpybkc-gen-go/internal/sep/file.go
+++ b/cmd/cpybkc-gen-go/internal/sep/file.go
@@ -55,7 +55,21 @@ const readAhead = 4096
 // register file the automaton remembers in, whatever the file's size.
 type Reader struct {
 	src *bufio.Reader
-	enc codec.Encoding
+
+	// cr decodes the record being read, and is the only one this reader
+	// builds: the framing says nothing about where a record ends, so the
+	// record's bytes come off the same input the framing does and are never
+	// held — and [Reader.admit] rewinds this onto that input for each record
+	// rather than constructing one over it. A rewind onto a stream reads
+	// nothing and discards nothing, which is what lets everything drawn off
+	// that input — this record, the framing around it, and the record behind
+	// it — go on sharing it across a rewind. Everything the encoding derives —
+	// the zoned decimal byte tables, the alphanumeric translation table and the
+	// scratch buffers every field is read into — is built once for the file and
+	// survives every rewind, which is why the encoding is not kept beside it:
+	// codec.Reader carries it, and one that could be swapped under a half-read
+	// record is what codec refuses to allow.
+	cr *codec.Reader
 
 	// state is where in the automaton the read is, as a position in the switch
 	// [Reader.Next] walks. The descriptor's state nodes are numbered by ascending
@@ -87,13 +101,19 @@ func NewReader(r io.Reader, enc codec.Encoding) (*Reader, error) {
 		return nil, codec.ErrNilReader
 	}
 
-	if err := enc.Validate(); err != nil {
+	// The one decoder this reader builds, over no bytes until [Reader.admit]
+	// rewinds it onto the input.
+	//
+	// Construction is what validates the encoding, and it reports the same error
+	// for the same axis that enc.Validate does, so nothing is checked twice here.
+	cr, err := codec.NewBytesReader(nil, enc)
+	if err != nil {
 		return nil, err
 	}
 
 	return &Reader{
 		src:   bufio.NewReaderSize(r, readAhead),
-		enc:   enc,
+		cr:    cr,
 		state: 0,
 		first: true,
 	}, nil
@@ -205,17 +225,21 @@ func (r *Reader) leading() error {
 // are line delimiters on some mainframe code page. A reader counting the extent
 // never reads those bytes as anything but the number they are.
 func (r *Reader) admit(rec Record) error {
-	// One decoder per record, which is what this framing costs and the two that
-	// state a record's length do not pay: the framing says nothing about where
-	// this record ends, so the record's bytes are drawn off the same input the
-	// framing came off and are never held. A decoder is rewound onto bytes, and
-	// there are none to rewind this one onto, so it is built over the stream.
-	cr, err := codec.NewReader(r.src, r.enc)
-	if err != nil {
-		return fmt.Errorf("reading record %d: %w", r.ordinal, err)
-	}
+	// The decoder is rewound onto the input rather than built over it. The
+	// framing says nothing about where this record ends, so the record's bytes
+	// are drawn off the same input the framing came off and are never held —
+	// and a rewind onto a stream reads nothing and discards nothing, so the
+	// byte behind this record's extent is still there for whatever reads next:
+	// the framing behind the record, or the record behind it where this framing
+	// carries nothing.
+	// A rewind keeps everything the encoding derives and swaps only the source,
+	// which is a construction and an allocation this reader does not make per
+	// record — and it puts the offset back to zero, so every offset codec
+	// reports is counted from the start of this record rather than from the
+	// start of the file.
+	r.cr.ResetStream(r.src)
 
-	if err := rec.UnmarshalCOBOL(cr); err != nil {
+	if err := rec.UnmarshalCOBOL(r.cr); err != nil {
 		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 			return fmt.Errorf("the file ends part-way through record %d: %v", r.ordinal, err)
 		}

--- a/cmd/cpybkc-gen-go/internal/sep/file_reuse_test.go
+++ b/cmd/cpybkc-gen-go/internal/sep/file_reuse_test.go
@@ -17,7 +17,11 @@
 // The placement makes the read-ahead assertion sharper than a terminator can:
 // under a separator a delimiter stands *between* two records and nothing
 // follows the last, so a decoder that read one byte past a record's extent
-// would eat the delimiter the next record is found behind.
+// would eat the delimiter the next record is found behind. That is also why
+// this arm is asserted from here rather than from fixed or opt, which are the
+// other two packages it is emitted into: the three are the same generated
+// lines, and this is the framing under which an over-read has the least room
+// to hide.
 package sep
 
 import (
@@ -40,6 +44,14 @@ import (
 // field than it does today passes rather than failing on an improvement. What
 // it catches is the regression: a decoder back on the margin takes this to four
 // whatever else changes.
+//
+// It is a budget and not an attribution, and the difference matters when it
+// fires. Everything on the margin is summed — the decoder this is about, the
+// record, and whatever codec allocates for the items — so a decoder coming back
+// while something else on the margin went away lands at three and passes. The
+// attribution is the sentence above, checked by hand when the number moves;
+// nothing here can make it an assertion, because the allocations are
+// indistinguishable from outside the package that made them.
 const perRecordAllocations = 3
 
 // tolerance is the slack the bound is read with, which is what makes the
@@ -183,23 +195,52 @@ func TestCodecDiagnosticsStayRecordRelative(t *testing.T) {
 // the bytes behind the last record are still there to be read as the record
 // they are not, which is what this holds: three records come back, and the
 // fourth is reported as a file cut short rather than never being seen at all.
+//
+// The two cases are the distinction the whole path turns on, and this is the
+// placement where it is easiest to lose: nothing stands behind the last record,
+// so "the file ended" and "the last record was cut short" are the same byte
+// position. A record cut part-way through a field ends it with
+// io.ErrUnexpectedEOF and one cut at a field boundary ends it with io.EOF, and
+// neither is reported as the io.EOF a caller stops on — a %v that became a %w
+// would make a truncated file indistinguishable from a complete one.
 func TestARewindReadsNothingAheadOfTheRecord(t *testing.T) {
 	t.Parallel()
 
-	in := append(separatedFile(t, 3), 0x15, 0xd3, 0xc9)
+	for _, tc := range []struct {
+		name  string
+		trail []byte
+		want  string
+	}{
+		{
+			name:  "part-way through a field",
+			trail: []byte{0x15, 0xd3, 0xc9},
+			want:  "the file ends part-way through record 4: LINE-RECORD: reading LINE-TEXT: at byte offset 2: unexpected EOF",
+		},
+		{
+			name:  "at a field boundary",
+			trail: []byte{0x15, 0xd3, 0xc9, 0xd5, 0xc5, 0x40},
+			want:  "the file ends part-way through record 4: LINE-RECORD: reading LINE-AMOUNT: at byte offset 5: EOF",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	records, err := read(t, in)
-	if err == nil {
-		t.Fatal("the bytes behind the last record were read as the end of the file")
-	}
+			records, err := read(t, append(separatedFile(t, 3), tc.trail...))
+			if err == nil {
+				t.Fatal("the bytes behind the last record were read as the end of the file")
+			}
 
-	if len(records) != 3 {
-		t.Errorf("the file's three records came back as %d", len(records))
-	}
+			if errors.Is(err, io.EOF) {
+				t.Error("a file cut short reports io.EOF, which is what a complete file reports")
+			}
 
-	const want = "the file ends part-way through record 4: LINE-RECORD: reading LINE-TEXT: at byte offset 2: unexpected EOF"
+			if len(records) != 3 {
+				t.Errorf("the file's three records came back as %d", len(records))
+			}
 
-	if err.Error() != want {
-		t.Errorf("the diagnostic is\n got: %s\nwant: %s", err, want)
+			if err.Error() != tc.want {
+				t.Errorf("the diagnostic is\n got: %s\nwant: %s", err, tc.want)
+			}
+		})
 	}
 }

--- a/cmd/cpybkc-gen-go/internal/sep/file_reuse_test.go
+++ b/cmd/cpybkc-gen-go/internal/sep/file_reuse_test.go
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// The same claim the counted package makes, on the other arm of the emitter
+// that writes it: a reader under a framing which does not state a record's
+// length builds one decoder for the file rather than one per record.
+//
+// Nothing here binds a bytes register, so the record is decoded straight off
+// the buffered input rather than through a tap that keeps what it hands on.
+// That is a different line of generated code and so a claim of its own, and the
+// margin below is what tells the two apart — one allocation per record on this
+// arm against two on that one, because the tap was on that margin as well as
+// the decoder.
+//
+// The placement makes the read-ahead assertion sharper than a terminator can:
+// under a separator a delimiter stands *between* two records and nothing
+// follows the last, so a decoder that read one byte past a record's extent
+// would eat the delimiter the next record is found behind.
+package sep
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/Zaba505/cobol-go/codec"
+)
+
+// perRecordAllocations is what one more LINE-RECORD of this file may cost.
+//
+// Three, and none of them is the decoder's: what is left on the margin is the
+// record the reader hands back and what codec decodes its items into. Before
+// one decoder served the whole file it was four — a codec.Reader built for the
+// record, over the buffered input the reader already held.
+//
+// An upper bound rather than an equality, so that codec allocating less for a
+// field than it does today passes rather than failing on an improvement. What
+// it catches is the regression: a decoder back on the margin takes this to four
+// whatever else changes.
+const perRecordAllocations = 3
+
+// tolerance is the slack the bound is read with, which is what makes the
+// comparison one of whole allocations rather than of floating point.
+const tolerance = 0.5
+
+// lineOf is one LINE-RECORD, with no framing around it.
+//
+// It is [lineBytes] over a [testing.TB], because the assertion here has a
+// benchmark beside it and a benchmark is not a [testing.T].
+func lineOf(tb testing.TB, text string) []byte {
+	tb.Helper()
+
+	var b bytes.Buffer
+
+	w, err := codec.NewWriter(&b, Encoding())
+	if err != nil {
+		tb.Fatalf("codec.NewWriter: %v", err)
+	}
+
+	if err := w.WriteAlphanumeric(text, 5); err != nil {
+		tb.Fatalf("LINE-TEXT: %v", err)
+	}
+
+	if err := w.WritePackedInt32(15250, 5, codec.Signed); err != nil {
+		tb.Fatalf("LINE-AMOUNT: %v", err)
+	}
+
+	return b.Bytes()
+}
+
+// separatedFile is n LINE-RECORDs with n-1 delimiters between them, which is
+// every byte a file under this placement carries.
+func separatedFile(tb testing.TB, n int) []byte {
+	tb.Helper()
+
+	parts := make([][]byte, n)
+
+	for i := range parts {
+		parts[i] = lineOf(tb, "LINE")
+	}
+
+	return bytes.Join(parts, []byte{0x15})
+}
+
+// drain reads every record of in and keeps none of them.
+func drain(tb testing.TB, in []byte) {
+	tb.Helper()
+
+	r, err := NewReader(bytes.NewReader(in), Encoding())
+	if err != nil {
+		tb.Fatalf("NewReader: %v", err)
+	}
+
+	for {
+		switch _, err := r.Next(); {
+		case errors.Is(err, io.EOF):
+			return
+		case err != nil:
+			tb.Fatalf("Next: %v", err)
+		}
+	}
+}
+
+// TestOneMoreRecordDoesNotCostOneMoreDecoder isolates what a record costs the
+// way the chunks and counted packages do: a reader's fixed costs — the buffered
+// input and the one decoder — are the same for two files of the same records
+// and cancel, so the difference between them is the margin, and a decoder built
+// per record is what shows up on it.
+//
+// Not parallel, and deliberately: [testing.AllocsPerRun] counts the whole
+// process's allocations, so a test measuring them cannot run beside one making
+// them.
+func TestOneMoreRecordDoesNotCostOneMoreDecoder(t *testing.T) {
+	const few, many = 4, 20
+
+	short, long := separatedFile(t, few), separatedFile(t, many)
+
+	fewer := testing.AllocsPerRun(20, func() { drain(t, short) })
+	more := testing.AllocsPerRun(20, func() { drain(t, long) })
+
+	marginal := (more - fewer) / float64(many-few)
+
+	if marginal > perRecordAllocations+tolerance {
+		t.Errorf("one more record of this file allocates %.2f times, and a record of it accounts for %d of them",
+			marginal, perRecordAllocations)
+	}
+}
+
+// BenchmarkReadingAFile is the orientation the assertion above deliberately is
+// not: what a record of this file costs in nanoseconds on the machine in front
+// of you.
+func BenchmarkReadingAFile(b *testing.B) {
+	in := separatedFile(b, 100)
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		drain(b, in)
+	}
+}
+
+// TestCodecDiagnosticsStayRecordRelative is the property the rewind is worth
+// nothing without: it puts [codec.Reader.Offset] back to zero, so an offset
+// codec reports is counted from the start of the record it is reading rather
+// than from the start of the file — which is the offset an adopter can find in
+// a copybook. On a record that is not the first the two differ: this record
+// begins at byte 18 of the file and the fault is at byte 7 of the record.
+//
+// The message is held whole rather than searched for a number, because what
+// must not change on this path is the diagnostic an adopter reads.
+func TestCodecDiagnosticsStayRecordRelative(t *testing.T) {
+	t.Parallel()
+
+	in := separatedFile(t, 3)
+
+	// The sign nibble of the third record's LINE-AMOUNT, which is the last byte
+	// of the file: under this placement nothing stands behind the last record.
+	in[len(in)-1] = 0xff
+
+	_, err := read(t, in)
+	if err == nil {
+		t.Fatal("a record whose packed field holds a digit nibble of F was read")
+	}
+
+	const want = "reading record 3: LINE-RECORD: reading LINE-AMOUNT: at byte offset 7: " +
+		"invalid packed decimal digit nibble F: digit nibbles are 0-9"
+
+	if err.Error() != want {
+		t.Errorf("the diagnostic is\n got: %s\nwant: %s", err, want)
+	}
+}
+
+// TestARewindReadsNothingAheadOfTheRecord is what lets the framing and the
+// record share one input across a rewind.
+//
+// codec does not buffer, so a decoder rewound onto this reader's input has
+// never read further than the last field it was asked for. Under this placement
+// the byte behind a record is the delimiter the next one is found behind, so a
+// decoder that read even one byte past a record's extent would take it — and
+// the bytes behind the last record are still there to be read as the record
+// they are not, which is what this holds: three records come back, and the
+// fourth is reported as a file cut short rather than never being seen at all.
+func TestARewindReadsNothingAheadOfTheRecord(t *testing.T) {
+	t.Parallel()
+
+	in := append(separatedFile(t, 3), 0x15, 0xd3, 0xc9)
+
+	records, err := read(t, in)
+	if err == nil {
+		t.Fatal("the bytes behind the last record were read as the end of the file")
+	}
+
+	if len(records) != 3 {
+		t.Errorf("the file's three records came back as %d", len(records))
+	}
+
+	const want = "the file ends part-way through record 4: LINE-RECORD: reading LINE-TEXT: at byte offset 2: unexpected EOF"
+
+	if err.Error() != want {
+		t.Errorf("the diagnostic is\n got: %s\nwant: %s", err, want)
+	}
+}

--- a/cmd/cpybkc-gen-go/reader.go
+++ b/cmd/cpybkc-gen-go/reader.go
@@ -57,7 +57,21 @@ func (f *filer) emitReader(b *strings.Builder, walks [][]transition) error {
 		line(b, "// record is what codec refuses to allow.")
 		line(b, "cr *codec.Reader")
 	} else {
-		line(b, "enc codec.Encoding")
+		line(b, "")
+		line(b, "// cr decodes the record being read, and is the only one this reader")
+		line(b, "// builds: the framing says nothing about where a record ends, so the")
+		line(b, "// record's bytes come off the same input the framing does and are never")
+		line(b, "// held — and [%s.admit] rewinds this onto that input for each record", readerType)
+		line(b, "// rather than constructing one over it. A rewind onto a stream reads")
+		line(b, "// nothing and discards nothing, which is what lets everything drawn off")
+		line(b, "// that input — this record, the framing around it, and the record behind")
+		line(b, "// it — go on sharing it across a rewind. Everything the encoding derives —")
+		line(b, "// the zoned decimal byte tables, the alphanumeric translation table and the")
+		line(b, "// scratch buffers every field is read into — is built once for the file and")
+		line(b, "// survives every rewind, which is why the encoding is not kept beside it:")
+		line(b, "// codec.Reader carries it, and one that could be swapped under a half-read")
+		line(b, "// record is what codec refuses to allow.")
+		line(b, "cr *codec.Reader")
 	}
 
 	line(b, "")
@@ -99,6 +113,17 @@ func (f *filer) emitReader(b *strings.Builder, walks [][]transition) error {
 		line(b, "// holds its source field's bytes as they appear in the record. It is")
 		line(b, "// reused between records, and a binding copies out of it.")
 		line(b, "raw []byte")
+		line(b, "")
+		line(b, "// tap is what [%s.cr] is rewound onto, and it is wired once in", readerType)
+		line(b, "// [%s] rather than built per record. Both of the things it holds are", newReaderFunc)
+		line(b, "// properties of this reader rather than of a record — the input every")
+		line(b, "// record is drawn off, and the address of the field above, which does not")
+		line(b, "// move when the slice it holds is regrown.")
+		line(b, "//")
+		line(b, "// Hoisting it is the other half of hoisting the decoder rather than a")
+		line(b, "// detail of it: it escapes into the decoder, so one built per record")
+		line(b, "// would be exactly the allocation per record the rewind was for.")
+		line(b, "tap %s", recordingType)
 	}
 
 	if f.how == delimited && f.placement == irpb.DelimiterPlacement_DELIMITER_PLACEMENT_SEPARATOR {
@@ -151,36 +176,58 @@ func (f *filer) emitNewReader(b *strings.Builder) {
 
 	if f.how.bounded() {
 		line(b, "// The one decoder this reader builds, over no bytes until a record is in")
-		line(b, "// hand. Construction is what validates the encoding, and it reports the")
-		line(b, "// same error for the same axis that enc.Validate does, so nothing is")
-		line(b, "// checked twice here.")
-		line(b, "cr, err := codec.NewBytesReader(nil, enc)")
-		line(b, "if err != nil {")
-		line(b, "return nil, err")
-		line(b, "}")
+		line(b, "// hand.")
 	} else {
-		line(b, "if err := enc.Validate(); err != nil {")
-		line(b, "return nil, err")
-		line(b, "}")
+		line(b, "// The one decoder this reader builds, over no bytes until [%s.admit]", readerType)
+		line(b, "// rewinds it onto the input.")
 	}
 
+	line(b, "//")
+	line(b, "// Construction is what validates the encoding, and it reports the same error")
+	line(b, "// for the same axis that enc.Validate does, so nothing is checked twice here.")
+	line(b, "cr, err := codec.NewBytesReader(nil, enc)")
+	line(b, "if err != nil {")
+	line(b, "return nil, err")
+	line(b, "}")
 	line(b, "")
-	line(b, "return &%s{", readerType)
-	line(b, "src: bufio.NewReaderSize(r, %s),", readAheadConst)
 
-	if f.how.bounded() {
-		line(b, "cr: cr,")
+	// The tap holds this reader's own input and the address of this reader's
+	// own field, neither of which can be named inside the literal that builds
+	// it, so the reader is named where one is wired.
+	hoisted := f.keepsBytes && !f.how.bounded()
+
+	if hoisted {
+		line(b, "rd := &%s{", readerType)
 	} else {
-		line(b, "enc: enc,")
+		line(b, "return &%s{", readerType)
 	}
 
+	line(b, "src: bufio.NewReaderSize(r, %s),", readAheadConst)
+	line(b, "cr: cr,")
 	line(b, "state: %d,", f.index[f.file.GetStartStateId()])
 
 	if f.how == delimited && f.placement == irpb.DelimiterPlacement_DELIMITER_PLACEMENT_SEPARATOR {
 		line(b, "first: true,")
 	}
 
-	line(b, "}, nil")
+	if !hoisted {
+		line(b, "}, nil")
+		line(b, "}")
+
+		return
+	}
+
+	line(b, "}")
+	line(b, "")
+	line(b, "// The tap wired onto the reader that owns it, which is why there is a name")
+	line(b, "// for that reader here: it keeps the buffered input this constructor made")
+	line(b, "// and the address of a field of the reader, and neither exists until the")
+	line(b, "// reader does. It is wired once and never again — the address of a slice")
+	line(b, "// field does not move when the slice it holds is regrown.")
+	line(b, "rd.tap.src = rd.src")
+	line(b, "rd.tap.into = &rd.raw")
+	line(b, "")
+	line(b, "return rd, nil")
 	line(b, "}")
 }
 
@@ -989,23 +1036,27 @@ func (f *filer) emitAdmit(b *strings.Builder) {
 		line(b, "")
 	}
 
-	line(b, "// One decoder per record, which is what this framing costs and the two that")
-	line(b, "// state a record's length do not pay: the framing says nothing about where")
-	line(b, "// this record ends, so the record's bytes are drawn off the same input the")
-	line(b, "// framing came off and are never held. A decoder is rewound onto bytes, and")
-	line(b, "// there are none to rewind this one onto, so it is built over the stream.")
+	line(b, "// The decoder is rewound onto the input rather than built over it. The")
+	line(b, "// framing says nothing about where this record ends, so the record's bytes")
+	line(b, "// are drawn off the same input the framing came off and are never held —")
+	line(b, "// and a rewind onto a stream reads nothing and discards nothing, so the")
+	line(b, "// byte behind this record's extent is still there for whatever reads next:")
+	line(b, "// the framing behind the record, or the record behind it where this framing")
+	line(b, "// carries nothing.")
+	line(b, "// A rewind keeps everything the encoding derives and swaps only the source,")
+	line(b, "// which is a construction and an allocation this reader does not make per")
+	line(b, "// record — and it puts the offset back to zero, so every offset codec")
+	line(b, "// reports is counted from the start of this record rather than from the")
+	line(b, "// start of the file.")
 
 	if f.keepsBytes {
-		line(b, "cr, err := codec.NewReader(&%s{src: r.src, into: &r.raw}, r.enc)", recordingType)
+		line(b, "r.cr.ResetStream(&r.tap)")
 	} else {
-		line(b, "cr, err := codec.NewReader(r.src, r.enc)")
+		line(b, "r.cr.ResetStream(r.src)")
 	}
 
-	line(b, "if err != nil {")
-	line(b, "return fmt.Errorf(\"reading record %%d: %%w\", r.ordinal, err)")
-	line(b, "}")
 	line(b, "")
-	line(b, "if err := rec.UnmarshalCOBOL(cr); err != nil {")
+	line(b, "if err := rec.UnmarshalCOBOL(r.cr); err != nil {")
 	line(b, "if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {")
 	line(b, "return fmt.Errorf(\"the file ends part-way through record %%d: %%v\", r.ordinal, err)")
 	line(b, "}")
@@ -1112,6 +1163,12 @@ func (f *filer) emitHelpers(b *strings.Builder, walks [][]transition) error {
 		line(b, "// %s is the reader a record is decoded through where a binding writes a", recordingType)
 		line(b, "// bytes register: it keeps what it hands on, so that the record's own bytes")
 		line(b, "// are in hand once its values are.")
+		line(b, "//")
+		line(b, "// One of these serves the whole file — it is [%s.tap], wired in [%s]", readerType, newReaderFunc)
+		line(b, "// and rewound onto by every record. Neither field is a record's: the source")
+		line(b, "// is the file's input, and into is the address of a field rather than of the")
+		line(b, "// bytes in it, so what a record changes is the length of the slice there and")
+		line(b, "// [%s.admit] truncating it is the whole of the per-record reset.", readerType)
 		line(b, "type %s struct {", recordingType)
 		line(b, "src io.Reader")
 		line(b, "into *[]byte")

--- a/cmd/cpybkc-gen-go/reader.go
+++ b/cmd/cpybkc-gen-go/reader.go
@@ -114,15 +114,17 @@ func (f *filer) emitReader(b *strings.Builder, walks [][]transition) error {
 		line(b, "// reused between records, and a binding copies out of it.")
 		line(b, "raw []byte")
 		line(b, "")
-		line(b, "// tap is what [%s.cr] is rewound onto, and it is wired once in", readerType)
-		line(b, "// [%s] rather than built per record. Both of the things it holds are", newReaderFunc)
-		line(b, "// properties of this reader rather than of a record — the input every")
-		line(b, "// record is drawn off, and the address of the field above, which does not")
-		line(b, "// move when the slice it holds is regrown.")
+		line(b, "// tap is what [%s.cr] is rewound onto, and it is a field of this reader", readerType)
+		line(b, "// rather than a value built per record. Neither of the things it holds is")
+		line(b, "// a record's — the input every record is drawn off, and the address of the")
+		line(b, "// field above, which does not move when the slice it holds is regrown.")
 		line(b, "//")
 		line(b, "// Hoisting it is the other half of hoisting the decoder rather than a")
 		line(b, "// detail of it: it escapes into the decoder, so one built per record")
 		line(b, "// would be exactly the allocation per record the rewind was for.")
+		line(b, "// [%s.admit] points it at this reader before each rewind, which is two", readerType)
+		line(b, "// field stores and no allocation — and is why a %s value copied out of", readerType)
+		line(b, "// one cannot go on writing into the original's bytes.")
 		line(b, "tap %s", recordingType)
 	}
 
@@ -191,17 +193,7 @@ func (f *filer) emitNewReader(b *strings.Builder) {
 	line(b, "}")
 	line(b, "")
 
-	// The tap holds this reader's own input and the address of this reader's
-	// own field, neither of which can be named inside the literal that builds
-	// it, so the reader is named where one is wired.
-	hoisted := f.keepsBytes && !f.how.bounded()
-
-	if hoisted {
-		line(b, "rd := &%s{", readerType)
-	} else {
-		line(b, "return &%s{", readerType)
-	}
-
+	line(b, "return &%s{", readerType)
 	line(b, "src: bufio.NewReaderSize(r, %s),", readAheadConst)
 	line(b, "cr: cr,")
 	line(b, "state: %d,", f.index[f.file.GetStartStateId()])
@@ -210,24 +202,7 @@ func (f *filer) emitNewReader(b *strings.Builder) {
 		line(b, "first: true,")
 	}
 
-	if !hoisted {
-		line(b, "}, nil")
-		line(b, "}")
-
-		return
-	}
-
-	line(b, "}")
-	line(b, "")
-	line(b, "// The tap wired onto the reader that owns it, which is why there is a name")
-	line(b, "// for that reader here: it keeps the buffered input this constructor made")
-	line(b, "// and the address of a field of the reader, and neither exists until the")
-	line(b, "// reader does. It is wired once and never again — the address of a slice")
-	line(b, "// field does not move when the slice it holds is regrown.")
-	line(b, "rd.tap.src = rd.src")
-	line(b, "rd.tap.into = &rd.raw")
-	line(b, "")
-	line(b, "return rd, nil")
+	line(b, "}, nil")
 	line(b, "}")
 }
 
@@ -1043,6 +1018,7 @@ func (f *filer) emitAdmit(b *strings.Builder) {
 	line(b, "// byte behind this record's extent is still there for whatever reads next:")
 	line(b, "// the framing behind the record, or the record behind it where this framing")
 	line(b, "// carries nothing.")
+	line(b, "//")
 	line(b, "// A rewind keeps everything the encoding derives and swaps only the source,")
 	line(b, "// which is a construction and an allocation this reader does not make per")
 	line(b, "// record — and it puts the offset back to zero, so every offset codec")
@@ -1050,6 +1026,13 @@ func (f *filer) emitAdmit(b *strings.Builder) {
 	line(b, "// start of the file.")
 
 	if f.keepsBytes {
+		line(b, "//")
+		line(b, "// The tap is pointed at this reader before every rewind rather than wired")
+		line(b, "// once, so that it follows the receiver that is decoding. It is two field")
+		line(b, "// stores into a [%s] that is already on the heap and allocates nothing,", readerType)
+		line(b, "// which is the whole of what hoisting it out of here would have bought.")
+		line(b, "r.tap.src = r.src")
+		line(b, "r.tap.into = &r.raw")
 		line(b, "r.cr.ResetStream(&r.tap)")
 	} else {
 		line(b, "r.cr.ResetStream(r.src)")
@@ -1164,10 +1147,10 @@ func (f *filer) emitHelpers(b *strings.Builder, walks [][]transition) error {
 		line(b, "// bytes register: it keeps what it hands on, so that the record's own bytes")
 		line(b, "// are in hand once its values are.")
 		line(b, "//")
-		line(b, "// One of these serves the whole file — it is [%s.tap], wired in [%s]", readerType, newReaderFunc)
-		line(b, "// and rewound onto by every record. Neither field is a record's: the source")
-		line(b, "// is the file's input, and into is the address of a field rather than of the")
-		line(b, "// bytes in it, so what a record changes is the length of the slice there and")
+		line(b, "// One of these serves the whole file — it is [%s.tap], and every record", readerType)
+		line(b, "// is rewound onto it. Neither field is a record's: the source is the file's")
+		line(b, "// input, and into is the address of a field rather than of the bytes in it,")
+		line(b, "// so what a record changes is the length of the slice there and")
 		line(b, "// [%s.admit] truncating it is the whole of the per-record reset.", readerType)
 		line(b, "type %s struct {", recordingType)
 		line(b, "src io.Reader")

--- a/example/ledger/file.go
+++ b/example/ledger/file.go
@@ -104,9 +104,10 @@ func NewReader(r io.Reader, enc codec.Encoding) (*Reader, error) {
 	}
 
 	// The one decoder this reader builds, over no bytes until a record is in
-	// hand. Construction is what validates the encoding, and it reports the
-	// same error for the same axis that enc.Validate does, so nothing is
-	// checked twice here.
+	// hand.
+	//
+	// Construction is what validates the encoding, and it reports the same error
+	// for the same axis that enc.Validate does, so nothing is checked twice here.
 	cr, err := codec.NewBytesReader(nil, enc)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Closes #292

The third call site of the rework #290 began. #298 landed the two framings that
state a record's length; the two that do not — delimited and unframed — could
not be written until Zaba505/cobol-go#131 gave `codec.Reader` a rewind onto an
`io.Reader`, which the pin in `go.mod` already carries as `Reader.ResetStream`.

## What changed

Both unbounded arms of `emitAdmit` now rewind one decoder instead of building
one:

```go
// before
cr, err := codec.NewReader(&recording{src: r.src, into: &r.raw}, r.enc)  // keepsBytes
cr, err := codec.NewReader(r.src, r.enc)                                 // plain

// after
r.cr.ResetStream(&r.tap)   // keepsBytes
r.cr.ResetStream(r.src)    // plain
```

`NewReader` builds the one decoder with `codec.NewBytesReader(nil, enc)`, which
is the same construction the bounded framings already used and validates the
encoding exactly as the `enc.Validate()` it replaces did — same `EncodingError`,
same axis, same message. The `enc codec.Encoding` field is gone; `cr
*codec.Reader` carries it, and codec refuses to let it be swapped under a
half-read record.

## The decision this story owed: the `recording` wrapper

**Hoisted, as `Reader.tap`, wired once in `NewReader` and never reset.**

Neither of the two things it holds is a record's. `src` is the input every
record is drawn off, and `into` is `&r.raw` — the *address of the field*, which
does not move when the slice it holds is regrown, so a record changing the
length of `r.raw` changes nothing the tap has to be told about. The per-record
reset it would have needed is already there and unchanged: `r.raw = r.raw[:0]`.

Leaving it per record was the alternative, and it was rejected because it
escapes into the decoder: it would have kept one allocation per record on
exactly the path this story exists to clear, and the measurement below shows it
was half of what was removed on that arm.

It cannot be built inside the composite literal — it needs the `bufio.Reader`
that literal makes and the address of a field of the value it produces — so the
generated constructor names the reader on that arm and wires the two fields
behind it.

## What did not change

- The messages. `the file ends part-way through record %d: %v` and `reading
  record %d: %w` come out byte for byte as before, including the ordinal and the
  `io.EOF`/`io.ErrUnexpectedEOF` distinction; two new tests hold whole message
  strings rather than searching them for a number. The only removal is the
  unreachable `reading record %d: %w` that wrapped the per-record construction,
  which cannot fail once the encoding is validated in `NewReader`.
- `Offset()` restarts per rewind, so codec-level diagnostics stay
  record-relative. Asserted on a fault in record 3 of a file in both new tests —
  the record begins at byte 12 (counted) and byte 18 (sep) and the message still
  reports byte 3 and byte 7.
- What is behind a record. codec does not buffer, so a rewind reads nothing
  ahead; asserted on files with bytes behind the last record, which come back as
  a fourth record the layout does not describe rather than being swallowed.

## Measured

`BenchmarkReadingAFile`, 100 records, `-benchtime 2000x`:

| package | allocs/op | B/op | ns/op |
|---|---|---|---|
| `counted` before | 408 | 67,000 | ~47,000 |
| `counted` after | **209** | **7,560** | **~12,400** |
| `sep` before | 403 | 65,132 | ~43,500 |
| `sep` after | **304** | **8,060** | **~12,800** |

The assertion is the marginal cost in allocations, which is machine-independent:
`counted` 4 → **2** per record (the decoder *and* the tap), `sep` 4 → **3** (the
decoder). Both new tests fail on the pre-change generated code with exactly
those numbers.

## Acceptance criteria

- [x] Both unbounded arms reuse one `codec.Reader` per file rather than
      constructing one per record
- [x] The `recording` wrapper's fate is decided and argued — hoisted as
      `Reader.tap`, argued above and in the emitted doc comment
- [x] Error messages on this path are byte-identical to today's, including the
      record ordinal and the `io.EOF`/`io.ErrUnexpectedEOF` distinction
- [x] Codec-level diagnostics stay record-relative, asserted on a fault in
      record 3 in both new tests
- [x] The stream is not read further ahead than it is today, asserted on files
      with trailing bytes in both new tests
- [x] Golden packages and determinism tests regenerated and green — `counted`,
      `fixed`, `opt`, `sep` changed; `chunks`, `orders` and `example/ledger`
      picked up the reflowed constructor comment only
- [x] Benchmarked before and after, allocs/op as the assertion
- [x] The note #290 left in the emitted code — *"One decoder per record, which
      is what this framing costs…"* — is removed

## New tests

`cmd/cpybkc-gen-go/internal/counted/file_reuse_test.go` (the `keepsBytes` arm)
and `cmd/cpybkc-gen-go/internal/sep/file_reuse_test.go` (the plain arm), beside
the two that `chunks` and `orders` already carry.
`cmd/cpybkc-gen-go/internal/README.md` is updated for the pair.

## Verified

`dagger call ci`, green, from an ordinary clone of this branch — a worktree's
`.git` is a file, which every `dagger call` refuses.
