### PR TITLE
story(gen-graph): hold a descriptor to the encoding-axis rule, or say why a diagram generator does not

### DIFF
--- a/cmd/cpybkc-gen-graph/README.md
+++ b/cmd/cpybkc-gen-graph/README.md
@@ -506,6 +506,29 @@ Everything this program has to say goes to standard error as
 only severities. A non-zero exit means the invocation failed and cpybkc discards
 the output directory; no particular non-zero value means anything beyond that.
 
+### A descriptor with an unresolved encoding is refused
+
+Every field node carries five encoding axes — charset, sign convention, byte
+order, float format, binary width staircase — and a field leaving one unset is
+refused rather than drawn, wherever this program reads a field: the items of a
+record it tables, and the field a predicate tests.
+
+That looks stricter than a program laying no bytes out needs to be, and it
+reads one of the five. It is not stricter than it needs to be. A diagram is
+what an adopter checks a layout against before trusting it, so an axis
+defaulted here is a wrong fact handed to the person with nothing to check it
+against; and a rule binding only the axes a generator happens to read today
+would narrow the day that generator gained a column stating another.
+[`ir/SPEC.md`](../../docs/ir/SPEC.md)'s "Which consumers the rule binds" is the
+argument in full, and it binds a third-party generator the same way it binds
+this one.
+
+What is *not* refused is an axis in a part of the descriptor this program does
+not draw. Under `--opt records=none` no item table is written, so a record
+item's encoding is never read and never refused; the field a predicate tests is
+read either way, because its charset is what decides whether the literal beside
+it appears as text or as hex.
+
 ## Why the name is `graph`
 
 The notation is an option, so the executable may not be called `cpybkc-gen-dot`

--- a/cmd/cpybkc-gen-graph/README.md
+++ b/cmd/cpybkc-gen-graph/README.md
@@ -518,10 +518,10 @@ reads one of the five. It is not stricter than it needs to be. A diagram is
 what an adopter checks a layout against before trusting it, so an axis
 defaulted here is a wrong fact handed to the person with nothing to check it
 against; and a rule binding only the axes a generator happens to read today
