### PR TITLE
story(layout): the worked example's layout names only the redefines a real file carries

### DIFF
--- a/cmd/cpybkc-gen-go/README.md
+++ b/cmd/cpybkc-gen-go/README.md
@@ -1210,12 +1210,20 @@ once per edge.
 
 This has to be decided rather than assumed, because it is the difference between
 a readable file and an unreadable one.
-[`example/graph/graph.md`](../../example/graph/graph.md) draws nine states and
-fifty transitions for one ordinary ledger — every posting state offers all six
-posting types — so a full edge cover would be fifty cases for the worked example
-alone, over seven. What an adopter is checking is *this record type is selected
-on these bytes*, which is a property of the **predicate**; the guards that make
-two edges carrying one predicate distinct are the automaton's business, and
+[`example/graph/graph.md`](../../example/graph/graph.md) draws five states and
+ten transitions for one ordinary ledger — every posting state offers both posting
+types and the trailer — so a full edge cover would be ten cases for the worked
+example alone, over three.
+
+That example's layout names two of the six record types its copybook admits, and
+the gap widens with the ones that do not: naming all six draws **nine** states
+and **fifty** transitions over the same file format, which is fifty cases against
+seven. The rule is decided on the shape rather than on either number, because
+which of them a repository's layouts look like is not this generator's to assume.
+
+What an adopter is checking is *this record type is selected on these bytes*,
+which is a property of the **predicate**; the guards that make two edges carrying
+one predicate distinct are the automaton's business, and
 [`cpybkc-gen-graph`](../cpybkc-gen-graph/) has already drawn them.
 
 So it is a bound on what these cases prove, and it is stated here for that

--- a/docs/cli/SPEC.md
+++ b/docs/cli/SPEC.md
@@ -523,14 +523,25 @@ have no default for any; [`framing`](../layout/SPEC.md#physical-framing), with
 [`discriminate`](../layout/SPEC.md#discrimination); and
 [`sequence`](../layout/SPEC.md#sequencing).
 
-`example/ledger.sexpr` is the measure. Its postings alone are six `record` forms
-and twelve `alternative` children — thirty-odd lines, every one of them
-recoverable from `posting.cpy` — against the eight `discriminate` forms its
-eight record types need and the one `sequence`, which are the file's actual
-description. Its six `rename`s sit between the two: which records need one is
-recoverable, and the six substitutes are a reading of what the file *means*, so
-`init` writes the question and not the answer. What it claims is that first
-column and nothing beyond it.
+`example/posting.cpy` is the measure, and the arithmetic is `init`'s output for
+it. That one copybook scaffolds six `record` forms and twelve `alternative`
+children — thirty-odd lines, every one of them recoverable from the copybook and
+none of them a thing the adopter has to know — against the `discriminate` form
+each of those six record types needs and the one `sequence`, which are the file's
+actual description and are recoverable from nothing. The six commented `rename`s
+sit between the two: which records need one is recoverable, and the substitutes
+are a reading of what the file *means*, so `init` writes the question and not the
+answer. What `init` claims is that first column and nothing beyond it.
+
+The measure is stated against the copybook rather than against
+`example/ledger.sexpr`, because the layout beside it names **two** of those six
+combinations — the two whose `alternative`s name a `REDEFINES` rather than a base
+description, which are the two a mainframe-produced extract carries. That is not
+`init` having derived too much. A copybook cannot say which combinations occur in
+a file, so `init` **MUST** emit all six and is right to; which of them the data
+holds is the adopter's knowledge, and narrowing to it is the layout's job. See
+[the worked example](../../example/README.md) for the same point from the layout
+end.
 
 ### The vector `init` takes
 
@@ -800,8 +811,10 @@ and in a file no layout is stored beside. A marked placeholder the adopter must
 replace has the same defect and adds a second reason the file does not read.
 
 And cpybkc **MUST NOT** name a record after the data. `example/ledger.sexpr`
-calls its six `DEBIT-POSTING`, `CREDIT-POSTING` and `MEMO-POSTING` crossed with
-`-REF`; that is a reading of what the file *means*, and no copybook holds it.
+calls the two combinations it names `DEBIT-POSTING` and `CREDIT-POSTING`; that is
+a reading of what the file *means*, and no copybook holds it — neither the names
+nor the fact that those two of the six `posting.cpy` admits are the ones its
+extracts carry.
 
 **No `rename` is emitted**, only a commented one. A rename on a record
 substitutes the name the IR carries — the name a generator turns into an

--- a/example/README.md
+++ b/example/README.md
@@ -49,13 +49,13 @@ opening a real dataset. The two kinds of `_test.go` are told apart by the
 The file tier and [`graph/graph.md`](graph/graph.md) are the two halves of one
 spot-check and are meant to be held against each other. The diagram answers
 *which records, in which order, told apart on which bytes* about the descriptor:
-`s77 --> s78: LEDGER-HEADER, when HDR-TYPE = 0xF0 0xF1, then r76 = HDR-COUNT` is
+`s40 --> s41: LEDGER-HEADER, when HDR-TYPE = 0xF0 0xF1, then r39 = HDR-COUNT` is
 the edge, and `TestALedgerHeaderThenTwoDebitPostingsThenALedgerTrailer` is that
 edge and the two it leads to as bytes — `0xf0 0xf1` at offset 0 of the first
 record, `0xf0 0xf0 0xf2` in `HDR-COUNT`, and the two debit postings the register
-it bound then admits. Seven cases cover all eight of the automaton's
-discriminators; the fifty edges the diagram draws are fifty ways to arrive at
-those eight, and [why one case per predicate rather than one per
+it bound then admits. Three cases cover all four of the automaton's
+discriminators; the ten edges the diagram draws are ten ways to arrive at those
+four, and [why one case per predicate rather than one per
 edge](../cmd/cpybkc-gen-go/README.md#decided-the-file-tier-covers-by-predicate-not-by-edge)
 is the whole of that decision.
 
@@ -113,7 +113,7 @@ describable, so the layout here is deliberately not a simple one. Three shapes
 in it are ordinary in production files and each is the reason this example is
 shaped the way it is.
 
-### Six record types out of one `01`-level
+### Six record types out of one `01`-level, and the two the file carries
 
 `posting.cpy` describes one fifty-byte record and redefines two independent runs
 inside it. `PST-BODY` is described three ways — as itself, as `PST-DEBIT` and as
@@ -123,28 +123,58 @@ one record type per alternative, and because the two runs are independent the
 alternatives *multiply* rather than merely branch: **six** record types come out
 of this one `01`-level.
 
-The layout is where each of them is named. Every one of the six `record` forms
-names the same copybook and the same `01`-level, and carries one `alternative`
-child per redefined run saying which description of it that form means:
+[`ledger.sexpr`](ledger.sexpr) names **two** of them, and that is the lesson
+rather than an omission.
+
+`PST-BODY` and `PST-TAIL` are *base descriptions*: they exist to declare the
+storage the `REDEFINES` items overlay. A file a mainframe produced carries the
+redefinitions, not the declaration underneath them — so the four combinations
+whose `alternative` names `PST-BODY` or `PST-TAIL` describe bytes no extract of
+this ledger holds. What is left is `PST-DEBIT` × `PST-TAIL-REF` and `PST-CREDIT`
+× `PST-TAIL-REF`, and the layout names exactly those:
 
 ```
-(record CREDIT-POSTING-REF
+(record CREDIT-POSTING
   (copybook "posting.cpy" POSTING-RECORD)
-  (alternative (item CREDIT-POSTING-REF PST-CREDIT))
-  (alternative (item CREDIT-POSTING-REF PST-TAIL-REF)))
+  (alternative (item CREDIT-POSTING PST-CREDIT))
+  (alternative (item CREDIT-POSTING PST-TAIL-REF)))
 ```
+
+**The copybook does not move.** [`posting.cpy`](posting.cpy) still describes all
+three ways `PST-BODY` can be read and both ways `PST-TAIL` can be, because that
+is what arrived from the mainframe and it is the source of truth. Narrowing to
+what a data file actually holds is the *layout's* job, and choosing is what a
+layout is for. Nothing here requires a layout to declare every combination its
+copybooks admit, and no `resolve` diagnostic fires on the ones it omits.
+
+`cpybkc init` derives one `record` form per combination — all six — and is right
+to: a copybook cannot say which combinations occur in a file. The two that
+survive here are the adopter's knowledge of their own data, which is why they are
+written in the layout and not inferred from anything.
+
+So the alternatives no longer multiply *in this layout*, and that is a property
+of `ledger.sexpr` rather than of `posting.cpy`. cpybkc's own coverage of the
+cross product is unaffected: `internal/resolve/shape_test.go` and
+`internal/scaffold/derive_test.go` carry inline fixtures enumerating all six.
 
 The pairing is stated and never inferred — cpybkc will not decide which bytes a
 record type describes by looking at which alternative its discriminator happens
 to reach into.
 
-All six carry one name in the IR, `POSTING-RECORD`, because that is what the
-copybook calls the record each of them is. Whether one name on six record types
-is a problem is a property of the target language, so the layout format does not
-require them to be told apart; Go requires it, and `cpybkc-gen-go` refuses to
-munge six record types into one identifier rather than picking. That is what the
-six `rename` forms are for, and they are why the package holds `DebitPosting`,
-`CreditPostingRef` and the rest.
+Both surviving record types carry one name in the IR, `POSTING-RECORD`, because
+that is what the copybook calls the record each of them is. Whether one name on
+two record types is a problem is a property of the target language, so the layout
+format does not require them to be told apart; Go requires it, and
+`cpybkc-gen-go` refuses to munge two record types into one identifier rather than
+picking. That is what the two `rename` forms are for, and they are why the
+package holds `DebitPosting` and `CreditPosting`.
+
+The `-REF` suffix went with the four that were dropped: it distinguished a
+`PST-TAIL-REF` posting from a `PST-TAIL` sibling, and there is no such sibling
+any more. For the same reason the `PST-TYPE` codes are `DR` and `CR` — what a
+ledger calls a debit and a credit — rather than the two-axis `DA`/`DB`/`CA`/`CB`
+scheme, whose second letter said which description of `PST-TAIL` a posting
+carried. There is no longer a second axis for a code to encode.
 
 ### Discrimination at two different offsets
 
@@ -169,7 +199,7 @@ how many postings follow, and the sequence counts them:
 ```
 (sequence
   (seq LEDGER-HEADER
-       (times (alt DEBIT-POSTING …) (item LEDGER-HEADER HDR-COUNT))
+       (times (alt DEBIT-POSTING CREDIT-POSTING) (item LEDGER-HEADER HDR-COUNT))
        LEDGER-TRAILER))
 ```
 
@@ -212,23 +242,23 @@ than of the file a person wrote.
 Everything in it is checkable against [`ledger.sexpr`](ledger.sexpr) by eye, and
 the point of it being here is that you should:
 
-- **Header, postings, trailer, in that order.** `[*] --> s77` is where a read
+- **Header, postings, trailer, in that order.** `[*] --> s40` is where a read
   begins; the one edge out of it is `LEDGER-HEADER`. Everything after it loops
   among the postings, and the only way out is `LEDGER-TRAILER`. That is
   `(seq LEDGER-HEADER (times (alt …)) LEDGER-TRAILER)` drawn.
-- **Six posting types, under a count.** Every state between the header and the
-  trailer offers all six — `DEBIT-POSTING`, `DEBIT-POSTING-REF`,
-  `CREDIT-POSTING`, `CREDIT-POSTING-REF`, `MEMO-POSTING`, `MEMO-POSTING-REF` —
-  which is the six `record` forms the copybook's three `REDEFINES` over two
-  independent runs resolve to, and the six names the `(alt …)` lists. Reading
-  one of them arrives at a state of its own, and a posting may be followed by a
-  posting of any type, so those seven states each carry the same seven
-  transitions and the picture is the complete graph over them. That density is
-  the layout's, not the drawing's.
+- **Two posting types, under a count.** Every state between the header and the
+  trailer offers both — `DEBIT-POSTING` and `CREDIT-POSTING` — which is the two
+  `record` forms this layout names out of the six the copybook admits, and the
+  two names the `(alt …)` lists. Reading one of them arrives at a state of its
+  own, and a posting may be followed by a posting of either type, so those three
+  states each carry the same three transitions and the picture is the complete
+  graph over them. That density is the layout's, not the drawing's: a layout
+  naming all six combinations would draw seven states and fifty edges for the
+  same file format.
 - **`HDR-COUNT` in the register table.** The header's edge carries
-  `then r76 = HDR-COUNT`; every posting edge carries `if r76 greater than zero,
-  then r76 = r76 - 1`; the trailer's carries `if r76 = 0`. The **Registers**
-  table names `r76` and every transition that binds it, because a register
+  `then r39 = HDR-COUNT`; every posting edge carries `if r39 greater than zero,
+  then r39 = r39 - 1`; the trailer's carries `if r39 = 0`. The **Registers**
+  table names `r39` and every transition that binds it, because a register
   carries an identifier and no name — without it the guards on the edges say
   nothing.
 
@@ -236,17 +266,17 @@ the point of it being here is that you should:
   header counts the postings](#why-the-header-counts-the-postings) says no state
   offers both a posting and the trailer, and what is drawn is every posting state
   offering both. Both are true, and the guards are the difference: the
-  alternatives are written at one state and are mutually exclusive on `r76`, so
+  alternatives are written at one state and are mutually exclusive on `r39`, so
   no *reachable* choice between them exists and the two offsets never have to be
   told apart. Read the guards, not the edge count.
 - **Two offsets, in the item tables.** `PST-TYPE` is at offset **12** in every
   posting table, behind the ten-byte account key and the two-byte sequence every
   posting shares; `HDR-TYPE` and `TRL-TYPE` are both at offset **0**. Those are
-  the eight `discriminate` forms, and the tables are where you check that the
+  the four `discriminate` forms, and the tables are where you check that the
   field a discriminator names is the field you meant.
-- **The literals are bytes.** `when PST-TYPE = 0xC4 0xC1` is `"DA"` in cp037,
+- **The literals are bytes.** `when PST-TYPE = 0xC4 0xD9` is `"DR"` in cp037,
   which is the charset `(encoding (charset cp037) …)` declares. A diagram that
-  printed `"DA"` would be printing ASCII for a field that is not in it.
+  printed `"DR"` would be printing ASCII for a field that is not in it.
 - **`*slack*` in the credit tables.** Four bytes at offset 38 that no credit
   posting describes — `PST-CREDIT` being shorter than the run it redefines —
   drawn as a row of its own rather than as a gap between two offsets.
@@ -257,7 +287,7 @@ is why the tables are worth checking against a copybook rather than being taken
 as a restatement of it.
 
 `format=mermaid` is the manifest's choice and it is a judgment call: this
-automaton is dense — nine states and fifty transitions — and
+automaton is small — five states and ten transitions — and
 [`cpybkc-gen-graph`'s README](../cmd/cpybkc-gen-graph/README.md#which-rendering-to-reach-for)
 reaches for `dot` at that density. Mermaid is what the example commits anyway,
 because a worked example is read where it is checked in: a `.md` renders the

--- a/example/README.md
+++ b/example/README.md
@@ -154,8 +154,12 @@ written in the layout and not inferred from anything.
 
 So the alternatives no longer multiply *in this layout*, and that is a property
 of `ledger.sexpr` rather than of `posting.cpy`. cpybkc's own coverage of the
-cross product is unaffected: `internal/resolve/shape_test.go` and
-`internal/scaffold/derive_test.go` carry inline fixtures enumerating all six.
+cross product does not go with them: `internal/resolve/shape_test.go` enumerates
+all six over a fixture written inline, and `internal/scaffold/derive_test.go`
+derives them from `posting.cpy` itself. That second one used to check the six by
+requiring *this layout* to enumerate them, and now pins the six it expects
+outright — so the coverage no longer depends on what a layout happens to name,
+which is the change this narrowing forced and an improvement on what was there.
 
 The pairing is stated and never inferred — cpybkc will not decide which bytes a
 record type describes by looking at which alternative its discriminator happens
@@ -188,7 +192,7 @@ reference: one strategy, two offsets.
 Two records that may be admitted at the *same* point in a file cannot be
 selected at two different offsets. A discriminator is evaluated before the
 record in front of a consumer has been identified, so nothing rules out a record
-carrying `99` in its first two bytes *and* `DA` in bytes twelve and thirteen —
+carrying `99` in its first two bytes *and* `DR` in bytes twelve and thirteen —
 and a state offering two transitions that can both apply is a layout `resolve`
 rejects before a consumer ever sees it.
 
@@ -253,8 +257,9 @@ the point of it being here is that you should:
   own, and a posting may be followed by a posting of either type, so those three
   states each carry the same three transitions and the picture is the complete
   graph over them. That density is the layout's, not the drawing's: a layout
-  naming all six combinations would draw seven states and fifty edges for the
-  same file format.
+  naming all six combinations would draw nine states and fifty edges for the
+  same file format, which is what this example drew until it narrowed to the two
+  the file carries.
 - **`HDR-COUNT` in the register table.** The header's edge carries
   `then r39 = HDR-COUNT`; every posting edge carries `if r39 greater than zero,
   then r39 = r39 - 1`; the trailer's carries `if r39 = 0`. The **Registers**
@@ -277,7 +282,7 @@ the point of it being here is that you should:
 - **The literals are bytes.** `when PST-TYPE = 0xC4 0xD9` is `"DR"` in cp037,
   which is the charset `(encoding (charset cp037) …)` declares. A diagram that
   printed `"DR"` would be printing ASCII for a field that is not in it.
-- **`*slack*` in the credit tables.** Four bytes at offset 38 that no credit
+- **`*slack*` in the credit table.** Four bytes at offset 38 that no credit
   posting describes — `PST-CREDIT` being shorter than the run it redefines —
   drawn as a row of its own rather than as a gap between two offsets.
 
@@ -286,16 +291,22 @@ those tables is the generator's own arithmetic; the document says so itself. Tha
 is why the tables are worth checking against a copybook rather than being taken
 as a restatement of it.
 
-`format=mermaid` is the manifest's choice and it is a judgment call: this
-automaton is small — five states and ten transitions — and
+`format=mermaid` is the manifest's choice, and it used to be a close one. While
+this layout named all six combinations the automaton was nine states and fifty
+transitions, and
 [`cpybkc-gen-graph`'s README](../cmd/cpybkc-gen-graph/README.md#which-rendering-to-reach-for)
-reaches for `dot` at that density. Mermaid is what the example commits anyway,
-because a worked example is read where it is checked in: a `.md` renders the
-diagram on the forge, and its registers and item tables are Markdown tables a
-reader can check by eye in the diff, where Graphviz's are HTML markup inside a
-file that renders nowhere on its own. Changing `"format": "mermaid"` to `"dot"`
-in [`cpybkc.json`](cpybkc.json) and regenerating is what it takes to see the
-other one.
+reaches for `dot` at that density. Naming the two record types the file carries
+took it to five states and ten transitions, which Mermaid draws comfortably — so
+the call is no longer close, and that is worth noticing on its own: which
+rendering a layout wants is decided by what the layout names, not by what its
+copybooks admit.
+
+Mermaid is what this example would commit either way, because a worked example is
+read where it is checked in: a `.md` renders the diagram on the forge, and its
+registers and item tables are Markdown tables a reader can check by eye in the
+diff, where Graphviz's are HTML markup inside a file that renders nowhere on its
+own. Changing `"format": "mermaid"` to `"dot"` in [`cpybkc.json`](cpybkc.json)
+and regenerating is what it takes to see the other one.
 
 ## One descriptor, two generators
 

--- a/example/graph/graph.md
+++ b/example/graph/graph.md
@@ -6,58 +6,18 @@
 
 ```mermaid
 stateDiagram-v2
-    [*] --> s77
-    s77 --> s78: LEDGER-HEADER, when HDR-TYPE = 0xF0 0xF1, then r76 = HDR-COUNT
-    s78 --> s79: DEBIT-POSTING, when PST-TYPE = 0xC4 0xC1, if r76 greater than zero, then r76 = r76 - 1
-    s78 --> s80: DEBIT-POSTING-REF, when PST-TYPE = 0xC4 0xC2, if r76 greater than zero, then r76 = r76 - 1
-    s78 --> s81: CREDIT-POSTING, when PST-TYPE = 0xC3 0xC1, if r76 greater than zero, then r76 = r76 - 1
-    s78 --> s82: CREDIT-POSTING-REF, when PST-TYPE = 0xC3 0xC2, if r76 greater than zero, then r76 = r76 - 1
-    s78 --> s83: MEMO-POSTING, when PST-TYPE = 0xD4 0xC1, if r76 greater than zero, then r76 = r76 - 1
-    s78 --> s84: MEMO-POSTING-REF, when PST-TYPE = 0xD4 0xC2, if r76 greater than zero, then r76 = r76 - 1
-    s78 --> s85: LEDGER-TRAILER, when TRL-TYPE = 0xF9 0xF9, if r76 = 0
-    s79 --> s79: DEBIT-POSTING, when PST-TYPE = 0xC4 0xC1, if r76 greater than zero, then r76 = r76 - 1
-    s79 --> s80: DEBIT-POSTING-REF, when PST-TYPE = 0xC4 0xC2, if r76 greater than zero, then r76 = r76 - 1
-    s79 --> s81: CREDIT-POSTING, when PST-TYPE = 0xC3 0xC1, if r76 greater than zero, then r76 = r76 - 1
-    s79 --> s82: CREDIT-POSTING-REF, when PST-TYPE = 0xC3 0xC2, if r76 greater than zero, then r76 = r76 - 1
-    s79 --> s83: MEMO-POSTING, when PST-TYPE = 0xD4 0xC1, if r76 greater than zero, then r76 = r76 - 1
-    s79 --> s84: MEMO-POSTING-REF, when PST-TYPE = 0xD4 0xC2, if r76 greater than zero, then r76 = r76 - 1
-    s79 --> s85: LEDGER-TRAILER, when TRL-TYPE = 0xF9 0xF9, if r76 = 0
-    s80 --> s79: DEBIT-POSTING, when PST-TYPE = 0xC4 0xC1, if r76 greater than zero, then r76 = r76 - 1
-    s80 --> s80: DEBIT-POSTING-REF, when PST-TYPE = 0xC4 0xC2, if r76 greater than zero, then r76 = r76 - 1
-    s80 --> s81: CREDIT-POSTING, when PST-TYPE = 0xC3 0xC1, if r76 greater than zero, then r76 = r76 - 1
-    s80 --> s82: CREDIT-POSTING-REF, when PST-TYPE = 0xC3 0xC2, if r76 greater than zero, then r76 = r76 - 1
-    s80 --> s83: MEMO-POSTING, when PST-TYPE = 0xD4 0xC1, if r76 greater than zero, then r76 = r76 - 1
-    s80 --> s84: MEMO-POSTING-REF, when PST-TYPE = 0xD4 0xC2, if r76 greater than zero, then r76 = r76 - 1
-    s80 --> s85: LEDGER-TRAILER, when TRL-TYPE = 0xF9 0xF9, if r76 = 0
-    s81 --> s79: DEBIT-POSTING, when PST-TYPE = 0xC4 0xC1, if r76 greater than zero, then r76 = r76 - 1
-    s81 --> s80: DEBIT-POSTING-REF, when PST-TYPE = 0xC4 0xC2, if r76 greater than zero, then r76 = r76 - 1
-    s81 --> s81: CREDIT-POSTING, when PST-TYPE = 0xC3 0xC1, if r76 greater than zero, then r76 = r76 - 1
-    s81 --> s82: CREDIT-POSTING-REF, when PST-TYPE = 0xC3 0xC2, if r76 greater than zero, then r76 = r76 - 1
-    s81 --> s83: MEMO-POSTING, when PST-TYPE = 0xD4 0xC1, if r76 greater than zero, then r76 = r76 - 1
-    s81 --> s84: MEMO-POSTING-REF, when PST-TYPE = 0xD4 0xC2, if r76 greater than zero, then r76 = r76 - 1
-    s81 --> s85: LEDGER-TRAILER, when TRL-TYPE = 0xF9 0xF9, if r76 = 0
-    s82 --> s79: DEBIT-POSTING, when PST-TYPE = 0xC4 0xC1, if r76 greater than zero, then r76 = r76 - 1
-    s82 --> s80: DEBIT-POSTING-REF, when PST-TYPE = 0xC4 0xC2, if r76 greater than zero, then r76 = r76 - 1
-    s82 --> s81: CREDIT-POSTING, when PST-TYPE = 0xC3 0xC1, if r76 greater than zero, then r76 = r76 - 1
-    s82 --> s82: CREDIT-POSTING-REF, when PST-TYPE = 0xC3 0xC2, if r76 greater than zero, then r76 = r76 - 1
-    s82 --> s83: MEMO-POSTING, when PST-TYPE = 0xD4 0xC1, if r76 greater than zero, then r76 = r76 - 1
-    s82 --> s84: MEMO-POSTING-REF, when PST-TYPE = 0xD4 0xC2, if r76 greater than zero, then r76 = r76 - 1
-    s82 --> s85: LEDGER-TRAILER, when TRL-TYPE = 0xF9 0xF9, if r76 = 0
-    s83 --> s79: DEBIT-POSTING, when PST-TYPE = 0xC4 0xC1, if r76 greater than zero, then r76 = r76 - 1
-    s83 --> s80: DEBIT-POSTING-REF, when PST-TYPE = 0xC4 0xC2, if r76 greater than zero, then r76 = r76 - 1
-    s83 --> s81: CREDIT-POSTING, when PST-TYPE = 0xC3 0xC1, if r76 greater than zero, then r76 = r76 - 1
-    s83 --> s82: CREDIT-POSTING-REF, when PST-TYPE = 0xC3 0xC2, if r76 greater than zero, then r76 = r76 - 1
-    s83 --> s83: MEMO-POSTING, when PST-TYPE = 0xD4 0xC1, if r76 greater than zero, then r76 = r76 - 1
-    s83 --> s84: MEMO-POSTING-REF, when PST-TYPE = 0xD4 0xC2, if r76 greater than zero, then r76 = r76 - 1
-    s83 --> s85: LEDGER-TRAILER, when TRL-TYPE = 0xF9 0xF9, if r76 = 0
-    s84 --> s79: DEBIT-POSTING, when PST-TYPE = 0xC4 0xC1, if r76 greater than zero, then r76 = r76 - 1
-    s84 --> s80: DEBIT-POSTING-REF, when PST-TYPE = 0xC4 0xC2, if r76 greater than zero, then r76 = r76 - 1
-    s84 --> s81: CREDIT-POSTING, when PST-TYPE = 0xC3 0xC1, if r76 greater than zero, then r76 = r76 - 1
-    s84 --> s82: CREDIT-POSTING-REF, when PST-TYPE = 0xC3 0xC2, if r76 greater than zero, then r76 = r76 - 1
-    s84 --> s83: MEMO-POSTING, when PST-TYPE = 0xD4 0xC1, if r76 greater than zero, then r76 = r76 - 1
-    s84 --> s84: MEMO-POSTING-REF, when PST-TYPE = 0xD4 0xC2, if r76 greater than zero, then r76 = r76 - 1
-    s84 --> s85: LEDGER-TRAILER, when TRL-TYPE = 0xF9 0xF9, if r76 = 0
-    s85 --> [*]
+    [*] --> s40
+    s40 --> s41: LEDGER-HEADER, when HDR-TYPE = 0xF0 0xF1, then r39 = HDR-COUNT
+    s41 --> s42: DEBIT-POSTING, when PST-TYPE = 0xC4 0xD9, if r39 greater than zero, then r39 = r39 - 1
+    s41 --> s43: CREDIT-POSTING, when PST-TYPE = 0xC3 0xD9, if r39 greater than zero, then r39 = r39 - 1
+    s41 --> s44: LEDGER-TRAILER, when TRL-TYPE = 0xF9 0xF9, if r39 = 0
+    s42 --> s42: DEBIT-POSTING, when PST-TYPE = 0xC4 0xD9, if r39 greater than zero, then r39 = r39 - 1
+    s42 --> s43: CREDIT-POSTING, when PST-TYPE = 0xC3 0xD9, if r39 greater than zero, then r39 = r39 - 1
+    s42 --> s44: LEDGER-TRAILER, when TRL-TYPE = 0xF9 0xF9, if r39 = 0
+    s43 --> s42: DEBIT-POSTING, when PST-TYPE = 0xC4 0xD9, if r39 greater than zero, then r39 = r39 - 1
+    s43 --> s43: CREDIT-POSTING, when PST-TYPE = 0xC3 0xD9, if r39 greater than zero, then r39 = r39 - 1
+    s43 --> s44: LEDGER-TRAILER, when TRL-TYPE = 0xF9 0xF9, if r39 = 0
+    s44 --> [*]
 ```
 
 ## Registers
@@ -66,7 +26,7 @@ A register is what the automaton remembers between records: a binding on a trans
 
 | Register | Holds | Bound by |
 | --- | --- | --- |
-| r76 | an integer | `s77 --> s78` (LEDGER-HEADER), `s78 --> s79` (DEBIT-POSTING), `s78 --> s80` (DEBIT-POSTING-REF), `s78 --> s81` (CREDIT-POSTING), `s78 --> s82` (CREDIT-POSTING-REF), `s78 --> s83` (MEMO-POSTING), `s78 --> s84` (MEMO-POSTING-REF), `s79 --> s79` (DEBIT-POSTING), `s79 --> s80` (DEBIT-POSTING-REF), `s79 --> s81` (CREDIT-POSTING), `s79 --> s82` (CREDIT-POSTING-REF), `s79 --> s83` (MEMO-POSTING), `s79 --> s84` (MEMO-POSTING-REF), `s80 --> s79` (DEBIT-POSTING), `s80 --> s80` (DEBIT-POSTING-REF), `s80 --> s81` (CREDIT-POSTING), `s80 --> s82` (CREDIT-POSTING-REF), `s80 --> s83` (MEMO-POSTING), `s80 --> s84` (MEMO-POSTING-REF), `s81 --> s79` (DEBIT-POSTING), `s81 --> s80` (DEBIT-POSTING-REF), `s81 --> s81` (CREDIT-POSTING), `s81 --> s82` (CREDIT-POSTING-REF), `s81 --> s83` (MEMO-POSTING), `s81 --> s84` (MEMO-POSTING-REF), `s82 --> s79` (DEBIT-POSTING), `s82 --> s80` (DEBIT-POSTING-REF), `s82 --> s81` (CREDIT-POSTING), `s82 --> s82` (CREDIT-POSTING-REF), `s82 --> s83` (MEMO-POSTING), `s82 --> s84` (MEMO-POSTING-REF), `s83 --> s79` (DEBIT-POSTING), `s83 --> s80` (DEBIT-POSTING-REF), `s83 --> s81` (CREDIT-POSTING), `s83 --> s82` (CREDIT-POSTING-REF), `s83 --> s83` (MEMO-POSTING), `s83 --> s84` (MEMO-POSTING-REF), `s84 --> s79` (DEBIT-POSTING), `s84 --> s80` (DEBIT-POSTING-REF), `s84 --> s81` (CREDIT-POSTING), `s84 --> s82` (CREDIT-POSTING-REF), `s84 --> s83` (MEMO-POSTING), `s84 --> s84` (MEMO-POSTING-REF) |
+| r39 | an integer | `s40 --> s41` (LEDGER-HEADER), `s41 --> s42` (DEBIT-POSTING), `s41 --> s43` (CREDIT-POSTING), `s42 --> s42` (DEBIT-POSTING), `s42 --> s43` (CREDIT-POSTING), `s43 --> s42` (DEBIT-POSTING), `s43 --> s43` (CREDIT-POSTING) |
 
 ## Records
 
@@ -97,19 +57,6 @@ Each record's items, in containment order, beginning at the first byte of the re
 | 14 | 6 | PST-DEBIT.PDB-COST-CENTRE | DISPLAY | X(6) | always |
 | 20 | 7 | PST-DEBIT.PDB-AMOUNT | PACKED-DECIMAL | S9(11)V9(2) | always |
 | 27 | 15 | PST-DEBIT.PDB-MEMO | DISPLAY | X(15) | always |
-| 42 | 8 | PST-TAIL | DISPLAY | X(8) | always |
-
-### DEBIT-POSTING-REF
-
-| Offset | Width | Item | Usage | Picture | Present |
-| --- | --- | --- | --- | --- | --- |
-| 0 | 10 | PST-ACCOUNT | DISPLAY | X(10) | always |
-| 10 | 2 | PST-SEQUENCE | DISPLAY | 9(2) | always |
-| 12 | 2 | PST-TYPE | DISPLAY | X(2) | always |
-| 14 | 28 | PST-DEBIT | — | — | always |
-| 14 | 6 | PST-DEBIT.PDB-COST-CENTRE | DISPLAY | X(6) | always |
-| 20 | 7 | PST-DEBIT.PDB-AMOUNT | PACKED-DECIMAL | S9(11)V9(2) | always |
-| 27 | 15 | PST-DEBIT.PDB-MEMO | DISPLAY | X(15) | always |
 | 42 | 8 | PST-TAIL-REF | — | — | always |
 | 42 | 4 | PST-TAIL-REF.PTR-BATCH | DISPLAY | 9(4) | always |
 | 46 | 4 | PST-TAIL-REF.PTR-LINE | DISPLAY | 9(4) | always |
@@ -126,42 +73,6 @@ Each record's items, in containment order, beginning at the first byte of the re
 | 18 | 6 | PST-CREDIT.PCR-AMOUNT | PACKED-DECIMAL | S9(9)V9(2) | always |
 | 24 | 14 | PST-CREDIT.PCR-REFERENCE | DISPLAY | X(14) | always |
 | 38 | 4 | *slack* | — | — | always |
-| 42 | 8 | PST-TAIL | DISPLAY | X(8) | always |
-
-### CREDIT-POSTING-REF
-
-| Offset | Width | Item | Usage | Picture | Present |
-| --- | --- | --- | --- | --- | --- |
-| 0 | 10 | PST-ACCOUNT | DISPLAY | X(10) | always |
-| 10 | 2 | PST-SEQUENCE | DISPLAY | 9(2) | always |
-| 12 | 2 | PST-TYPE | DISPLAY | X(2) | always |
-| 14 | 24 | PST-CREDIT | — | — | always |
-| 14 | 4 | PST-CREDIT.PCR-SOURCE | DISPLAY | X(4) | always |
-| 18 | 6 | PST-CREDIT.PCR-AMOUNT | PACKED-DECIMAL | S9(9)V9(2) | always |
-| 24 | 14 | PST-CREDIT.PCR-REFERENCE | DISPLAY | X(14) | always |
-| 38 | 4 | *slack* | — | — | always |
-| 42 | 8 | PST-TAIL-REF | — | — | always |
-| 42 | 4 | PST-TAIL-REF.PTR-BATCH | DISPLAY | 9(4) | always |
-| 46 | 4 | PST-TAIL-REF.PTR-LINE | DISPLAY | 9(4) | always |
-
-### MEMO-POSTING
-
-| Offset | Width | Item | Usage | Picture | Present |
-| --- | --- | --- | --- | --- | --- |
-| 0 | 10 | PST-ACCOUNT | DISPLAY | X(10) | always |
-| 10 | 2 | PST-SEQUENCE | DISPLAY | 9(2) | always |
-| 12 | 2 | PST-TYPE | DISPLAY | X(2) | always |
-| 14 | 28 | PST-BODY | DISPLAY | X(28) | always |
-| 42 | 8 | PST-TAIL | DISPLAY | X(8) | always |
-
-### MEMO-POSTING-REF
-
-| Offset | Width | Item | Usage | Picture | Present |
-| --- | --- | --- | --- | --- | --- |
-| 0 | 10 | PST-ACCOUNT | DISPLAY | X(10) | always |
-| 10 | 2 | PST-SEQUENCE | DISPLAY | 9(2) | always |
-| 12 | 2 | PST-TYPE | DISPLAY | X(2) | always |
-| 14 | 28 | PST-BODY | DISPLAY | X(28) | always |
 | 42 | 8 | PST-TAIL-REF | — | — | always |
 | 42 | 4 | PST-TAIL-REF.PTR-BATCH | DISPLAY | 9(4) | always |
 | 46 | 4 | PST-TAIL-REF.PTR-LINE | DISPLAY | 9(4) | always |

--- a/example/ledger.sexpr
+++ b/example/ledger.sexpr
@@ -2,11 +2,11 @@
 ;; postings, and a trailer.
 ;;
 ;; What is hard about it, and why it is the worked example, is in README.md
-;; beside this file. In short: the postings are six record types resolved out
-;; of one 01-level by three REDEFINES over two independent runs, and this file
-;; discriminates at two different offsets -- the header and the trailer on the
-;; field they open with, a posting on a type code behind the account key every
-;; posting shares.
+;; beside this file. In short: `posting.cpy` admits six record types, resolved
+;; out of one 01-level by three REDEFINES over two independent runs; this file
+;; names the two of them the extract actually carries, and discriminates at two
+;; different offsets -- the header and the trailer on the field they open with,
+;; a posting on a type code behind the account key every posting shares.
 
 ;; The encoding profile. All four axes, always, with no default for any.
 (encoding
@@ -26,72 +26,58 @@
 (record LEDGER-HEADER  (copybook "header.cpy" LEDGER-HEADER))
 (record LEDGER-TRAILER (copybook "trailer.cpy" LEDGER-TRAILER))
 
-;; And the six the postings' copybook resolves to. Each `record` form names the
-;; same 01-level and states which description of each redefined run it means:
-;; one `alternative` child per run, and the two together select one of the six
-;; combinations. The pairing is stated here and is never inferred from which
-;; alternative a discriminator happens to reach into.
+;; And the postings. `posting.cpy` admits six combinations -- PST-BODY described
+;; three ways, PST-TAIL described two, the two runs independent -- and every
+;; `alternative` below names a REDEFINES rather than a base description. That is
+;; not tidiness: PST-BODY and PST-TAIL are the declarations that exist to give
+;; their alternatives storage, and a file a mainframe produced carries the
+;; redefinitions. The four combinations naming a base describe bytes this
+;; extract does not hold, so this layout does not name them.
+;;
+;; Choosing is what a layout is for. The copybook cannot say which combinations
+;; occur -- `cpybkc init` derives all six from it and is right to -- and saying
+;; so is the adopter's, stated here.
+;;
+;; Each `record` form names the same 01-level and carries one `alternative`
+;; child per redefined run, saying which description of it that form means. The
+;; pairing is stated here and is never inferred from which alternative a
+;; discriminator happens to reach into.
 (record DEBIT-POSTING
   (copybook "posting.cpy" POSTING-RECORD)
   (alternative (item DEBIT-POSTING PST-DEBIT))
-  (alternative (item DEBIT-POSTING PST-TAIL)))
-
-(record DEBIT-POSTING-REF
-  (copybook "posting.cpy" POSTING-RECORD)
-  (alternative (item DEBIT-POSTING-REF PST-DEBIT))
-  (alternative (item DEBIT-POSTING-REF PST-TAIL-REF)))
+  (alternative (item DEBIT-POSTING PST-TAIL-REF)))
 
 (record CREDIT-POSTING
   (copybook "posting.cpy" POSTING-RECORD)
   (alternative (item CREDIT-POSTING PST-CREDIT))
-  (alternative (item CREDIT-POSTING PST-TAIL)))
+  (alternative (item CREDIT-POSTING PST-TAIL-REF)))
 
-(record CREDIT-POSTING-REF
-  (copybook "posting.cpy" POSTING-RECORD)
-  (alternative (item CREDIT-POSTING-REF PST-CREDIT))
-  (alternative (item CREDIT-POSTING-REF PST-TAIL-REF)))
-
-(record MEMO-POSTING
-  (copybook "posting.cpy" POSTING-RECORD)
-  (alternative (item MEMO-POSTING PST-BODY))
-  (alternative (item MEMO-POSTING PST-TAIL)))
-
-(record MEMO-POSTING-REF
-  (copybook "posting.cpy" POSTING-RECORD)
-  (alternative (item MEMO-POSTING-REF PST-BODY))
-  (alternative (item MEMO-POSTING-REF PST-TAIL-REF)))
-
-;; Six record types over one 01-level carry one name between them -- the one the
-;; copybook's 01-level gives them -- until a rename says otherwise. Nothing in
-;; the layout format requires one, because whether one name on six record types
-;; is a problem is a property of the target language. It is a problem in Go, and
-;; `cpybkc-gen-go` refuses rather than munging six record types into one
-;; identifier, so this layout names them.
-(rename DEBIT-POSTING      "DEBIT-POSTING")
-(rename DEBIT-POSTING-REF  "DEBIT-POSTING-REF")
-(rename CREDIT-POSTING     "CREDIT-POSTING")
-(rename CREDIT-POSTING-REF "CREDIT-POSTING-REF")
-(rename MEMO-POSTING       "MEMO-POSTING")
-(rename MEMO-POSTING-REF   "MEMO-POSTING-REF")
+;; Both posting record types over one 01-level carry one name between them --
+;; the one the copybook's 01-level gives them -- until a rename says otherwise.
+;; Nothing in the layout format requires one, because whether one name on two
+;; record types is a problem is a property of the target language. It is a
+;; problem in Go, and `cpybkc-gen-go` refuses rather than munging two record
+;; types into one identifier, so this layout names them.
+(rename DEBIT-POSTING  "DEBIT-POSTING")
+(rename CREDIT-POSTING "CREDIT-POSTING")
 
 ;; How to tell them apart. The header and the trailer are selected on the field
 ;; they open with; every posting is selected on PST-TYPE, which sits twelve
 ;; bytes into the record behind the key it shares. Both are `equals` on an item
 ;; reference -- one strategy, two offsets.
-(discriminate LEDGER-HEADER      (equals (item LEDGER-HEADER HDR-TYPE) "01"))
-(discriminate LEDGER-TRAILER     (equals (item LEDGER-TRAILER TRL-TYPE) "99"))
-(discriminate DEBIT-POSTING      (equals (item DEBIT-POSTING PST-TYPE) "DA"))
-(discriminate DEBIT-POSTING-REF  (equals (item DEBIT-POSTING-REF PST-TYPE) "DB"))
-(discriminate CREDIT-POSTING     (equals (item CREDIT-POSTING PST-TYPE) "CA"))
-(discriminate CREDIT-POSTING-REF (equals (item CREDIT-POSTING-REF PST-TYPE) "CB"))
-(discriminate MEMO-POSTING       (equals (item MEMO-POSTING PST-TYPE) "MA"))
-(discriminate MEMO-POSTING-REF   (equals (item MEMO-POSTING-REF PST-TYPE) "MB"))
+;;
+;; The codes say which description of PST-BODY the posting carries, and nothing
+;; else: PST-TAIL-REF is the only tail this extract holds, so there is no second
+;; axis for a code to encode. `DR` and `CR` are what a ledger calls a debit and
+;; a credit.
+(discriminate LEDGER-HEADER  (equals (item LEDGER-HEADER HDR-TYPE) "01"))
+(discriminate LEDGER-TRAILER (equals (item LEDGER-TRAILER TRL-TYPE) "99"))
+(discriminate DEBIT-POSTING  (equals (item DEBIT-POSTING PST-TYPE) "DR"))
+(discriminate CREDIT-POSTING (equals (item CREDIT-POSTING PST-TYPE) "CR"))
 
 ;; The order they may appear in.
 (sequence
   (seq LEDGER-HEADER
-       (times (alt DEBIT-POSTING DEBIT-POSTING-REF
-                   CREDIT-POSTING CREDIT-POSTING-REF
-                   MEMO-POSTING MEMO-POSTING-REF)
+       (times (alt DEBIT-POSTING CREDIT-POSTING)
               (item LEDGER-HEADER HDR-COUNT))
        LEDGER-TRAILER))

--- a/example/ledger/codec.go
+++ b/example/ledger/codec.go
@@ -48,16 +48,8 @@ var (
 	_ codec.Marshaler   = (*LedgerTrailer)(nil)
 	_ codec.Unmarshaler = (*DebitPosting)(nil)
 	_ codec.Marshaler   = (*DebitPosting)(nil)
-	_ codec.Unmarshaler = (*DebitPostingRef)(nil)
-	_ codec.Marshaler   = (*DebitPostingRef)(nil)
 	_ codec.Unmarshaler = (*CreditPosting)(nil)
 	_ codec.Marshaler   = (*CreditPosting)(nil)
-	_ codec.Unmarshaler = (*CreditPostingRef)(nil)
-	_ codec.Marshaler   = (*CreditPostingRef)(nil)
-	_ codec.Unmarshaler = (*MemoPosting)(nil)
-	_ codec.Marshaler   = (*MemoPosting)(nil)
-	_ codec.Unmarshaler = (*MemoPostingRef)(nil)
-	_ codec.Marshaler   = (*MemoPostingRef)(nil)
 )
 
 // zeroFill is what a writer emits for a run of bytes a record its caller built
@@ -256,91 +248,6 @@ func (p *DebitPosting) UnmarshalCOBOL(r *codec.Reader) error {
 		return fmt.Errorf("POSTING-RECORD: reading PDB-MEMO: %w", err)
 	}
 
-	if p.PstTail, err = r.ReadAlphanumeric(8); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PST-TAIL: %w", err)
-	}
-
-	return nil
-}
-
-// MarshalCOBOL writes this POSTING-RECORD into w, in the order docs/ir/SPEC.md
-// resolved its items, emitting the bytes retained for every slack node and
-// every unnamed item it carries, and zero bytes for one it does not.
-//
-// It is codec's Marshaler. Two values are the descriptor's rather than the
-// caller's and are supplied rather than taken from the record: an OCCURS
-// DEPENDING ON count is emitted as the number of occurrences written, and
-// slack — and the bytes of an item the copybook gives no data-name — is
-// emitted as what was retained for it. Everything else is the caller's,
-// including the value a discriminator tests — a writer evaluates a predicate
-// and never inverts one.
-func (p *DebitPosting) MarshalCOBOL(w *codec.Writer) error {
-	var err error
-
-	if err = w.WriteAlphanumeric(p.PstAccount, 10); err != nil {
-		return fmt.Errorf("POSTING-RECORD: writing PST-ACCOUNT: %w", err)
-	}
-
-	if err = w.WriteZonedInt32(p.PstSequence, 2, codec.SignUnsigned); err != nil {
-		return fmt.Errorf("POSTING-RECORD: writing PST-SEQUENCE: %w", err)
-	}
-
-	if err = w.WriteAlphanumeric(p.PstType, 2); err != nil {
-		return fmt.Errorf("POSTING-RECORD: writing PST-TYPE: %w", err)
-	}
-
-	if err = w.WriteAlphanumeric(p.PstDebit.PdbCostCentre, 6); err != nil {
-		return fmt.Errorf("POSTING-RECORD: writing PDB-COST-CENTRE: %w", err)
-	}
-
-	if err = w.WritePackedInt64(p.PstDebit.PdbAmount, 13, codec.Signed); err != nil {
-		return fmt.Errorf("POSTING-RECORD: writing PDB-AMOUNT: %w", err)
-	}
-
-	if err = w.WriteAlphanumeric(p.PstDebit.PdbMemo, 15); err != nil {
-		return fmt.Errorf("POSTING-RECORD: writing PDB-MEMO: %w", err)
-	}
-
-	if err = w.WriteAlphanumeric(p.PstTail, 8); err != nil {
-		return fmt.Errorf("POSTING-RECORD: writing PST-TAIL: %w", err)
-	}
-
-	return nil
-}
-
-// UnmarshalCOBOL reads one POSTING-RECORD out of r, in the order docs/ir/SPEC.md
-// resolved its items, and retains the bytes of every slack node it carries and
-// of every item the copybook gives no data-name.
-//
-// It is codec's Unmarshaler. The Encoding is r's: the five axes are properties
-// of the file in hand, and Encoding is what this descriptor resolved.
-func (p *DebitPostingRef) UnmarshalCOBOL(r *codec.Reader) error {
-	var err error
-
-	if p.PstAccount, err = r.ReadAlphanumeric(10); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PST-ACCOUNT: %w", err)
-	}
-
-	if p.PstSequence, err = r.ReadZonedInt32(2, codec.SignUnsigned); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PST-SEQUENCE: %w", err)
-	}
-
-	if p.PstType, err = r.ReadAlphanumeric(2); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PST-TYPE: %w", err)
-	}
-
-	if p.PstDebit.PdbCostCentre, err = r.ReadAlphanumeric(6); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PDB-COST-CENTRE: %w", err)
-	}
-
-	if p.PstDebit.PdbAmount, err = r.ReadPackedInt64(13); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PDB-AMOUNT: %w", err)
-	}
-
-	if p.PstDebit.PdbMemo, err = r.ReadAlphanumeric(15); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PDB-MEMO: %w", err)
-	}
-
 	if p.PstTailRef.PtrBatch, err = r.ReadZonedInt32(4, codec.SignUnsigned); err != nil {
 		return fmt.Errorf("POSTING-RECORD: reading PTR-BATCH: %w", err)
 	}
@@ -363,7 +270,7 @@ func (p *DebitPostingRef) UnmarshalCOBOL(r *codec.Reader) error {
 // emitted as what was retained for it. Everything else is the caller's,
 // including the value a discriminator tests — a writer evaluates a predicate
 // and never inverts one.
-func (p *DebitPostingRef) MarshalCOBOL(w *codec.Writer) error {
+func (p *DebitPosting) MarshalCOBOL(w *codec.Writer) error {
 	var err error
 
 	if err = w.WriteAlphanumeric(p.PstAccount, 10); err != nil {
@@ -438,8 +345,12 @@ func (p *CreditPosting) UnmarshalCOBOL(r *codec.Reader) error {
 		return fmt.Errorf("POSTING-RECORD: reading the 4 bytes no item of it covers: %w", err)
 	}
 
-	if p.PstTail, err = r.ReadAlphanumeric(8); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PST-TAIL: %w", err)
+	if p.PstTailRef.PtrBatch, err = r.ReadZonedInt32(4, codec.SignUnsigned); err != nil {
+		return fmt.Errorf("POSTING-RECORD: reading PTR-BATCH: %w", err)
+	}
+
+	if p.PstTailRef.PtrLine, err = r.ReadZonedInt32(4, codec.SignUnsigned); err != nil {
+		return fmt.Errorf("POSTING-RECORD: reading PTR-LINE: %w", err)
 	}
 
 	return nil
@@ -494,258 +405,6 @@ func (p *CreditPosting) MarshalCOBOL(w *codec.Writer) error {
 		if err = w.WriteBytes(p.slack[0]); err != nil {
 			return fmt.Errorf("POSTING-RECORD: writing the 4 bytes no item of it covers: %w", err)
 		}
-	}
-
-	if err = w.WriteAlphanumeric(p.PstTail, 8); err != nil {
-		return fmt.Errorf("POSTING-RECORD: writing PST-TAIL: %w", err)
-	}
-
-	return nil
-}
-
-// UnmarshalCOBOL reads one POSTING-RECORD out of r, in the order docs/ir/SPEC.md
-// resolved its items, and retains the bytes of every slack node it carries and
-// of every item the copybook gives no data-name.
-//
-// It is codec's Unmarshaler. The Encoding is r's: the five axes are properties
-// of the file in hand, and Encoding is what this descriptor resolved.
-func (p *CreditPostingRef) UnmarshalCOBOL(r *codec.Reader) error {
-	var err error
-
-	if p.PstAccount, err = r.ReadAlphanumeric(10); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PST-ACCOUNT: %w", err)
-	}
-
-	if p.PstSequence, err = r.ReadZonedInt32(2, codec.SignUnsigned); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PST-SEQUENCE: %w", err)
-	}
-
-	if p.PstType, err = r.ReadAlphanumeric(2); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PST-TYPE: %w", err)
-	}
-
-	if p.PstCredit.PcrSource, err = r.ReadAlphanumeric(4); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PCR-SOURCE: %w", err)
-	}
-
-	if p.PstCredit.PcrAmount, err = r.ReadPackedInt64(11); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PCR-AMOUNT: %w", err)
-	}
-
-	if p.PstCredit.PcrReference, err = r.ReadAlphanumeric(14); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PCR-REFERENCE: %w", err)
-	}
-
-	if p.slack[0], err = r.ReadBytes(4); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading the 4 bytes no item of it covers: %w", err)
-	}
-
-	if p.PstTailRef.PtrBatch, err = r.ReadZonedInt32(4, codec.SignUnsigned); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PTR-BATCH: %w", err)
-	}
-
-	if p.PstTailRef.PtrLine, err = r.ReadZonedInt32(4, codec.SignUnsigned); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PTR-LINE: %w", err)
-	}
-
-	return nil
-}
-
-// MarshalCOBOL writes this POSTING-RECORD into w, in the order docs/ir/SPEC.md
-// resolved its items, emitting the bytes retained for every slack node and
-// every unnamed item it carries, and zero bytes for one it does not.
-//
-// It is codec's Marshaler. Two values are the descriptor's rather than the
-// caller's and are supplied rather than taken from the record: an OCCURS
-// DEPENDING ON count is emitted as the number of occurrences written, and
-// slack — and the bytes of an item the copybook gives no data-name — is
-// emitted as what was retained for it. Everything else is the caller's,
-// including the value a discriminator tests — a writer evaluates a predicate
-// and never inverts one.
-func (p *CreditPostingRef) MarshalCOBOL(w *codec.Writer) error {
-	var err error
-
-	if err = w.WriteAlphanumeric(p.PstAccount, 10); err != nil {
-		return fmt.Errorf("POSTING-RECORD: writing PST-ACCOUNT: %w", err)
-	}
-
-	if err = w.WriteZonedInt32(p.PstSequence, 2, codec.SignUnsigned); err != nil {
-		return fmt.Errorf("POSTING-RECORD: writing PST-SEQUENCE: %w", err)
-	}
-
-	if err = w.WriteAlphanumeric(p.PstType, 2); err != nil {
-		return fmt.Errorf("POSTING-RECORD: writing PST-TYPE: %w", err)
-	}
-
-	if err = w.WriteAlphanumeric(p.PstCredit.PcrSource, 4); err != nil {
-		return fmt.Errorf("POSTING-RECORD: writing PCR-SOURCE: %w", err)
-	}
-
-	if err = w.WritePackedInt64(p.PstCredit.PcrAmount, 11, codec.Signed); err != nil {
-		return fmt.Errorf("POSTING-RECORD: writing PCR-AMOUNT: %w", err)
-	}
-
-	if err = w.WriteAlphanumeric(p.PstCredit.PcrReference, 14); err != nil {
-		return fmt.Errorf("POSTING-RECORD: writing PCR-REFERENCE: %w", err)
-	}
-
-	switch {
-	case p.slack[0] == nil:
-		if err = w.WriteBytes(zeroFill[:4]); err != nil {
-			return fmt.Errorf("POSTING-RECORD: writing 4 zero bytes for slack this record carries none for: %w", err)
-		}
-	case len(p.slack[0]) != 4:
-		return fmt.Errorf("POSTING-RECORD: a writer reports a retained run rather than truncating or padding it, and the run for a slack node of 4 bytes is %d", len(p.slack[0]))
-	default:
-		if err = w.WriteBytes(p.slack[0]); err != nil {
-			return fmt.Errorf("POSTING-RECORD: writing the 4 bytes no item of it covers: %w", err)
-		}
-	}
-
-	if err = w.WriteZonedInt32(p.PstTailRef.PtrBatch, 4, codec.SignUnsigned); err != nil {
-		return fmt.Errorf("POSTING-RECORD: writing PTR-BATCH: %w", err)
-	}
-
-	if err = w.WriteZonedInt32(p.PstTailRef.PtrLine, 4, codec.SignUnsigned); err != nil {
-		return fmt.Errorf("POSTING-RECORD: writing PTR-LINE: %w", err)
-	}
-
-	return nil
-}
-
-// UnmarshalCOBOL reads one POSTING-RECORD out of r, in the order docs/ir/SPEC.md
-// resolved its items, and retains the bytes of every slack node it carries and
-// of every item the copybook gives no data-name.
-//
-// It is codec's Unmarshaler. The Encoding is r's: the five axes are properties
-// of the file in hand, and Encoding is what this descriptor resolved.
-func (p *MemoPosting) UnmarshalCOBOL(r *codec.Reader) error {
-	var err error
-
-	if p.PstAccount, err = r.ReadAlphanumeric(10); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PST-ACCOUNT: %w", err)
-	}
-
-	if p.PstSequence, err = r.ReadZonedInt32(2, codec.SignUnsigned); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PST-SEQUENCE: %w", err)
-	}
-
-	if p.PstType, err = r.ReadAlphanumeric(2); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PST-TYPE: %w", err)
-	}
-
-	if p.PstBody, err = r.ReadAlphanumeric(28); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PST-BODY: %w", err)
-	}
-
-	if p.PstTail, err = r.ReadAlphanumeric(8); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PST-TAIL: %w", err)
-	}
-
-	return nil
-}
-
-// MarshalCOBOL writes this POSTING-RECORD into w, in the order docs/ir/SPEC.md
-// resolved its items, emitting the bytes retained for every slack node and
-// every unnamed item it carries, and zero bytes for one it does not.
-//
-// It is codec's Marshaler. Two values are the descriptor's rather than the
-// caller's and are supplied rather than taken from the record: an OCCURS
-// DEPENDING ON count is emitted as the number of occurrences written, and
-// slack — and the bytes of an item the copybook gives no data-name — is
-// emitted as what was retained for it. Everything else is the caller's,
-// including the value a discriminator tests — a writer evaluates a predicate
-// and never inverts one.
-func (p *MemoPosting) MarshalCOBOL(w *codec.Writer) error {
-	var err error
-
-	if err = w.WriteAlphanumeric(p.PstAccount, 10); err != nil {
-		return fmt.Errorf("POSTING-RECORD: writing PST-ACCOUNT: %w", err)
-	}
-
-	if err = w.WriteZonedInt32(p.PstSequence, 2, codec.SignUnsigned); err != nil {
-		return fmt.Errorf("POSTING-RECORD: writing PST-SEQUENCE: %w", err)
-	}
-
-	if err = w.WriteAlphanumeric(p.PstType, 2); err != nil {
-		return fmt.Errorf("POSTING-RECORD: writing PST-TYPE: %w", err)
-	}
-
-	if err = w.WriteAlphanumeric(p.PstBody, 28); err != nil {
-		return fmt.Errorf("POSTING-RECORD: writing PST-BODY: %w", err)
-	}
-
-	if err = w.WriteAlphanumeric(p.PstTail, 8); err != nil {
-		return fmt.Errorf("POSTING-RECORD: writing PST-TAIL: %w", err)
-	}
-
-	return nil
-}
-
-// UnmarshalCOBOL reads one POSTING-RECORD out of r, in the order docs/ir/SPEC.md
-// resolved its items, and retains the bytes of every slack node it carries and
-// of every item the copybook gives no data-name.
-//
-// It is codec's Unmarshaler. The Encoding is r's: the five axes are properties
-// of the file in hand, and Encoding is what this descriptor resolved.
-func (p *MemoPostingRef) UnmarshalCOBOL(r *codec.Reader) error {
-	var err error
-
-	if p.PstAccount, err = r.ReadAlphanumeric(10); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PST-ACCOUNT: %w", err)
-	}
-
-	if p.PstSequence, err = r.ReadZonedInt32(2, codec.SignUnsigned); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PST-SEQUENCE: %w", err)
-	}
-
-	if p.PstType, err = r.ReadAlphanumeric(2); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PST-TYPE: %w", err)
-	}
-
-	if p.PstBody, err = r.ReadAlphanumeric(28); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PST-BODY: %w", err)
-	}
-
-	if p.PstTailRef.PtrBatch, err = r.ReadZonedInt32(4, codec.SignUnsigned); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PTR-BATCH: %w", err)
-	}
-
-	if p.PstTailRef.PtrLine, err = r.ReadZonedInt32(4, codec.SignUnsigned); err != nil {
-		return fmt.Errorf("POSTING-RECORD: reading PTR-LINE: %w", err)
-	}
-
-	return nil
-}
-
-// MarshalCOBOL writes this POSTING-RECORD into w, in the order docs/ir/SPEC.md
-// resolved its items, emitting the bytes retained for every slack node and
-// every unnamed item it carries, and zero bytes for one it does not.
-//
-// It is codec's Marshaler. Two values are the descriptor's rather than the
-// caller's and are supplied rather than taken from the record: an OCCURS
-// DEPENDING ON count is emitted as the number of occurrences written, and
-// slack — and the bytes of an item the copybook gives no data-name — is
-// emitted as what was retained for it. Everything else is the caller's,
-// including the value a discriminator tests — a writer evaluates a predicate
-// and never inverts one.
-func (p *MemoPostingRef) MarshalCOBOL(w *codec.Writer) error {
-	var err error
-
-	if err = w.WriteAlphanumeric(p.PstAccount, 10); err != nil {
-		return fmt.Errorf("POSTING-RECORD: writing PST-ACCOUNT: %w", err)
-	}
-
-	if err = w.WriteZonedInt32(p.PstSequence, 2, codec.SignUnsigned); err != nil {
-		return fmt.Errorf("POSTING-RECORD: writing PST-SEQUENCE: %w", err)
-	}
-
-	if err = w.WriteAlphanumeric(p.PstType, 2); err != nil {
-		return fmt.Errorf("POSTING-RECORD: writing PST-TYPE: %w", err)
-	}
-
-	if err = w.WriteAlphanumeric(p.PstBody, 28); err != nil {
-		return fmt.Errorf("POSTING-RECORD: writing PST-BODY: %w", err)
 	}
 
 	if err = w.WriteZonedInt32(p.PstTailRef.PtrBatch, 4, codec.SignUnsigned); err != nil {

--- a/example/ledger/file.go
+++ b/example/ledger/file.go
@@ -98,8 +98,8 @@ type Reader struct {
 	// nothing has written is a malformed descriptor rather than a zero: a consumer
 	// MUST NOT supply a zero, an empty byte string or the value of any other
 	// register. See docs/ir/SPEC.md, "The automaton remembers, in registers".
-	register76      int64
-	register76Bound bool
+	register39      int64
+	register39Bound bool
 }
 
 // NewReader reads the records of r under enc.
@@ -181,20 +181,20 @@ func (r *Reader) Next() (Record, error) {
 	}
 
 	switch r.state {
-	case 0: // the state the descriptor carries as node 77
+	case 0: // the state the descriptor carries as node 40
 		expected := make([]string, 0, 1)
 
 		// Transition 1, which admits LEDGER-HEADER.
 		expected = append(expected, "LEDGER-HEADER")
-		if matches77At0(r.look) {
+		if matches40At0(r.look) {
 			rec := new(LedgerHeader)
 
 			if err := r.admit(rec); err != nil {
 				return nil, err
 			}
 
-			r.register76 = int64(rec.HdrCount)
-			r.register76Bound = true
+			r.register39 = int64(rec.HdrCount)
+			r.register39Bound = true
 
 			r.state = 1
 
@@ -202,1547 +202,283 @@ func (r *Reader) Next() (Record, error) {
 		}
 
 		return nil, r.undescribed(expected, "")
-	case 1: // the state the descriptor carries as node 78
-		expected := make([]string, 0, 7)
+	case 1: // the state the descriptor carries as node 41
+		expected := make([]string, 0, 3)
 
 		var excluded string
 
 		// Transition 1, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
+		if !r.register39Bound {
+			return nil, r.unbound(39)
 		}
 
-		if r.register76 > 0 {
+		if r.register39 > 0 {
 			expected = append(expected, "POSTING-RECORD")
-			if matches78At0(r.look) {
+			if matches41At0(r.look) {
 				rec := new(DebitPosting)
 
 				if err := r.admit(rec); err != nil {
 					return nil, err
 				}
 
-				if !r.register76Bound {
-					return nil, r.unbound(76)
+				if !r.register39Bound {
+					return nil, r.unbound(39)
 				}
 
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
+				if r.register39 <= 0 {
+					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 39, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
 				}
 
-				r.register76--
+				r.register39--
 
 				r.state = 2
 
 				return rec, nil
 			}
-		} else if excluded == "" && matches78At0(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
+		} else if excluded == "" && matches41At0(r.look) {
+			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 39 is greater than zero; node 39 holds %d", r.register39)
 		}
 
 		// Transition 2, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
+		if !r.register39Bound {
+			return nil, r.unbound(39)
 		}
 
-		if r.register76 > 0 {
+		if r.register39 > 0 {
 			expected = append(expected, "POSTING-RECORD")
-			if matches78At1(r.look) {
-				rec := new(DebitPostingRef)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 3
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches78At1(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 3, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches78At2(r.look) {
+			if matches41At1(r.look) {
 				rec := new(CreditPosting)
 
 				if err := r.admit(rec); err != nil {
 					return nil, err
 				}
 
-				if !r.register76Bound {
-					return nil, r.unbound(76)
+				if !r.register39Bound {
+					return nil, r.unbound(39)
 				}
 
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
+				if r.register39 <= 0 {
+					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 39, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
 				}
 
-				r.register76--
+				r.register39--
 
-				r.state = 4
+				r.state = 3
 
 				return rec, nil
 			}
-		} else if excluded == "" && matches78At2(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
+		} else if excluded == "" && matches41At1(r.look) {
+			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 39 is greater than zero; node 39 holds %d", r.register39)
 		}
 
-		// Transition 4, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
+		// Transition 3, which admits LEDGER-TRAILER.
+		if !r.register39Bound {
+			return nil, r.unbound(39)
 		}
 
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches78At3(r.look) {
-				rec := new(CreditPostingRef)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 5
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches78At3(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 5, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches78At4(r.look) {
-				rec := new(MemoPosting)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 6
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches78At4(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 6, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches78At5(r.look) {
-				rec := new(MemoPostingRef)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 7
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches78At5(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 7, which admits LEDGER-TRAILER.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 == 0 {
+		if r.register39 == 0 {
 			expected = append(expected, "LEDGER-TRAILER")
-			if matches78At6(r.look) {
+			if matches41At2(r.look) {
 				rec := new(LedgerTrailer)
 
 				if err := r.admit(rec); err != nil {
 					return nil, err
 				}
 
-				r.state = 8
+				r.state = 4
 
 				return rec, nil
 			}
-		} else if excluded == "" && matches78At6(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted LEDGER-TRAILER, which is taken only where the register the descriptor carries as node 76 is 0; node 76 holds %d", r.register76)
+		} else if excluded == "" && matches41At2(r.look) {
+			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted LEDGER-TRAILER, which is taken only where the register the descriptor carries as node 39 is 0; node 39 holds %d", r.register39)
 		}
 
 		return nil, r.undescribed(expected, excluded)
-	case 2: // the state the descriptor carries as node 79
-		expected := make([]string, 0, 7)
+	case 2: // the state the descriptor carries as node 42
+		expected := make([]string, 0, 3)
 
 		var excluded string
 
 		// Transition 1, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
+		if !r.register39Bound {
+			return nil, r.unbound(39)
 		}
 
-		if r.register76 > 0 {
+		if r.register39 > 0 {
 			expected = append(expected, "POSTING-RECORD")
-			if matches79At0(r.look) {
+			if matches42At0(r.look) {
 				rec := new(DebitPosting)
 
 				if err := r.admit(rec); err != nil {
 					return nil, err
 				}
 
-				if !r.register76Bound {
-					return nil, r.unbound(76)
+				if !r.register39Bound {
+					return nil, r.unbound(39)
 				}
 
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
+				if r.register39 <= 0 {
+					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 39, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
 				}
 
-				r.register76--
+				r.register39--
 
 				r.state = 2
 
 				return rec, nil
 			}
-		} else if excluded == "" && matches79At0(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
+		} else if excluded == "" && matches42At0(r.look) {
+			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 39 is greater than zero; node 39 holds %d", r.register39)
 		}
 
 		// Transition 2, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
+		if !r.register39Bound {
+			return nil, r.unbound(39)
 		}
 
-		if r.register76 > 0 {
+		if r.register39 > 0 {
 			expected = append(expected, "POSTING-RECORD")
-			if matches79At1(r.look) {
-				rec := new(DebitPostingRef)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 3
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches79At1(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 3, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches79At2(r.look) {
+			if matches42At1(r.look) {
 				rec := new(CreditPosting)
 
 				if err := r.admit(rec); err != nil {
 					return nil, err
 				}
 
-				if !r.register76Bound {
-					return nil, r.unbound(76)
+				if !r.register39Bound {
+					return nil, r.unbound(39)
 				}
 
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
+				if r.register39 <= 0 {
+					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 39, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
 				}
 
-				r.register76--
+				r.register39--
 
-				r.state = 4
+				r.state = 3
 
 				return rec, nil
 			}
-		} else if excluded == "" && matches79At2(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
+		} else if excluded == "" && matches42At1(r.look) {
+			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 39 is greater than zero; node 39 holds %d", r.register39)
 		}
 
-		// Transition 4, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
+		// Transition 3, which admits LEDGER-TRAILER.
+		if !r.register39Bound {
+			return nil, r.unbound(39)
 		}
 
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches79At3(r.look) {
-				rec := new(CreditPostingRef)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 5
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches79At3(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 5, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches79At4(r.look) {
-				rec := new(MemoPosting)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 6
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches79At4(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 6, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches79At5(r.look) {
-				rec := new(MemoPostingRef)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 7
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches79At5(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 7, which admits LEDGER-TRAILER.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 == 0 {
+		if r.register39 == 0 {
 			expected = append(expected, "LEDGER-TRAILER")
-			if matches79At6(r.look) {
+			if matches42At2(r.look) {
 				rec := new(LedgerTrailer)
 
 				if err := r.admit(rec); err != nil {
 					return nil, err
 				}
 
-				r.state = 8
+				r.state = 4
 
 				return rec, nil
 			}
-		} else if excluded == "" && matches79At6(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted LEDGER-TRAILER, which is taken only where the register the descriptor carries as node 76 is 0; node 76 holds %d", r.register76)
+		} else if excluded == "" && matches42At2(r.look) {
+			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted LEDGER-TRAILER, which is taken only where the register the descriptor carries as node 39 is 0; node 39 holds %d", r.register39)
 		}
 
 		return nil, r.undescribed(expected, excluded)
-	case 3: // the state the descriptor carries as node 80
-		expected := make([]string, 0, 7)
+	case 3: // the state the descriptor carries as node 43
+		expected := make([]string, 0, 3)
 
 		var excluded string
 
 		// Transition 1, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
+		if !r.register39Bound {
+			return nil, r.unbound(39)
 		}
 
-		if r.register76 > 0 {
+		if r.register39 > 0 {
 			expected = append(expected, "POSTING-RECORD")
-			if matches80At0(r.look) {
+			if matches43At0(r.look) {
 				rec := new(DebitPosting)
 
 				if err := r.admit(rec); err != nil {
 					return nil, err
 				}
 
-				if !r.register76Bound {
-					return nil, r.unbound(76)
+				if !r.register39Bound {
+					return nil, r.unbound(39)
 				}
 
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
+				if r.register39 <= 0 {
+					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 39, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
 				}
 
-				r.register76--
+				r.register39--
 
 				r.state = 2
 
 				return rec, nil
 			}
-		} else if excluded == "" && matches80At0(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
+		} else if excluded == "" && matches43At0(r.look) {
+			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 39 is greater than zero; node 39 holds %d", r.register39)
 		}
 
 		// Transition 2, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
+		if !r.register39Bound {
+			return nil, r.unbound(39)
 		}
 
-		if r.register76 > 0 {
+		if r.register39 > 0 {
 			expected = append(expected, "POSTING-RECORD")
-			if matches80At1(r.look) {
-				rec := new(DebitPostingRef)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 3
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches80At1(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 3, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches80At2(r.look) {
+			if matches43At1(r.look) {
 				rec := new(CreditPosting)
 
 				if err := r.admit(rec); err != nil {
 					return nil, err
 				}
 
-				if !r.register76Bound {
-					return nil, r.unbound(76)
+				if !r.register39Bound {
+					return nil, r.unbound(39)
 				}
 
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
+				if r.register39 <= 0 {
+					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 39, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
 				}
 
-				r.register76--
-
-				r.state = 4
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches80At2(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 4, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches80At3(r.look) {
-				rec := new(CreditPostingRef)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 5
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches80At3(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 5, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches80At4(r.look) {
-				rec := new(MemoPosting)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 6
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches80At4(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 6, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches80At5(r.look) {
-				rec := new(MemoPostingRef)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 7
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches80At5(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 7, which admits LEDGER-TRAILER.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 == 0 {
-			expected = append(expected, "LEDGER-TRAILER")
-			if matches80At6(r.look) {
-				rec := new(LedgerTrailer)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				r.state = 8
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches80At6(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted LEDGER-TRAILER, which is taken only where the register the descriptor carries as node 76 is 0; node 76 holds %d", r.register76)
-		}
-
-		return nil, r.undescribed(expected, excluded)
-	case 4: // the state the descriptor carries as node 81
-		expected := make([]string, 0, 7)
-
-		var excluded string
-
-		// Transition 1, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches81At0(r.look) {
-				rec := new(DebitPosting)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 2
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches81At0(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 2, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches81At1(r.look) {
-				rec := new(DebitPostingRef)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
+				r.register39--
 
 				r.state = 3
 
 				return rec, nil
 			}
-		} else if excluded == "" && matches81At1(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
+		} else if excluded == "" && matches43At1(r.look) {
+			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 39 is greater than zero; node 39 holds %d", r.register39)
 		}
 
-		// Transition 3, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
+		// Transition 3, which admits LEDGER-TRAILER.
+		if !r.register39Bound {
+			return nil, r.unbound(39)
 		}
 
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches81At2(r.look) {
-				rec := new(CreditPosting)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 4
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches81At2(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 4, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches81At3(r.look) {
-				rec := new(CreditPostingRef)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 5
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches81At3(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 5, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches81At4(r.look) {
-				rec := new(MemoPosting)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 6
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches81At4(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 6, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches81At5(r.look) {
-				rec := new(MemoPostingRef)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 7
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches81At5(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 7, which admits LEDGER-TRAILER.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 == 0 {
+		if r.register39 == 0 {
 			expected = append(expected, "LEDGER-TRAILER")
-			if matches81At6(r.look) {
+			if matches43At2(r.look) {
 				rec := new(LedgerTrailer)
 
 				if err := r.admit(rec); err != nil {
 					return nil, err
 				}
 
-				r.state = 8
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches81At6(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted LEDGER-TRAILER, which is taken only where the register the descriptor carries as node 76 is 0; node 76 holds %d", r.register76)
-		}
-
-		return nil, r.undescribed(expected, excluded)
-	case 5: // the state the descriptor carries as node 82
-		expected := make([]string, 0, 7)
-
-		var excluded string
-
-		// Transition 1, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches82At0(r.look) {
-				rec := new(DebitPosting)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 2
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches82At0(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 2, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches82At1(r.look) {
-				rec := new(DebitPostingRef)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 3
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches82At1(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 3, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches82At2(r.look) {
-				rec := new(CreditPosting)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
 				r.state = 4
 
 				return rec, nil
 			}
-		} else if excluded == "" && matches82At2(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 4, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches82At3(r.look) {
-				rec := new(CreditPostingRef)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 5
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches82At3(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 5, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches82At4(r.look) {
-				rec := new(MemoPosting)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 6
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches82At4(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 6, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches82At5(r.look) {
-				rec := new(MemoPostingRef)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 7
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches82At5(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 7, which admits LEDGER-TRAILER.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 == 0 {
-			expected = append(expected, "LEDGER-TRAILER")
-			if matches82At6(r.look) {
-				rec := new(LedgerTrailer)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				r.state = 8
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches82At6(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted LEDGER-TRAILER, which is taken only where the register the descriptor carries as node 76 is 0; node 76 holds %d", r.register76)
+		} else if excluded == "" && matches43At2(r.look) {
+			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted LEDGER-TRAILER, which is taken only where the register the descriptor carries as node 39 is 0; node 39 holds %d", r.register39)
 		}
 
 		return nil, r.undescribed(expected, excluded)
-	case 6: // the state the descriptor carries as node 83
-		expected := make([]string, 0, 7)
-
-		var excluded string
-
-		// Transition 1, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches83At0(r.look) {
-				rec := new(DebitPosting)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 2
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches83At0(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 2, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches83At1(r.look) {
-				rec := new(DebitPostingRef)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 3
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches83At1(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 3, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches83At2(r.look) {
-				rec := new(CreditPosting)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 4
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches83At2(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 4, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches83At3(r.look) {
-				rec := new(CreditPostingRef)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 5
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches83At3(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 5, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches83At4(r.look) {
-				rec := new(MemoPosting)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 6
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches83At4(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 6, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches83At5(r.look) {
-				rec := new(MemoPostingRef)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 7
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches83At5(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 7, which admits LEDGER-TRAILER.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 == 0 {
-			expected = append(expected, "LEDGER-TRAILER")
-			if matches83At6(r.look) {
-				rec := new(LedgerTrailer)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				r.state = 8
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches83At6(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted LEDGER-TRAILER, which is taken only where the register the descriptor carries as node 76 is 0; node 76 holds %d", r.register76)
-		}
-
-		return nil, r.undescribed(expected, excluded)
-	case 7: // the state the descriptor carries as node 84
-		expected := make([]string, 0, 7)
-
-		var excluded string
-
-		// Transition 1, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches84At0(r.look) {
-				rec := new(DebitPosting)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 2
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches84At0(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 2, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches84At1(r.look) {
-				rec := new(DebitPostingRef)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 3
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches84At1(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 3, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches84At2(r.look) {
-				rec := new(CreditPosting)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 4
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches84At2(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 4, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches84At3(r.look) {
-				rec := new(CreditPostingRef)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 5
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches84At3(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 5, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches84At4(r.look) {
-				rec := new(MemoPosting)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 6
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches84At4(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 6, which admits POSTING-RECORD.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 > 0 {
-			expected = append(expected, "POSTING-RECORD")
-			if matches84At5(r.look) {
-				rec := new(MemoPostingRef)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				if !r.register76Bound {
-					return nil, r.unbound(76)
-				}
-
-				if r.register76 <= 0 {
-					return nil, fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", r.ordinal)
-				}
-
-				r.register76--
-
-				r.state = 7
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches84At5(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", r.register76)
-		}
-
-		// Transition 7, which admits LEDGER-TRAILER.
-		if !r.register76Bound {
-			return nil, r.unbound(76)
-		}
-
-		if r.register76 == 0 {
-			expected = append(expected, "LEDGER-TRAILER")
-			if matches84At6(r.look) {
-				rec := new(LedgerTrailer)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				r.state = 8
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches84At6(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted LEDGER-TRAILER, which is taken only where the register the descriptor carries as node 76 is 0; node 76 holds %d", r.register76)
-		}
-
-		return nil, r.undescribed(expected, excluded)
-	case 8: // the state the descriptor carries as node 85
+	case 4: // the state the descriptor carries as node 44
 		return nil, r.undescribed(nil, "")
 	default:
 		return nil, fmt.Errorf("record %d: the automaton is in a state this file does not carry", r.ordinal)
@@ -1758,7 +494,7 @@ func (r *Reader) Next() (Record, error) {
 // of what its own header promised.
 func (r *Reader) accepts() error {
 	switch r.state {
-	case 8:
+	case 4:
 		return nil
 	default:
 		return fmt.Errorf("the file ends after %d records and the layout describes a record to come", r.ordinal)
@@ -1878,14 +614,14 @@ func (r *Reader) fill(n int) error {
 	return err
 }
 
-// matches77At0 is the predicate selecting transition 1 of the state the descriptor
-// carries as node 77: it admits LEDGER-HEADER.
+// matches40At0 is the predicate selecting transition 1 of the state the descriptor
+// carries as node 40: it admits LEDGER-HEADER.
 //
 // A target that is not wholly inside the bytes it is handed does not match. A
 // reader hands it the record the framing bounds, or as much of the input as it
 // can see where the framing bounds nothing; a writer hands it the whole of the
 // record it is about to emit.
-func matches77At0(b []byte) bool {
+func matches40At0(b []byte) bool {
 	if len(b) < 2 {
 		return false
 	}
@@ -1893,104 +629,44 @@ func matches77At0(b []byte) bool {
 	return bytes.Equal(b[0:2], []byte("\xf0\xf1"))
 }
 
-// matches78At0 is the predicate selecting transition 1 of the state the descriptor
-// carries as node 78: it admits POSTING-RECORD.
+// matches41At0 is the predicate selecting transition 1 of the state the descriptor
+// carries as node 41: it admits POSTING-RECORD.
 //
 // A target that is not wholly inside the bytes it is handed does not match. A
 // reader hands it the record the framing bounds, or as much of the input as it
 // can see where the framing bounds nothing; a writer hands it the whole of the
 // record it is about to emit.
-func matches78At0(b []byte) bool {
+func matches41At0(b []byte) bool {
 	if len(b) < 14 {
 		return false
 	}
 
-	return bytes.Equal(b[12:14], []byte("\xc4\xc1"))
+	return bytes.Equal(b[12:14], []byte("\xc4\xd9"))
 }
 
-// matches78At1 is the predicate selecting transition 2 of the state the descriptor
-// carries as node 78: it admits POSTING-RECORD.
+// matches41At1 is the predicate selecting transition 2 of the state the descriptor
+// carries as node 41: it admits POSTING-RECORD.
 //
 // A target that is not wholly inside the bytes it is handed does not match. A
 // reader hands it the record the framing bounds, or as much of the input as it
 // can see where the framing bounds nothing; a writer hands it the whole of the
 // record it is about to emit.
-func matches78At1(b []byte) bool {
+func matches41At1(b []byte) bool {
 	if len(b) < 14 {
 		return false
 	}
 
-	return bytes.Equal(b[12:14], []byte("\xc4\xc2"))
+	return bytes.Equal(b[12:14], []byte("\xc3\xd9"))
 }
 
-// matches78At2 is the predicate selecting transition 3 of the state the descriptor
-// carries as node 78: it admits POSTING-RECORD.
+// matches41At2 is the predicate selecting transition 3 of the state the descriptor
+// carries as node 41: it admits LEDGER-TRAILER.
 //
 // A target that is not wholly inside the bytes it is handed does not match. A
 // reader hands it the record the framing bounds, or as much of the input as it
 // can see where the framing bounds nothing; a writer hands it the whole of the
 // record it is about to emit.
-func matches78At2(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xc3\xc1"))
-}
-
-// matches78At3 is the predicate selecting transition 4 of the state the descriptor
-// carries as node 78: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches78At3(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xc3\xc2"))
-}
-
-// matches78At4 is the predicate selecting transition 5 of the state the descriptor
-// carries as node 78: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches78At4(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xd4\xc1"))
-}
-
-// matches78At5 is the predicate selecting transition 6 of the state the descriptor
-// carries as node 78: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches78At5(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xd4\xc2"))
-}
-
-// matches78At6 is the predicate selecting transition 7 of the state the descriptor
-// carries as node 78: it admits LEDGER-TRAILER.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches78At6(b []byte) bool {
+func matches41At2(b []byte) bool {
 	if len(b) < 2 {
 		return false
 	}
@@ -1998,104 +674,44 @@ func matches78At6(b []byte) bool {
 	return bytes.Equal(b[0:2], []byte("\xf9\xf9"))
 }
 
-// matches79At0 is the predicate selecting transition 1 of the state the descriptor
-// carries as node 79: it admits POSTING-RECORD.
+// matches42At0 is the predicate selecting transition 1 of the state the descriptor
+// carries as node 42: it admits POSTING-RECORD.
 //
 // A target that is not wholly inside the bytes it is handed does not match. A
 // reader hands it the record the framing bounds, or as much of the input as it
 // can see where the framing bounds nothing; a writer hands it the whole of the
 // record it is about to emit.
-func matches79At0(b []byte) bool {
+func matches42At0(b []byte) bool {
 	if len(b) < 14 {
 		return false
 	}
 
-	return bytes.Equal(b[12:14], []byte("\xc4\xc1"))
+	return bytes.Equal(b[12:14], []byte("\xc4\xd9"))
 }
 
-// matches79At1 is the predicate selecting transition 2 of the state the descriptor
-// carries as node 79: it admits POSTING-RECORD.
+// matches42At1 is the predicate selecting transition 2 of the state the descriptor
+// carries as node 42: it admits POSTING-RECORD.
 //
 // A target that is not wholly inside the bytes it is handed does not match. A
 // reader hands it the record the framing bounds, or as much of the input as it
 // can see where the framing bounds nothing; a writer hands it the whole of the
 // record it is about to emit.
-func matches79At1(b []byte) bool {
+func matches42At1(b []byte) bool {
 	if len(b) < 14 {
 		return false
 	}
 
-	return bytes.Equal(b[12:14], []byte("\xc4\xc2"))
+	return bytes.Equal(b[12:14], []byte("\xc3\xd9"))
 }
 
-// matches79At2 is the predicate selecting transition 3 of the state the descriptor
-// carries as node 79: it admits POSTING-RECORD.
+// matches42At2 is the predicate selecting transition 3 of the state the descriptor
+// carries as node 42: it admits LEDGER-TRAILER.
 //
 // A target that is not wholly inside the bytes it is handed does not match. A
 // reader hands it the record the framing bounds, or as much of the input as it
 // can see where the framing bounds nothing; a writer hands it the whole of the
 // record it is about to emit.
-func matches79At2(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xc3\xc1"))
-}
-
-// matches79At3 is the predicate selecting transition 4 of the state the descriptor
-// carries as node 79: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches79At3(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xc3\xc2"))
-}
-
-// matches79At4 is the predicate selecting transition 5 of the state the descriptor
-// carries as node 79: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches79At4(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xd4\xc1"))
-}
-
-// matches79At5 is the predicate selecting transition 6 of the state the descriptor
-// carries as node 79: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches79At5(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xd4\xc2"))
-}
-
-// matches79At6 is the predicate selecting transition 7 of the state the descriptor
-// carries as node 79: it admits LEDGER-TRAILER.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches79At6(b []byte) bool {
+func matches42At2(b []byte) bool {
 	if len(b) < 2 {
 		return false
 	}
@@ -2103,524 +719,44 @@ func matches79At6(b []byte) bool {
 	return bytes.Equal(b[0:2], []byte("\xf9\xf9"))
 }
 
-// matches80At0 is the predicate selecting transition 1 of the state the descriptor
-// carries as node 80: it admits POSTING-RECORD.
+// matches43At0 is the predicate selecting transition 1 of the state the descriptor
+// carries as node 43: it admits POSTING-RECORD.
 //
 // A target that is not wholly inside the bytes it is handed does not match. A
 // reader hands it the record the framing bounds, or as much of the input as it
 // can see where the framing bounds nothing; a writer hands it the whole of the
 // record it is about to emit.
-func matches80At0(b []byte) bool {
+func matches43At0(b []byte) bool {
 	if len(b) < 14 {
 		return false
 	}
 
-	return bytes.Equal(b[12:14], []byte("\xc4\xc1"))
+	return bytes.Equal(b[12:14], []byte("\xc4\xd9"))
 }
 
-// matches80At1 is the predicate selecting transition 2 of the state the descriptor
-// carries as node 80: it admits POSTING-RECORD.
+// matches43At1 is the predicate selecting transition 2 of the state the descriptor
+// carries as node 43: it admits POSTING-RECORD.
 //
 // A target that is not wholly inside the bytes it is handed does not match. A
 // reader hands it the record the framing bounds, or as much of the input as it
 // can see where the framing bounds nothing; a writer hands it the whole of the
 // record it is about to emit.
-func matches80At1(b []byte) bool {
+func matches43At1(b []byte) bool {
 	if len(b) < 14 {
 		return false
 	}
 
-	return bytes.Equal(b[12:14], []byte("\xc4\xc2"))
+	return bytes.Equal(b[12:14], []byte("\xc3\xd9"))
 }
 
-// matches80At2 is the predicate selecting transition 3 of the state the descriptor
-// carries as node 80: it admits POSTING-RECORD.
+// matches43At2 is the predicate selecting transition 3 of the state the descriptor
+// carries as node 43: it admits LEDGER-TRAILER.
 //
 // A target that is not wholly inside the bytes it is handed does not match. A
 // reader hands it the record the framing bounds, or as much of the input as it
 // can see where the framing bounds nothing; a writer hands it the whole of the
 // record it is about to emit.
-func matches80At2(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xc3\xc1"))
-}
-
-// matches80At3 is the predicate selecting transition 4 of the state the descriptor
-// carries as node 80: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches80At3(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xc3\xc2"))
-}
-
-// matches80At4 is the predicate selecting transition 5 of the state the descriptor
-// carries as node 80: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches80At4(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xd4\xc1"))
-}
-
-// matches80At5 is the predicate selecting transition 6 of the state the descriptor
-// carries as node 80: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches80At5(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xd4\xc2"))
-}
-
-// matches80At6 is the predicate selecting transition 7 of the state the descriptor
-// carries as node 80: it admits LEDGER-TRAILER.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches80At6(b []byte) bool {
-	if len(b) < 2 {
-		return false
-	}
-
-	return bytes.Equal(b[0:2], []byte("\xf9\xf9"))
-}
-
-// matches81At0 is the predicate selecting transition 1 of the state the descriptor
-// carries as node 81: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches81At0(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xc4\xc1"))
-}
-
-// matches81At1 is the predicate selecting transition 2 of the state the descriptor
-// carries as node 81: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches81At1(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xc4\xc2"))
-}
-
-// matches81At2 is the predicate selecting transition 3 of the state the descriptor
-// carries as node 81: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches81At2(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xc3\xc1"))
-}
-
-// matches81At3 is the predicate selecting transition 4 of the state the descriptor
-// carries as node 81: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches81At3(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xc3\xc2"))
-}
-
-// matches81At4 is the predicate selecting transition 5 of the state the descriptor
-// carries as node 81: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches81At4(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xd4\xc1"))
-}
-
-// matches81At5 is the predicate selecting transition 6 of the state the descriptor
-// carries as node 81: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches81At5(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xd4\xc2"))
-}
-
-// matches81At6 is the predicate selecting transition 7 of the state the descriptor
-// carries as node 81: it admits LEDGER-TRAILER.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches81At6(b []byte) bool {
-	if len(b) < 2 {
-		return false
-	}
-
-	return bytes.Equal(b[0:2], []byte("\xf9\xf9"))
-}
-
-// matches82At0 is the predicate selecting transition 1 of the state the descriptor
-// carries as node 82: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches82At0(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xc4\xc1"))
-}
-
-// matches82At1 is the predicate selecting transition 2 of the state the descriptor
-// carries as node 82: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches82At1(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xc4\xc2"))
-}
-
-// matches82At2 is the predicate selecting transition 3 of the state the descriptor
-// carries as node 82: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches82At2(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xc3\xc1"))
-}
-
-// matches82At3 is the predicate selecting transition 4 of the state the descriptor
-// carries as node 82: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches82At3(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xc3\xc2"))
-}
-
-// matches82At4 is the predicate selecting transition 5 of the state the descriptor
-// carries as node 82: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches82At4(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xd4\xc1"))
-}
-
-// matches82At5 is the predicate selecting transition 6 of the state the descriptor
-// carries as node 82: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches82At5(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xd4\xc2"))
-}
-
-// matches82At6 is the predicate selecting transition 7 of the state the descriptor
-// carries as node 82: it admits LEDGER-TRAILER.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches82At6(b []byte) bool {
-	if len(b) < 2 {
-		return false
-	}
-
-	return bytes.Equal(b[0:2], []byte("\xf9\xf9"))
-}
-
-// matches83At0 is the predicate selecting transition 1 of the state the descriptor
-// carries as node 83: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches83At0(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xc4\xc1"))
-}
-
-// matches83At1 is the predicate selecting transition 2 of the state the descriptor
-// carries as node 83: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches83At1(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xc4\xc2"))
-}
-
-// matches83At2 is the predicate selecting transition 3 of the state the descriptor
-// carries as node 83: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches83At2(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xc3\xc1"))
-}
-
-// matches83At3 is the predicate selecting transition 4 of the state the descriptor
-// carries as node 83: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches83At3(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xc3\xc2"))
-}
-
-// matches83At4 is the predicate selecting transition 5 of the state the descriptor
-// carries as node 83: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches83At4(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xd4\xc1"))
-}
-
-// matches83At5 is the predicate selecting transition 6 of the state the descriptor
-// carries as node 83: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches83At5(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xd4\xc2"))
-}
-
-// matches83At6 is the predicate selecting transition 7 of the state the descriptor
-// carries as node 83: it admits LEDGER-TRAILER.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches83At6(b []byte) bool {
-	if len(b) < 2 {
-		return false
-	}
-
-	return bytes.Equal(b[0:2], []byte("\xf9\xf9"))
-}
-
-// matches84At0 is the predicate selecting transition 1 of the state the descriptor
-// carries as node 84: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches84At0(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xc4\xc1"))
-}
-
-// matches84At1 is the predicate selecting transition 2 of the state the descriptor
-// carries as node 84: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches84At1(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xc4\xc2"))
-}
-
-// matches84At2 is the predicate selecting transition 3 of the state the descriptor
-// carries as node 84: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches84At2(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xc3\xc1"))
-}
-
-// matches84At3 is the predicate selecting transition 4 of the state the descriptor
-// carries as node 84: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches84At3(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xc3\xc2"))
-}
-
-// matches84At4 is the predicate selecting transition 5 of the state the descriptor
-// carries as node 84: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches84At4(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xd4\xc1"))
-}
-
-// matches84At5 is the predicate selecting transition 6 of the state the descriptor
-// carries as node 84: it admits POSTING-RECORD.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches84At5(b []byte) bool {
-	if len(b) < 14 {
-		return false
-	}
-
-	return bytes.Equal(b[12:14], []byte("\xd4\xc2"))
-}
-
-// matches84At6 is the predicate selecting transition 7 of the state the descriptor
-// carries as node 84: it admits LEDGER-TRAILER.
-//
-// A target that is not wholly inside the bytes it is handed does not match. A
-// reader hands it the record the framing bounds, or as much of the input as it
-// can see where the framing bounds nothing; a writer hands it the whole of the
-// record it is about to emit.
-func matches84At6(b []byte) bool {
+func matches43At2(b []byte) bool {
 	if len(b) < 2 {
 		return false
 	}
@@ -2675,8 +811,8 @@ type Writer struct {
 	// nothing has written is a malformed descriptor rather than a zero: a consumer
 	// MUST NOT supply a zero, an empty byte string or the value of any other
 	// register. See docs/ir/SPEC.md, "The automaton remembers, in registers".
-	register76      int64
-	register76Bound bool
+	register39      int64
+	register39Bound bool
 }
 
 // NewWriter writes records into w under enc.
@@ -2713,22 +849,14 @@ func (w *Writer) Write(rec Record) error {
 	switch v := rec.(type) {
 	case *CreditPosting:
 		return w.writeCreditPosting(v)
-	case *CreditPostingRef:
-		return w.writeCreditPostingRef(v)
 	case *DebitPosting:
 		return w.writeDebitPosting(v)
-	case *DebitPostingRef:
-		return w.writeDebitPostingRef(v)
 	case *LedgerHeader:
 		return w.writeLedgerHeader(v)
 	case *LedgerTrailer:
 		return w.writeLedgerTrailer(v)
-	case *MemoPosting:
-		return w.writeMemoPosting(v)
-	case *MemoPostingRef:
-		return w.writeMemoPostingRef(v)
 	default:
-		return fmt.Errorf("record %d: this file's records are POSTING-RECORD, POSTING-RECORD, POSTING-RECORD, POSTING-RECORD, LEDGER-HEADER, LEDGER-TRAILER, POSTING-RECORD and POSTING-RECORD, and a %T is none of them", w.ordinal+1, rec)
+		return fmt.Errorf("record %d: this file's records are POSTING-RECORD, POSTING-RECORD, LEDGER-HEADER and LEDGER-TRAILER, and a %T is none of them", w.ordinal+1, rec)
 	}
 }
 
@@ -2742,7 +870,7 @@ func (w *Writer) Write(rec Record) error {
 // It does not close the io.Writer it was handed, which belongs to the caller.
 func (w *Writer) Close() error {
 	switch w.state {
-	case 8:
+	case 4:
 		return nil
 	default:
 		return fmt.Errorf("the file is closed after %d records and the layout describes a record to come", w.ordinal)
@@ -2774,455 +902,95 @@ func (w *Writer) writeCreditPosting(rec *CreditPosting) error {
 	var excluded string
 
 	switch w.state {
-	case 1: // the state the descriptor carries as node 78
-		// Transition 3 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
+	case 1: // the state the descriptor carries as node 41
+		// Transition 2 of that state.
+		if !w.register39Bound {
+			return w.unbound(39)
 		}
 
-		if w.register76 > 0 {
-			if matches78At2(raw) {
+		if w.register39 > 0 {
+			if matches41At1(raw) {
 				if err := w.emit(raw); err != nil {
 					return err
 				}
 
-				if !w.register76Bound {
-					return w.unbound(76)
+				if !w.register39Bound {
+					return w.unbound(39)
 				}
 
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
+				if w.register39 <= 0 {
+					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 39, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
 				}
 
-				w.register76--
+				w.register39--
 
-				w.state = 4
+				w.state = 3
 				w.ordinal++
 
 				return nil
 			}
-		} else if excluded == "" && matches78At2(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
+		} else if excluded == "" && matches41At1(raw) {
+			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 39 is greater than zero; node 39 holds %d", w.register39)
 		}
-	case 2: // the state the descriptor carries as node 79
-		// Transition 3 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
+	case 2: // the state the descriptor carries as node 42
+		// Transition 2 of that state.
+		if !w.register39Bound {
+			return w.unbound(39)
 		}
 
-		if w.register76 > 0 {
-			if matches79At2(raw) {
+		if w.register39 > 0 {
+			if matches42At1(raw) {
 				if err := w.emit(raw); err != nil {
 					return err
 				}
 
-				if !w.register76Bound {
-					return w.unbound(76)
+				if !w.register39Bound {
+					return w.unbound(39)
 				}
 
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
+				if w.register39 <= 0 {
+					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 39, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
 				}
 
-				w.register76--
+				w.register39--
 
-				w.state = 4
+				w.state = 3
 				w.ordinal++
 
 				return nil
 			}
-		} else if excluded == "" && matches79At2(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
+		} else if excluded == "" && matches42At1(raw) {
+			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 39 is greater than zero; node 39 holds %d", w.register39)
 		}
-	case 3: // the state the descriptor carries as node 80
-		// Transition 3 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
+	case 3: // the state the descriptor carries as node 43
+		// Transition 2 of that state.
+		if !w.register39Bound {
+			return w.unbound(39)
 		}
 
-		if w.register76 > 0 {
-			if matches80At2(raw) {
+		if w.register39 > 0 {
+			if matches43At1(raw) {
 				if err := w.emit(raw); err != nil {
 					return err
 				}
 
-				if !w.register76Bound {
-					return w.unbound(76)
+				if !w.register39Bound {
+					return w.unbound(39)
 				}
 
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
+				if w.register39 <= 0 {
+					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 39, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
 				}
 
-				w.register76--
+				w.register39--
 
-				w.state = 4
+				w.state = 3
 				w.ordinal++
 
 				return nil
 			}
-		} else if excluded == "" && matches80At2(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 4: // the state the descriptor carries as node 81
-		// Transition 3 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches81At2(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 4
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches81At2(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 5: // the state the descriptor carries as node 82
-		// Transition 3 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches82At2(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 4
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches82At2(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 6: // the state the descriptor carries as node 83
-		// Transition 3 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches83At2(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 4
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches83At2(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 7: // the state the descriptor carries as node 84
-		// Transition 3 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches84At2(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 4
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches84At2(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	}
-
-	return w.refuse("POSTING-RECORD", excluded)
-}
-
-// writeCreditPostingRef emits one POSTING-RECORD.
-//
-// The record is laid out first and the transition is chosen against those
-// bytes, because what a predicate tests is what is about to be emitted.
-func (w *Writer) writeCreditPostingRef(rec *CreditPostingRef) error {
-	// The encoder is rewound onto the buffer it filled for the record before
-	// this one rather than built over a fresh one. A rewind keeps everything
-	// the encoding derives and the capacity that buffer reached, and it puts
-	// the offset back to zero, so every offset codec reports is counted from
-	// the start of this record rather than from the start of the file.
-	w.cw.Reset(w.cw.Bytes())
-
-	if err := rec.MarshalCOBOL(w.cw); err != nil {
-		return fmt.Errorf("writing record %d: %w", w.ordinal+1, err)
-	}
-
-	// The record's bytes, which are the encoder's own buffer and are valid
-	// until the rewind above happens again. Nothing below holds them past
-	// that: a predicate reads them, the framing writes them out, and a
-	// binding taking a register's bytes out of them copies.
-	raw := w.cw.Bytes()
-
-	var excluded string
-
-	switch w.state {
-	case 1: // the state the descriptor carries as node 78
-		// Transition 4 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches78At3(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 5
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches78At3(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 2: // the state the descriptor carries as node 79
-		// Transition 4 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches79At3(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 5
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches79At3(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 3: // the state the descriptor carries as node 80
-		// Transition 4 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches80At3(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 5
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches80At3(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 4: // the state the descriptor carries as node 81
-		// Transition 4 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches81At3(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 5
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches81At3(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 5: // the state the descriptor carries as node 82
-		// Transition 4 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches82At3(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 5
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches82At3(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 6: // the state the descriptor carries as node 83
-		// Transition 4 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches83At3(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 5
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches83At3(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 7: // the state the descriptor carries as node 84
-		// Transition 4 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches84At3(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 5
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches84At3(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
+		} else if excluded == "" && matches43At1(raw) {
+			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 39 is greater than zero; node 39 holds %d", w.register39)
 		}
 	}
 
@@ -3254,455 +1022,95 @@ func (w *Writer) writeDebitPosting(rec *DebitPosting) error {
 	var excluded string
 
 	switch w.state {
-	case 1: // the state the descriptor carries as node 78
+	case 1: // the state the descriptor carries as node 41
 		// Transition 1 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
+		if !w.register39Bound {
+			return w.unbound(39)
 		}
 
-		if w.register76 > 0 {
-			if matches78At0(raw) {
+		if w.register39 > 0 {
+			if matches41At0(raw) {
 				if err := w.emit(raw); err != nil {
 					return err
 				}
 
-				if !w.register76Bound {
-					return w.unbound(76)
+				if !w.register39Bound {
+					return w.unbound(39)
 				}
 
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
+				if w.register39 <= 0 {
+					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 39, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
 				}
 
-				w.register76--
+				w.register39--
 
 				w.state = 2
 				w.ordinal++
 
 				return nil
 			}
-		} else if excluded == "" && matches78At0(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
+		} else if excluded == "" && matches41At0(raw) {
+			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 39 is greater than zero; node 39 holds %d", w.register39)
 		}
-	case 2: // the state the descriptor carries as node 79
+	case 2: // the state the descriptor carries as node 42
 		// Transition 1 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
+		if !w.register39Bound {
+			return w.unbound(39)
 		}
 
-		if w.register76 > 0 {
-			if matches79At0(raw) {
+		if w.register39 > 0 {
+			if matches42At0(raw) {
 				if err := w.emit(raw); err != nil {
 					return err
 				}
 
-				if !w.register76Bound {
-					return w.unbound(76)
+				if !w.register39Bound {
+					return w.unbound(39)
 				}
 
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
+				if w.register39 <= 0 {
+					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 39, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
 				}
 
-				w.register76--
+				w.register39--
 
 				w.state = 2
 				w.ordinal++
 
 				return nil
 			}
-		} else if excluded == "" && matches79At0(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
+		} else if excluded == "" && matches42At0(raw) {
+			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 39 is greater than zero; node 39 holds %d", w.register39)
 		}
-	case 3: // the state the descriptor carries as node 80
+	case 3: // the state the descriptor carries as node 43
 		// Transition 1 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
+		if !w.register39Bound {
+			return w.unbound(39)
 		}
 
-		if w.register76 > 0 {
-			if matches80At0(raw) {
+		if w.register39 > 0 {
+			if matches43At0(raw) {
 				if err := w.emit(raw); err != nil {
 					return err
 				}
 
-				if !w.register76Bound {
-					return w.unbound(76)
+				if !w.register39Bound {
+					return w.unbound(39)
 				}
 
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
+				if w.register39 <= 0 {
+					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 39, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
 				}
 
-				w.register76--
+				w.register39--
 
 				w.state = 2
 				w.ordinal++
 
 				return nil
 			}
-		} else if excluded == "" && matches80At0(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 4: // the state the descriptor carries as node 81
-		// Transition 1 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches81At0(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 2
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches81At0(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 5: // the state the descriptor carries as node 82
-		// Transition 1 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches82At0(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 2
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches82At0(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 6: // the state the descriptor carries as node 83
-		// Transition 1 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches83At0(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 2
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches83At0(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 7: // the state the descriptor carries as node 84
-		// Transition 1 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches84At0(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 2
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches84At0(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	}
-
-	return w.refuse("POSTING-RECORD", excluded)
-}
-
-// writeDebitPostingRef emits one POSTING-RECORD.
-//
-// The record is laid out first and the transition is chosen against those
-// bytes, because what a predicate tests is what is about to be emitted.
-func (w *Writer) writeDebitPostingRef(rec *DebitPostingRef) error {
-	// The encoder is rewound onto the buffer it filled for the record before
-	// this one rather than built over a fresh one. A rewind keeps everything
-	// the encoding derives and the capacity that buffer reached, and it puts
-	// the offset back to zero, so every offset codec reports is counted from
-	// the start of this record rather than from the start of the file.
-	w.cw.Reset(w.cw.Bytes())
-
-	if err := rec.MarshalCOBOL(w.cw); err != nil {
-		return fmt.Errorf("writing record %d: %w", w.ordinal+1, err)
-	}
-
-	// The record's bytes, which are the encoder's own buffer and are valid
-	// until the rewind above happens again. Nothing below holds them past
-	// that: a predicate reads them, the framing writes them out, and a
-	// binding taking a register's bytes out of them copies.
-	raw := w.cw.Bytes()
-
-	var excluded string
-
-	switch w.state {
-	case 1: // the state the descriptor carries as node 78
-		// Transition 2 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches78At1(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 3
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches78At1(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 2: // the state the descriptor carries as node 79
-		// Transition 2 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches79At1(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 3
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches79At1(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 3: // the state the descriptor carries as node 80
-		// Transition 2 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches80At1(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 3
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches80At1(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 4: // the state the descriptor carries as node 81
-		// Transition 2 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches81At1(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 3
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches81At1(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 5: // the state the descriptor carries as node 82
-		// Transition 2 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches82At1(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 3
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches82At1(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 6: // the state the descriptor carries as node 83
-		// Transition 2 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches83At1(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 3
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches83At1(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 7: // the state the descriptor carries as node 84
-		// Transition 2 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches84At1(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 3
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches84At1(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
+		} else if excluded == "" && matches43At0(raw) {
+			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 39 is greater than zero; node 39 holds %d", w.register39)
 		}
 	}
 
@@ -3732,15 +1140,15 @@ func (w *Writer) writeLedgerHeader(rec *LedgerHeader) error {
 	raw := w.cw.Bytes()
 
 	switch w.state {
-	case 0: // the state the descriptor carries as node 77
+	case 0: // the state the descriptor carries as node 40
 		// Transition 1 of that state.
-		if matches77At0(raw) {
+		if matches40At0(raw) {
 			if err := w.emit(raw); err != nil {
 				return err
 			}
 
-			w.register76 = int64(rec.HdrCount)
-			w.register76Bound = true
+			w.register39 = int64(rec.HdrCount)
+			w.register39Bound = true
 
 			w.state = 1
 			w.ordinal++
@@ -3777,629 +1185,69 @@ func (w *Writer) writeLedgerTrailer(rec *LedgerTrailer) error {
 	var excluded string
 
 	switch w.state {
-	case 1: // the state the descriptor carries as node 78
-		// Transition 7 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
+	case 1: // the state the descriptor carries as node 41
+		// Transition 3 of that state.
+		if !w.register39Bound {
+			return w.unbound(39)
 		}
 
-		if w.register76 == 0 {
-			if matches78At6(raw) {
+		if w.register39 == 0 {
+			if matches41At2(raw) {
 				if err := w.emit(raw); err != nil {
 					return err
 				}
 
-				w.state = 8
+				w.state = 4
 				w.ordinal++
 
 				return nil
 			}
-		} else if excluded == "" && matches78At6(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is 0; node 76 holds %d", w.register76)
+		} else if excluded == "" && matches41At2(raw) {
+			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 39 is 0; node 39 holds %d", w.register39)
 		}
-	case 2: // the state the descriptor carries as node 79
-		// Transition 7 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
+	case 2: // the state the descriptor carries as node 42
+		// Transition 3 of that state.
+		if !w.register39Bound {
+			return w.unbound(39)
 		}
 
-		if w.register76 == 0 {
-			if matches79At6(raw) {
+		if w.register39 == 0 {
+			if matches42At2(raw) {
 				if err := w.emit(raw); err != nil {
 					return err
 				}
 
-				w.state = 8
+				w.state = 4
 				w.ordinal++
 
 				return nil
 			}
-		} else if excluded == "" && matches79At6(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is 0; node 76 holds %d", w.register76)
+		} else if excluded == "" && matches42At2(raw) {
+			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 39 is 0; node 39 holds %d", w.register39)
 		}
-	case 3: // the state the descriptor carries as node 80
-		// Transition 7 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
+	case 3: // the state the descriptor carries as node 43
+		// Transition 3 of that state.
+		if !w.register39Bound {
+			return w.unbound(39)
 		}
 
-		if w.register76 == 0 {
-			if matches80At6(raw) {
+		if w.register39 == 0 {
+			if matches43At2(raw) {
 				if err := w.emit(raw); err != nil {
 					return err
 				}
 
-				w.state = 8
+				w.state = 4
 				w.ordinal++
 
 				return nil
 			}
-		} else if excluded == "" && matches80At6(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is 0; node 76 holds %d", w.register76)
-		}
-	case 4: // the state the descriptor carries as node 81
-		// Transition 7 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 == 0 {
-			if matches81At6(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				w.state = 8
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches81At6(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is 0; node 76 holds %d", w.register76)
-		}
-	case 5: // the state the descriptor carries as node 82
-		// Transition 7 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 == 0 {
-			if matches82At6(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				w.state = 8
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches82At6(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is 0; node 76 holds %d", w.register76)
-		}
-	case 6: // the state the descriptor carries as node 83
-		// Transition 7 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 == 0 {
-			if matches83At6(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				w.state = 8
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches83At6(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is 0; node 76 holds %d", w.register76)
-		}
-	case 7: // the state the descriptor carries as node 84
-		// Transition 7 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 == 0 {
-			if matches84At6(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				w.state = 8
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches84At6(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is 0; node 76 holds %d", w.register76)
+		} else if excluded == "" && matches43At2(raw) {
+			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 39 is 0; node 39 holds %d", w.register39)
 		}
 	}
 
 	return w.refuse("LEDGER-TRAILER", excluded)
-}
-
-// writeMemoPosting emits one POSTING-RECORD.
-//
-// The record is laid out first and the transition is chosen against those
-// bytes, because what a predicate tests is what is about to be emitted.
-func (w *Writer) writeMemoPosting(rec *MemoPosting) error {
-	// The encoder is rewound onto the buffer it filled for the record before
-	// this one rather than built over a fresh one. A rewind keeps everything
-	// the encoding derives and the capacity that buffer reached, and it puts
-	// the offset back to zero, so every offset codec reports is counted from
-	// the start of this record rather than from the start of the file.
-	w.cw.Reset(w.cw.Bytes())
-
-	if err := rec.MarshalCOBOL(w.cw); err != nil {
-		return fmt.Errorf("writing record %d: %w", w.ordinal+1, err)
-	}
-
-	// The record's bytes, which are the encoder's own buffer and are valid
-	// until the rewind above happens again. Nothing below holds them past
-	// that: a predicate reads them, the framing writes them out, and a
-	// binding taking a register's bytes out of them copies.
-	raw := w.cw.Bytes()
-
-	var excluded string
-
-	switch w.state {
-	case 1: // the state the descriptor carries as node 78
-		// Transition 5 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches78At4(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 6
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches78At4(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 2: // the state the descriptor carries as node 79
-		// Transition 5 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches79At4(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 6
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches79At4(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 3: // the state the descriptor carries as node 80
-		// Transition 5 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches80At4(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 6
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches80At4(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 4: // the state the descriptor carries as node 81
-		// Transition 5 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches81At4(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 6
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches81At4(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 5: // the state the descriptor carries as node 82
-		// Transition 5 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches82At4(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 6
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches82At4(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 6: // the state the descriptor carries as node 83
-		// Transition 5 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches83At4(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 6
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches83At4(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 7: // the state the descriptor carries as node 84
-		// Transition 5 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches84At4(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 6
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches84At4(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	}
-
-	return w.refuse("POSTING-RECORD", excluded)
-}
-
-// writeMemoPostingRef emits one POSTING-RECORD.
-//
-// The record is laid out first and the transition is chosen against those
-// bytes, because what a predicate tests is what is about to be emitted.
-func (w *Writer) writeMemoPostingRef(rec *MemoPostingRef) error {
-	// The encoder is rewound onto the buffer it filled for the record before
-	// this one rather than built over a fresh one. A rewind keeps everything
-	// the encoding derives and the capacity that buffer reached, and it puts
-	// the offset back to zero, so every offset codec reports is counted from
-	// the start of this record rather than from the start of the file.
-	w.cw.Reset(w.cw.Bytes())
-
-	if err := rec.MarshalCOBOL(w.cw); err != nil {
-		return fmt.Errorf("writing record %d: %w", w.ordinal+1, err)
-	}
-
-	// The record's bytes, which are the encoder's own buffer and are valid
-	// until the rewind above happens again. Nothing below holds them past
-	// that: a predicate reads them, the framing writes them out, and a
-	// binding taking a register's bytes out of them copies.
-	raw := w.cw.Bytes()
-
-	var excluded string
-
-	switch w.state {
-	case 1: // the state the descriptor carries as node 78
-		// Transition 6 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches78At5(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 7
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches78At5(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 2: // the state the descriptor carries as node 79
-		// Transition 6 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches79At5(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 7
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches79At5(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 3: // the state the descriptor carries as node 80
-		// Transition 6 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches80At5(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 7
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches80At5(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 4: // the state the descriptor carries as node 81
-		// Transition 6 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches81At5(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 7
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches81At5(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 5: // the state the descriptor carries as node 82
-		// Transition 6 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches82At5(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 7
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches82At5(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 6: // the state the descriptor carries as node 83
-		// Transition 6 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches83At5(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 7
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches83At5(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	case 7: // the state the descriptor carries as node 84
-		// Transition 6 of that state.
-		if !w.register76Bound {
-			return w.unbound(76)
-		}
-
-		if w.register76 > 0 {
-			if matches84At5(raw) {
-				if err := w.emit(raw); err != nil {
-					return err
-				}
-
-				if !w.register76Bound {
-					return w.unbound(76)
-				}
-
-				if w.register76 <= 0 {
-					return fmt.Errorf("record %d takes one off the register the descriptor carries as node 76, which is already at zero: a counter that would run below zero is a bug in whatever produced this descriptor", w.ordinal)
-				}
-
-				w.register76--
-
-				w.state = 7
-				w.ordinal++
-
-				return nil
-			}
-		} else if excluded == "" && matches84At5(raw) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 76 is greater than zero; node 76 holds %d", w.register76)
-		}
-	}
-
-	return w.refuse("POSTING-RECORD", excluded)
 }
 
 // refuse is what a writer says when no transition leaving the state it is in

--- a/example/ledger/file_test.go
+++ b/example/ledger/file_test.go
@@ -117,7 +117,7 @@ func TestALedgerHeaderThenALedgerTrailer(t *testing.T) {
 // below, the records they read back as, and the same bytes written back.
 //
 // The discriminators it walks: HDR-TYPE holding "\xf0\xf1", PST-TYPE holding
-// "\xc4\xc1" and TRL-TYPE holding "\xf9\xf9".
+// "\xc4\xd9" and TRL-TYPE holding "\xf9\xf9".
 func TestALedgerHeaderThenTwoDebitPostingsThenALedgerTrailer(t *testing.T) {
 	t.Parallel()
 
@@ -133,22 +133,24 @@ func TestALedgerHeaderThenTwoDebitPostingsThenALedgerTrailer(t *testing.T) {
 		0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, // record 2: PST-ACCOUNT @0 X(10)
 		0xc1, 0xc1, //
 		0xf1, 0xf1, // record 2: PST-SEQUENCE @10 9(2)
-		0xc4, 0xc1, // record 2: PST-TYPE @12 X(2)
+		0xc4, 0xd9, // record 2: PST-TYPE @12 X(2)
 		0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, // record 2: PST-DEBIT.PDB-COST-CENTRE @14 X(6)
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x1d, // record 2: PST-DEBIT.PDB-AMOUNT @20 S9(11)V9(2) PACKED-DECIMAL
 		0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, // record 2: PST-DEBIT.PDB-MEMO @27 X(15)
 		0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, //
-		0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, // record 2: PST-TAIL @42 X(8)
+		0xf0, 0xf0, 0xf4, 0xf3, // record 2: PST-TAIL-REF.PTR-BATCH @42 9(4)
+		0xf0, 0xf0, 0xf4, 0xf7, // record 2: PST-TAIL-REF.PTR-LINE @46 9(4)
 		0x00, 0x36, 0x00, 0x00, // record 3: the record descriptor word — 54 bytes, itself included
 		0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, // record 3: PST-ACCOUNT @0 X(10)
 		0xc1, 0xc1, //
 		0xf1, 0xf1, // record 3: PST-SEQUENCE @10 9(2)
-		0xc4, 0xc1, // record 3: PST-TYPE @12 X(2)
+		0xc4, 0xd9, // record 3: PST-TYPE @12 X(2)
 		0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, // record 3: PST-DEBIT.PDB-COST-CENTRE @14 X(6)
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x1d, // record 3: PST-DEBIT.PDB-AMOUNT @20 S9(11)V9(2) PACKED-DECIMAL
 		0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, // record 3: PST-DEBIT.PDB-MEMO @27 X(15)
 		0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, //
-		0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, // record 3: PST-TAIL @42 X(8)
+		0xf0, 0xf0, 0xf4, 0xf3, // record 3: PST-TAIL-REF.PTR-BATCH @42 9(4)
+		0xf0, 0xf0, 0xf4, 0xf7, // record 3: PST-TAIL-REF.PTR-LINE @46 9(4)
 		0x00, 0x1c, 0x00, 0x00, // record 4: the record descriptor word — 28 bytes, itself included
 		0xf9, 0xf9, // record 4: TRL-TYPE @0 X(2)
 		0xf0, 0xf0, 0xf0, 0xf0, 0xf0, 0xf3, // record 4: TRL-COUNT @2 9(6)
@@ -194,8 +196,8 @@ func TestALedgerHeaderThenTwoDebitPostingsThenALedgerTrailer(t *testing.T) {
 		t.Fatalf("record 2 is POSTING-RECORD and came back as a %T, want a *ledger.DebitPosting", records[1])
 	}
 
-	if record2.PstType != "DA" {
-		t.Errorf("PST-TYPE: got %q, want %q", record2.PstType, "DA")
+	if record2.PstType != "DR" {
+		t.Errorf("PST-TYPE: got %q, want %q", record2.PstType, "DR")
 	}
 
 	record3, ok := records[2].(*ledger.DebitPosting)
@@ -203,136 +205,8 @@ func TestALedgerHeaderThenTwoDebitPostingsThenALedgerTrailer(t *testing.T) {
 		t.Fatalf("record 3 is POSTING-RECORD and came back as a %T, want a *ledger.DebitPosting", records[2])
 	}
 
-	if record3.PstType != "DA" {
-		t.Errorf("PST-TYPE: got %q, want %q", record3.PstType, "DA")
-	}
-
-	record4, ok := records[3].(*ledger.LedgerTrailer)
-	if !ok {
-		t.Fatalf("record 4 is LEDGER-TRAILER and came back as a %T, want a *ledger.LedgerTrailer", records[3])
-	}
-
-	if record4.TrlType != "99" {
-		t.Errorf("TRL-TYPE: got %q, want %q", record4.TrlType, "99")
-	}
-
-	var out bytes.Buffer
-
-	w, err := ledger.NewWriter(&out, ledger.Encoding())
-	if err != nil {
-		t.Fatalf("NewWriter: %v", err)
-	}
-
-	for _, rec := range records {
-		if err := w.Write(rec); err != nil {
-			t.Fatalf("Write: %v", err)
-		}
-	}
-
-	if err := w.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
-	}
-
-	if !bytes.Equal(out.Bytes(), in) {
-		t.Errorf("the file does not write back the bytes it was read from\n got: % x\nwant: % x", out.Bytes(), in)
-	}
-}
-
-// TestALedgerHeaderThenTwoDebitPostingRefsThenALedgerTrailer is a file of
-// LEDGER-HEADER, two POSTING-RECORD records and LEDGER-TRAILER: the bytes
-// below, the records they read back as, and the same bytes written back.
-//
-// The discriminators it walks: HDR-TYPE holding "\xf0\xf1", PST-TYPE holding
-// "\xc4\xc2" and TRL-TYPE holding "\xf9\xf9".
-func TestALedgerHeaderThenTwoDebitPostingRefsThenALedgerTrailer(t *testing.T) {
-	t.Parallel()
-
-	in := []byte{
-		0x00, 0x1c, 0x00, 0x00, // record 1: the record descriptor word — 28 bytes, itself included
-		0xf0, 0xf1, // record 1: HDR-TYPE @0 X(2)
-		0xc3, 0xc3, 0xc3, 0xc3, 0xc3, 0xc3, 0xc3, 0xc3, // record 1: HDR-LEDGER-ID @2 X(10)
-		0xc3, 0xc3, //
-		0xf0, 0xf0, 0xf0, 0xf0, 0xf1, 0xf3, // record 1: HDR-PERIOD @12 9(6)
-		0xe2, 0xe2, 0xe2, // record 1: HDR-CURRENCY @18 X(3)
-		0xf0, 0xf0, 0xf2, // record 1: HDR-COUNT @21 9(3)
-		0x00, 0x36, 0x00, 0x00, // record 2: the record descriptor word — 54 bytes, itself included
-		0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, // record 2: PST-ACCOUNT @0 X(10)
-		0xc1, 0xc1, //
-		0xf1, 0xf1, // record 2: PST-SEQUENCE @10 9(2)
-		0xc4, 0xc2, // record 2: PST-TYPE @12 X(2)
-		0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, // record 2: PST-DEBIT.PDB-COST-CENTRE @14 X(6)
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x1d, // record 2: PST-DEBIT.PDB-AMOUNT @20 S9(11)V9(2) PACKED-DECIMAL
-		0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, // record 2: PST-DEBIT.PDB-MEMO @27 X(15)
-		0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, //
-		0xf0, 0xf0, 0xf4, 0xf3, // record 2: PST-TAIL-REF.PTR-BATCH @42 9(4)
-		0xf0, 0xf0, 0xf4, 0xf7, // record 2: PST-TAIL-REF.PTR-LINE @46 9(4)
-		0x00, 0x36, 0x00, 0x00, // record 3: the record descriptor word — 54 bytes, itself included
-		0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, // record 3: PST-ACCOUNT @0 X(10)
-		0xc1, 0xc1, //
-		0xf1, 0xf1, // record 3: PST-SEQUENCE @10 9(2)
-		0xc4, 0xc2, // record 3: PST-TYPE @12 X(2)
-		0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, // record 3: PST-DEBIT.PDB-COST-CENTRE @14 X(6)
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x1d, // record 3: PST-DEBIT.PDB-AMOUNT @20 S9(11)V9(2) PACKED-DECIMAL
-		0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, // record 3: PST-DEBIT.PDB-MEMO @27 X(15)
-		0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, //
-		0xf0, 0xf0, 0xf4, 0xf3, // record 3: PST-TAIL-REF.PTR-BATCH @42 9(4)
-		0xf0, 0xf0, 0xf4, 0xf7, // record 3: PST-TAIL-REF.PTR-LINE @46 9(4)
-		0x00, 0x1c, 0x00, 0x00, // record 4: the record descriptor word — 28 bytes, itself included
-		0xf9, 0xf9, // record 4: TRL-TYPE @0 X(2)
-		0xf0, 0xf0, 0xf0, 0xf0, 0xf0, 0xf3, // record 4: TRL-COUNT @2 9(6)
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x9d, // record 4: TRL-NET @8 S9(13)V9(2) PACKED-DECIMAL
-		0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, // record 4: FILLER @16 X(8)
-	}
-
-	r, err := ledger.NewReader(bytes.NewReader(in), ledger.Encoding())
-	if err != nil {
-		t.Fatalf("NewReader: %v", err)
-	}
-
-	var records []ledger.Record
-
-	for {
-		rec, err := r.Next()
-		if errors.Is(err, io.EOF) {
-			break
-		}
-
-		if err != nil {
-			t.Fatalf("Next: %v", err)
-		}
-
-		records = append(records, rec)
-	}
-
-	if len(records) != 4 {
-		t.Fatalf("the file holds 4 records and the reader produced %d", len(records))
-	}
-
-	record1, ok := records[0].(*ledger.LedgerHeader)
-	if !ok {
-		t.Fatalf("record 1 is LEDGER-HEADER and came back as a %T, want a *ledger.LedgerHeader", records[0])
-	}
-
-	if record1.HdrType != "01" {
-		t.Errorf("HDR-TYPE: got %q, want %q", record1.HdrType, "01")
-	}
-
-	record2, ok := records[1].(*ledger.DebitPostingRef)
-	if !ok {
-		t.Fatalf("record 2 is POSTING-RECORD and came back as a %T, want a *ledger.DebitPostingRef", records[1])
-	}
-
-	if record2.PstType != "DB" {
-		t.Errorf("PST-TYPE: got %q, want %q", record2.PstType, "DB")
-	}
-
-	record3, ok := records[2].(*ledger.DebitPostingRef)
-	if !ok {
-		t.Fatalf("record 3 is POSTING-RECORD and came back as a %T, want a *ledger.DebitPostingRef", records[2])
-	}
-
-	if record3.PstType != "DB" {
-		t.Errorf("PST-TYPE: got %q, want %q", record3.PstType, "DB")
+	if record3.PstType != "DR" {
+		t.Errorf("PST-TYPE: got %q, want %q", record3.PstType, "DR")
 	}
 
 	record4, ok := records[3].(*ledger.LedgerTrailer)
@@ -371,7 +245,7 @@ func TestALedgerHeaderThenTwoDebitPostingRefsThenALedgerTrailer(t *testing.T) {
 // below, the records they read back as, and the same bytes written back.
 //
 // The discriminators it walks: HDR-TYPE holding "\xf0\xf1", PST-TYPE holding
-// "\xc3\xc1" and TRL-TYPE holding "\xf9\xf9".
+// "\xc3\xd9" and TRL-TYPE holding "\xf9\xf9".
 func TestALedgerHeaderThenTwoCreditPostingsThenALedgerTrailer(t *testing.T) {
 	t.Parallel()
 
@@ -387,24 +261,26 @@ func TestALedgerHeaderThenTwoCreditPostingsThenALedgerTrailer(t *testing.T) {
 		0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, // record 2: PST-ACCOUNT @0 X(10)
 		0xc1, 0xc1, //
 		0xf1, 0xf1, // record 2: PST-SEQUENCE @10 9(2)
-		0xc3, 0xc1, // record 2: PST-TYPE @12 X(2)
+		0xc3, 0xd9, // record 2: PST-TYPE @12 X(2)
 		0xd6, 0xd6, 0xd6, 0xd6, // record 2: PST-CREDIT.PCR-SOURCE @14 X(4)
 		0x00, 0x00, 0x00, 0x00, 0x01, 0x9d, // record 2: PST-CREDIT.PCR-AMOUNT @18 S9(9)V9(2) PACKED-DECIMAL
 		0xe8, 0xe8, 0xe8, 0xe8, 0xe8, 0xe8, 0xe8, 0xe8, // record 2: PST-CREDIT.PCR-REFERENCE @24 X(14)
 		0xe8, 0xe8, 0xe8, 0xe8, 0xe8, 0xe8, //
 		0xc6, 0xc7, 0xc8, 0xc9, // record 2: (slack) @38 4 bytes no item covers
-		0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, // record 2: PST-TAIL @42 X(8)
+		0xf0, 0xf0, 0xf4, 0xf3, // record 2: PST-TAIL-REF.PTR-BATCH @42 9(4)
+		0xf0, 0xf0, 0xf4, 0xf7, // record 2: PST-TAIL-REF.PTR-LINE @46 9(4)
 		0x00, 0x36, 0x00, 0x00, // record 3: the record descriptor word — 54 bytes, itself included
 		0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, // record 3: PST-ACCOUNT @0 X(10)
 		0xc1, 0xc1, //
 		0xf1, 0xf1, // record 3: PST-SEQUENCE @10 9(2)
-		0xc3, 0xc1, // record 3: PST-TYPE @12 X(2)
+		0xc3, 0xd9, // record 3: PST-TYPE @12 X(2)
 		0xd6, 0xd6, 0xd6, 0xd6, // record 3: PST-CREDIT.PCR-SOURCE @14 X(4)
 		0x00, 0x00, 0x00, 0x00, 0x01, 0x9d, // record 3: PST-CREDIT.PCR-AMOUNT @18 S9(9)V9(2) PACKED-DECIMAL
 		0xe8, 0xe8, 0xe8, 0xe8, 0xe8, 0xe8, 0xe8, 0xe8, // record 3: PST-CREDIT.PCR-REFERENCE @24 X(14)
 		0xe8, 0xe8, 0xe8, 0xe8, 0xe8, 0xe8, //
 		0xc6, 0xc7, 0xc8, 0xc9, // record 3: (slack) @38 4 bytes no item covers
-		0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, // record 3: PST-TAIL @42 X(8)
+		0xf0, 0xf0, 0xf4, 0xf3, // record 3: PST-TAIL-REF.PTR-BATCH @42 9(4)
+		0xf0, 0xf0, 0xf4, 0xf7, // record 3: PST-TAIL-REF.PTR-LINE @46 9(4)
 		0x00, 0x1c, 0x00, 0x00, // record 4: the record descriptor word — 28 bytes, itself included
 		0xf9, 0xf9, // record 4: TRL-TYPE @0 X(2)
 		0xf0, 0xf0, 0xf0, 0xf0, 0xf0, 0xf3, // record 4: TRL-COUNT @2 9(6)
@@ -450,8 +326,8 @@ func TestALedgerHeaderThenTwoCreditPostingsThenALedgerTrailer(t *testing.T) {
 		t.Fatalf("record 2 is POSTING-RECORD and came back as a %T, want a *ledger.CreditPosting", records[1])
 	}
 
-	if record2.PstType != "CA" {
-		t.Errorf("PST-TYPE: got %q, want %q", record2.PstType, "CA")
+	if record2.PstType != "CR" {
+		t.Errorf("PST-TYPE: got %q, want %q", record2.PstType, "CR")
 	}
 
 	record3, ok := records[2].(*ledger.CreditPosting)
@@ -459,392 +335,8 @@ func TestALedgerHeaderThenTwoCreditPostingsThenALedgerTrailer(t *testing.T) {
 		t.Fatalf("record 3 is POSTING-RECORD and came back as a %T, want a *ledger.CreditPosting", records[2])
 	}
 
-	if record3.PstType != "CA" {
-		t.Errorf("PST-TYPE: got %q, want %q", record3.PstType, "CA")
-	}
-
-	record4, ok := records[3].(*ledger.LedgerTrailer)
-	if !ok {
-		t.Fatalf("record 4 is LEDGER-TRAILER and came back as a %T, want a *ledger.LedgerTrailer", records[3])
-	}
-
-	if record4.TrlType != "99" {
-		t.Errorf("TRL-TYPE: got %q, want %q", record4.TrlType, "99")
-	}
-
-	var out bytes.Buffer
-
-	w, err := ledger.NewWriter(&out, ledger.Encoding())
-	if err != nil {
-		t.Fatalf("NewWriter: %v", err)
-	}
-
-	for _, rec := range records {
-		if err := w.Write(rec); err != nil {
-			t.Fatalf("Write: %v", err)
-		}
-	}
-
-	if err := w.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
-	}
-
-	if !bytes.Equal(out.Bytes(), in) {
-		t.Errorf("the file does not write back the bytes it was read from\n got: % x\nwant: % x", out.Bytes(), in)
-	}
-}
-
-// TestALedgerHeaderThenTwoCreditPostingRefsThenALedgerTrailer is a file of
-// LEDGER-HEADER, two POSTING-RECORD records and LEDGER-TRAILER: the bytes
-// below, the records they read back as, and the same bytes written back.
-//
-// The discriminators it walks: HDR-TYPE holding "\xf0\xf1", PST-TYPE holding
-// "\xc3\xc2" and TRL-TYPE holding "\xf9\xf9".
-func TestALedgerHeaderThenTwoCreditPostingRefsThenALedgerTrailer(t *testing.T) {
-	t.Parallel()
-
-	in := []byte{
-		0x00, 0x1c, 0x00, 0x00, // record 1: the record descriptor word — 28 bytes, itself included
-		0xf0, 0xf1, // record 1: HDR-TYPE @0 X(2)
-		0xc3, 0xc3, 0xc3, 0xc3, 0xc3, 0xc3, 0xc3, 0xc3, // record 1: HDR-LEDGER-ID @2 X(10)
-		0xc3, 0xc3, //
-		0xf0, 0xf0, 0xf0, 0xf0, 0xf1, 0xf3, // record 1: HDR-PERIOD @12 9(6)
-		0xe2, 0xe2, 0xe2, // record 1: HDR-CURRENCY @18 X(3)
-		0xf0, 0xf0, 0xf2, // record 1: HDR-COUNT @21 9(3)
-		0x00, 0x36, 0x00, 0x00, // record 2: the record descriptor word — 54 bytes, itself included
-		0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, // record 2: PST-ACCOUNT @0 X(10)
-		0xc1, 0xc1, //
-		0xf1, 0xf1, // record 2: PST-SEQUENCE @10 9(2)
-		0xc3, 0xc2, // record 2: PST-TYPE @12 X(2)
-		0xd6, 0xd6, 0xd6, 0xd6, // record 2: PST-CREDIT.PCR-SOURCE @14 X(4)
-		0x00, 0x00, 0x00, 0x00, 0x01, 0x9d, // record 2: PST-CREDIT.PCR-AMOUNT @18 S9(9)V9(2) PACKED-DECIMAL
-		0xe8, 0xe8, 0xe8, 0xe8, 0xe8, 0xe8, 0xe8, 0xe8, // record 2: PST-CREDIT.PCR-REFERENCE @24 X(14)
-		0xe8, 0xe8, 0xe8, 0xe8, 0xe8, 0xe8, //
-		0xc6, 0xc7, 0xc8, 0xc9, // record 2: (slack) @38 4 bytes no item covers
-		0xf0, 0xf0, 0xf4, 0xf3, // record 2: PST-TAIL-REF.PTR-BATCH @42 9(4)
-		0xf0, 0xf0, 0xf4, 0xf7, // record 2: PST-TAIL-REF.PTR-LINE @46 9(4)
-		0x00, 0x36, 0x00, 0x00, // record 3: the record descriptor word — 54 bytes, itself included
-		0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, // record 3: PST-ACCOUNT @0 X(10)
-		0xc1, 0xc1, //
-		0xf1, 0xf1, // record 3: PST-SEQUENCE @10 9(2)
-		0xc3, 0xc2, // record 3: PST-TYPE @12 X(2)
-		0xd6, 0xd6, 0xd6, 0xd6, // record 3: PST-CREDIT.PCR-SOURCE @14 X(4)
-		0x00, 0x00, 0x00, 0x00, 0x01, 0x9d, // record 3: PST-CREDIT.PCR-AMOUNT @18 S9(9)V9(2) PACKED-DECIMAL
-		0xe8, 0xe8, 0xe8, 0xe8, 0xe8, 0xe8, 0xe8, 0xe8, // record 3: PST-CREDIT.PCR-REFERENCE @24 X(14)
-		0xe8, 0xe8, 0xe8, 0xe8, 0xe8, 0xe8, //
-		0xc6, 0xc7, 0xc8, 0xc9, // record 3: (slack) @38 4 bytes no item covers
-		0xf0, 0xf0, 0xf4, 0xf3, // record 3: PST-TAIL-REF.PTR-BATCH @42 9(4)
-		0xf0, 0xf0, 0xf4, 0xf7, // record 3: PST-TAIL-REF.PTR-LINE @46 9(4)
-		0x00, 0x1c, 0x00, 0x00, // record 4: the record descriptor word — 28 bytes, itself included
-		0xf9, 0xf9, // record 4: TRL-TYPE @0 X(2)
-		0xf0, 0xf0, 0xf0, 0xf0, 0xf0, 0xf3, // record 4: TRL-COUNT @2 9(6)
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x9d, // record 4: TRL-NET @8 S9(13)V9(2) PACKED-DECIMAL
-		0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, // record 4: FILLER @16 X(8)
-	}
-
-	r, err := ledger.NewReader(bytes.NewReader(in), ledger.Encoding())
-	if err != nil {
-		t.Fatalf("NewReader: %v", err)
-	}
-
-	var records []ledger.Record
-
-	for {
-		rec, err := r.Next()
-		if errors.Is(err, io.EOF) {
-			break
-		}
-
-		if err != nil {
-			t.Fatalf("Next: %v", err)
-		}
-
-		records = append(records, rec)
-	}
-
-	if len(records) != 4 {
-		t.Fatalf("the file holds 4 records and the reader produced %d", len(records))
-	}
-
-	record1, ok := records[0].(*ledger.LedgerHeader)
-	if !ok {
-		t.Fatalf("record 1 is LEDGER-HEADER and came back as a %T, want a *ledger.LedgerHeader", records[0])
-	}
-
-	if record1.HdrType != "01" {
-		t.Errorf("HDR-TYPE: got %q, want %q", record1.HdrType, "01")
-	}
-
-	record2, ok := records[1].(*ledger.CreditPostingRef)
-	if !ok {
-		t.Fatalf("record 2 is POSTING-RECORD and came back as a %T, want a *ledger.CreditPostingRef", records[1])
-	}
-
-	if record2.PstType != "CB" {
-		t.Errorf("PST-TYPE: got %q, want %q", record2.PstType, "CB")
-	}
-
-	record3, ok := records[2].(*ledger.CreditPostingRef)
-	if !ok {
-		t.Fatalf("record 3 is POSTING-RECORD and came back as a %T, want a *ledger.CreditPostingRef", records[2])
-	}
-
-	if record3.PstType != "CB" {
-		t.Errorf("PST-TYPE: got %q, want %q", record3.PstType, "CB")
-	}
-
-	record4, ok := records[3].(*ledger.LedgerTrailer)
-	if !ok {
-		t.Fatalf("record 4 is LEDGER-TRAILER and came back as a %T, want a *ledger.LedgerTrailer", records[3])
-	}
-
-	if record4.TrlType != "99" {
-		t.Errorf("TRL-TYPE: got %q, want %q", record4.TrlType, "99")
-	}
-
-	var out bytes.Buffer
-
-	w, err := ledger.NewWriter(&out, ledger.Encoding())
-	if err != nil {
-		t.Fatalf("NewWriter: %v", err)
-	}
-
-	for _, rec := range records {
-		if err := w.Write(rec); err != nil {
-			t.Fatalf("Write: %v", err)
-		}
-	}
-
-	if err := w.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
-	}
-
-	if !bytes.Equal(out.Bytes(), in) {
-		t.Errorf("the file does not write back the bytes it was read from\n got: % x\nwant: % x", out.Bytes(), in)
-	}
-}
-
-// TestALedgerHeaderThenTwoMemoPostingsThenALedgerTrailer is a file of
-// LEDGER-HEADER, two POSTING-RECORD records and LEDGER-TRAILER: the bytes
-// below, the records they read back as, and the same bytes written back.
-//
-// The discriminators it walks: HDR-TYPE holding "\xf0\xf1", PST-TYPE holding
-// "\xd4\xc1" and TRL-TYPE holding "\xf9\xf9".
-func TestALedgerHeaderThenTwoMemoPostingsThenALedgerTrailer(t *testing.T) {
-	t.Parallel()
-
-	in := []byte{
-		0x00, 0x1c, 0x00, 0x00, // record 1: the record descriptor word — 28 bytes, itself included
-		0xf0, 0xf1, // record 1: HDR-TYPE @0 X(2)
-		0xc3, 0xc3, 0xc3, 0xc3, 0xc3, 0xc3, 0xc3, 0xc3, // record 1: HDR-LEDGER-ID @2 X(10)
-		0xc3, 0xc3, //
-		0xf0, 0xf0, 0xf0, 0xf0, 0xf1, 0xf3, // record 1: HDR-PERIOD @12 9(6)
-		0xe2, 0xe2, 0xe2, // record 1: HDR-CURRENCY @18 X(3)
-		0xf0, 0xf0, 0xf2, // record 1: HDR-COUNT @21 9(3)
-		0x00, 0x36, 0x00, 0x00, // record 2: the record descriptor word — 54 bytes, itself included
-		0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, // record 2: PST-ACCOUNT @0 X(10)
-		0xc1, 0xc1, //
-		0xf1, 0xf1, // record 2: PST-SEQUENCE @10 9(2)
-		0xd4, 0xc1, // record 2: PST-TYPE @12 X(2)
-		0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, // record 2: PST-BODY @14 X(28)
-		0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, //
-		0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, //
-		0xd6, 0xd6, 0xd6, 0xd6, //
-		0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, // record 2: PST-TAIL @42 X(8)
-		0x00, 0x36, 0x00, 0x00, // record 3: the record descriptor word — 54 bytes, itself included
-		0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, // record 3: PST-ACCOUNT @0 X(10)
-		0xc1, 0xc1, //
-		0xf1, 0xf1, // record 3: PST-SEQUENCE @10 9(2)
-		0xd4, 0xc1, // record 3: PST-TYPE @12 X(2)
-		0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, // record 3: PST-BODY @14 X(28)
-		0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, //
-		0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, //
-		0xd6, 0xd6, 0xd6, 0xd6, //
-		0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, // record 3: PST-TAIL @42 X(8)
-		0x00, 0x1c, 0x00, 0x00, // record 4: the record descriptor word — 28 bytes, itself included
-		0xf9, 0xf9, // record 4: TRL-TYPE @0 X(2)
-		0xf0, 0xf0, 0xf0, 0xf0, 0xf0, 0xf3, // record 4: TRL-COUNT @2 9(6)
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x9d, // record 4: TRL-NET @8 S9(13)V9(2) PACKED-DECIMAL
-		0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, // record 4: FILLER @16 X(8)
-	}
-
-	r, err := ledger.NewReader(bytes.NewReader(in), ledger.Encoding())
-	if err != nil {
-		t.Fatalf("NewReader: %v", err)
-	}
-
-	var records []ledger.Record
-
-	for {
-		rec, err := r.Next()
-		if errors.Is(err, io.EOF) {
-			break
-		}
-
-		if err != nil {
-			t.Fatalf("Next: %v", err)
-		}
-
-		records = append(records, rec)
-	}
-
-	if len(records) != 4 {
-		t.Fatalf("the file holds 4 records and the reader produced %d", len(records))
-	}
-
-	record1, ok := records[0].(*ledger.LedgerHeader)
-	if !ok {
-		t.Fatalf("record 1 is LEDGER-HEADER and came back as a %T, want a *ledger.LedgerHeader", records[0])
-	}
-
-	if record1.HdrType != "01" {
-		t.Errorf("HDR-TYPE: got %q, want %q", record1.HdrType, "01")
-	}
-
-	record2, ok := records[1].(*ledger.MemoPosting)
-	if !ok {
-		t.Fatalf("record 2 is POSTING-RECORD and came back as a %T, want a *ledger.MemoPosting", records[1])
-	}
-
-	if record2.PstType != "MA" {
-		t.Errorf("PST-TYPE: got %q, want %q", record2.PstType, "MA")
-	}
-
-	record3, ok := records[2].(*ledger.MemoPosting)
-	if !ok {
-		t.Fatalf("record 3 is POSTING-RECORD and came back as a %T, want a *ledger.MemoPosting", records[2])
-	}
-
-	if record3.PstType != "MA" {
-		t.Errorf("PST-TYPE: got %q, want %q", record3.PstType, "MA")
-	}
-
-	record4, ok := records[3].(*ledger.LedgerTrailer)
-	if !ok {
-		t.Fatalf("record 4 is LEDGER-TRAILER and came back as a %T, want a *ledger.LedgerTrailer", records[3])
-	}
-
-	if record4.TrlType != "99" {
-		t.Errorf("TRL-TYPE: got %q, want %q", record4.TrlType, "99")
-	}
-
-	var out bytes.Buffer
-
-	w, err := ledger.NewWriter(&out, ledger.Encoding())
-	if err != nil {
-		t.Fatalf("NewWriter: %v", err)
-	}
-
-	for _, rec := range records {
-		if err := w.Write(rec); err != nil {
-			t.Fatalf("Write: %v", err)
-		}
-	}
-
-	if err := w.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
-	}
-
-	if !bytes.Equal(out.Bytes(), in) {
-		t.Errorf("the file does not write back the bytes it was read from\n got: % x\nwant: % x", out.Bytes(), in)
-	}
-}
-
-// TestALedgerHeaderThenTwoMemoPostingRefsThenALedgerTrailer is a file of
-// LEDGER-HEADER, two POSTING-RECORD records and LEDGER-TRAILER: the bytes
-// below, the records they read back as, and the same bytes written back.
-//
-// The discriminators it walks: HDR-TYPE holding "\xf0\xf1", PST-TYPE holding
-// "\xd4\xc2" and TRL-TYPE holding "\xf9\xf9".
-func TestALedgerHeaderThenTwoMemoPostingRefsThenALedgerTrailer(t *testing.T) {
-	t.Parallel()
-
-	in := []byte{
-		0x00, 0x1c, 0x00, 0x00, // record 1: the record descriptor word — 28 bytes, itself included
-		0xf0, 0xf1, // record 1: HDR-TYPE @0 X(2)
-		0xc3, 0xc3, 0xc3, 0xc3, 0xc3, 0xc3, 0xc3, 0xc3, // record 1: HDR-LEDGER-ID @2 X(10)
-		0xc3, 0xc3, //
-		0xf0, 0xf0, 0xf0, 0xf0, 0xf1, 0xf3, // record 1: HDR-PERIOD @12 9(6)
-		0xe2, 0xe2, 0xe2, // record 1: HDR-CURRENCY @18 X(3)
-		0xf0, 0xf0, 0xf2, // record 1: HDR-COUNT @21 9(3)
-		0x00, 0x36, 0x00, 0x00, // record 2: the record descriptor word — 54 bytes, itself included
-		0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, // record 2: PST-ACCOUNT @0 X(10)
-		0xc1, 0xc1, //
-		0xf1, 0xf1, // record 2: PST-SEQUENCE @10 9(2)
-		0xd4, 0xc2, // record 2: PST-TYPE @12 X(2)
-		0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, // record 2: PST-BODY @14 X(28)
-		0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, //
-		0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, //
-		0xd6, 0xd6, 0xd6, 0xd6, //
-		0xf0, 0xf0, 0xf4, 0xf3, // record 2: PST-TAIL-REF.PTR-BATCH @42 9(4)
-		0xf0, 0xf0, 0xf4, 0xf7, // record 2: PST-TAIL-REF.PTR-LINE @46 9(4)
-		0x00, 0x36, 0x00, 0x00, // record 3: the record descriptor word — 54 bytes, itself included
-		0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, // record 3: PST-ACCOUNT @0 X(10)
-		0xc1, 0xc1, //
-		0xf1, 0xf1, // record 3: PST-SEQUENCE @10 9(2)
-		0xd4, 0xc2, // record 3: PST-TYPE @12 X(2)
-		0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, // record 3: PST-BODY @14 X(28)
-		0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, //
-		0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, //
-		0xd6, 0xd6, 0xd6, 0xd6, //
-		0xf0, 0xf0, 0xf4, 0xf3, // record 3: PST-TAIL-REF.PTR-BATCH @42 9(4)
-		0xf0, 0xf0, 0xf4, 0xf7, // record 3: PST-TAIL-REF.PTR-LINE @46 9(4)
-		0x00, 0x1c, 0x00, 0x00, // record 4: the record descriptor word — 28 bytes, itself included
-		0xf9, 0xf9, // record 4: TRL-TYPE @0 X(2)
-		0xf0, 0xf0, 0xf0, 0xf0, 0xf0, 0xf3, // record 4: TRL-COUNT @2 9(6)
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x9d, // record 4: TRL-NET @8 S9(13)V9(2) PACKED-DECIMAL
-		0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, // record 4: FILLER @16 X(8)
-	}
-
-	r, err := ledger.NewReader(bytes.NewReader(in), ledger.Encoding())
-	if err != nil {
-		t.Fatalf("NewReader: %v", err)
-	}
-
-	var records []ledger.Record
-
-	for {
-		rec, err := r.Next()
-		if errors.Is(err, io.EOF) {
-			break
-		}
-
-		if err != nil {
-			t.Fatalf("Next: %v", err)
-		}
-
-		records = append(records, rec)
-	}
-
-	if len(records) != 4 {
-		t.Fatalf("the file holds 4 records and the reader produced %d", len(records))
-	}
-
-	record1, ok := records[0].(*ledger.LedgerHeader)
-	if !ok {
-		t.Fatalf("record 1 is LEDGER-HEADER and came back as a %T, want a *ledger.LedgerHeader", records[0])
-	}
-
-	if record1.HdrType != "01" {
-		t.Errorf("HDR-TYPE: got %q, want %q", record1.HdrType, "01")
-	}
-
-	record2, ok := records[1].(*ledger.MemoPostingRef)
-	if !ok {
-		t.Fatalf("record 2 is POSTING-RECORD and came back as a %T, want a *ledger.MemoPostingRef", records[1])
-	}
-
-	if record2.PstType != "MB" {
-		t.Errorf("PST-TYPE: got %q, want %q", record2.PstType, "MB")
-	}
-
-	record3, ok := records[2].(*ledger.MemoPostingRef)
-	if !ok {
-		t.Fatalf("record 3 is POSTING-RECORD and came back as a %T, want a *ledger.MemoPostingRef", records[2])
-	}
-
-	if record3.PstType != "MB" {
-		t.Errorf("PST-TYPE: got %q, want %q", record3.PstType, "MB")
+	if record3.PstType != "CR" {
+		t.Errorf("PST-TYPE: got %q, want %q", record3.PstType, "CR")
 	}
 
 	record4, ok := records[3].(*ledger.LedgerTrailer)

--- a/example/ledger/records.go
+++ b/example/ledger/records.go
@@ -72,35 +72,6 @@ type DebitPosting struct {
 		PdbMemo string
 	}
 
-	// PstTail is PST-TAIL — alphanumeric, DISPLAY, 8 bytes.
-	PstTail string
-}
-
-// DebitPostingRef is the POSTING-RECORD record, as docs/ir/SPEC.md resolved it.
-// The layout renames it to DEBIT-POSTING-REF.
-type DebitPostingRef struct {
-	// PstAccount is PST-ACCOUNT — alphanumeric, DISPLAY, 10 bytes.
-	PstAccount string
-
-	// PstSequence is PST-SEQUENCE — numeric, DISPLAY, 2 digits, unsigned, 2 bytes.
-	PstSequence int32
-
-	// PstType is PST-TYPE — alphanumeric, DISPLAY, 2 bytes.
-	PstType string
-
-	// PstDebit is PST-DEBIT — a group of 3 members.
-	PstDebit struct {
-		// PdbCostCentre is PDB-COST-CENTRE — alphanumeric, DISPLAY, 6 bytes.
-		PdbCostCentre string
-
-		// PdbAmount is PDB-AMOUNT — numeric, PACKED-DECIMAL, 13 digits, signed, 7 bytes.
-		// The value is unscaled: the item's value is this field times 10^-2.
-		PdbAmount int64
-
-		// PdbMemo is PDB-MEMO — alphanumeric, DISPLAY, 15 bytes.
-		PdbMemo string
-	}
-
 	// PstTailRef is PST-TAIL-REF — a group of 2 members.
 	PstTailRef struct {
 		// PtrBatch is PTR-BATCH — numeric, DISPLAY, 4 digits, unsigned, 4 bytes.
@@ -136,45 +107,6 @@ type CreditPosting struct {
 		PcrReference string
 	}
 
-	// PstTail is PST-TAIL — alphanumeric, DISPLAY, 8 bytes.
-	PstTail string
-
-	// slack is the bytes retained for the slack nodes among this item's
-	// members, in the order those nodes occupy the record: one run each, as
-	// they stood when the record was read, and one set of them per occurrence
-	// of this struct. A nil run is one the record does not carry; an empty run
-	// is a run of no bytes, and the two are not the same.
-	//
-	// They travel with the record and there is nothing here for a caller to do.
-	// See docs/ir/SPEC.md, "Slack survives a read".
-	slack [1][]byte
-}
-
-// CreditPostingRef is the POSTING-RECORD record, as docs/ir/SPEC.md resolved it.
-// The layout renames it to CREDIT-POSTING-REF.
-type CreditPostingRef struct {
-	// PstAccount is PST-ACCOUNT — alphanumeric, DISPLAY, 10 bytes.
-	PstAccount string
-
-	// PstSequence is PST-SEQUENCE — numeric, DISPLAY, 2 digits, unsigned, 2 bytes.
-	PstSequence int32
-
-	// PstType is PST-TYPE — alphanumeric, DISPLAY, 2 bytes.
-	PstType string
-
-	// PstCredit is PST-CREDIT — a group of 3 members.
-	PstCredit struct {
-		// PcrSource is PCR-SOURCE — alphanumeric, DISPLAY, 4 bytes.
-		PcrSource string
-
-		// PcrAmount is PCR-AMOUNT — numeric, PACKED-DECIMAL, 11 digits, signed, 6 bytes.
-		// The value is unscaled: the item's value is this field times 10^-2.
-		PcrAmount int64
-
-		// PcrReference is PCR-REFERENCE — alphanumeric, DISPLAY, 14 bytes.
-		PcrReference string
-	}
-
 	// PstTailRef is PST-TAIL-REF — a group of 2 members.
 	PstTailRef struct {
 		// PtrBatch is PTR-BATCH — numeric, DISPLAY, 4 digits, unsigned, 4 bytes.
@@ -193,48 +125,4 @@ type CreditPostingRef struct {
 	// They travel with the record and there is nothing here for a caller to do.
 	// See docs/ir/SPEC.md, "Slack survives a read".
 	slack [1][]byte
-}
-
-// MemoPosting is the POSTING-RECORD record, as docs/ir/SPEC.md resolved it.
-// The layout renames it to MEMO-POSTING.
-type MemoPosting struct {
-	// PstAccount is PST-ACCOUNT — alphanumeric, DISPLAY, 10 bytes.
-	PstAccount string
-
-	// PstSequence is PST-SEQUENCE — numeric, DISPLAY, 2 digits, unsigned, 2 bytes.
-	PstSequence int32
-
-	// PstType is PST-TYPE — alphanumeric, DISPLAY, 2 bytes.
-	PstType string
-
-	// PstBody is PST-BODY — alphanumeric, DISPLAY, 28 bytes.
-	PstBody string
-
-	// PstTail is PST-TAIL — alphanumeric, DISPLAY, 8 bytes.
-	PstTail string
-}
-
-// MemoPostingRef is the POSTING-RECORD record, as docs/ir/SPEC.md resolved it.
-// The layout renames it to MEMO-POSTING-REF.
-type MemoPostingRef struct {
-	// PstAccount is PST-ACCOUNT — alphanumeric, DISPLAY, 10 bytes.
-	PstAccount string
-
-	// PstSequence is PST-SEQUENCE — numeric, DISPLAY, 2 digits, unsigned, 2 bytes.
-	PstSequence int32
-
-	// PstType is PST-TYPE — alphanumeric, DISPLAY, 2 bytes.
-	PstType string
-
-	// PstBody is PST-BODY — alphanumeric, DISPLAY, 28 bytes.
-	PstBody string
-
-	// PstTailRef is PST-TAIL-REF — a group of 2 members.
-	PstTailRef struct {
-		// PtrBatch is PTR-BATCH — numeric, DISPLAY, 4 digits, unsigned, 4 bytes.
-		PtrBatch int32
-
-		// PtrLine is PTR-LINE — numeric, DISPLAY, 4 digits, unsigned, 4 bytes.
-		PtrLine int32
-	}
 }

--- a/example/ledger/records_test.go
+++ b/example/ledger/records_test.go
@@ -142,12 +142,13 @@ func TestDebitPostingReadsBackTheBytesItWasReadFrom(t *testing.T) {
 		0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, // PST-ACCOUNT @0 X(10)
 		0xc1, 0xc1, //
 		0xf1, 0xf1, // PST-SEQUENCE @10 9(2)
-		0xc4, 0xc1, // PST-TYPE @12 X(2)
+		0xc4, 0xd9, // PST-TYPE @12 X(2)
 		0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, // PST-DEBIT.PDB-COST-CENTRE @14 X(6)
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x1d, // PST-DEBIT.PDB-AMOUNT @20 S9(11)V9(2) PACKED-DECIMAL
 		0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, // PST-DEBIT.PDB-MEMO @27 X(15)
 		0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, //
-		0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, // PST-TAIL @42 X(8)
+		0xf0, 0xf0, 0xf4, 0xf3, // PST-TAIL-REF.PTR-BATCH @42 9(4)
+		0xf0, 0xf0, 0xf4, 0xf7, // PST-TAIL-REF.PTR-LINE @46 9(4)
 	}
 
 	r, err := codec.NewReader(bytes.NewReader(in), ledger.Encoding())
@@ -169,81 +170,8 @@ func TestDebitPostingReadsBackTheBytesItWasReadFrom(t *testing.T) {
 		t.Errorf("PST-SEQUENCE: got %d, want %d", record.PstSequence, 11)
 	}
 
-	if record.PstType != "DA" {
-		t.Errorf("PST-TYPE: got %q, want %q", record.PstType, "DA")
-	}
-
-	if record.PstDebit.PdbCostCentre != "OOOOOO" {
-		t.Errorf("PST-DEBIT.PDB-COST-CENTRE: got %q, want %q", record.PstDebit.PdbCostCentre, "OOOOOO")
-	}
-
-	if record.PstDebit.PdbAmount != -21 {
-		t.Errorf("PST-DEBIT.PDB-AMOUNT: got %d, want %d", record.PstDebit.PdbAmount, -21)
-	}
-
-	if record.PstDebit.PdbMemo != "BBBBBBBBBBBBBBB" {
-		t.Errorf("PST-DEBIT.PDB-MEMO: got %q, want %q", record.PstDebit.PdbMemo, "BBBBBBBBBBBBBBB")
-	}
-
-	if record.PstTail != "QQQQQQQQ" {
-		t.Errorf("PST-TAIL: got %q, want %q", record.PstTail, "QQQQQQQQ")
-	}
-
-	var out bytes.Buffer
-
-	w, err := codec.NewWriter(&out, ledger.Encoding())
-	if err != nil {
-		t.Fatalf("codec.NewWriter: %v", err)
-	}
-
-	if err := record.MarshalCOBOL(w); err != nil {
-		t.Fatalf("MarshalCOBOL: %v", err)
-	}
-
-	if !bytes.Equal(out.Bytes(), in) {
-		t.Errorf("the record does not write back the bytes it was read from\n got: % x\nwant: % x", out.Bytes(), in)
-	}
-}
-
-// TestDebitPostingRefReadsBackTheBytesItWasReadFrom is POSTING-RECORD: the
-// bytes below, every field they decode into, and the same bytes written back.
-func TestDebitPostingRefReadsBackTheBytesItWasReadFrom(t *testing.T) {
-	t.Parallel()
-
-	in := []byte{
-		0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, // PST-ACCOUNT @0 X(10)
-		0xc1, 0xc1, //
-		0xf1, 0xf1, // PST-SEQUENCE @10 9(2)
-		0xc4, 0xc2, // PST-TYPE @12 X(2)
-		0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, // PST-DEBIT.PDB-COST-CENTRE @14 X(6)
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x1d, // PST-DEBIT.PDB-AMOUNT @20 S9(11)V9(2) PACKED-DECIMAL
-		0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, // PST-DEBIT.PDB-MEMO @27 X(15)
-		0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, 0xc2, //
-		0xf0, 0xf0, 0xf4, 0xf3, // PST-TAIL-REF.PTR-BATCH @42 9(4)
-		0xf0, 0xf0, 0xf4, 0xf7, // PST-TAIL-REF.PTR-LINE @46 9(4)
-	}
-
-	r, err := codec.NewReader(bytes.NewReader(in), ledger.Encoding())
-	if err != nil {
-		t.Fatalf("codec.NewReader: %v", err)
-	}
-
-	var record ledger.DebitPostingRef
-
-	if err := record.UnmarshalCOBOL(r); err != nil {
-		t.Fatalf("UnmarshalCOBOL: %v", err)
-	}
-
-	if record.PstAccount != "AAAAAAAAAA" {
-		t.Errorf("PST-ACCOUNT: got %q, want %q", record.PstAccount, "AAAAAAAAAA")
-	}
-
-	if record.PstSequence != 11 {
-		t.Errorf("PST-SEQUENCE: got %d, want %d", record.PstSequence, 11)
-	}
-
-	if record.PstType != "DB" {
-		t.Errorf("PST-TYPE: got %q, want %q", record.PstType, "DB")
+	if record.PstType != "DR" {
+		t.Errorf("PST-TYPE: got %q, want %q", record.PstType, "DR")
 	}
 
 	if record.PstDebit.PdbCostCentre != "OOOOOO" {
@@ -291,13 +219,14 @@ func TestCreditPostingReadsBackTheBytesItWasReadFrom(t *testing.T) {
 		0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, // PST-ACCOUNT @0 X(10)
 		0xc1, 0xc1, //
 		0xf1, 0xf1, // PST-SEQUENCE @10 9(2)
-		0xc3, 0xc1, // PST-TYPE @12 X(2)
+		0xc3, 0xd9, // PST-TYPE @12 X(2)
 		0xd6, 0xd6, 0xd6, 0xd6, // PST-CREDIT.PCR-SOURCE @14 X(4)
 		0x00, 0x00, 0x00, 0x00, 0x01, 0x9d, // PST-CREDIT.PCR-AMOUNT @18 S9(9)V9(2) PACKED-DECIMAL
 		0xe8, 0xe8, 0xe8, 0xe8, 0xe8, 0xe8, 0xe8, 0xe8, // PST-CREDIT.PCR-REFERENCE @24 X(14)
 		0xe8, 0xe8, 0xe8, 0xe8, 0xe8, 0xe8, //
 		0xc6, 0xc7, 0xc8, 0xc9, // (slack) @38 4 bytes no item covers
-		0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, // PST-TAIL @42 X(8)
+		0xf0, 0xf0, 0xf4, 0xf3, // PST-TAIL-REF.PTR-BATCH @42 9(4)
+		0xf0, 0xf0, 0xf4, 0xf7, // PST-TAIL-REF.PTR-LINE @46 9(4)
 	}
 
 	r, err := codec.NewReader(bytes.NewReader(in), ledger.Encoding())
@@ -319,8 +248,8 @@ func TestCreditPostingReadsBackTheBytesItWasReadFrom(t *testing.T) {
 		t.Errorf("PST-SEQUENCE: got %d, want %d", record.PstSequence, 11)
 	}
 
-	if record.PstType != "CA" {
-		t.Errorf("PST-TYPE: got %q, want %q", record.PstType, "CA")
+	if record.PstType != "CR" {
+		t.Errorf("PST-TYPE: got %q, want %q", record.PstType, "CR")
 	}
 
 	if record.PstCredit.PcrSource != "OOOO" {
@@ -333,213 +262,6 @@ func TestCreditPostingReadsBackTheBytesItWasReadFrom(t *testing.T) {
 
 	if record.PstCredit.PcrReference != "YYYYYYYYYYYYYY" {
 		t.Errorf("PST-CREDIT.PCR-REFERENCE: got %q, want %q", record.PstCredit.PcrReference, "YYYYYYYYYYYYYY")
-	}
-
-	if record.PstTail != "QQQQQQQQ" {
-		t.Errorf("PST-TAIL: got %q, want %q", record.PstTail, "QQQQQQQQ")
-	}
-
-	var out bytes.Buffer
-
-	w, err := codec.NewWriter(&out, ledger.Encoding())
-	if err != nil {
-		t.Fatalf("codec.NewWriter: %v", err)
-	}
-
-	if err := record.MarshalCOBOL(w); err != nil {
-		t.Fatalf("MarshalCOBOL: %v", err)
-	}
-
-	if !bytes.Equal(out.Bytes(), in) {
-		t.Errorf("the record does not write back the bytes it was read from\n got: % x\nwant: % x", out.Bytes(), in)
-	}
-}
-
-// TestCreditPostingRefReadsBackTheBytesItWasReadFrom is POSTING-RECORD: the
-// bytes below, every field they decode into, and the same bytes written back.
-func TestCreditPostingRefReadsBackTheBytesItWasReadFrom(t *testing.T) {
-	t.Parallel()
-
-	in := []byte{
-		0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, // PST-ACCOUNT @0 X(10)
-		0xc1, 0xc1, //
-		0xf1, 0xf1, // PST-SEQUENCE @10 9(2)
-		0xc3, 0xc2, // PST-TYPE @12 X(2)
-		0xd6, 0xd6, 0xd6, 0xd6, // PST-CREDIT.PCR-SOURCE @14 X(4)
-		0x00, 0x00, 0x00, 0x00, 0x01, 0x9d, // PST-CREDIT.PCR-AMOUNT @18 S9(9)V9(2) PACKED-DECIMAL
-		0xe8, 0xe8, 0xe8, 0xe8, 0xe8, 0xe8, 0xe8, 0xe8, // PST-CREDIT.PCR-REFERENCE @24 X(14)
-		0xe8, 0xe8, 0xe8, 0xe8, 0xe8, 0xe8, //
-		0xc6, 0xc7, 0xc8, 0xc9, // (slack) @38 4 bytes no item covers
-		0xf0, 0xf0, 0xf4, 0xf3, // PST-TAIL-REF.PTR-BATCH @42 9(4)
-		0xf0, 0xf0, 0xf4, 0xf7, // PST-TAIL-REF.PTR-LINE @46 9(4)
-	}
-
-	r, err := codec.NewReader(bytes.NewReader(in), ledger.Encoding())
-	if err != nil {
-		t.Fatalf("codec.NewReader: %v", err)
-	}
-
-	var record ledger.CreditPostingRef
-
-	if err := record.UnmarshalCOBOL(r); err != nil {
-		t.Fatalf("UnmarshalCOBOL: %v", err)
-	}
-
-	if record.PstAccount != "AAAAAAAAAA" {
-		t.Errorf("PST-ACCOUNT: got %q, want %q", record.PstAccount, "AAAAAAAAAA")
-	}
-
-	if record.PstSequence != 11 {
-		t.Errorf("PST-SEQUENCE: got %d, want %d", record.PstSequence, 11)
-	}
-
-	if record.PstType != "CB" {
-		t.Errorf("PST-TYPE: got %q, want %q", record.PstType, "CB")
-	}
-
-	if record.PstCredit.PcrSource != "OOOO" {
-		t.Errorf("PST-CREDIT.PCR-SOURCE: got %q, want %q", record.PstCredit.PcrSource, "OOOO")
-	}
-
-	if record.PstCredit.PcrAmount != -19 {
-		t.Errorf("PST-CREDIT.PCR-AMOUNT: got %d, want %d", record.PstCredit.PcrAmount, -19)
-	}
-
-	if record.PstCredit.PcrReference != "YYYYYYYYYYYYYY" {
-		t.Errorf("PST-CREDIT.PCR-REFERENCE: got %q, want %q", record.PstCredit.PcrReference, "YYYYYYYYYYYYYY")
-	}
-
-	if record.PstTailRef.PtrBatch != 43 {
-		t.Errorf("PST-TAIL-REF.PTR-BATCH: got %d, want %d", record.PstTailRef.PtrBatch, 43)
-	}
-
-	if record.PstTailRef.PtrLine != 47 {
-		t.Errorf("PST-TAIL-REF.PTR-LINE: got %d, want %d", record.PstTailRef.PtrLine, 47)
-	}
-
-	var out bytes.Buffer
-
-	w, err := codec.NewWriter(&out, ledger.Encoding())
-	if err != nil {
-		t.Fatalf("codec.NewWriter: %v", err)
-	}
-
-	if err := record.MarshalCOBOL(w); err != nil {
-		t.Fatalf("MarshalCOBOL: %v", err)
-	}
-
-	if !bytes.Equal(out.Bytes(), in) {
-		t.Errorf("the record does not write back the bytes it was read from\n got: % x\nwant: % x", out.Bytes(), in)
-	}
-}
-
-// TestMemoPostingReadsBackTheBytesItWasReadFrom is POSTING-RECORD: the bytes
-// below, every field they decode into, and the same bytes written back.
-func TestMemoPostingReadsBackTheBytesItWasReadFrom(t *testing.T) {
-	t.Parallel()
-
-	in := []byte{
-		0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, // PST-ACCOUNT @0 X(10)
-		0xc1, 0xc1, //
-		0xf1, 0xf1, // PST-SEQUENCE @10 9(2)
-		0xd4, 0xc1, // PST-TYPE @12 X(2)
-		0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, // PST-BODY @14 X(28)
-		0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, //
-		0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, //
-		0xd6, 0xd6, 0xd6, 0xd6, //
-		0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, 0xd8, // PST-TAIL @42 X(8)
-	}
-
-	r, err := codec.NewReader(bytes.NewReader(in), ledger.Encoding())
-	if err != nil {
-		t.Fatalf("codec.NewReader: %v", err)
-	}
-
-	var record ledger.MemoPosting
-
-	if err := record.UnmarshalCOBOL(r); err != nil {
-		t.Fatalf("UnmarshalCOBOL: %v", err)
-	}
-
-	if record.PstAccount != "AAAAAAAAAA" {
-		t.Errorf("PST-ACCOUNT: got %q, want %q", record.PstAccount, "AAAAAAAAAA")
-	}
-
-	if record.PstSequence != 11 {
-		t.Errorf("PST-SEQUENCE: got %d, want %d", record.PstSequence, 11)
-	}
-
-	if record.PstType != "MA" {
-		t.Errorf("PST-TYPE: got %q, want %q", record.PstType, "MA")
-	}
-
-	if record.PstBody != "OOOOOOOOOOOOOOOOOOOOOOOOOOOO" {
-		t.Errorf("PST-BODY: got %q, want %q", record.PstBody, "OOOOOOOOOOOOOOOOOOOOOOOOOOOO")
-	}
-
-	if record.PstTail != "QQQQQQQQ" {
-		t.Errorf("PST-TAIL: got %q, want %q", record.PstTail, "QQQQQQQQ")
-	}
-
-	var out bytes.Buffer
-
-	w, err := codec.NewWriter(&out, ledger.Encoding())
-	if err != nil {
-		t.Fatalf("codec.NewWriter: %v", err)
-	}
-
-	if err := record.MarshalCOBOL(w); err != nil {
-		t.Fatalf("MarshalCOBOL: %v", err)
-	}
-
-	if !bytes.Equal(out.Bytes(), in) {
-		t.Errorf("the record does not write back the bytes it was read from\n got: % x\nwant: % x", out.Bytes(), in)
-	}
-}
-
-// TestMemoPostingRefReadsBackTheBytesItWasReadFrom is POSTING-RECORD: the
-// bytes below, every field they decode into, and the same bytes written back.
-func TestMemoPostingRefReadsBackTheBytesItWasReadFrom(t *testing.T) {
-	t.Parallel()
-
-	in := []byte{
-		0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, // PST-ACCOUNT @0 X(10)
-		0xc1, 0xc1, //
-		0xf1, 0xf1, // PST-SEQUENCE @10 9(2)
-		0xd4, 0xc2, // PST-TYPE @12 X(2)
-		0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, // PST-BODY @14 X(28)
-		0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, //
-		0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, 0xd6, //
-		0xd6, 0xd6, 0xd6, 0xd6, //
-		0xf0, 0xf0, 0xf4, 0xf3, // PST-TAIL-REF.PTR-BATCH @42 9(4)
-		0xf0, 0xf0, 0xf4, 0xf7, // PST-TAIL-REF.PTR-LINE @46 9(4)
-	}
-
-	r, err := codec.NewReader(bytes.NewReader(in), ledger.Encoding())
-	if err != nil {
-		t.Fatalf("codec.NewReader: %v", err)
-	}
-
-	var record ledger.MemoPostingRef
-
-	if err := record.UnmarshalCOBOL(r); err != nil {
-		t.Fatalf("UnmarshalCOBOL: %v", err)
-	}
-
-	if record.PstAccount != "AAAAAAAAAA" {
-		t.Errorf("PST-ACCOUNT: got %q, want %q", record.PstAccount, "AAAAAAAAAA")
-	}
-
-	if record.PstSequence != 11 {
-		t.Errorf("PST-SEQUENCE: got %d, want %d", record.PstSequence, 11)
-	}
-
-	if record.PstType != "MB" {
-		t.Errorf("PST-TYPE: got %q, want %q", record.PstType, "MB")
-	}
-
-	if record.PstBody != "OOOOOOOOOOOOOOOOOOOOOOOOOOOO" {
-		t.Errorf("PST-BODY: got %q, want %q", record.PstBody, "OOOOOOOOOOOOOOOOOOOOOOOOOOOO")
 	}
 
 	if record.PstTailRef.PtrBatch != 43 {

--- a/example/ledger/roundtrip_test.go
+++ b/example/ledger/roundtrip_test.go
@@ -118,9 +118,10 @@ func key(w *codec.Writer, account string, sequence int32, code string) error {
 	return w.WriteAlphanumeric(code, 2)
 }
 
-// debitBytes is one posting whose body is PST-DEBIT, with code selecting which
-// description of PST-TAIL goes behind it.
-func debitBytes(t *testing.T, enc codec.Encoding, code string, tail func(*codec.Writer) error) []byte {
+// debitBytes is one posting whose body is PST-DEBIT and whose tail is
+// PST-TAIL-REF, which is the only tail this layout names. code is a parameter
+// so that a caller can write one the layout does not describe.
+func debitBytes(t *testing.T, enc codec.Encoding, code string) []byte {
 	t.Helper()
 
 	return laidOut(t, enc, func(w *codec.Writer) error {
@@ -140,14 +141,14 @@ func debitBytes(t *testing.T, enc codec.Encoding, code string, tail func(*codec.
 			return err
 		}
 
-		return tail(w)
+		return refTail(w)
 	})
 }
 
 // creditBytes is one posting whose body is PST-CREDIT — four bytes shorter than
 // the run it redefines, so the four behind it are slack, and they are written
 // here as bytes no item of the record describes.
-func creditBytes(t *testing.T, enc codec.Encoding, code string, tail func(*codec.Writer) error) []byte {
+func creditBytes(t *testing.T, enc codec.Encoding, code string) []byte {
 	t.Helper()
 
 	return laidOut(t, enc, func(w *codec.Writer) error {
@@ -174,33 +175,13 @@ func creditBytes(t *testing.T, enc codec.Encoding, code string, tail func(*codec
 			return err
 		}
 
-		return tail(w)
+		return refTail(w)
 	})
 }
 
-// memoBytes is one posting described by the base PST-BODY.
-func memoBytes(t *testing.T, enc codec.Encoding, code string, tail func(*codec.Writer) error) []byte {
-	t.Helper()
-
-	return laidOut(t, enc, func(w *codec.Writer) error {
-		if err := key(w, "4001200000", 3, code); err != nil {
-			return err
-		}
-
-		if err := w.WriteAlphanumeric("MEMO ONLY, NO POSTING", 28); err != nil {
-			return err
-		}
-
-		return tail(w)
-	})
-}
-
-// plainTail is PST-TAIL, the base description of the second redefined run.
-func plainTail(w *codec.Writer) error {
-	return w.WriteAlphanumeric("TAIL0001", 8)
-}
-
-// refTail is PST-TAIL-REF, the other one.
+// refTail is PST-TAIL-REF, the description of the second redefined run this
+// extract carries. PST-TAIL itself is the base description that gives it its
+// storage, and no record of this layout is described by it.
 func refTail(w *codec.Writer) error {
 	if err := w.WriteZonedInt32(7, 4, codec.SignUnsigned); err != nil {
 		return err
@@ -209,8 +190,12 @@ func refTail(w *codec.Writer) error {
 	return w.WriteZonedInt32(42, 4, codec.SignUnsigned)
 }
 
-// fileBytes is a whole ledger extract: the header, one posting of every one of
-// the six record types the two redefined runs multiply out to, and the trailer.
+// fileBytes is a whole ledger extract: the header, one posting of each of the
+// two record types this layout names, and the trailer.
+//
+// Two rather than the six `posting.cpy` admits, because the other four are
+// described by PST-BODY or PST-TAIL — the base descriptions of the two
+// redefined runs — and an extract a mainframe produced does not carry them.
 func fileBytes(t *testing.T) []byte {
 	t.Helper()
 
@@ -219,14 +204,10 @@ func fileBytes(t *testing.T) []byte {
 	var b bytes.Buffer
 
 	for _, raw := range [][]byte{
-		headerBytes(t, enc, 6),
-		debitBytes(t, enc, "DA", plainTail),
-		debitBytes(t, enc, "DB", refTail),
-		creditBytes(t, enc, "CA", plainTail),
-		creditBytes(t, enc, "CB", refTail),
-		memoBytes(t, enc, "MA", plainTail),
-		memoBytes(t, enc, "MB", refTail),
-		trailerBytes(t, enc, 6),
+		headerBytes(t, enc, 2),
+		debitBytes(t, enc, "DR"),
+		creditBytes(t, enc, "CR"),
+		trailerBytes(t, enc, 2),
 	} {
 		b.Write(framed(raw))
 	}
@@ -292,16 +273,8 @@ func recordType(v any) string {
 		return "LedgerTrailer"
 	case *DebitPosting:
 		return "DebitPosting"
-	case *DebitPostingRef:
-		return "DebitPostingRef"
 	case *CreditPosting:
 		return "CreditPosting"
-	case *CreditPostingRef:
-		return "CreditPostingRef"
-	case *MemoPosting:
-		return "MemoPosting"
-	case *MemoPostingRef:
-		return "MemoPostingRef"
 	default:
 		return "something else"
 	}
@@ -321,18 +294,17 @@ func TestAMultiRecordFileReadsBackAsTheFileItWas(t *testing.T) {
 	want := fileBytes(t)
 
 	records := read(t, Encoding(), want)
-	if len(records) != 8 {
-		t.Fatalf("the file holds eight records and the reader produced %d", len(records))
+	if len(records) != 4 {
+		t.Fatalf("the file holds four records and the reader produced %d", len(records))
 	}
 
-	// Every one of the six record types the two redefined runs multiply out
-	// to, between the header and the trailer, and each one selected by the
-	// type code twelve bytes into the record rather than by its position.
+	// Both of the record types this layout names, between the header and the
+	// trailer, and each one selected by the type code twelve bytes into the
+	// record rather than by its position.
 	for i, kind := range []any{
 		(*LedgerHeader)(nil),
-		(*DebitPosting)(nil), (*DebitPostingRef)(nil),
-		(*CreditPosting)(nil), (*CreditPostingRef)(nil),
-		(*MemoPosting)(nil), (*MemoPostingRef)(nil),
+		(*DebitPosting)(nil),
+		(*CreditPosting)(nil),
 		(*LedgerTrailer)(nil),
 	} {
 		if got, want := recordType(records[i]), recordType(kind); got != want {
@@ -354,13 +326,13 @@ func TestTheBytesACreditPostingDoesNotDescribeSurviveARead(t *testing.T) {
 	t.Parallel()
 
 	records := read(t, Encoding(), fileBytes(t))
-	if len(records) != 8 {
-		t.Fatalf("the file holds eight records and the reader produced %d", len(records))
+	if len(records) != 4 {
+		t.Fatalf("the file holds four records and the reader produced %d", len(records))
 	}
 
-	credit, ok := records[3].(*CreditPosting)
+	credit, ok := records[2].(*CreditPosting)
 	if !ok {
-		t.Fatalf("record 4 is a %s, want a CreditPosting", recordType(records[3]))
+		t.Fatalf("record 3 is a %s, want a CreditPosting", recordType(records[2]))
 	}
 
 	// The run is retained rather than merely declared. The field is an array
@@ -395,7 +367,7 @@ func TestAFileHoldingFewerPostingsThanItsHeaderCountsIsTruncated(t *testing.T) {
 	b.Write(framed(headerBytes(t, enc, 6)))
 
 	for range 5 {
-		b.Write(framed(debitBytes(t, enc, "DA", plainTail)))
+		b.Write(framed(debitBytes(t, enc, "DR")))
 	}
 
 	r, err := NewReader(bytes.NewReader(b.Bytes()), enc)
@@ -447,13 +419,16 @@ func TestAWriterClosedAPostingShortOfTheCountIsReported(t *testing.T) {
 		t.Fatalf("Write: %v", err)
 	}
 
-	posting := &MemoPosting{
+	posting := &DebitPosting{
 		PstAccount:  "4001200000",
 		PstSequence: 1,
-		PstType:     "MA",
-		PstBody:     "MEMO ONLY, NO POSTING",
-		PstTail:     "TAIL0001",
+		PstType:     "DR",
 	}
+	posting.PstDebit.PdbCostCentre = "CC1000"
+	posting.PstDebit.PdbAmount = 1234567
+	posting.PstDebit.PdbMemo = "OFFICE SUPPLIES"
+	posting.PstTailRef.PtrBatch = 7
+	posting.PstTailRef.PtrLine = 42
 
 	if err := w.Write(posting); err != nil {
 		t.Fatalf("Write: %v", err)
@@ -470,9 +445,9 @@ func TestAWriterClosedAPostingShortOfTheCountIsReported(t *testing.T) {
 }
 
 // TestARecordMatchingNoAlternativeIsReportedAgainstItsOrdinal is the negative
-// half. Six type codes select six record types and a seventh selects none, and
-// a reader that admitted one anyway would decode a run of bytes as whichever
-// record type happened to be first.
+// half. Two type codes select the two record types this layout names and a
+// third selects none, and a reader that admitted one anyway would decode a run
+// of bytes as whichever record type happened to be first.
 //
 // The ordinal is the assertion. A file is read one record at a time and nothing
 // else in the report says where in the file the trouble is, so a diagnostic
@@ -487,8 +462,8 @@ func TestARecordMatchingNoAlternativeIsReportedAgainstItsOrdinal(t *testing.T) {
 	// The header, one posting the layout describes, and then one carrying a
 	// type code no `discriminate` form in the layout names.
 	b.Write(framed(headerBytes(t, enc, 6)))
-	b.Write(framed(debitBytes(t, enc, "DA", plainTail)))
-	b.Write(framed(debitBytes(t, enc, "ZZ", plainTail)))
+	b.Write(framed(debitBytes(t, enc, "DR")))
+	b.Write(framed(debitBytes(t, enc, "ZZ")))
 
 	r, err := NewReader(bytes.NewReader(b.Bytes()), enc)
 	if err != nil {

--- a/example/parquet/README.md
+++ b/example/parquet/README.md
@@ -119,29 +119,46 @@ diagnostics and does not export it — but it is a *diagnostic* and never a colu
 `TestAMappingErrorFailsTheConversion` asserts the failure says which record it
 was.
 
-### The six postings: one table
+### The postings: one table
 
-The copybook's three `REDEFINES` over two independent runs resolve to **six**
-record types out of one `01`-level, and `PST-TYPE` discriminates all six. They
-are written as **one** table, with one nullable column per alternative of each
-run:
+The copybook's three `REDEFINES` over two independent runs admit **six** record
+types out of one `01`-level. [`ledger.sexpr`](../ledger.sexpr) names **two** of
+them, and that is the first thing to notice here: the schema is a function of the
+*layout*, not of the copybook. The four it leaves out are the ones described by
+`PST-BODY` or `PST-TAIL` — the base descriptions the two `REDEFINES` runs exist
+to give storage to, which a file a mainframe produced does not carry.
+
+`PST-TYPE` discriminates the two, and they are written as **one** table, with one
+nullable column per description of each run the layout actually names:
 
 ```
-pst_body   pst_debit   pst_credit      the first run, PST-BODY, described three ways
-pst_tail   pst_tail_ref                the second run, PST-TAIL, described two ways
+pst_debit   pst_credit      the first run, PST-BODY, described two ways here
+pst_tail_ref                the second run, PST-TAIL, described one way here
 ```
 
-Exactly one of the first three and one of the last two is present on any row, so
-the record type is recoverable from a row without consulting anything else —
-which `TestTheMergedTableKeepsTheRecordTypeRecoverable` asserts for all six.
+Two consequences, and both of them are decisions:
 
-The alternative is **six narrow tables**, one per record type. It is a real
-option and it is better for some consumers: a debit's amount and a credit's
-amount are genuinely different columns, and a reader who only wants debits gets a
-table with nothing nullable in it. Six tables cost you the ability to ask "every
-posting on this account" without a six-way union, and they multiply by the number
-of independent redefined runs rather than adding — this layout would be six
-tables, and a layout with three runs of three would be twenty-seven.
+- Exactly one of `pst_debit` and `pst_credit` is present on any row, so the
+  record type is recoverable from a row without consulting anything else —
+  `TestTheMergedTableKeepsTheRecordTypeRecoverable`.
+- `pst_tail_ref` is **required**, not optional. One description of a run in play
+  is not a choice a row is making, and an optional column that is null on no row
+  of any extract is one every query null-checks for nothing.
+  `TestTheOnlyDescriptionOfATailIsARequiredColumn` asserts both that and the
+  absence of a `pst_body` or `pst_tail` column.
+
+Narrow the layout differently and this schema is different, which is the point.
+Had the extract carried all six, the first run would be three nullable columns
+and the second two.
+
+The alternative is **narrow tables**, one per record type. It is a real option
+and it is better for some consumers: a debit's amount and a credit's amount are
+genuinely different columns, and a reader who only wants debits gets a table with
+nothing nullable in it. Narrow tables cost you the ability to ask "every posting
+on this account" without a union, and they multiply by the number of independent
+redefined runs rather than adding — this layout would be two tables, one naming
+all six combinations would be six, and a layout with three runs of three would be
+twenty-seven.
 
 ### Nested, not flattened
 

--- a/example/parquet/convert.go
+++ b/example/parquet/convert.go
@@ -70,9 +70,17 @@ type extractRow struct {
 //
 // The header's identifying fields are denormalized onto every row and the
 // trailer's are not; README.md says why in terms of what SUM does to each. The
-// six record types the copybook's REDEFINES resolve to are one table rather than
-// six, and the two independent runs each become one optional column per
-// alternative — which is what keeps the record type recoverable from a row.
+// record types the layout names are one table rather than one each, and a run
+// the layout names more than one description of becomes one optional column per
+// description — which is what keeps the record type recoverable from a row.
+//
+// The shape of this struct is a function of the **layout** and not of the
+// copybook. `posting.cpy` admits six combinations; `ledger.sexpr` names the two
+// the extract carries, and the four it leaves out are the ones described by
+// PST-BODY or PST-TAIL — the base descriptions of the two redefined runs, which
+// a file a mainframe produced does not hold. So there is no `pst_body` and no
+// `pst_tail` column: a column for a description no record of this file is ever
+// described by would be null on every row of every extract.
 type postingRow struct {
 	HdrLedgerID string `parquet:"hdr_ledger_id"`
 	HdrPeriod   int32  `parquet:"hdr_period"`
@@ -82,17 +90,18 @@ type postingRow struct {
 	PstSequence int32  `parquet:"pst_sequence"`
 	PstType     string `parquet:"pst_type"`
 
-	// The first redefined run, PST-BODY, described three ways. Exactly one of
-	// these three is present on any row, and which one is a function of
-	// pst_type.
-	PstBody   *string     `parquet:"pst_body"`
+	// The first redefined run, PST-BODY. The layout names two of its three
+	// descriptions, so exactly one of these two is present on any row and
+	// which one is a function of pst_type.
 	PstDebit  *debitBody  `parquet:"pst_debit"`
 	PstCredit *creditBody `parquet:"pst_credit"`
 
-	// The second run, PST-TAIL, described two ways. Independent of the first,
-	// which is why six record types and not three come out of one 01-level.
-	PstTail    *string  `parquet:"pst_tail"`
-	PstTailRef *tailRef `parquet:"pst_tail_ref"`
+	// The second run, PST-TAIL. The layout names one description of it —
+	// PST-TAIL-REF — so every posting carries it and the column is required
+	// rather than optional. An optional column here would be one a query has
+	// to null-check on a file where it is never null, and its record type
+	// would look like something a row was still choosing between.
+	PstTailRef tailRef `parquet:"pst_tail_ref"`
 }
 
 // debitBody is PST-DEBIT, nested rather than flattened.
@@ -403,14 +412,14 @@ func extractRowOf(hdr *ledger.LedgerHeader, trl *ledger.LedgerTrailer) extractRo
 
 // postingRowOf is the row one posting contributes, under the header in force.
 //
-// An item present in one alternative and absent in the others becomes an
-// optional column, and `new(expr)` is what points at one: it allocates and
-// copies, so the row does not alias a record the reader is free to reuse behind
-// it — a batch is held until it is flushed, which is up to sixty-four records
-// later.
+// An item present in one alternative and absent in the other becomes an
+// optional column, and taking the address of a fresh composite literal is what
+// points at one: it allocates and copies, so the row does not alias a record the
+// reader is free to reuse behind it — a batch is held until it is flushed, which
+// is up to sixty-four records later.
 //
-// A record that is not one of this file's six posting types is an error and
-// never a row. The six are what the layout's `(alt …)` lists, and a seventh
+// A record that is not one of this file's two posting types is an error and
+// never a row. The two are what the layout's `(alt …)` lists, and a third
 // arriving here means the layout and this conversion have gone out of step —
 // which is a thing to report, not to write a zero row for.
 func postingRowOf(hdr *ledger.LedgerHeader, rec ledger.Record) (postingRow, error) {
@@ -424,29 +433,13 @@ func postingRowOf(hdr *ledger.LedgerHeader, rec ledger.Record) (postingRow, erro
 	case *ledger.DebitPosting:
 		row.PstAccount, row.PstSequence, row.PstType = v.PstAccount, v.PstSequence, v.PstType
 		row.PstDebit = &debitBody{v.PstDebit.PdbCostCentre, v.PstDebit.PdbAmount, v.PstDebit.PdbMemo}
-		row.PstTail = new(v.PstTail)
-	case *ledger.DebitPostingRef:
-		row.PstAccount, row.PstSequence, row.PstType = v.PstAccount, v.PstSequence, v.PstType
-		row.PstDebit = &debitBody{v.PstDebit.PdbCostCentre, v.PstDebit.PdbAmount, v.PstDebit.PdbMemo}
-		row.PstTailRef = &tailRef{v.PstTailRef.PtrBatch, v.PstTailRef.PtrLine}
+		row.PstTailRef = tailRef{v.PstTailRef.PtrBatch, v.PstTailRef.PtrLine}
 	case *ledger.CreditPosting:
 		row.PstAccount, row.PstSequence, row.PstType = v.PstAccount, v.PstSequence, v.PstType
 		row.PstCredit = &creditBody{v.PstCredit.PcrSource, v.PstCredit.PcrAmount, v.PstCredit.PcrReference}
-		row.PstTail = new(v.PstTail)
-	case *ledger.CreditPostingRef:
-		row.PstAccount, row.PstSequence, row.PstType = v.PstAccount, v.PstSequence, v.PstType
-		row.PstCredit = &creditBody{v.PstCredit.PcrSource, v.PstCredit.PcrAmount, v.PstCredit.PcrReference}
-		row.PstTailRef = &tailRef{v.PstTailRef.PtrBatch, v.PstTailRef.PtrLine}
-	case *ledger.MemoPosting:
-		row.PstAccount, row.PstSequence, row.PstType = v.PstAccount, v.PstSequence, v.PstType
-		row.PstBody = new(v.PstBody)
-		row.PstTail = new(v.PstTail)
-	case *ledger.MemoPostingRef:
-		row.PstAccount, row.PstSequence, row.PstType = v.PstAccount, v.PstSequence, v.PstType
-		row.PstBody = new(v.PstBody)
-		row.PstTailRef = &tailRef{v.PstTailRef.PtrBatch, v.PstTailRef.PtrLine}
+		row.PstTailRef = tailRef{v.PstTailRef.PtrBatch, v.PstTailRef.PtrLine}
 	default:
-		return postingRow{}, fmt.Errorf("this file's postings are DEBIT-POSTING, DEBIT-POSTING-REF, CREDIT-POSTING, CREDIT-POSTING-REF, MEMO-POSTING and MEMO-POSTING-REF, and a %T is none of them", rec)
+		return postingRow{}, fmt.Errorf("this file's postings are DEBIT-POSTING and CREDIT-POSTING, and a %T is neither of them", rec)
 	}
 
 	return row, nil

--- a/example/parquet/convert_test.go
+++ b/example/parquet/convert_test.go
@@ -26,12 +26,14 @@ import (
 	"github.com/parquet-go/parquet-go/format"
 )
 
-// postingsPerType is how many of the six posting types the fixtures cycle
-// through, which is all of them.
-const postingsPerType = 6
+// postingTypes is how many posting record types the fixtures cycle through,
+// which is all of them: `ledger.sexpr` names two of the six combinations
+// `posting.cpy` admits, and the four it leaves out are described by PST-BODY or
+// PST-TAIL — the base descriptions a mainframe-produced extract does not carry.
+const postingTypes = 2
 
-// ledgerBytes is a well-formed ledger extract of n postings, cycling through all
-// six of the record types this layout resolves out of one 01-level.
+// ledgerBytes is a well-formed ledger extract of n postings, cycling through
+// both of the record types this layout names.
 //
 // trlCount is stated apart from n so that a file whose trailer disagrees with
 // its own rows can be built: nothing in the layout ties TRL-COUNT to the
@@ -91,64 +93,30 @@ const (
 	creditAmount = int64(-98765432109)
 )
 
-// posting is the i'th posting of a fixture, of the i'th of the six record types.
+// posting is the i'th posting of a fixture, of the i'th of the two record types.
 func posting(i int32) ledger.Record {
 	account := fmt.Sprintf("ACCT%06d", i)
 	sequence := i % 100
 
-	switch i % postingsPerType {
-	case 0:
-		p := &ledger.DebitPosting{PstAccount: account, PstSequence: sequence, PstType: "DA", PstTail: "TAIL0001"}
+	if i%postingTypes == 0 {
+		p := &ledger.DebitPosting{PstAccount: account, PstSequence: sequence, PstType: "DR"}
 		p.PstDebit.PdbCostCentre = "CC0001"
 		p.PstDebit.PdbAmount = debitAmount
 		p.PstDebit.PdbMemo = "DEBIT MEMO ABCD"
-
-		return p
-	case 1:
-		p := &ledger.DebitPostingRef{PstAccount: account, PstSequence: sequence, PstType: "DB"}
-		p.PstDebit.PdbCostCentre = "CC0002"
-		p.PstDebit.PdbAmount = debitAmount
-		p.PstDebit.PdbMemo = "DEBIT MEMO EFGH"
 		p.PstTailRef.PtrBatch = 4321
 		p.PstTailRef.PtrLine = 8765
 
 		return p
-	case 2:
-		p := &ledger.CreditPosting{PstAccount: account, PstSequence: sequence, PstType: "CA", PstTail: "TAIL0002"}
-		p.PstCredit.PcrSource = "SRC1"
-		p.PstCredit.PcrAmount = creditAmount
-		p.PstCredit.PcrReference = "CREDIT REF ABC"
-
-		return p
-	case 3:
-		p := &ledger.CreditPostingRef{PstAccount: account, PstSequence: sequence, PstType: "CB"}
-		p.PstCredit.PcrSource = "SRC2"
-		p.PstCredit.PcrAmount = creditAmount
-		p.PstCredit.PcrReference = "CREDIT REF DEF"
-		p.PstTailRef.PtrBatch = 1234
-		p.PstTailRef.PtrLine = 5678
-
-		return p
-	case 4:
-		return &ledger.MemoPosting{
-			PstAccount:  account,
-			PstSequence: sequence,
-			PstType:     "MA",
-			PstBody:     "MEMO BODY TWENTY EIGHT BYTES",
-			PstTail:     "TAIL0003",
-		}
-	default:
-		p := &ledger.MemoPostingRef{
-			PstAccount:  account,
-			PstSequence: sequence,
-			PstType:     "MB",
-			PstBody:     "MEMO BODY TWENTY EIGHT BYTES",
-		}
-		p.PstTailRef.PtrBatch = 2468
-		p.PstTailRef.PtrLine = 1357
-
-		return p
 	}
+
+	p := &ledger.CreditPosting{PstAccount: account, PstSequence: sequence, PstType: "CR"}
+	p.PstCredit.PcrSource = "SRC2"
+	p.PstCredit.PcrAmount = creditAmount
+	p.PstCredit.PcrReference = "CREDIT REF DEF"
+	p.PstTailRef.PtrBatch = 1234
+	p.PstTailRef.PtrLine = 5678
+
+	return p
 }
 
 // converted runs the conversion over a ledger extract of n postings whose
@@ -210,7 +178,7 @@ func rowsOf[T any](t *testing.T, b []byte) []T {
 // TestTheTwoGrainsBecomeTwoFiles is the first thing an adopter meets: a Parquet
 // file carries exactly one schema, and this extract has two grains.
 func TestTheTwoGrainsBecomeTwoFiles(t *testing.T) {
-	extract, posting, err := converted(t, postingsPerType, postingsPerType)
+	extract, posting, err := converted(t, postingTypes, postingTypes)
 	if err != nil {
 		t.Fatalf("convert: %v", err)
 	}
@@ -224,8 +192,8 @@ func TestTheTwoGrainsBecomeTwoFiles(t *testing.T) {
 		HdrLedgerID: "GL-MAIN",
 		HdrPeriod:   202601,
 		HdrCurrency: "USD",
-		HdrCount:    postingsPerType,
-		TrlCount:    postingsPerType,
+		HdrCount:    postingTypes,
+		TrlCount:    postingTypes,
 		TrlNet:      trailerNet,
 	}
 	if extracts[0] != want {
@@ -233,15 +201,15 @@ func TestTheTwoGrainsBecomeTwoFiles(t *testing.T) {
 	}
 
 	postings := rowsOf[postingRow](t, posting)
-	if len(postings) != postingsPerType {
-		t.Fatalf("the posting table holds %d rows, want %d: its grain is the posting", len(postings), postingsPerType)
+	if len(postings) != postingTypes {
+		t.Fatalf("the posting table holds %d rows, want %d: its grain is the posting", len(postings), postingTypes)
 	}
 }
 
 // TestHeaderContextIsDenormalizedOntoEveryPosting is the decision that makes the
 // posting table usable on its own.
 func TestHeaderContextIsDenormalizedOntoEveryPosting(t *testing.T) {
-	_, posting, err := converted(t, postingsPerType, postingsPerType)
+	_, posting, err := converted(t, postingTypes, postingTypes)
 	if err != nil {
 		t.Fatalf("convert: %v", err)
 	}
@@ -259,7 +227,7 @@ func TestHeaderContextIsDenormalizedOntoEveryPosting(t *testing.T) {
 // summaries *of* the posting rows, so denormalizing them would make
 // SUM(trl_net) return the total times the row count.
 func TestTrailerFieldsDoNotPromote(t *testing.T) {
-	_, posting, err := converted(t, postingsPerType, postingsPerType)
+	_, posting, err := converted(t, postingTypes, postingTypes)
 	if err != nil {
 		t.Fatalf("convert: %v", err)
 	}
@@ -277,10 +245,11 @@ func TestTrailerFieldsDoNotPromote(t *testing.T) {
 }
 
 // TestTheMergedTableKeepsTheRecordTypeRecoverable is the merged-versus-narrow
-// decision, asserted rather than described: six record types share one table, so
-// PST-TYPE and the group that is present have to name which of the six a row was.
+// decision, asserted rather than described: both record types share one table,
+// so PST-TYPE and the group that is present have to name which of the two a row
+// was.
 func TestTheMergedTableKeepsTheRecordTypeRecoverable(t *testing.T) {
-	_, posting, err := converted(t, postingsPerType, postingsPerType)
+	_, posting, err := converted(t, postingTypes, postingTypes)
 	if err != nil {
 		t.Fatalf("convert: %v", err)
 	}
@@ -293,54 +262,83 @@ func TestTheMergedTableKeepsTheRecordTypeRecoverable(t *testing.T) {
 	cases := []struct {
 		pstType string
 		body    string
-		tail    string
 	}{
-		{"DA", "pst_debit", "pst_tail"},
-		{"DB", "pst_debit", "pst_tail_ref"},
-		{"CA", "pst_credit", "pst_tail"},
-		{"CB", "pst_credit", "pst_tail_ref"},
-		{"MA", "pst_body", "pst_tail"},
-		{"MB", "pst_body", "pst_tail_ref"},
+		{"DR", "pst_debit"},
+		{"CR", "pst_credit"},
 	}
 
 	for _, c := range cases {
 		row, ok := byType[c.pstType]
 		if !ok {
-			t.Errorf("no row carries PST-TYPE %q, and the six record types are what the layout's (alt …) lists", c.pstType)
+			t.Errorf("no row carries PST-TYPE %q, and the two record types are what the layout's (alt …) lists", c.pstType)
 
 			continue
 		}
 
-		if got := present(row); got != c.body+"+"+c.tail {
-			t.Errorf("PST-TYPE %q arrived as %s, want %s+%s: the two redefined runs are independent, so the alternatives multiply", c.pstType, got, c.body, c.tail)
+		if got := present(row); got != c.body {
+			t.Errorf("PST-TYPE %q arrived as %s, want %s: the description of PST-BODY a row carries is what says which record type it was", c.pstType, got, c.body)
 		}
 	}
 }
 
-// present names the alternative of each of the two redefined runs that a row
-// carries, which is exactly what recovers its record type.
+// present names the description of PST-BODY that a row carries, which is
+// exactly what recovers its record type.
+//
+// There is no second term. PST-TAIL is described one way in this layout, so
+// every row carries pst_tail_ref and it distinguishes nothing —
+// [TestTheOnlyDescriptionOfATailIsARequiredColumn] is where that is asserted.
 func present(row postingRow) string {
-	body := "none"
-
 	switch {
-	case row.PstBody != nil:
-		body = "pst_body"
 	case row.PstDebit != nil:
-		body = "pst_debit"
+		return "pst_debit"
 	case row.PstCredit != nil:
-		body = "pst_credit"
+		return "pst_credit"
+	default:
+		return "none"
+	}
+}
+
+// TestTheOnlyDescriptionOfATailIsARequiredColumn is the half of the merged table
+// that the layout's narrowing changes.
+//
+// PST-TAIL is a redefined run of two descriptions in `posting.cpy` and of *one*
+// in `ledger.sexpr`: every posting this extract carries is described by
+// PST-TAIL-REF. A run with one description in play is not a choice a row is
+// making, so the column is required — an optional one would be null on no row
+// ever, and a reader would have to null-check it to find that out.
+//
+// And the descriptions the layout does not name carry no column at all. A
+// column that is null on every row of every extract is one a query has to know
+// to ignore.
+func TestTheOnlyDescriptionOfATailIsARequiredColumn(t *testing.T) {
+	_, posting, err := converted(t, postingTypes, postingTypes)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
 	}
 
-	tail := "none"
-
-	switch {
-	case row.PstTail != nil:
-		tail = "pst_tail"
-	case row.PstTailRef != nil:
-		tail = "pst_tail_ref"
+	f, err := parquet.OpenFile(bytes.NewReader(posting), int64(len(posting)))
+	if err != nil {
+		t.Fatalf("opening the posting table: %v", err)
 	}
 
-	return body + "+" + tail
+	tail := parquet.Node(nil)
+
+	for _, field := range f.Schema().Fields() {
+		switch field.Name() {
+		case "pst_body", "pst_tail":
+			t.Errorf("the posting table carries a %q column, and no record this layout names is described by it: it would be null on every row of every extract", field.Name())
+		case "pst_tail_ref":
+			tail = field
+		}
+	}
+
+	if tail == nil {
+		t.Fatal("the posting table carries no pst_tail_ref column, and every posting this layout names is described by PST-TAIL-REF")
+	}
+
+	if tail.Optional() {
+		t.Error("pst_tail_ref is optional, and the layout names one description of PST-TAIL: a column that is null on no row is one every query null-checks for nothing")
+	}
 }
 
 // TestEveryPostingReadIsAPostingWritten is the terminal flush, and it is run
@@ -393,7 +391,7 @@ func TestEveryPostingReadIsAPostingWritten(t *testing.T) {
 // Reading the written file back and comparing against what the ledger reader
 // produced is what makes that a fact rather than a plausible sentence.
 func TestTheThreeAmountsRoundTripThroughDecimal(t *testing.T) {
-	extract, posting, err := converted(t, postingsPerType, postingsPerType)
+	extract, posting, err := converted(t, postingTypes, postingTypes)
 	if err != nil {
 		t.Fatalf("convert: %v", err)
 	}
@@ -480,9 +478,9 @@ func assertDecimal(t *testing.T, file []byte, path string, precision, scale int3
 // TestTheTrailerCountIsReconciled is the check a conversion that streams can
 // still make, and it runs before either footer is written.
 func TestTheTrailerCountIsReconciled(t *testing.T) {
-	extract, posting, err := converted(t, postingsPerType, postingsPerType+1)
+	extract, posting, err := converted(t, postingTypes, postingTypes+1)
 	if err == nil {
-		t.Fatalf("a file whose TRL-COUNT is %d and whose body holds %d postings converted without complaint", postingsPerType+1, postingsPerType)
+		t.Fatalf("a file whose TRL-COUNT is %d and whose body holds %d postings converted without complaint", postingTypes+1, postingTypes)
 	}
 
 	if !strings.Contains(err.Error(), "TRL-COUNT") {
@@ -534,7 +532,7 @@ func TestAMappingErrorFailsTheConversion(t *testing.T) {
 
 	err := convert(src, &extract, &posting)
 	if err == nil {
-		t.Fatal("a record none of the six posting types describes converted without complaint")
+		t.Fatal("a record neither of the two posting types describes converted without complaint")
 	}
 
 	if !strings.Contains(err.Error(), "record 2") {

--- a/internal/scaffold/derive_test.go
+++ b/internal/scaffold/derive_test.go
@@ -468,6 +468,32 @@ func TestEveryFaultIsReportedRatherThanTheFirst(t *testing.T) {
 	}
 }
 
+// exampleCrossProduct is every combination `example/posting.cpy` admits, sorted:
+// PST-BODY described three ways crossed with PST-TAIL described two, which is
+// the six record types docs/cli/SPEC.md's `init` arithmetic counts.
+//
+// Written down rather than derived a second way. The point of pinning it is that
+// a derivation which lost or duplicated a combination is caught, and a `want`
+// computed by the code under test would agree with such a change.
+var exampleCrossProduct = []string{
+	"PST-BODY+PST-TAIL",
+	"PST-BODY+PST-TAIL-REF",
+	"PST-CREDIT+PST-TAIL",
+	"PST-CREDIT+PST-TAIL-REF",
+	"PST-DEBIT+PST-TAIL",
+	"PST-DEBIT+PST-TAIL-REF",
+}
+
+// exampleBaseDescriptions are the two items in `example/posting.cpy` that a
+// REDEFINES is written *over*: PST-BODY, which PST-DEBIT and PST-CREDIT redefine,
+// and PST-TAIL, which PST-TAIL-REF does.
+//
+// They are ordinary COBOL declarations and `init` derives combinations naming
+// them, correctly — a copybook cannot say which of its descriptions a file
+// carries. What a mainframe-produced file holds is the redefinitions, which is
+// why the worked example's layout names neither of these.
+var exampleBaseDescriptions = []string{"PST-BODY", "PST-TAIL"}
+
 // The measure docs/cli/SPEC.md sets: `example/posting.cpy` is six record types
 // over one 01-level with twelve `alternative` children, and every one of them is
 // recoverable from the copybook alone.
@@ -475,11 +501,17 @@ func TestEveryFaultIsReportedRatherThanTheFirst(t *testing.T) {
 // The worked example's layout names **two** of those six — the two whose every
 // alternative is a REDEFINES rather than a base description, which are the two a
 // mainframe-produced extract carries. So the two sides are not equal and must not
-// be asserted to be: what holds is that the derivation is the whole cross product
-// and that everything the layout names is in it. A layout combination the scaffold
-// did not derive would be a combination `init` cannot offer, which is the failure
-// this test is for; a derived combination the layout does not name is the adopter
-// having chosen, which is what a layout is for.
+// be asserted to be. What is asserted instead is both halves of that, and neither
+// is weaker than the equality this replaced:
+//
+//   - the derivation is exactly [exampleCrossProduct], so a combination lost,
+//     duplicated or renamed is still caught — it used to be caught by the layout
+//     enumerating all six, and pinning the list is what carries that over;
+//   - every combination the layout names is one the derivation offers. A layout
+//     combination the scaffold did not derive is a combination `init` cannot
+//     offer, which is the failure this test is for; a derived combination the
+//     layout does not name is the adopter having chosen, which is what a layout
+//     is for.
 //
 // What the layout also has that the scaffold does not is the names — a reading of
 // what the file means — and the forms the scaffold leaves commented.
@@ -494,35 +526,6 @@ func TestTheWorkedExampleDerivesLedgersRecordsAndAlternatives(t *testing.T) {
 	// The path as `example/ledger.sexpr` spells it, which is what makes the
 	// two comparable.
 	derived := deriveOf(t, book("posting.cpy", string(source)))
-
-	file, err := layout.ParseFile(filepath.Join("..", "..", "example", "ledger.sexpr"))
-	if err != nil {
-		t.Fatalf("parsing the worked example's layout: %v", err)
-	}
-
-	written, err := layoutmodel.ReadRecords(file)
-	if err != nil {
-		t.Fatalf("reading the worked example's records: %v", err)
-	}
-
-	var want []string
-
-	for _, record := range written {
-		if record.Path != "posting.cpy" {
-			continue
-		}
-
-		chosen := make([]string, 0, len(record.Alternatives))
-		for _, alternative := range record.Alternatives {
-			// The whole containment path rather than the leaf name. A
-			// reference into the wrong group has the same leaf, so comparing
-			// leaves would let this test pass over a scaffold naming bytes
-			// nobody meant.
-			chosen = append(chosen, strings.Join(alternative.Path, " "))
-		}
-
-		want = append(want, strings.Join(chosen, "+"))
-	}
 
 	var got []string
 
@@ -539,22 +542,87 @@ func TestTheWorkedExampleDerivesLedgersRecordsAndAlternatives(t *testing.T) {
 		got = append(got, strings.Join(chosen, "+"))
 	}
 
-	if len(got) != 6 {
-		t.Fatalf("derived %d record types from posting.cpy, want the six the two independent runs multiply out to", len(got))
+	// Compared as a set. Which combination is written first is the derivation's
+	// own order and is not a statement about the copybook; which alternatives
+	// are chosen is.
+	slices.Sort(got)
+
+	if !slices.Equal(got, exampleCrossProduct) {
+		t.Fatalf("derived the combinations\n%v\nand posting.cpy admits\n%v", got, exampleCrossProduct)
 	}
+
+	want := workedExampleCombinations(t)
 
 	if len(want) != 2 {
 		t.Fatalf("the layout names %d combinations of posting.cpy, want the two whose alternatives are all REDEFINES", len(want))
 	}
 
-	// Compared as sets. Which combination is written first is the layout
-	// author's and the derivation's own order, and neither is a statement
-	// about the copybook; which alternatives are chosen is.
-	slices.Sort(got)
-
 	for _, combination := range want {
 		if !slices.Contains(got, combination) {
-			t.Errorf("the layout names the combination\n%s\nand the scaffold derived only\n%v", combination, got)
+			t.Errorf("the layout names the combination\n%s\nwhich the scaffold does not derive; it derives\n%v", combination, got)
 		}
 	}
+}
+
+// TestTheWorkedExampleLayoutNamesNoBaseDescription is the property the worked
+// example exists to demonstrate, asserted rather than reviewed by eye.
+//
+// A base description is the declaration a REDEFINES is written over. It is real
+// COBOL and `init` scaffolds combinations naming it, but a file a mainframe
+// produced carries the redefinitions and never the declaration underneath them —
+// so a layout that names one describes bytes no extract holds.
+//
+// Without this, a combination naming PST-BODY or PST-TAIL could be added back to
+// `example/ledger.sexpr` and every other test in this repository would still
+// pass: the derivation offers all six, `resolve` raises no diagnostic on the
+// four, and the generated tree would simply regenerate around it.
+func TestTheWorkedExampleLayoutNamesNoBaseDescription(t *testing.T) {
+	t.Parallel()
+
+	for _, combination := range workedExampleCombinations(t) {
+		for chosen := range strings.SplitSeq(combination, "+") {
+			if slices.Contains(exampleBaseDescriptions, chosen) {
+				t.Errorf("the layout's combination %s names %s, which is the base description of a redefined run: a mainframe-produced extract carries the REDEFINES and not the declaration they are written over",
+					combination, chosen)
+			}
+		}
+	}
+}
+
+// workedExampleCombinations is which description of each redefined run every
+// `record` form in `example/ledger.sexpr` over `posting.cpy` means, in the
+// layout's own order.
+//
+// The whole containment path rather than the leaf name: a reference into the
+// wrong group has the same leaf, so comparing leaves would let a caller pass
+// over a layout naming bytes nobody meant.
+func workedExampleCombinations(t *testing.T) []string {
+	t.Helper()
+
+	file, err := layout.ParseFile(filepath.Join("..", "..", "example", "ledger.sexpr"))
+	if err != nil {
+		t.Fatalf("parsing the worked example's layout: %v", err)
+	}
+
+	written, err := layoutmodel.ReadRecords(file)
+	if err != nil {
+		t.Fatalf("reading the worked example's records: %v", err)
+	}
+
+	var combinations []string
+
+	for _, record := range written {
+		if record.Path != "posting.cpy" {
+			continue
+		}
+
+		chosen := make([]string, 0, len(record.Alternatives))
+		for _, alternative := range record.Alternatives {
+			chosen = append(chosen, strings.Join(alternative.Path, " "))
+		}
+
+		combinations = append(combinations, strings.Join(chosen, "+"))
+	}
+
+	return combinations
 }

--- a/internal/scaffold/derive_test.go
+++ b/internal/scaffold/derive_test.go
@@ -468,11 +468,21 @@ func TestEveryFaultIsReportedRatherThanTheFirst(t *testing.T) {
 	}
 }
 
-// The measure docs/cli/SPEC.md sets: the worked example's postings are six
-// record types over one 01-level with twelve `alternative` children, and every
-// one of them is recoverable from the copybook. What the layout has that the
-// scaffold does not is the names — a reading of what the file means — and the
-// forms the scaffold leaves commented.
+// The measure docs/cli/SPEC.md sets: `example/posting.cpy` is six record types
+// over one 01-level with twelve `alternative` children, and every one of them is
+// recoverable from the copybook alone.
+//
+// The worked example's layout names **two** of those six — the two whose every
+// alternative is a REDEFINES rather than a base description, which are the two a
+// mainframe-produced extract carries. So the two sides are not equal and must not
+// be asserted to be: what holds is that the derivation is the whole cross product
+// and that everything the layout names is in it. A layout combination the scaffold
+// did not derive would be a combination `init` cannot offer, which is the failure
+// this test is for; a derived combination the layout does not name is the adopter
+// having chosen, which is what a layout is for.
+//
+// What the layout also has that the scaffold does not is the names — a reading of
+// what the file means — and the forms the scaffold leaves commented.
 func TestTheWorkedExampleDerivesLedgersRecordsAndAlternatives(t *testing.T) {
 	t.Parallel()
 
@@ -529,17 +539,22 @@ func TestTheWorkedExampleDerivesLedgersRecordsAndAlternatives(t *testing.T) {
 		got = append(got, strings.Join(chosen, "+"))
 	}
 
-	if len(got) != 6 || len(want) != 6 {
-		t.Fatalf("derived %d record types against the layout's %d, want six each", len(got), len(want))
+	if len(got) != 6 {
+		t.Fatalf("derived %d record types from posting.cpy, want the six the two independent runs multiply out to", len(got))
+	}
+
+	if len(want) != 2 {
+		t.Fatalf("the layout names %d combinations of posting.cpy, want the two whose alternatives are all REDEFINES", len(want))
 	}
 
 	// Compared as sets. Which combination is written first is the layout
 	// author's and the derivation's own order, and neither is a statement
-	// about the copybook; which twelve alternatives are chosen is.
+	// about the copybook; which alternatives are chosen is.
 	slices.Sort(got)
-	slices.Sort(want)
 
-	if !slices.Equal(got, want) {
-		t.Errorf("derived the combinations\n%v\nand the layout states\n%v", got, want)
+	for _, combination := range want {
+		if !slices.Contains(got, combination) {
+			t.Errorf("the layout names the combination\n%s\nand the scaffold derived only\n%v", combination, got)
+		}
 	}
 }


### PR DESCRIPTION
Closes #305

`example/ledger.sexpr` named all six combinations `posting.cpy` admits. Four of
them have an `alternative` naming `PST-BODY` or `PST-TAIL` — the **base
descriptions** of the two redefined runs, the declarations that exist to give
the alternatives their storage. A mainframe-produced extract carries the
`REDEFINES` descriptions and never the declaration underneath them, so four of
the worked example's six record types described bytes no extract holds.

The copybook does not move. Narrowing to what a data file actually holds is the
layout's job, and demonstrating that is precisely what the worked example is
for.

## Acceptance criteria

- [x] **No `alternative` in `example/ledger.sexpr` names a base description;
  every one names a `REDEFINES`.** What survives is `PST-DEBIT` ×
  `PST-TAIL-REF` and `PST-CREDIT` × `PST-TAIL-REF`.
- [x] **`example/posting.cpy` is byte-identical.** It is not in the diff.
- [x] **The two survivors are named for what they are, and their `PST-TYPE`
  codes are chosen deliberately.** `DEBIT-POSTING` and `CREDIT-POSTING`: the
  `-REF` suffix distinguished them from siblings that no longer exist. The codes
  are `DR` and `CR` — what a ledger calls a debit and a credit — rather than the
  inherited `DB`/`CB`, whose second letter encoded which description of
  `PST-TAIL` a posting carried. With one tail description in play there is no
  second axis for a code to encode.
- [x] **`example/ledger/` and `example/graph/graph.md` regenerated,
  `example/regenerate_test.go` green.** The automaton is five states and ten
  transitions where it was nine and fifty.
- [x] **`example/README.md` explains why the layout names fewer record types
  than the copybook admits.** The headline section keeps its arithmetic — six
  combinations out of one `01`-level — and becomes the more useful lesson: the
  layout names the two the file carries, `cpybkc init` still derives all six and
  is right to, and choosing is what a layout is for.
- [x] **`docs/cli/SPEC.md`'s counts are true again**, re-anchored on what `init`
  derives from `posting.cpy` (line ~526), where six `record` forms and twelve
  `alternative` children is still exactly right. Line ~803's "cpybkc MUST NOT
  name a record after the data" now cites the two names the layout gives.
- [x] **`example/parquet/` compiles and passes:** no `pst_body` or `pst_tail`
  column, `pst_tail_ref` required rather than optional, `postingRowOf` down to
  two cases.
- [x] **`dagger call ci` green.**

## Judgment calls

**`DR`/`CR` for the type codes.** The old scheme was two-axis — first letter the
body description, second the tail. Keeping `DA` would have implied an axis the
layout no longer has. `DR`/`CR` are the standard ledger abbreviations and say
only which description of `PST-BODY` the posting carries, which is the only
thing left to say.

**`pst_tail_ref` is required, not optional** (`tailRef` rather than `*tailRef`).
A run with one description in play is not a choice a row is making, and an
optional column that is null on no row of any extract is one every query
null-checks for nothing. `TestTheOnlyDescriptionOfATailIsARequiredColumn`
asserts that and the absence of a `pst_body`/`pst_tail` column. No schema
decision belonging to the two follow-on `example/parquet` stories is made here.

**One test outside the stated scope had to move.**
`internal/scaffold`'s `TestTheWorkedExampleDerivesLedgersRecordsAndAlternatives`
derived the six combinations from `posting.cpy` and asserted them **equal** to
the layout's records. That equality is now false by design. It asserts instead
that the derivation is the whole cross product (six) and that every combination
the layout names is in it — a layout combination the scaffold could not derive is
still the failure the test is for, and a derived combination the layout does not
name is the adopter having chosen. No non-test file under `internal/scaffold`,
`internal/resolve` or `cmd/cpybkc` changed; `init` still derives all six.

## Verified

- `dagger call ci` — green, from an ordinary clone (Dagger cannot resolve
  `gitDir` inside a git worktree; CONTRIBUTING.md documents this).
  `ci` calls `ExampleParquetCi`, so the Parquet module is covered by it.
- `go test ./...` and `golangci-lint run ./...` (0 issues) in the worktree.
- `example/regenerate_test.go` is what pins the regenerated tree byte for byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)