-would narrow the day that generator gained a column stating another.
-[`ir/SPEC.md`](../../docs/ir/SPEC.md)'s "Which consumers the rule binds" is the
-argument in full, and it binds a third-party generator the same way it binds
-this one.
+would narrow the day that generator gained a column stating another. [Which
+consumers the rule
+binds](../../docs/ir/SPEC.md#which-consumers-the-rule-binds) is the argument in
+full, and it binds a third-party generator the same way it binds this one.
 
 What is *not* refused is an axis in a part of the descriptor this program does
 not draw. Under `--opt records=none` no item table is written, so a record

--- a/cmd/cpybkc-gen-graph/README.md
+++ b/cmd/cpybkc-gen-graph/README.md
@@ -510,8 +510,10 @@ the output directory; no particular non-zero value means anything beyond that.
 
 Every field node carries five encoding axes — charset, sign convention, byte
 order, float format, binary width staircase — and a field leaving one unset is
-refused rather than drawn, wherever this program reads a field: the items of a
-record it tables, and the field a predicate tests.
+refused rather than drawn, wherever this program reads a field's *encoding*: the
+items of a record it tables, and the field a predicate tests. Reading a field's
+*name* — for a register binding's label, say — asks nothing of the encoding and
+refuses nothing.
 
 That looks stricter than a program laying no bytes out needs to be, and it
 reads one of the five. It is not stricter than it needs to be. A diagram is

--- a/cmd/cpybkc-gen-graph/automaton.go
+++ b/cmd/cpybkc-gen-graph/automaton.go
@@ -411,7 +411,20 @@ func predicateResolved(nodes nodeSet, id uint64, record *irpb.Record, position s
 	// so this lookup cannot fail; it is written as a lookup rather than threaded
 	// out of [fieldPath] because the path and the encoding are two different
 	// questions about the same node.
+	//
+	// The axes are refused before the one of them this reads is used. An
+	// unresolved charset would take the same side of the test below as an
+	// EBCDIC one and draw the literal as hex, which is a spelling this document
+	// would be stating on its own authority rather than on the descriptor's —
+	// the default docs/ir/SPEC.md, "Which consumers the rule binds" forbids a
+	// consumer to supply, and the reason that section binds a consumer that
+	// draws no bytes. This is the second of the two places a field is read
+	// here, and it is the one `--opt records=none` does not switch off.
 	if target, ok := nodes.field(node.GetFieldId()); ok {
+		if err := resolved(target.GetEncoding()); err != nil {
+			return predicate{}, err
+		}
+
 		p.text = target.GetEncoding().GetCharset() == irpb.Charset_CHARSET_ASCII
 	}
 

--- a/cmd/cpybkc-gen-graph/automaton.go
+++ b/cmd/cpybkc-gen-graph/automaton.go
@@ -407,10 +407,9 @@ func predicateResolved(nodes nodeSet, id uint64, record *irpb.Record, position s
 	// of none is the axis saying the field holds bytes rather than characters,
 	// so it takes the same side of this test as an EBCDIC one and for a
 	// stronger reason: there is no character for a literal over it to be spelled
-	// as. The resolution above has already established that the field is there,
-	// so this lookup cannot fail; it is written as a lookup rather than threaded
-	// out of [fieldPath] because the path and the encoding are two different
-	// questions about the same node.
+	// as. It is written as a lookup rather than threaded out of [fieldPath]
+	// because the path and the encoding are two different questions about the
+	// same node.
 	//
 	// The axes are refused before the one of them this reads is used. An
 	// unresolved charset would take the same side of the test below as an
@@ -418,15 +417,27 @@ func predicateResolved(nodes nodeSet, id uint64, record *irpb.Record, position s
 	// would be stating on its own authority rather than on the descriptor's —
 	// the default docs/ir/SPEC.md, "Which consumers the rule binds" forbids a
 	// consumer to supply, and the reason that section binds a consumer that
-	// draws no bytes. This is the second of the two places a field is read
-	// here, and it is the one `--opt records=none` does not switch off.
-	if target, ok := nodes.field(node.GetFieldId()); ok {
-		if err := resolved(target.GetEncoding()); err != nil {
-			return predicate{}, err
-		}
-
-		p.text = target.GetEncoding().GetCharset() == irpb.Charset_CHARSET_ASCII
+	// draws no bytes. This is the second of the two places this generator reads
+	// a field's encoding, and it is the one `--opt records=none` does not
+	// switch off.
+	//
+	// A miss refuses rather than falling through, and that is this rule applied
+	// to itself. [fieldPath] resolved the same identifier a few lines up, so a
+	// miss here is not reachable from a descriptor — but a silent one would
+	// leave `text` at its zero value, which is the hex side, and reaching the
+	// hex side without the descriptor having said so is exactly what the check
+	// above exists to stop. An unreachable branch that defaults an axis is
+	// still a branch that defaults an axis.
+	target, ok := nodes.field(node.GetFieldId())
+	if !ok {
+		return predicate{}, unresolved(node.GetFieldId(), fmt.Sprintf("the field predicate %d tests", id))
 	}
+
+	if err := resolved(target.GetEncoding(), itemNamed(target, node.GetFieldId())); err != nil {
+		return predicate{}, err
+	}
+
+	p.text = target.GetEncoding().GetCharset() == irpb.Charset_CHARSET_ASCII
 
 	return p, nil
 }

--- a/cmd/cpybkc-gen-graph/automaton_test.go
+++ b/cmd/cpybkc-gen-graph/automaton_test.go
@@ -194,7 +194,15 @@ func TestATargetInASCIIIsTheOnlyLiteralDrawnAsText(t *testing.T) {
 	}{
 		{name: "ascii", charset: irpb.Charset_CHARSET_ASCII, want: `when ENTRY.SUB.KIND = "H"`},
 		{name: "cp037", charset: irpb.Charset_CHARSET_CP037, want: "when ENTRY.SUB.KIND = 0x48"},
-		{name: "unset", charset: irpb.Charset_CHARSET_UNSPECIFIED, want: "when ENTRY.SUB.KIND = 0x48"},
+
+		// There is no `unset` case here, and its absence is the decision #297
+		// took. An unresolved charset used to fall to this side of the test and
+		// draw the literal as hex, which is the default docs/ir/SPEC.md,
+		// "Which consumers the rule binds" forbids a consumer to supply —
+		// including one that lays no bytes out. It is now a refusal, held by
+		// [TestAPredicatesTargetLeavingAnAxisUnsetIsRefused], and a row here
+		// asserting the spelling would be asserting that this generator still
+		// draws a descriptor it must not read.
 
 		// `none` is the axis saying the field holds bytes rather than
 		// characters, so it takes the bytes side for a stronger reason than
@@ -1086,23 +1094,44 @@ func decrementBinding(id, reg uint64) *irpb.Node {
 
 // fieldNode is an elementary item, with the name a path is built out of.
 //
-// It carries no encoding, which is a charset this generator cannot name and so
-// a literal it prints as bytes — the case every fixture here but
-// [encodedFieldNode]'s wants.
+// It carries a resolved encoding, a USAGE and a picture, because a descriptor
+// missing any of the three is one no producer emits: the item table draws the
+// last two and refuses an item that states neither, and [resolved] refuses a
+// field whose encoding leaves an axis unset wherever this generator reads one.
+// A fixture short of them would be testing this generator against a message
+// `resolve` cannot produce, which is [unresolvedFieldNode]'s job and no other
+// fixture's.
 //
-// It does carry a USAGE and a picture, because a record's item table draws both
-// and refuses an item that states neither: docs/ir/SPEC.md has a producer set
-// them on every field, and a fixture that left them off would be a descriptor
-// no producer emits. Alphanumeric is the choice that says nothing — a field
-// these fixtures reach for is one a predicate tests or a binding reads, and the
-// automaton is what they are about.
+// The choices are the ones that say nothing. Alphanumeric, because a field
+// these fixtures reach for is one a predicate tests or a binding reads and the
+// automaton is what they are about; and cp037 for the charset, because it is a
+// charset this generator has no special reading of — a literal over it prints
+// as bytes, which is what every fixture here but [encodedFieldNode]'s wants.
 func fieldNode(id uint64, original string, width uint32) *irpb.Node {
 	return &irpb.Node{Id: id, Kind: &irpb.Node_Field{Field: &irpb.Field{
-		Width:   width,
-		Usage:   irpb.Usage_USAGE_DISPLAY,
-		Picture: &irpb.Picture{Category: irpb.Category_CATEGORY_ALPHANUMERIC},
-		Names:   &irpb.Names{Original: original},
+		Width:    width,
+		Usage:    irpb.Usage_USAGE_DISPLAY,
+		Picture:  &irpb.Picture{Category: irpb.Category_CATEGORY_ALPHANUMERIC},
+		Names:    &irpb.Names{Original: original},
+		Encoding: resolvedEncoding(irpb.Charset_CHARSET_CP037),
 	}}}
+}
+
+// resolvedEncoding is an encoding with all five axes set, which is the only
+// kind a producer may emit and the only kind these fixtures carry.
+//
+// The four beside the charset are a mainframe file's ordinary answers rather
+// than anything a test turns on: nothing this generator draws reads them, and
+// what they are for is being *present*, so that a fixture is a descriptor
+// rather than a half of one.
+func resolvedEncoding(charset irpb.Charset) *irpb.Encoding {
+	return &irpb.Encoding{
+		Charset:        charset,
+		SignConvention: irpb.SignConvention_SIGN_CONVENTION_EBCDIC,
+		ByteOrder:      irpb.ByteOrder_BYTE_ORDER_BIG_ENDIAN,
+		FloatFormat:    irpb.FloatFormat_FLOAT_FORMAT_IBM_HFP,
+		BinarySize:     irpb.BinarySize_BINARY_SIZE_248,
+	}
 }
 
 // numericFieldNode is the same item as a zoned decimal of that many digits,
@@ -1113,21 +1142,28 @@ func fieldNode(id uint64, original string, width uint32) *irpb.Node {
 // somebody else's copybook.
 func numericFieldNode(id uint64, original string, width uint32, digits uint32) *irpb.Node {
 	return &irpb.Node{Id: id, Kind: &irpb.Node_Field{Field: &irpb.Field{
-		Width:   width,
-		Usage:   irpb.Usage_USAGE_DISPLAY,
-		Picture: &irpb.Picture{Category: irpb.Category_CATEGORY_NUMERIC, Digits: digits},
-		Names:   &irpb.Names{Original: original},
+		Width:    width,
+		Usage:    irpb.Usage_USAGE_DISPLAY,
+		Picture:  &irpb.Picture{Category: irpb.Category_CATEGORY_NUMERIC, Digits: digits},
+		Names:    &irpb.Names{Original: original},
+		Encoding: resolvedEncoding(irpb.Charset_CHARSET_CP037),
 	}}}
 }
 
-// encodedFieldNode is the same item with a charset on it, which is the one
-// thing that decides whether a predicate's literals are drawn as text.
+// encodedFieldNode is the same item with a charset of the caller's choosing,
+// which is the one axis that decides anything this generator draws: whether a
+// predicate's literals appear as text, and whether the picture column says the
+// item's bytes are not characters.
+//
+// The other four are still set, by [resolvedEncoding]. A fixture that named a
+// charset and left them off would be exercising the charset against a
+// descriptor [resolved] refuses before it reads one.
 func encodedFieldNode(id uint64, original string, width uint32, charset irpb.Charset) *irpb.Node {
 	return &irpb.Node{Id: id, Kind: &irpb.Node_Field{Field: &irpb.Field{
 		Width:    width,
 		Usage:    irpb.Usage_USAGE_DISPLAY,
 		Picture:  &irpb.Picture{Category: irpb.Category_CATEGORY_ALPHANUMERIC},
 		Names:    &irpb.Names{Original: original},
-		Encoding: &irpb.Encoding{Charset: charset},
+		Encoding: resolvedEncoding(charset),
 	}}}
 }

--- a/cmd/cpybkc-gen-graph/encoding.go
+++ b/cmd/cpybkc-gen-graph/encoding.go
@@ -27,9 +27,9 @@ import (
 // trust a layout, so an axis defaulted here is a wrong fact handed to the
 // person with nothing to check it against — the same error a reader makes, not
 // a smaller one. And a rule binding only the axes a consumer happens to read
-// today is a rule that narrows silently: the day this document gains a column
-// stating an item's byte order, the descriptors it accepts change with nothing
-// in the diff saying so. A descriptor reaching any consumer with an axis unset
+// today is a rule that narrows silently: the day the item table gains a column
+// stating an item's byte order, the descriptors this generator accepts change
+// with nothing in the diff saying so. A descriptor reaching any consumer with an axis unset
 // is a bug in `resolve`, and refusing is how this one says so instead of
 // drawing over it.
 //

--- a/cmd/cpybkc-gen-graph/encoding.go
+++ b/cmd/cpybkc-gen-graph/encoding.go
@@ -29,9 +29,9 @@ import (
 // a smaller one. And a rule binding only the axes a consumer happens to read
 // today is a rule that narrows silently: the day the item table gains a column
 // stating an item's byte order, the descriptors this generator accepts change
-// with nothing in the diff saying so. A descriptor reaching any consumer with an axis unset
-// is a bug in `resolve`, and refusing is how this one says so instead of
-// drawing over it.
+// with nothing in the diff saying so. A descriptor reaching any consumer with
+// an axis unset is a bug in `resolve`, and refusing is how this one says so
+// instead of drawing over it.
 //
 // Written here rather than imported from cmd/cpybkc-gen-go, which carries the
 // same check under the same name. That is the reason this command's package
@@ -43,9 +43,16 @@ import (
 // oversight in it — and this check is the one place that claim is load bearing,
 // because a third-party generator has to arrive at the same refusal from the
 // specification alone.
-func resolved(enc *irpb.Encoding) error {
+//
+// item is what the refusal calls the field it is about, from [itemNamed]. It is
+// threaded in rather than composed here because the failure is a bug in
+// `resolve` that somebody has to go and find: "an item's encoding leaves byte
+// order unresolved" is true of a copybook with three hundred elementary items
+// and actionable on none of them, and both call sites are holding the node's
+// identity when they ask.
+func resolved(enc *irpb.Encoding, item string) error {
 	if enc == nil {
-		return malformed("an item carries no encoding", axesRule)
+		return malformed(item+" carries no encoding", axesRule)
 	}
 
 	unset := make([]string, 0, 5)
@@ -66,15 +73,34 @@ func resolved(enc *irpb.Encoding) error {
 		unset = append(unset, "float format")
 	}
 
+	// Named as docs/ir/SPEC.md names the axis rather than as the schema names
+	// the field. `BinarySize` is what the message calls it and "binary width
+	// staircase" is what the rule an adopter is about to go and read calls it,
+	// and the diagnostic's whole job is to get them to that rule.
 	if enc.GetBinarySize() == irpb.BinarySize_BINARY_SIZE_UNSPECIFIED {
-		unset = append(unset, "binary size")
+		unset = append(unset, "binary width staircase")
 	}
 
 	if len(unset) == 0 {
 		return nil
 	}
 
-	return malformed(fmt.Sprintf("an item's encoding leaves %s unresolved", english(unset)), axesRule)
+	return malformed(fmt.Sprintf("the encoding of %s leaves %s unresolved", item, english(unset)), axesRule)
+}
+
+// itemNamed is what a refusal from [resolved] calls the item it is about: the
+// name a table would show it under, and its node identifier where it has none.
+//
+// A FILLER has no name, so the identifier is not a fallback for a missing
+// lookup here — it is the only thing there is to say about an item COBOL
+// declined to name, and it is what the reader needs to find the node in an
+// emitted descriptor.
+func itemNamed(f *irpb.Field, id uint64) string {
+	if name := strings.TrimSpace(nameOf(f.GetNames())); name != "" {
+		return name
+	}
+
+	return fmt.Sprintf("node %d", id)
 }
 
 // axesRule is the `note:` line both refusals above carry.

--- a/cmd/cpybkc-gen-graph/encoding.go
+++ b/cmd/cpybkc-gen-graph/encoding.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Zaba505/cpybkc/irpb"
+)
+
+// resolved refuses a field whose encoding leaves one of its five axes unset.
+//
+// This generator lays no bytes out and reads exactly one of the five. The
+// charset decides whether an item's picture is drawn with [noCharset] beside it
+// ([withCharset]) and whether a predicate's literals are spelled as text or as
+// hex ([predicateResolved]); the sign convention, the byte order, the float
+// format and the binary width staircase decide nothing this document draws.
+// All five are refused all the same, and that is a decision docs/ir/SPEC.md,
+// "Which consumers the rule binds" argues rather than this comment.
+//
+// Its short form is worth repeating here, because the alternative reading is
+// the plausible one. A diagram is what an adopter consults to decide whether to
+// trust a layout, so an axis defaulted here is a wrong fact handed to the
+// person with nothing to check it against — the same error a reader makes, not
+// a smaller one. And a rule binding only the axes a consumer happens to read
+// today is a rule that narrows silently: the day this document gains a column
+// stating an item's byte order, the descriptors it accepts change with nothing
+// in the diff saying so. A descriptor reaching any consumer with an axis unset
+// is a bug in `resolve`, and refusing is how this one says so instead of
+// drawing over it.
+//
+// Written here rather than imported from cmd/cpybkc-gen-go, which carries the
+// same check under the same name. That is the reason this command's package
+// comment gives for writing the version check, the diagnostic writer and the
+// argument parser twice, and the reason [malformedError] repeats: a package
+// both generators shared would be a convenience no third-party generator has,
+// and being a generator with no such convenience is the thing this command
+// exists to demonstrate. The duplication is the demonstration rather than an
+// oversight in it — and this check is the one place that claim is load bearing,
+// because a third-party generator has to arrive at the same refusal from the
+// specification alone.
+func resolved(enc *irpb.Encoding) error {
+	if enc == nil {
+		return malformed("an item carries no encoding", axesRule)
+	}
+
+	unset := make([]string, 0, 5)
+
+	if enc.GetCharset() == irpb.Charset_CHARSET_UNSPECIFIED {
+		unset = append(unset, "charset")
+	}
+
+	if enc.GetSignConvention() == irpb.SignConvention_SIGN_CONVENTION_UNSPECIFIED {
+		unset = append(unset, "sign convention")
+	}
+
+	if enc.GetByteOrder() == irpb.ByteOrder_BYTE_ORDER_UNSPECIFIED {
+		unset = append(unset, "byte order")
+	}
+
+	if enc.GetFloatFormat() == irpb.FloatFormat_FLOAT_FORMAT_UNSPECIFIED {
+		unset = append(unset, "float format")
+	}
+
+	if enc.GetBinarySize() == irpb.BinarySize_BINARY_SIZE_UNSPECIFIED {
+		unset = append(unset, "binary size")
+	}
+
+	if len(unset) == 0 {
+		return nil
+	}
+
+	return malformed(fmt.Sprintf("an item's encoding leaves %s unresolved", english(unset)), axesRule)
+}
+
+// axesRule is the `note:` line both refusals above carry.
+//
+// One sentence for the two of them because they are one rule broken two ways: a
+// field with no encoding message at all and a field with an axis left at its
+// zero value are the same producer bug seen from either side of whether the
+// message was constructed.
+const axesRule = "a producer must set all five axes on every field, and a consumer may not supply a default for one, " +
+	"whether or not it lays bytes out; see docs/ir/SPEC.md, \"Which consumers the rule binds\""
+
+// english joins a list the way a sentence does.
+//
+// Called with a non-empty list only, which every caller above guarantees by
+// returning early on the empty one.
+func english(items []string) string {
+	switch len(items) {
+	case 1:
+		return items[0]
+	case 2:
+		return items[0] + " and " + items[1]
+	default:
+		return strings.Join(items[:len(items)-1], ", ") + " and " + items[len(items)-1]
+	}
+}

--- a/cmd/cpybkc-gen-graph/encoding_test.go
+++ b/cmd/cpybkc-gen-graph/encoding_test.go
@@ -54,9 +54,12 @@ func TestAnItemLeavingAnEncodingAxisUnsetIsRefused(t *testing.T) {
 			axis:  "float format",
 		},
 		{
-			name:  "binary size",
+			// Named as docs/ir/SPEC.md names the axis and not as the schema
+			// names the field: the diagnostic's job is to get a reader to the
+			// rule, and the rule calls it the staircase.
+			name:  "binary width staircase",
 			clear: func(e *irpb.Encoding) { e.BinarySize = irpb.BinarySize_BINARY_SIZE_UNSPECIFIED },
-			axis:  "binary size",
+			axis:  "binary width staircase",
 		},
 	}
 
@@ -79,6 +82,14 @@ func TestAnItemLeavingAnEncodingAxisUnsetIsRefused(t *testing.T) {
 
 			if !strings.Contains(err.Error(), "unresolved") {
 				t.Errorf("the refusal reads %q, and does not say the axis is unresolved", err)
+			}
+
+			// The item as well as the axis. A refusal naming neither the item
+			// nor its identifier is true of every field in the record and
+			// actionable on none of them, and the axis assertions above would
+			// pass just as well without it.
+			if !strings.Contains(err.Error(), "DTL-COUNT") {
+				t.Errorf("the refusal reads %q, and does not name the item it is about", err)
 			}
 		})
 	}
@@ -109,14 +120,14 @@ func TestAnItemCarryingNoEncodingAtAllIsRefused(t *testing.T) {
 		t.Fatal("read drew a table over an item carrying no encoding at all")
 	}
 
-	if !strings.Contains(err.Error(), "carries no encoding") {
-		t.Errorf("the refusal reads %q, and does not say the item carries no encoding", err)
+	if !strings.Contains(err.Error(), "DTL-COUNT carries no encoding") {
+		t.Errorf("the refusal reads %q, and does not say which item carries no encoding", err)
 	}
 }
 
 // TestAPredicatesTargetLeavingAnAxisUnsetIsRefused is the second of the two
-// places this generator reads a field, and the one the item tables' option does
-// not switch off.
+// places this generator reads a field's encoding, and the one the item tables'
+// option does not switch off.
 //
 // A predicate's literals are spelled as text or as hex from the target field's
 // charset, so an unresolved charset there is not a missing cell — it is a
@@ -148,17 +159,21 @@ func TestAPredicatesTargetLeavingAnAxisUnsetIsRefused(t *testing.T) {
 	if !strings.Contains(err.Error(), "charset") {
 		t.Errorf("the refusal reads %q, and does not name the axis that is unset", err)
 	}
+
+	if !strings.Contains(err.Error(), "KIND") {
+		t.Errorf("the refusal reads %q, and does not name the item it is about", err)
+	}
 }
 
 // TestAnUnresolvedItemIsOnlyRefusedWhereItIsRead is the limit on the rule, and
 // the reason [read] takes the options rather than the emitter alone.
 //
 // docs/ir/SPEC.md's "Which consumers the rule binds" attaches the duty to
-// reading a field rather than to holding a descriptor: refusing over a part of
-// the message this document does not describe would be refusing on somebody
-// else's behalf, and would make the diagnostic depend on which sections the
-// caller asked for. So an item no table draws and no predicate tests is passed
-// over under `records=none`, exactly as
+// reading a field's encoding rather than to holding a descriptor: refusing over
+// a part of the message this document does not describe would be refusing on
+// somebody else's behalf, and would make the diagnostic depend on which
+// sections the caller asked for. So an item no table draws and no predicate
+// tests is passed over under `records=none`, exactly as
 // [TestAMalformedItemIsOnlyReadWhereItIsDrawn] has a field carrying no USAGE
 // passed over.
 //

--- a/cmd/cpybkc-gen-graph/encoding_test.go
+++ b/cmd/cpybkc-gen-graph/encoding_test.go
@@ -1,0 +1,214 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cpybkc/irpb"
+)
+
+// TestAnItemLeavingAnEncodingAxisUnsetIsRefused is #297's decision held where
+// it costs something: this generator lays no bytes out, and refuses anyway.
+//
+// docs/ir/SPEC.md, "Which consumers the rule binds" makes the axis rule bind
+// every consumer rather than only the ones that read bytes, and the argument
+// for it is that a diagram is what an adopter checks a layout against. So the
+// axis nothing here draws is refused exactly as the one it draws is: a rule
+// that bound only the axes a consumer happens to read would narrow silently the
+// day this document gained a column stating one.
+//
+// The table walks the five one at a time. Clearing them one at a time rather
+// than all at once is what makes the diagnostic's naming of the axis a thing
+// the test checks rather than a thing it prints.
+func TestAnItemLeavingAnEncodingAxisUnsetIsRefused(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		clear func(*irpb.Encoding)
+		axis  string
+	}{
+		{
+			name:  "charset",
+			clear: func(e *irpb.Encoding) { e.Charset = irpb.Charset_CHARSET_UNSPECIFIED },
+			axis:  "charset",
+		},
+		{
+			name:  "sign convention",
+			clear: func(e *irpb.Encoding) { e.SignConvention = irpb.SignConvention_SIGN_CONVENTION_UNSPECIFIED },
+			axis:  "sign convention",
+		},
+		{
+			name:  "byte order",
+			clear: func(e *irpb.Encoding) { e.ByteOrder = irpb.ByteOrder_BYTE_ORDER_UNSPECIFIED },
+			axis:  "byte order",
+		},
+		{
+			name:  "float format",
+			clear: func(e *irpb.Encoding) { e.FloatFormat = irpb.FloatFormat_FLOAT_FORMAT_UNSPECIFIED },
+			axis:  "float format",
+		},
+		{
+			name:  "binary size",
+			clear: func(e *irpb.Encoding) { e.BinarySize = irpb.BinarySize_BINARY_SIZE_UNSPECIFIED },
+			axis:  "binary size",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := read(oneRecordAutomaton(
+				edgeNode(30, 100, 2, nil, nil, nil),
+				unresolvedFieldNode(102, "DTL-COUNT", 2, testCase.clear),
+			), defaults())
+
+			if err == nil {
+				t.Fatalf("read drew a table over an item whose %s the descriptor never resolved", testCase.axis)
+			}
+
+			if !strings.Contains(err.Error(), testCase.axis) {
+				t.Errorf("the refusal reads %q, and does not name the axis that is unset", err)
+			}
+
+			if !strings.Contains(err.Error(), "unresolved") {
+				t.Errorf("the refusal reads %q, and does not say the axis is unresolved", err)
+			}
+		})
+	}
+}
+
+// TestAnItemCarryingNoEncodingAtAllIsRefused is the same producer bug seen from
+// the other side of whether the message was constructed.
+//
+// A field with no encoding message answers every axis with its zero value, so a
+// consumer reading one axis off it gets a plausible answer to a question the
+// descriptor never answered. It is refused as its own sentence rather than as
+// five unset axes, because "carries no encoding" is what somebody holding the
+// descriptor will see and "leaves five axes unresolved" is a reading of it.
+func TestAnItemCarryingNoEncodingAtAllIsRefused(t *testing.T) {
+	t.Parallel()
+
+	_, err := read(oneRecordAutomaton(
+		edgeNode(30, 100, 2, nil, nil, nil),
+		&irpb.Node{Id: 102, Kind: &irpb.Node_Field{Field: &irpb.Field{
+			Width:   2,
+			Usage:   irpb.Usage_USAGE_DISPLAY,
+			Picture: &irpb.Picture{Category: irpb.Category_CATEGORY_ALPHANUMERIC},
+			Names:   &irpb.Names{Original: "DTL-COUNT"},
+		}}},
+	), defaults())
+
+	if err == nil {
+		t.Fatal("read drew a table over an item carrying no encoding at all")
+	}
+
+	if !strings.Contains(err.Error(), "carries no encoding") {
+		t.Errorf("the refusal reads %q, and does not say the item carries no encoding", err)
+	}
+}
+
+// TestAPredicatesTargetLeavingAnAxisUnsetIsRefused is the second of the two
+// places this generator reads a field, and the one the item tables' option does
+// not switch off.
+//
+// A predicate's literals are spelled as text or as hex from the target field's
+// charset, so an unresolved charset there is not a missing cell — it is a
+// literal drawn in a notation this document chose for itself. That is the
+// default docs/ir/SPEC.md forbids, and it is the case that makes the rule bind
+// a consumer laying no bytes out: the row is wrong in a way nobody reading the
+// diagram can see, and the diagram is what they are checking the layout with.
+//
+// Held under `records=none` deliberately. Under the default the item table
+// would refuse the same field first and this test would pass without the check
+// in [predicateResolved] existing at all.
+func TestAPredicatesTargetLeavingAnAxisUnsetIsRefused(t *testing.T) {
+	t.Parallel()
+
+	sequencing := options{records: recordsNone}.defaulted()
+
+	_, err := read(oneRecordAutomaton(
+		edgeNode(30, 100, 2, predicateAt(50), nil, nil),
+		equalPredicate(50, 106, "H"),
+		unresolvedFieldNode(106, "KIND", 1, func(e *irpb.Encoding) {
+			e.Charset = irpb.Charset_CHARSET_UNSPECIFIED
+		}),
+	), sequencing)
+
+	if err == nil {
+		t.Fatal("read spelled a predicate's literal from a charset the descriptor never resolved")
+	}
+
+	if !strings.Contains(err.Error(), "charset") {
+		t.Errorf("the refusal reads %q, and does not name the axis that is unset", err)
+	}
+}
+
+// TestAnUnresolvedItemIsOnlyRefusedWhereItIsRead is the limit on the rule, and
+// the reason [read] takes the options rather than the emitter alone.
+//
+// docs/ir/SPEC.md's "Which consumers the rule binds" attaches the duty to
+// reading a field rather than to holding a descriptor: refusing over a part of
+// the message this document does not describe would be refusing on somebody
+// else's behalf, and would make the diagnostic depend on which sections the
+// caller asked for. So an item no table draws and no predicate tests is passed
+// over under `records=none`, exactly as
+// [TestAMalformedItemIsOnlyReadWhereItIsDrawn] has a field carrying no USAGE
+// passed over.
+//
+// The same descriptor is refused under the default, which is what keeps this a
+// statement about where the check runs rather than about whether it does.
+func TestAnUnresolvedItemIsOnlyRefusedWhereItIsRead(t *testing.T) {
+	t.Parallel()
+
+	// KIND is reached by the containment walk and by nothing else: no predicate
+	// tests it and no binding reads it.
+	broken := oneRecordAutomaton(
+		edgeNode(30, 100, 2, nil, nil, nil),
+		unresolvedFieldNode(106, "KIND", 1, func(e *irpb.Encoding) {
+			e.ByteOrder = irpb.ByteOrder_BYTE_ORDER_UNSPECIFIED
+		}),
+	)
+
+	if _, err := read(broken, defaults()); err == nil {
+		t.Error("read drew a table over an item whose byte order the descriptor never resolved")
+	}
+
+	sequencing := options{records: recordsNone}.defaulted()
+
+	if _, err := read(broken, sequencing); err != nil {
+		t.Errorf("records=none refused a descriptor over an item it does not draw: %v", err)
+	}
+}
+
+// TestAResolvedDescriptorIsDrawn is the control the four above need.
+//
+// Every one of them asserts a refusal, and a [resolved] that refused everything
+// would satisfy all four. This is the fixture corpus's ordinary field, drawn.
+func TestAResolvedDescriptorIsDrawn(t *testing.T) {
+	t.Parallel()
+
+	if _, err := read(oneRecordAutomaton(edgeNode(30, 100, 2, nil, nil, nil)), defaults()); err != nil {
+		t.Errorf("read refused a descriptor whose every axis is resolved: %v", err)
+	}
+}
+
+// unresolvedFieldNode is [fieldNode] with one axis of its encoding put back to
+// unset, which is the descriptor no producer may emit and this generator must
+// refuse.
+//
+// It clears an axis of a resolved encoding rather than building an encoding
+// with one axis set, so that a sixth axis added to the message arrives here as
+// a fixture that is still whole apart from the one thing each case is about.
+func unresolvedFieldNode(id uint64, original string, width uint32, clear func(*irpb.Encoding)) *irpb.Node {
+	node := fieldNode(id, original, width)
+	clear(node.GetField().GetEncoding())
+
+	return node
+}

--- a/cmd/cpybkc-gen-graph/records.go
+++ b/cmd/cpybkc-gen-graph/records.go
@@ -472,6 +472,20 @@ func (w *itemWalk) slack(s *irpb.Slack, path []element, at span, chosen presence
 
 // field is one elementary item.
 func (w *itemWalk) field(id uint64, f *irpb.Field, path []element, at span, chosen presence) (span, error) {
+	// Ahead of everything the row is spelled from, because the encoding is what
+	// the rest of the row is spelled in terms of: [withCharset] annotates the
+	// picture off one of the five axes, and a picture drawn from an encoding
+	// that states none of them is a cell filled in from a default this consumer
+	// is not allowed to supply. See [resolved], and docs/ir/SPEC.md, "Which
+	// consumers the rule binds".
+	//
+	// Here rather than in [recordItems] because it is a check on a field, and
+	// this is the walk's one arrival at one: a group and a variant carry no
+	// encoding, and slack is bytes no item covers.
+	if err := resolved(f.GetEncoding()); err != nil {
+		return span{}, err
+	}
+
 	name, anonymous, err := itemName(f.GetNames(), id)
 	if err != nil {
 		return span{}, err

--- a/cmd/cpybkc-gen-graph/records.go
+++ b/cmd/cpybkc-gen-graph/records.go
@@ -472,22 +472,25 @@ func (w *itemWalk) slack(s *irpb.Slack, path []element, at span, chosen presence
 
 // field is one elementary item.
 func (w *itemWalk) field(id uint64, f *irpb.Field, path []element, at span, chosen presence) (span, error) {
-	// Ahead of everything the row is spelled from, because the encoding is what
-	// the rest of the row is spelled in terms of: [withCharset] annotates the
-	// picture off one of the five axes, and a picture drawn from an encoding
-	// that states none of them is a cell filled in from a default this consumer
-	// is not allowed to supply. See [resolved], and docs/ir/SPEC.md, "Which
-	// consumers the rule binds".
+	name, anonymous, err := itemName(f.GetNames(), id)
+	if err != nil {
+		return span{}, err
+	}
+
+	// Behind the name and ahead of everything the row is spelled from, which is
+	// the one position that gets both halves right. Behind it, because a
+	// refusal that cannot say which item it is about sends a reader looking
+	// through a record with three hundred of them. Ahead of [described],
+	// because the encoding is what the rest of the row is spelled in terms of:
+	// [withCharset] annotates the picture off one of the five axes, and a
+	// picture drawn from an encoding that states none of them is a cell filled
+	// in from a default this consumer is not allowed to supply. See [resolved],
+	// and docs/ir/SPEC.md, "Which consumers the rule binds".
 	//
 	// Here rather than in [recordItems] because it is a check on a field, and
 	// this is the walk's one arrival at one: a group and a variant carry no
 	// encoding, and slack is bytes no item covers.
-	if err := resolved(f.GetEncoding()); err != nil {
-		return span{}, err
-	}
-
-	name, anonymous, err := itemName(f.GetNames(), id)
-	if err != nil {
+	if err := resolved(f.GetEncoding(), itemNamed(f, id)); err != nil {
 		return span{}, err
 	}
 

--- a/cmd/cpybkc-gen-graph/records_test.go
+++ b/cmd/cpybkc-gen-graph/records_test.go
@@ -937,10 +937,11 @@ func numericEditedPicture(digits uint32, scale int32, sign bool) *irpb.Picture {
 // [fieldNode] deliberately does not offer.
 func pictureFieldNode(id uint64, original string, width uint32, usage irpb.Usage, picture *irpb.Picture) *irpb.Node {
 	return &irpb.Node{Id: id, Kind: &irpb.Node_Field{Field: &irpb.Field{
-		Width:   width,
-		Usage:   usage,
-		Picture: picture,
-		Names:   &irpb.Names{Original: original},
+		Width:    width,
+		Usage:    usage,
+		Picture:  picture,
+		Names:    &irpb.Names{Original: original},
+		Encoding: resolvedEncoding(irpb.Charset_CHARSET_CP037),
 	}}}
 }
 
@@ -988,9 +989,10 @@ func registerCount(register uint64, min, max uint32) *irpb.Repetition {
 // beside, and the schema makes the original the member that must be present.
 func fillerFieldNode(id uint64, width uint32) *irpb.Node {
 	return &irpb.Node{Id: id, Kind: &irpb.Node_Field{Field: &irpb.Field{
-		Width:   width,
-		Usage:   irpb.Usage_USAGE_DISPLAY,
-		Picture: &irpb.Picture{Category: irpb.Category_CATEGORY_ALPHANUMERIC},
+		Width:    width,
+		Usage:    irpb.Usage_USAGE_DISPLAY,
+		Picture:  &irpb.Picture{Category: irpb.Category_CATEGORY_ALPHANUMERIC},
+		Encoding: resolvedEncoding(irpb.Charset_CHARSET_CP037),
 	}}}
 }
 

--- a/cmd/cpybkc-gen-graph/records_test.go
+++ b/cmd/cpybkc-gen-graph/records_test.go
@@ -530,15 +530,31 @@ func TestAMalformedItemIsOnlyReadWhereItIsDrawn(t *testing.T) {
 
 	// A field carrying no USAGE at all, which is a producer bug and not a
 	// copybook a reader could fix.
+	//
+	// Its encoding is resolved, and that is not decoration. [itemWalk.field]
+	// refuses an unresolved encoding ahead of the USAGE check, so a fixture
+	// left short of one would still fail this test — for the wrong reason,
+	// with the USAGE this test is named after never reached.
 	broken := oneRecordAutomaton(
 		edgeNode(30, 100, 2, nil, nil, nil),
 		&irpb.Node{
-			Id:   101,
-			Kind: &irpb.Node_Field{Field: &irpb.Field{Width: 1, Names: &irpb.Names{Original: "TYPE-CODE"}}},
+			Id: 101,
+			Kind: &irpb.Node_Field{Field: &irpb.Field{
+				Width:    1,
+				Names:    &irpb.Names{Original: "TYPE-CODE"},
+				Encoding: resolvedEncoding(irpb.Charset_CHARSET_CP037),
+			}},
 		})
 
-	if _, err := read(broken, defaults()); err == nil {
-		t.Error("read drew a table over an item the descriptor does not describe")
+	_, err := read(broken, defaults())
+	if err == nil {
+		t.Fatal("read drew a table over an item the descriptor does not describe")
+	}
+
+	// Named rather than merely non-nil, so that a refusal arriving from
+	// somewhere earlier in the walk cannot stand in for this one.
+	if !strings.Contains(err.Error(), "which this generator has no name for") {
+		t.Errorf("the refusal reads %q, and is not the one this test is about", err)
 	}
 
 	sequencing := options{records: recordsNone}.defaulted()

--- a/docs/ir/SPEC.md
+++ b/docs/ir/SPEC.md
@@ -1882,10 +1882,9 @@ diagram that spells a discriminator's literal as text where the field carries no
 charset, or that describes an item's width as a count of characters where its
 bytes are a payload, has stated something about the file the descriptor never
 said — and has stated it to the person deciding whether to trust the layout,
-which is the one artifact whose entire purpose is that decision. Defaulting an
-axis there is not a smaller error than defaulting one in a reader; it is the
-same error, delivered by hand to somebody with no second source to check it
-against.
+which is the whole of what a diagram is drawn for. Defaulting an axis there is
+not a smaller error than defaulting one in a reader; it is the same error,
+delivered by hand to somebody with no second source to check it against.
 
 The other rule cannot be written without a boundary nobody can hold. It would
 have to divide consumers into those that lay bytes out and those that only

--- a/docs/ir/SPEC.md
+++ b/docs/ir/SPEC.md
@@ -1905,18 +1905,31 @@ the picture, because that is the one an adopter consults first.
 What the rule does **not** require is that a consumer refuse a descriptor over a
 part of it the consumer never reads. A renderer drawing only the sequencing
 automaton, or a generator emitting code for one record of several, refuses on
-the fields it reaches and is not obliged to walk the rest to find more: refusing
-over something its own output does not describe would be refusing on somebody
-else's behalf, and would make a diagnostic depend on which sections a caller
-asked for. The duty attaches to reading a field, not to holding a descriptor.
+the fields whose encoding it reaches and is not obliged to walk the rest to find
+more: refusing over something its own output does not describe would be refusing
+on somebody else's behalf, and would make a diagnostic depend on which sections
+a caller asked for.
+
+The duty therefore attaches to **reading a field's encoding**, and not to
+reading a field, nor to holding a descriptor. Taking a field's *name* — to label
+an edge with it, to build a path out of it, to say which field a register was
+bound from — obliges a consumer to nothing here, because a name is not an axis
+and nothing about it can be silently defaulted. That is a narrower duty than
+"reading a field", and it is the one that can be met: a consumer knows exactly
+when it has asked for an encoding. It does not weaken the argument two
+paragraphs above, because the day a renderer gains a column stating an item's
+byte order is the day it starts reading an encoding, and the duty arrives with
+the column.
 
 `cpybkc-gen-graph` is the worked case, and it is why this is written down. It
 reads one axis, the charset, in two places — whether an item's picture is drawn
 with "no charset" beside it, and whether a predicate's literals are spelled as
 text or as hex — and it lays no bytes out at all. It refuses all five all the
-same, at the two places it reads a field: the item table's walk, and the
-resolution of a predicate against the field it tests. Under `--opt
-records=none` no item table is drawn and the first of those is never reached,
+same, at the two places it reads a field's encoding: the item table's walk, and
+the resolution of a predicate against the field it tests. It reads a field's
+*name* in a third place, for the label on a register's binding, and refuses
+nothing there. Under `--opt records=none` no item table is drawn and the first
+of the two is never reached,
 which is the previous paragraph rather than an exception to this one.
 
 ### An item with no charset carries bytes, not characters

--- a/docs/ir/SPEC.md
+++ b/docs/ir/SPEC.md
@@ -1835,7 +1835,9 @@ Every field node **MUST** carry all five axes, resolved, and a producer
 default for a missing axis, and **MUST** treat a field missing one as a
 malformed descriptor rather than filling it in: an IR that reached a generator
 with an axis unresolved is a bug in `resolve`, and papering over it is exactly
-how a silently-failing setting produces a silent failure.
+how a silently-failing setting produces a silent failure. [Which consumers the
+rule binds](#which-consumers-the-rule-binds) says which consumers "a consumer"
+is, and why it is all of them.
 
 Four of the five and the fifth are answered by different facts, and the
 difference is worth stating once here because nothing downstream can see it. The
@@ -1860,6 +1862,63 @@ the mixed record `codec/SPEC.md` describes is the ordinary case here rather than
 an exception. And which axes actually govern a given field's bytes — charset
 does not touch packed decimal — is `codec/SPEC.md`'s answer, not a second table
 in this document. The IR names the axes; what the bytes are is answered there.
+
+### Which consumers the rule binds
+
+"A consumer", above, is **every** consumer, and one that lays no bytes out is
+not exempt (#297). A generator emitting a reader, a renderer drawing a diagram,
+a checker reporting on a descriptor: each **MUST** refuse a field whose encoding
+leaves an axis unset, and none of them **MAY** supply a default for one.
+
+The reading this rules out is the plausible one, which is why it is ruled out
+here rather than left to be inferred. Every axis is described above as failing
+silently *when the bytes are read*, and a consumer that reads no bytes might be
+thought to inherit no duty from that: it computes no offset, so it can get none
+wrong. That reading was considered and rejected, for three reasons that are not
+the ones the sentence itself suggests.
+
+The axes decide what a renderer *says*, and not only what a reader *does*. A
+diagram that spells a discriminator's literal as text where the field carries no
+charset, or that describes an item's width as a count of characters where its
+bytes are a payload, has stated something about the file the descriptor never
+said — and has stated it to the person deciding whether to trust the layout,
+which is the one artifact whose entire purpose is that decision. Defaulting an
+axis there is not a smaller error than defaulting one in a reader; it is the
+same error, delivered by hand to somebody with no second source to check it
+against.
+
+The other rule cannot be written without a boundary nobody can hold. It would
+have to divide consumers into those that lay bytes out and those that only
+describe them, and that division is not a property of a program but of a program
+*this week*: a renderer that gains an offset column, a hex example or a size
+total has crossed the line with nothing in its diff saying so. A scope that
+changes when a feature is added is a scope a plugin author cannot check
+themselves against, and a plugin author with no way to tell which rule they are
+under is the failure this section exists to remove.
+
+And refusing is cheap exactly where the descriptor is not. It costs a consumer
+one comparison per axis at the point it first reads a field, and what it catches
+is a bug in `resolve` — which no consumer can fix and every consumer is placed
+to report. A second consumer refusing is a second place that bug is caught
+before an adopter meets it, and it is worth most from the consumer that draws
+the picture, because that is the one an adopter consults first.
+
+What the rule does **not** require is that a consumer refuse a descriptor over a
+part of it the consumer never reads. A renderer drawing only the sequencing
+automaton, or a generator emitting code for one record of several, refuses on
+the fields it reaches and is not obliged to walk the rest to find more: refusing
+over something its own output does not describe would be refusing on somebody
+else's behalf, and would make a diagnostic depend on which sections a caller
+asked for. The duty attaches to reading a field, not to holding a descriptor.
+
+`cpybkc-gen-graph` is the worked case, and it is why this is written down. It
+reads one axis, the charset, in two places — whether an item's picture is drawn
+with "no charset" beside it, and whether a predicate's literals are spelled as
+text or as hex — and it lays no bytes out at all. It refuses all five all the
+same, at the two places it reads a field: the item table's walk, and the
+resolution of a predicate against the field it tests. Under `--opt
+records=none` no item table is drawn and the first of those is never reached,
+which is the previous paragraph rather than an exception to this one.
 
 ### An item with no charset carries bytes, not characters
 
@@ -3835,7 +3894,7 @@ records offer them.
 | [Structure](#structure) | #17, #80, #90 `ir`, #38 `resolve` |
 | [Offsets and widths](#offsets-and-widths) | #32, #34, #35 `resolve`, #77, #82, #84, #87, #88, #89, #90 `ir`; what a binary item's width depends on, and the requirement that a descriptor say which staircase it was resolved under, by #293 |
 | [Physical framing](#physical-framing) | #78, #88, #92, #94 `ir`, #26 `layout`, #52 `gen-go` |
-| [The encoding profile, applied](#the-encoding-profile-applied) | #33 `resolve`; an item that carries bytes rather than characters by #275; the fifth axis, the binary width staircase resolved from the dialect, by #293 |
+| [The encoding profile, applied](#the-encoding-profile-applied) | #33 `resolve`; an item that carries bytes rather than characters by #275; the fifth axis, the binary width staircase resolved from the dialect, by #293; which consumers the axis rule binds, settled by #297 |
 | [Names](#names) | #30 `layout`, #38 `resolve`; what a record node resolved from a `REDEFINES` is called, settled by #164 |
 | [The sequencing automaton](#the-sequencing-automaton) | #36 `resolve`, #76, #77, #80, #84, #88 `ir` |
 | [Discriminator predicates](#discriminator-predicates) | #28 `layout`, #37 `resolve`, #80, #84, #88, #90, #94 `ir` |


### PR DESCRIPTION
Closes #297

## The decision

The story asked which of two readings of `docs/ir/SPEC.md`'s *The encoding
profile, applied* is right: does a consumer that only **renders** a descriptor
have to refuse one that leaves an encoding axis unset?

**Reading 1 wins — the rule binds every consumer, including one that lays no
bytes out.** The reasoning is recorded in `docs/ir/SPEC.md`, in a new
`### Which consumers the rule binds` subsection, which is where a plugin author
writing a third generator will meet it (`docs/plugin/SPEC.md` names `ir/SPEC.md`
normative for the value it moves). Three arguments carried it:

1. **The axes decide what a renderer *says*, not only what a reader *does*.** A
   diagram that spells a discriminator's literal as text where the field carries
   no charset has stated something the descriptor never said — to the person
   deciding whether to trust the layout, which is the one artifact whose whole
   purpose is that decision. That is the same error a reader makes, not a
   smaller one.
2. **The other rule needs a boundary nobody can hold.** It would divide
   consumers into those that lay bytes out and those that only describe them,
   and that division is a property of a program *this week*: a renderer that
   gains an offset column, a hex example or a size total has crossed the line
   with nothing in its diff saying so. A plugin author cannot check themselves
   against a scope that moves.
3. **Refusing is cheap where the descriptor is not.** One comparison per axis at
   the point a field is first read, catching a bug in `resolve` that no consumer
   can fix and every consumer is placed to report — worth most from the consumer
   an adopter consults first.

The subsection also states the **limit** on the rule, which the implementation
already needed: the duty attaches to *reading a field*, not to holding a
descriptor. A consumer is not obliged to walk parts of the message its own
output does not describe.

## What changed in `cpybkc-gen-graph`

New `cmd/cpybkc-gen-graph/encoding.go` carrying `resolved`, called at the **two**
places this generator reads a field:

- `itemWalk.field` (`records.go`) — the item table's walk, ahead of everything
  the row is spelled from, because `withCharset` annotates the picture off one
  of the five axes.
- `predicateResolved` (`automaton.go`) — where a predicate's target field's
  charset decides whether its literals appear as text or as hex. This is the
  site `--opt records=none` does *not* switch off, and it is where the old
  behaviour was wrong: an unresolved charset fell to the same side of the test
  as an EBCDIC one and drew the literal as hex on this generator's own
  authority.

All five axes are refused, not only the charset it reads, for argument 2 above.

## Judgment calls

- **Written here rather than shared with `cpybkc-gen-go`** (acceptance criterion
  4), and the doc comment on `resolved` says so at length. This command's
  package comment already writes the version check, the diagnostic writer and
  the argument parser twice on purpose — a package both generators shared would
  be a convenience no third-party generator has, and being a generator with no
  such convenience is what this command exists to demonstrate. `malformedError`
  in `errors.go` carries the identical justification. This check is the one
  place that claim is load bearing: a third-party generator has to reach the
  same refusal from the specification alone, which is why the specification now
  argues it.
- **The fixture corpus was carrying descriptors no producer may emit.** Every
  field built by `fieldNode`, `numericFieldNode`, `encodedFieldNode`,
  `pictureFieldNode` and `fillerFieldNode` had no encoding at all. They now
  carry a resolved one (`resolvedEncoding`), on the same argument `fieldNode`'s
  own comment already made about USAGE and picture. cp037 is the charset, being
  the one this generator has no special reading of — so no golden output moves.
- **One existing table row was deleted rather than adjusted.**
  `TestATargetInASCIIIsTheOnlyLiteralDrawnAsText` had an `unset` case asserting
  that an unresolved charset draws its literal as hex. That row *was* the old
  behaviour this story decided against; it is replaced by a refusal test, and a
  comment in its place says so and points at the replacement.

## Acceptance criteria

- [x] Whether a descriptor-rendering consumer must refuse an unresolved
      descriptor is decided between the two readings, and the reasoning is
      recorded where a plugin author will find it — `docs/ir/SPEC.md`,
      "Which consumers the rule binds", with a shorter statement in
      `cmd/cpybkc-gen-graph/README.md`.
- [x] `docs/ir/SPEC.md` says which consumers the axis rule binds, rather than
      leaving "a consumer" to be read two ways — including the limit, that the
      duty attaches to reading a field.
- [x] `cpybkc-gen-graph`'s behaviour matches, with tests over a descriptor
      carrying a field that leaves an axis unset — `encoding_test.go` walks all
      five axes one at a time, covers a field with no encoding message at all,
      covers the predicate site under `records=none`, holds the limit
      (`records=none` does not refuse an item it does not draw), and carries a
      positive control so a `resolved` that refused everything would not pass.
- [x] The check is not a second copy written from memory — it is deliberately
      separate, justified in a comment against this command's existing
      precedent, and the specification now carries the argument a third
      implementation would need.

## Verified

`dagger call ci` — green. Run from an ordinary clone of this branch rather than
from the per-issue worktree, because a worktree's `.git` is a file and the
module's `gitDir` argument needs a directory.