### PR TITLE
story(gen-go): the parquet conversion writes one table and reconciles both control totals

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -26,8 +26,8 @@ a field nothing outside can — see
 leaves it alone.
 
 [`parquet/`](parquet) is neither either, and for a different reason: it is what
-somebody *does* with the generated package. It converts this ledger into the two
-Parquet files a data platform would query it as, and it is here because the
+somebody *does* with the generated package. It converts this ledger into the
+Parquet table a data platform would query it as, and it is here because the
 decisions that takes are real, unobvious, and met all at once the first time an
 adopter tries it — [not because there is a right answer to
 generate](https://github.com/Zaba505/cpybkc/issues/272). It is a **Go module of

--- a/example/parquet/README.md
+++ b/example/parquet/README.md
@@ -35,6 +35,21 @@ name left for it to choose, and a flag that still named a directory would be
 inventing `posting.parquet` inside it for you to go and find. It defaults to
 `posting.parquet` in the working directory.
 
+Two consequences of that change, both of which an adopter meets on the first run
+after it:
+
+- **A `-out` that is an existing directory is refused, by name.** Left alone it
+  would surface as `is a directory` from `os.Create`, wrapped in a sentence about
+  the *input* file — which sends you to read your extract over a mistake in a
+  flag. `TestOutNamingADirectoryIsReportedAgainstTheRightFlag` asserts the
+  message names `-out` and does not name `-in`.
+- **`-out` is clobbered whether or not the run succeeds.** `os.Create` truncates,
+  and a failed conversion then removes what it truncated, so a run over a bad
+  extract destroys an earlier good output at the same path. That is the price of
+  "a failed run leaves nothing a reader will open", and with the default being a
+  bare `posting.parquet` in the working directory it is easy to meet. Write to a
+  fresh path if the previous one matters.
+
 `ledger.dat` is *a dataset of these
 records*, and this repository does not commit one — a ledger extract is bytes in
 cp037 behind DFSMS record descriptor words, which is not a thing to read in a
@@ -131,7 +146,10 @@ Either mismatch is an error, and both run **before the footer is written**, so a
 conversion that does not reconcile leaves a file no reader will open rather than
 one a query would happily return wrong answers from. That ordering is the whole
 trick: a Parquet file is its footer, so "fail before the footer" and "leave
-nothing queryable" are the same sentence.
+nothing queryable" are the same sentence. On disk it goes one step further and
+leaves no file at all — `write` removes the path it created, which
+`TestAFailedRunLeavesNoFileBehind` asserts by reading the output directory back
+rather than by inspecting a buffer.
 
 `TRL-COUNT` is nearly free — the conversion is already counting rows. `TRL-NET`
 costs an `int64` and one addition per posting, and it is worth it: a count agrees
@@ -364,6 +382,7 @@ it violated is a test:
 | a **mapping error that fails the conversion** | a discarded error appends a zero row: empty account, zero amount, indistinguishable from data | same |
 | `TRL-COUNT` **reconciled** | the file, the layout or the conversion is wrong and nothing says so | `TestTheTrailerCountIsReconciled` |
 | `TRL-NET` **reconciled** | a count that agrees over amounts that do not; the accumulator is the only part of this that costs anything | `TestTheTrailerNetIsReconciled` |
+| the **failed output removed** | a footerless file sits where a good one used to, and the next reader finds out | `TestAFailedRunLeavesNoFileBehind` |
 
 The terminal-flush test runs over **999 postings** — the most `HDR-COUNT`'s
 `PIC 9(3)` can describe — because 999 is not a multiple of the batch size, and a

--- a/example/parquet/README.md
+++ b/example/parquet/README.md
@@ -7,7 +7,7 @@ tested.
 
 **It is a reference and not a recommendation.** Every one of the decisions below
 is one you have to make for yourself on your own layout; this makes one honest
-reading of them, says why, and marks the four where another adopter would
+reading of them, says why, and marks each place where another adopter would
 reasonably choose differently. An adopter who reads it and does something else
 has used it correctly.
 
@@ -25,10 +25,17 @@ are written down here, next to code that compiles.
 because there is nothing here that would be right to reuse.
 
 ```console
-$ go run . -in ledger.dat -out /tmp/ledger
+$ go run . -in ledger.dat -out /tmp/ledger/posting.parquet
 ```
 
-`-out` is created if it is not there. `ledger.dat` is *a dataset of these
+`-out` names **the file**, not a directory, and the directory it sits in is
+created if it is not there. It named a directory when there were two tables,
+because the conversion was choosing both filenames; with one table there is no
+name left for it to choose, and a flag that still named a directory would be
+inventing `posting.parquet` inside it for you to go and find. It defaults to
+`posting.parquet` in the working directory.
+
+`ledger.dat` is *a dataset of these
 records*, and this repository does not commit one — a ledger extract is bytes in
 cp037 behind DFSMS record descriptor words, which is not a thing to read in a
 diff. `convert_test.go`'s `ledgerBytes` makes its fixtures through
@@ -57,23 +64,43 @@ own: `dagger call example-parquet-ci`, beside `ir-ci`, `pipeline-ci` and
 `companion-ci`. See [CONTRIBUTING.md](../../CONTRIBUTING.md#the-parquet-example-is-checked-like-any-other-go-module-here)
 for what that stage has to do that the other four do not.
 
-## Two grains, so two files
+## Two grains, one table
 
-A Parquet file carries exactly one schema. This extract has **two grains** — the
-header and trailer are one row per file, the postings are one row each — so the
-output is two files and the conversion is across both:
+A Parquet file carries exactly one schema, and this extract has **two grains** —
+the header and trailer are one row per file, the postings are one row each. That
+is real and it is the first thing to check on your own layout: count the grains,
+not the record types. It does **not** follow that you write a file per grain.
 
-| table | grain | what it carries |
-|---|---|---|
-| `extract.parquet` | one row per file | `LEDGER-HEADER` × `LEDGER-TRAILER` |
-| `posting.parquet` | one row per posting | the posting, with header context denormalized onto it |
+The output is one table, `posting.parquet`, at the posting grain. The file-level
+grain is spent rather than stored, and each of its fields goes somewhere:
 
-An adopter who has not met this assumes one file and finds out late. It is the
-first thing to check on your own layout: count the grains, not the record types.
+| item | where it goes |
+|---|---|
+| `HDR-LEDGER-ID`, `HDR-PERIOD`, `HDR-CURRENCY` | denormalized onto every posting row |
+| `HDR-COUNT` | nowhere — `ledger.Reader` already holds the body to it |
+| `TRL-COUNT`, `TRL-NET` | reconciled against the rows written, then discarded |
+
+The reason is that a file-level table needs a **key**, and this converter will
+not mint one. A row of a file-level table with no key is a row that can only be
+joined to its postings by having been read out of the same file — which is a join
+a query engine cannot express, so in practice that table is either read on its own
+or joined on the denormalized `hdr_ledger_id` and `hdr_period` that are *already
+on every posting row*. The second table earns nothing the first does not already
+carry, and it costs a second file, a second schema, and a second thing to keep in
+step. See [No key is minted](#no-key-is-minted-and-here-is-why-one-is-not-needed)
+— it is the same argument, arriving at a table instead of at a column.
+
+So the rule this example ended up with, and the one to try first on your own
+layout: **one table per data record type, with the parent's identifying fields
+denormalized onto it, and the parent's summaries checked rather than kept.** A
+file-level grain becomes a second table when it carries something that is neither
+identifying nor a summary — a run date, a source system, an operator's comment,
+anything a posting row would want and cannot be checked against the body. This
+header carries no such field. Yours may.
 
 ## The decisions
 
-### Grains stay separate; header *fields* do not
+### The header's *fields* travel, even though its grain gets no table
 
 `hdr_ledger_id`, `hdr_period` and `hdr_currency` are copied onto **every**
 posting row.
@@ -81,12 +108,13 @@ posting row.
 That is not the waste it looks like. In a columnar store a column that is
 constant across a row group is one dictionary entry and an RLE run — a few bytes
 — and it earns min/max statistics, so a query filtering on the period skips row
-groups instead of joining. This is the whole of what makes `posting` usable on
-its own.
+groups instead of joining. This is the whole of what makes the posting table usable
+on its own — and, with no second table to fall back on, the whole of what keeps
+the header readable at all.
 
-### Trailer fields do not promote
+### Trailer fields do not promote — they are checked and dropped
 
-`TRL-COUNT` and `TRL-NET` stay in `extract`.
+`TRL-COUNT` and `TRL-NET` are not columns anywhere.
 
 They are *summaries of* the posting rows, so denormalizing them means
 `SUM(trl_net)` silently returns the total times the row count — a wrong answer
@@ -94,11 +122,27 @@ that looks like a right one. `TestTrailerFieldsDoNotPromote` asserts the posting
 schema carries no `trl_` column, because this is the decision that is cheapest to
 undo by accident.
 
-`extract` is also where the reconciliation belongs, and the conversion makes it:
-`TRL-COUNT` against the rows actually written, and a mismatch is an error. It
-runs **before either footer is written**, so a conversion that does not reconcile
-leaves two files no reader will open rather than two a query would happily return
-wrong answers from.
+What a summary is *for* is checking, and the conversion makes both checks:
+
+- `TRL-COUNT` against the rows actually written.
+- `TRL-NET` against the posting amounts, accumulated as they are read.
+
+Either mismatch is an error, and both run **before the footer is written**, so a
+conversion that does not reconcile leaves a file no reader will open rather than
+one a query would happily return wrong answers from. That ordering is the whole
+trick: a Parquet file is its footer, so "fail before the footer" and "leave
+nothing queryable" are the same sentence.
+
+`TRL-COUNT` is nearly free — the conversion is already counting rows. `TRL-NET`
+costs an `int64` and one addition per posting, and it is worth it: a count agrees
+on a file whose amounts are all wrong.
+
+`HDR-COUNT` is a summary too, and this conversion does nothing with it at all.
+`ledger.sexpr` reads it into a register — `(times … (item LEDGER-HEADER
+HDR-COUNT))` — so a file whose body disagrees with its own header is reported by
+`ledger.Reader` before a row ever reaches here. A converter checking it again
+would be re-implementing the layout, and a column for it would be a number that
+cannot disagree with `COUNT(*)`.
 
 ### No key is minted, and here is why one is not needed
 
@@ -118,6 +162,38 @@ The conversion does count an ordinal — `ledger.Reader` keeps one for its own
 diagnostics and does not export it — but it is a *diagnostic* and never a column.
 `TestAMappingErrorFailsTheConversion` asserts the failure says which record it
 was.
+
+### The sign the net assumes
+
+**This conversion adds every posting amount with the sign the record stores it
+under.** `PDB-AMOUNT` and `PCR-AMOUNT` are both `PIC S9(n)V99`; a debit arrives
+positive and a credit negative, and `TRL-NET` is their plain sum.
+
+That is an assumption, and the copybook does not make it. `posting.cpy` says the
+amounts are signed and says nothing whatever about what a debit or a credit does
+to a total. A layout that stores both as **magnitudes** and means the credit to
+subtract is just as ordinary, and on such a file this conversion computes a net
+that is wrong by twice the credits — and reports the mismatch rather than
+accepting it, which is the outcome an adopter needs.
+`TestTheNetTakesEachAmountWithTheSignTheRecordStoresIt` is that file, asserted.
+
+If yours is the other kind, negate the credit arm of `postingRowOf` and say so
+there. What you must not do is delete the reconciliation to make it pass.
+
+### The scale is not a coincidence, and one day it will not hold
+
+`TRL-NET` is `PIC S9(13)V99`, `PDB-AMOUNT` is `PIC S9(11)V99`, `PCR-AMOUNT` is
+`PIC S9(9)V99`. All three carry **scale 2**, so the unscaled integers
+`cpybkc-gen-go` produces are already in the same units and the accumulator is
+plain `int64` addition. Nothing multiplies or divides by a hundred.
+
+That is a property of this layout and not of decimals. A trailer keeping whole
+currency units over postings keeping cents needs one side scaled here, and a
+conversion that forgot would fail the reconciliation on every file — or pass it
+on the one file whose net is zero. The precision has a bound of its own worth
+noticing: `HDR-COUNT` is `PIC 9(3)`, so at most 999 amounts of at most thirteen
+digits are summed, and `int64` holds nineteen. A layout with a wider count, or
+wider amounts, is one where that has to be checked rather than argued.
 
 ### The postings: one table
 
@@ -190,24 +266,51 @@ trimmed of their `DISPLAY` padding, so `hdr_ledger_id` is `"GL-MAIN"` and not
 mentioned because a downstream join against a system that kept the padding will
 not match.
 
+#### Where the line actually is, since the net crosses it
+
+The sign convention above is a semantic the copybook does not carry, and this
+conversion assumes one anyway. That looks like the opposite of this section, so
+here is the line it is drawn on:
+
+- **A semantic that changes what is stored is out.** `HDR-PERIOD` stays an
+  integer. Nothing here writes a date, a currency-scaled amount, or a debit
+  re-signed to somebody's convention. What lands in the file is what the reader
+  produced, re-annotated.
+- **A semantic that only *checks* what is stored can be in — stated, and
+  falsifiable.** `TRL-NET` exists to be reconciled; a converter that reads it and
+  says nothing has ignored the one thing the trailer is for. You cannot check it
+  without assuming an arithmetic, so the assumption is written down here, written
+  down at `postingRowOf`, and named in the error the check produces — and when it
+  is wrong for your file, the run fails loudly on the first extract instead of
+  being wrong quietly forever.
+
+The distinction that matters is not "did the converter assume something" but
+"what does the assumption do when it is wrong". A guessed date silently
+mis-stores every row. A guessed sign fails a check on the first file.
+
 ## The type mapping, on the items this example carries
 
-The three amounts are the interesting case, and they need **no conversion at
+The two amount columns are the interesting case, and they need **no conversion at
 all**:
 
 | item | PICTURE | Go, as generated | Parquet |
 |---|---|---|---|
-| `TRL-NET` | `PIC S9(13)V99 COMP-3` | `int64`, unscaled | `DECIMAL(15,2)` |
 | `PDB-AMOUNT` | `PIC S9(11)V99 COMP-3` | `int64`, unscaled | `DECIMAL(13,2)` |
 | `PCR-AMOUNT` | `PIC S9(9)V99 COMP-3` | `int64`, unscaled | `DECIMAL(11,2)` |
+| `TRL-NET` | `PIC S9(13)V99 COMP-3` | `int64`, unscaled | *no column — reconciled* |
 
 `cpybkc-gen-go` writes a scaled item as [the unscaled integer with the scale in
 the doc comment](../../cmd/cpybkc-gen-go/README.md), which is precisely what
 `DECIMAL(p,s)` is. Nothing in `convert.go` divides by a hundred, and
-`TestTheThreeAmountsRoundTripThroughDecimal` reads the written files back, checks
-the unscaled values against what the reader produced, and checks the annotation
-in the file's own schema — which is what a query engine reads, rather than the Go
-struct tag.
+`TestTheTwoAmountColumnsRoundTripThroughDecimal` reads the written file back,
+checks the unscaled values against what the reader produced, and checks the
+annotation in the file's own schema — which is what a query engine reads, rather
+than the Go struct tag.
+
+`TRL-NET` is in that table for an item that is never written, because the mapping
+is what makes the reconciliation legal: all three are scale 2, so the accumulator
+adds the unscaled integers as they stand. `DECIMAL(15,2)` is what it *would* be
+annotated as, and knowing that is what tells you the addition needs no rescaling.
 
 This is worth showing precisely because it looks like it should need a
 conversion. Applying the scale here would apply it twice by the time a value
@@ -260,6 +363,7 @@ it violated is a test:
 | the **ordinal counted by the caller** | the diagnostic cannot say which record failed; `Reader`'s own is unexported | `TestAMappingErrorFailsTheConversion` |
 | a **mapping error that fails the conversion** | a discarded error appends a zero row: empty account, zero amount, indistinguishable from data | same |
 | `TRL-COUNT` **reconciled** | the file, the layout or the conversion is wrong and nothing says so | `TestTheTrailerCountIsReconciled` |
+| `TRL-NET` **reconciled** | a count that agrees over amounts that do not; the accumulator is the only part of this that costs anything | `TestTheTrailerNetIsReconciled` |
 
 The terminal-flush test runs over **999 postings** — the most `HDR-COUNT`'s
 `PIC 9(3)` can describe — because 999 is not a multiple of the batch size, and a

--- a/example/parquet/convert.go
+++ b/example/parquet/convert.go
@@ -4,12 +4,12 @@
 // https://opensource.org/licenses/MIT
 
 // Command parquet converts the ledger extract in the directory above this one
-// into the two Parquet files a data platform would query it as.
+// into the Parquet table a data platform would query it as.
 //
 // It is a worked conversion and a reference, not a recommendation and not a
 // library. Every decision it makes is one an adopter has to make for themselves
 // on their own layout; README.md beside this file states each of them, says why
-// this one was taken, and marks the four where another adopter would reasonably
+// this one was taken, and marks each place where another adopter would reasonably
 // differ. An adopter who reads it and does something else has used it correctly.
 //
 // It is package main rather than a package with a Convert function so that
@@ -45,34 +45,19 @@ import (
 // a test rather than theoretical.
 const batchSize = 64
 
-// extractRow is the `extract` table: one row per file.
+// postingRow is the `posting` table, and it is the only table: one row per
+// posting.
 //
-// A Parquet file carries exactly one schema and this example has two grains, so
-// there are two tables. The header and the trailer describe the extract as a
-// whole, and this is where they live — both of them, together, so that
-// TRL-COUNT and TRL-NET sit beside the HDR-COUNT they are a summary of.
-type extractRow struct {
-	HdrLedgerID string `parquet:"hdr_ledger_id"`
-	HdrPeriod   int32  `parquet:"hdr_period"`
-	HdrCurrency string `parquet:"hdr_currency"`
-	HdrCount    int32  `parquet:"hdr_count"`
-
-	TrlCount int32 `parquet:"trl_count"`
-
-	// TrlNet is TRL-NET, PIC S9(13)V99 COMP-3: fifteen digits with two after
-	// the point. cpybkc-gen-go produced it as an unscaled int64 with the scale
-	// in its doc comment, which is exactly what DECIMAL(15,2) is, so this is a
-	// re-annotation and not a conversion. Nothing here divides by a hundred.
-	TrlNet int64 `parquet:"trl_net,decimal(2:15)"`
-}
-
-// postingRow is the `posting` table: one row per posting.
+// A Parquet file carries exactly one schema and this extract has two grains, so
+// the file-level one had to go somewhere. Its identifying fields are
+// denormalized onto every row here; its summaries — TRL-COUNT and TRL-NET — are
+// reconciled by [convert] and never stored; and HDR-COUNT is the reader's
+// business rather than this conversion's. README.md says why a second table is
+// the wrong home for them.
 //
-// The header's identifying fields are denormalized onto every row and the
-// trailer's are not; README.md says why in terms of what SUM does to each. The
-// record types the layout names are one table rather than one each, and a run
-// the layout names more than one description of becomes one optional column per
-// description — which is what keeps the record type recoverable from a row.
+// The record types the layout names are one table rather than one each, and a
+// run the layout names more than one description of becomes one optional column
+// per description — which is what keeps the record type recoverable from a row.
 //
 // The shape of this struct is a function of the **layout** and not of the
 // copybook. `posting.cpy` admits six combinations; `ledger.sexpr` names the two
@@ -158,8 +143,8 @@ func main() {
 	os.Exit(1)
 }
 
-// run converts the dataset named by -in into extract.parquet and
-// posting.parquet under -out, creating that directory if it is not there.
+// run converts the dataset named by -in into the Parquet file named by -out,
+// creating the directory that file sits in if it is not there.
 //
 // What a failed run leaves behind is write's business; see there.
 func run(args []string, stderr io.Writer) error {
@@ -167,7 +152,12 @@ func run(args []string, stderr io.Writer) error {
 	flags.SetOutput(stderr)
 
 	in := flags.String("in", "", "the ledger extract to convert")
-	out := flags.String("out", ".", "the directory the two Parquet files are written to")
+	// -out names the file and not a directory. With two tables it had to name a
+	// directory, because the conversion was choosing both filenames; with one
+	// there is no name for it to choose, and a flag that still named a
+	// directory would be inventing `posting.parquet` inside it for the caller
+	// to then go and find.
+	out := flags.String("out", "posting.parquet", "the Parquet file to write")
 
 	if err := flags.Parse(args); err != nil {
 		// The flag set has already written its message and the usage to stderr,
@@ -199,13 +189,14 @@ func run(args []string, stderr io.Writer) error {
 		return err
 	}
 
-	// -out is created rather than assumed, so that the invocation README.md
-	// documents runs as it is written on a machine that has never run it.
-	if err := os.MkdirAll(*out, 0o750); err != nil {
+	// The directory -out sits in is created rather than assumed, so that the
+	// invocation README.md documents runs as it is written on a machine that
+	// has never run it. The file itself is os.Create's business below.
+	if err := os.MkdirAll(filepath.Dir(*out), 0o750); err != nil {
 		return err
 	}
 
-	if err := write(r, filepath.Join(*out, "extract.parquet"), filepath.Join(*out, "posting.parquet")); err != nil {
+	if err := write(r, *out); err != nil {
 		return fmt.Errorf("converting %s: %w", *in, err)
 	}
 
@@ -216,36 +207,28 @@ func run(args []string, stderr io.Writer) error {
 // main exits non-zero on it and says nothing further.
 var errAlreadyReported = errors.New("")
 
-// write creates the two tables and converts into them.
+// write creates the table and converts into it.
 //
 // Nothing it created survives a failure. A conversion that fails returns before
-// either footer is written, and a Parquet file with no footer is bytes that read
-// as corruption rather than as a run somebody has to repeat — so the two paths
-// are removed, and only the ones this call actually opened.
+// the footer is written, and a Parquet file with no footer is bytes that read as
+// corruption rather than as a run somebody has to repeat — so the path is
+// removed, and only when this call is the one that opened it.
 //
-// Both files are closed whatever happens, and a failure to close is joined to
+// The file is closed whatever happens, and a failure to close is joined to
 // whatever the conversion reported rather than replacing it: a full disk shows
 // up here and nowhere else.
-func write(src recordSource, extractPath, postingPath string) error {
-	extract, err := os.Create(extractPath)
+func write(src recordSource, path string) error {
+	f, err := os.Create(path)
 	if err != nil {
 		return err
 	}
 
-	posting, err := os.Create(postingPath)
-	if err != nil {
-		// posting was never opened by this call, so it is not this call's to
-		// remove: a file of that name is one an earlier successful conversion
-		// into the same directory left behind.
-		return errors.Join(err, extract.Close(), remove(extractPath))
-	}
-
-	err = errors.Join(convert(src, extract, posting), extract.Close(), posting.Close())
+	err = errors.Join(convert(src, f), f.Close())
 	if err == nil {
 		return nil
 	}
 
-	return errors.Join(err, remove(extractPath), remove(postingPath))
+	return errors.Join(err, remove(path))
 }
 
 // remove deletes a path this run created, treating an absent one as done rather
@@ -262,15 +245,14 @@ func remove(path string) error {
 	return nil
 }
 
-// convert reads every record of src once and writes the two tables.
+// convert reads every record of src once and writes the posting table.
 //
 // One pass, and the file is never held: what this carries at any moment is the
-// header, the batch of posting rows in hand, and the row group parquet-go is
-// buffering behind it. That is the whole of its footprint, and README.md states
-// it that way rather than as "constant".
-func convert(src recordSource, extract, posting io.Writer) error {
-	postings := parquet.NewGenericWriter[postingRow](posting)
-	extracts := parquet.NewGenericWriter[extractRow](extract)
+// header, the batch of posting rows in hand, the row group parquet-go is
+// buffering behind it, and two running totals. That is the whole of its
+// footprint, and README.md states it that way rather than as "constant".
+func convert(src recordSource, w io.Writer) error {
+	postings := parquet.NewGenericWriter[postingRow](w)
 
 	var hdr *ledger.LedgerHeader
 	var trl *ledger.LedgerTrailer
@@ -284,6 +266,27 @@ func convert(src recordSource, extract, posting io.Writer) error {
 	// batch is reused between flushes. Its capacity is the bound.
 	batch := make([]postingRow, 0, batchSize)
 	written := int64(0)
+
+	// net accumulates the posting amounts, to be reconciled against TRL-NET
+	// below. It is plain int64 addition with no rescaling anywhere, and that is
+	// a property of this layout rather than of decimals in general: TRL-NET is
+	// PIC S9(13)V99, PDB-AMOUNT is PIC S9(11)V99 and PCR-AMOUNT is
+	// PIC S9(9)V99, so all three carry scale 2 and their unscaled integers are
+	// already in the same units. A layout whose trailer kept whole currency
+	// units while its postings kept cents needs one side multiplied by a
+	// hundred here — and a conversion that forgot to would fail this
+	// reconciliation on every file, or pass it on the one file whose net is
+	// zero.
+	//
+	// The sign each amount contributes is an assumption and not a reading; see
+	// postingRowOf, and README.md, "The sign the net assumes".
+	//
+	// It cannot overflow on a file this layout describes. HDR-COUNT is
+	// PIC 9(3) and ledger.Reader holds the body to it, so at most 999 amounts
+	// of at most thirteen digits are summed — about 1e16, against int64's
+	// 9.2e18. A layout with a wider count, or wider amounts, is one where that
+	// has to be checked rather than argued.
+	net := int64(0)
 
 	flush := func() error {
 		if len(batch) == 0 {
@@ -343,7 +346,7 @@ func convert(src recordSource, extract, posting io.Writer) error {
 			return fmt.Errorf("record %d is a posting and no LEDGER-HEADER has been read: the header's fields are denormalized onto every posting row and there is nothing to denormalize", ordinal)
 		}
 
-		row, err := postingRowOf(hdr, rec)
+		row, amount, err := postingRowOf(hdr, rec)
 		if err != nil {
 			// The row is not appended. #272's sample discarded this error and
 			// appended the zero value, which writes a posting whose account is
@@ -353,6 +356,7 @@ func convert(src recordSource, extract, posting io.Writer) error {
 		}
 
 		batch = append(batch, row)
+		net += amount
 
 		if len(batch) == batchSize {
 			if err := flush(); err != nil {
@@ -376,41 +380,27 @@ func convert(src recordSource, extract, posting io.Writer) error {
 		return errors.New("the file carried no LEDGER-TRAILER")
 	}
 
-	// Reconciliation before either footer is written, so that a conversion which
-	// does not reconcile leaves two files no Parquet reader will open rather
-	// than two a query would happily return wrong answers from.
+	// Both reconciliations before the footer is written, so that a conversion
+	// which does not reconcile leaves a file no Parquet reader will open rather
+	// than one a query would happily return wrong answers from. This is what
+	// becomes of the trailer: it is checked and discarded, not stored.
 	if int64(trl.TrlCount) != written {
 		return fmt.Errorf("TRL-COUNT is %d and %d posting rows were written: the trailer counts the rows of this extract, so the two disagreeing means the file, the layout or this conversion is wrong and none of the three is a thing to write out anyway", trl.TrlCount, written)
+	}
+
+	if trl.TrlNet != net {
+		return fmt.Errorf("TRL-NET is %d and the posting amounts sum to %d, both unscaled at scale 2: the trailer totals the rows of this extract, so the two disagreeing means the file is wrong or this conversion's sign convention is — it adds every amount with the sign the record stores it under, and a layout whose credits are stored positive and are meant to subtract disagrees here first", trl.TrlNet, net)
 	}
 
 	if err := postings.Close(); err != nil {
 		return fmt.Errorf("closing the posting table: %w", err)
 	}
 
-	if _, err := extracts.Write([]extractRow{extractRowOf(hdr, trl)}); err != nil {
-		return fmt.Errorf("writing the extract row: %w", err)
-	}
-
-	if err := extracts.Close(); err != nil {
-		return fmt.Errorf("closing the extract table: %w", err)
-	}
-
 	return nil
 }
 
-// extractRowOf is the one row of the `extract` table.
-func extractRowOf(hdr *ledger.LedgerHeader, trl *ledger.LedgerTrailer) extractRow {
-	return extractRow{
-		HdrLedgerID: hdr.HdrLedgerId,
-		HdrPeriod:   hdr.HdrPeriod,
-		HdrCurrency: hdr.HdrCurrency,
-		HdrCount:    hdr.HdrCount,
-		TrlCount:    trl.TrlCount,
-		TrlNet:      trl.TrlNet,
-	}
-}
-
-// postingRowOf is the row one posting contributes, under the header in force.
+// postingRowOf is the row one posting contributes, under the header in force,
+// and the amount it contributes to the net.
 //
 // An item present in one alternative and absent in the other becomes an
 // optional column, and taking the address of a fresh composite literal is what
@@ -418,29 +408,48 @@ func extractRowOf(hdr *ledger.LedgerHeader, trl *ledger.LedgerTrailer) extractRo
 // reader is free to reuse behind it — a batch is held until it is flushed, which
 // is up to sixty-four records later.
 //
+// The amount comes back beside the row rather than being read off it, so that
+// there is exactly one place that decides what a record of each type contributes
+// — the arm that builds the row. Reading it back off the row would mean a second
+// switch on which optional group is present, which is a second place for the
+// same decision to be made and a place for the two to drift apart.
+//
+// **That amount is the copybook's value with the sign the record stores it
+// under, and taking it that way is an assumption the copybook does not make.**
+// `posting.cpy` gives both amounts a signed PICTURE and says nothing about what
+// a debit or a credit does to a total; this conversion reads the file as one
+// that already carries the sign, so the net is a plain sum. A layout that stores
+// both magnitudes positive and means the credit to subtract needs the credit arm
+// negated here, and README.md's "The sign the net assumes" is where that is
+// argued rather than merely noted.
+//
 // A record that is not one of this file's two posting types is an error and
 // never a row. The two are what the layout's `(alt …)` lists, and a third
 // arriving here means the layout and this conversion have gone out of step —
 // which is a thing to report, not to write a zero row for.
-func postingRowOf(hdr *ledger.LedgerHeader, rec ledger.Record) (postingRow, error) {
+func postingRowOf(hdr *ledger.LedgerHeader, rec ledger.Record) (postingRow, int64, error) {
 	row := postingRow{
 		HdrLedgerID: hdr.HdrLedgerId,
 		HdrPeriod:   hdr.HdrPeriod,
 		HdrCurrency: hdr.HdrCurrency,
 	}
 
+	amount := int64(0)
+
 	switch v := rec.(type) {
 	case *ledger.DebitPosting:
 		row.PstAccount, row.PstSequence, row.PstType = v.PstAccount, v.PstSequence, v.PstType
 		row.PstDebit = &debitBody{v.PstDebit.PdbCostCentre, v.PstDebit.PdbAmount, v.PstDebit.PdbMemo}
 		row.PstTailRef = tailRef{v.PstTailRef.PtrBatch, v.PstTailRef.PtrLine}
+		amount = v.PstDebit.PdbAmount
 	case *ledger.CreditPosting:
 		row.PstAccount, row.PstSequence, row.PstType = v.PstAccount, v.PstSequence, v.PstType
 		row.PstCredit = &creditBody{v.PstCredit.PcrSource, v.PstCredit.PcrAmount, v.PstCredit.PcrReference}
 		row.PstTailRef = tailRef{v.PstTailRef.PtrBatch, v.PstTailRef.PtrLine}
+		amount = v.PstCredit.PcrAmount
 	default:
-		return postingRow{}, fmt.Errorf("this file's postings are DEBIT-POSTING and CREDIT-POSTING, and a %T is neither of them", rec)
+		return postingRow{}, 0, fmt.Errorf("this file's postings are DEBIT-POSTING and CREDIT-POSTING, and a %T is neither of them", rec)
 	}
 
-	return row, nil
+	return row, amount, nil
 }

--- a/example/parquet/convert.go
+++ b/example/parquet/convert.go
@@ -189,6 +189,22 @@ func run(args []string, stderr io.Writer) error {
 		return err
 	}
 
+	// -out named a directory while this conversion wrote two files, so the
+	// invocation an adopter already has hands over one that exists. That
+	// reaches os.Create as "is a directory", which is a true sentence about the
+	// wrong thing: the mistake is in the flag, and the fix is a filename rather
+	// than a permission or a disk. So the flag checks its own argument, and
+	// this is the only output-side failure worth telling apart by hand —
+	// the rest are ordinary I/O and read as such.
+	//
+	// A -out that is not a directory is taken at its word, extension or no
+	// extension. There is nothing to check there: a path that names no file yet
+	// is exactly what this flag is for, and refusing one that does not end in
+	// .parquet would be this conversion having an opinion about filenames.
+	if info, err := os.Stat(*out); err == nil && info.IsDir() {
+		return fmt.Errorf("-out is %s, which is a directory: it named the directory to write two files into while this conversion wrote two, and it names the file now that it writes one — try -out %s", *out, filepath.Join(*out, "posting.parquet"))
+	}
+
 	// The directory -out sits in is created rather than assumed, so that the
 	// invocation README.md documents runs as it is written on a machine that
 	// has never run it. The file itself is os.Create's business below.
@@ -196,8 +212,11 @@ func run(args []string, stderr io.Writer) error {
 		return err
 	}
 
+	// Both paths, because what write reports can be a fact about either of
+	// them, and a wrapper naming only the input reads as a bad input file
+	// whatever actually went wrong.
 	if err := write(r, *out); err != nil {
-		return fmt.Errorf("converting %s: %w", *in, err)
+		return fmt.Errorf("converting %s into %s: %w", *in, *out, err)
 	}
 
 	return nil
@@ -209,10 +228,16 @@ var errAlreadyReported = errors.New("")
 
 // write creates the table and converts into it.
 //
-// Nothing it created survives a failure. A conversion that fails returns before
-// the footer is written, and a Parquet file with no footer is bytes that read as
-// corruption rather than as a run somebody has to repeat — so the path is
-// removed, and only when this call is the one that opened it.
+// **path is clobbered whether or not this succeeds.** os.Create truncates, and a
+// failed conversion then removes what it truncated — so a run that fails against
+// the path an earlier successful run wrote destroys that output, and leaves no
+// file rather than a short one. That is the deliberate half: a conversion that
+// fails returns before the footer is written, and a Parquet file with no footer
+// is bytes that read as corruption rather than as a run somebody has to repeat,
+// so the path goes. The destructive half is the ordinary cost of an output path
+// that is opened for writing, and it is said out loud here because the default
+// -out is a bare posting.parquet in the working directory, which makes a second
+// run over a bad extract an easy way to meet it.
 //
 // The file is closed whatever happens, and a failure to close is joined to
 // whatever the conversion reported rather than replacing it: a full disk shows

--- a/example/parquet/convert_test.go
+++ b/example/parquet/convert_test.go
@@ -18,6 +18,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -32,13 +34,14 @@ import (
 // PST-TAIL — the base descriptions a mainframe-produced extract does not carry.
 const postingTypes = 2
 
-// ledgerBytes is a well-formed ledger extract of n postings, cycling through
-// both of the record types this layout names.
+// ledgerBytes is a ledger extract of n postings, cycling through both of the
+// record types this layout names.
 //
-// trlCount is stated apart from n so that a file whose trailer disagrees with
-// its own rows can be built: nothing in the layout ties TRL-COUNT to the
-// postings, and a reconciliation nobody can make fail is not a reconciliation.
-func ledgerBytes(t *testing.T, n int32, trlCount int32) []byte {
+// trlCount and trlNet are stated apart from the postings so that a file whose
+// trailer disagrees with its own rows can be built: nothing in the layout ties
+// either of them to the body, and a reconciliation nobody can make fail is not a
+// reconciliation. [netOf] is what makes a well-formed one.
+func ledgerBytes(t *testing.T, n int32, trlCount int32, trlNet int64) []byte {
 	t.Helper()
 
 	var b bytes.Buffer
@@ -67,7 +70,7 @@ func ledgerBytes(t *testing.T, n int32, trlCount int32) []byte {
 	if err := w.Write(&ledger.LedgerTrailer{
 		TrlType:  "99",
 		TrlCount: trlCount,
-		TrlNet:   trailerNet,
+		TrlNet:   trlNet,
 	}); err != nil {
 		t.Fatalf("writing the trailer: %v", err)
 	}
@@ -79,19 +82,40 @@ func ledgerBytes(t *testing.T, n int32, trlCount int32) []byte {
 	return b.Bytes()
 }
 
-// trailerNet is TRL-NET's unscaled value: fifteen digits with two after the
-// point, so -1234567890123.45. It is carried through the conversion unchanged
-// and nothing here divides by a hundred, which is the point of asserting it.
-const trailerNet = int64(-123456789012345)
-
 // debitAmount and creditAmount are the unscaled values of the two posting
 // amounts, chosen to fill their own precisions rather than to be small:
 // PDB-AMOUNT is thirteen digits and PCR-AMOUNT eleven, and a value that fits in
 // both would not tell a mistaken precision from a correct one.
+//
+// The debit is thirteen digits and not nine-nine-nine-nine, because now that
+// TRL-NET is reconciled the largest fixture here has to sum inside the
+// trailer's own fifteen: 999 postings of this one come to
+// 887,012,346,228,013, which fits, where 999 of a full 9,999,999,999,999 would
+// not. That is a property a real layout's trailer has to have and this one only
+// just does — a trailer two digits narrower than the sum of the rows it totals
+// is a layout that cannot describe its own worst case.
+//
+// The credit is negative because this file stores the sign of a posting on the
+// posting; see [TestTheNetTakesEachAmountWithTheSignTheRecordStoresIt].
 const (
-	debitAmount  = int64(9876543210987)
+	debitAmount  = int64(1876543210987)
 	creditAmount = int64(-98765432109)
 )
+
+// netOf is the TRL-NET a well-formed fixture of n postings carries: the amounts
+// its records store, summed.
+//
+// It is arithmetic over this file's own two constants rather than a second copy
+// of the conversion's accumulator — [posting] hands out a debit on every even i,
+// so n/2 of them are debits and the rest credits. A constant written down here
+// instead would have to be recomputed by hand every time either amount moved,
+// and the reconciliation would start failing for a reason that is not the one
+// under test.
+func netOf(n int32) int64 {
+	debits := n / 2
+
+	return int64(debits)*debitAmount + int64(n-debits)*creditAmount
+}
 
 // posting is the i'th posting of a fixture, of the i'th of the two record types.
 func posting(i int32) ledger.Record {
@@ -120,22 +144,38 @@ func posting(i int32) ledger.Record {
 }
 
 // converted runs the conversion over a ledger extract of n postings whose
-// trailer counts trlCount of them, and returns the two files it wrote.
-func converted(t *testing.T, n int32, trlCount int32) (extract, posting []byte, err error) {
+// trailer counts trlCount of them and totals trlNet, and returns the one file it
+// wrote.
+//
+// The bytes come back whether or not the conversion succeeded, because what a
+// failed conversion left behind is half of what the reconciliation tests assert.
+func converted(t *testing.T, n int32, trlCount int32, trlNet int64) ([]byte, error) {
 	t.Helper()
 
-	raw := ledgerBytes(t, n, trlCount)
+	raw := ledgerBytes(t, n, trlCount, trlNet)
 
 	r, rerr := ledger.NewReader(bytes.NewReader(raw), ledger.Encoding())
 	if rerr != nil {
 		t.Fatalf("ledger.NewReader: %v", rerr)
 	}
 
-	var extractBuf, postingBuf bytes.Buffer
+	var posting bytes.Buffer
 
-	err = convert(r, &extractBuf, &postingBuf)
+	err := convert(r, &posting)
 
-	return extractBuf.Bytes(), postingBuf.Bytes(), err
+	return posting.Bytes(), err
+}
+
+// postingTable is the table a well-formed extract of n postings converts to.
+func postingTable(t *testing.T, n int32) []byte {
+	t.Helper()
+
+	posting, err := converted(t, n, n, netOf(n))
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+
+	return posting
 }
 
 // rowsOf reads a whole Parquet file back as T.
@@ -175,46 +215,60 @@ func rowsOf[T any](t *testing.T, b []byte) []T {
 	return rows[:read]
 }
 
-// TestTheTwoGrainsBecomeTwoFiles is the first thing an adopter meets: a Parquet
-// file carries exactly one schema, and this extract has two grains.
-func TestTheTwoGrainsBecomeTwoFiles(t *testing.T) {
-	extract, posting, err := converted(t, postingTypes, postingTypes)
+// TestTheConversionWritesOneFile is the first thing an adopter meets, and it is
+// the decision this example changed its mind about: a Parquet file carries
+// exactly one schema and this extract has two grains, and the answer is still
+// one file. The file-level grain is denormalized and reconciled away rather than
+// given a table of its own.
+//
+// It goes through [run] rather than through [convert], because "one file" is a
+// claim about what is on the disk afterwards and not about how many writers the
+// conversion opened. That is also what asserts -out: it names the file, so a
+// directory that reads back with exactly one entry in it is both halves of the
+// claim at once.
+func TestTheConversionWritesOneFile(t *testing.T) {
+	in := filepath.Join(t.TempDir(), "ledger.dat")
+	if err := os.WriteFile(in, ledgerBytes(t, postingTypes, postingTypes, netOf(postingTypes)), 0o600); err != nil {
+		t.Fatalf("writing the fixture extract: %v", err)
+	}
+
+	// A directory that is not there yet, because the invocation README.md
+	// documents has to run on a machine that has never run it.
+	dir := filepath.Join(t.TempDir(), "out")
+	out := filepath.Join(dir, "posting.parquet")
+
+	if err := run([]string{"-in", in, "-out", out}, io.Discard); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
 	if err != nil {
-		t.Fatalf("convert: %v", err)
+		t.Fatalf("reading the output directory back: %v", err)
 	}
 
-	extracts := rowsOf[extractRow](t, extract)
-	if len(extracts) != 1 {
-		t.Fatalf("the extract table holds %d rows, want 1: its grain is the file", len(extracts))
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
 	}
 
-	want := extractRow{
-		HdrLedgerID: "GL-MAIN",
-		HdrPeriod:   202601,
-		HdrCurrency: "USD",
-		HdrCount:    postingTypes,
-		TrlCount:    postingTypes,
-		TrlNet:      trailerNet,
-	}
-	if extracts[0] != want {
-		t.Errorf("the extract row is %+v, want %+v", extracts[0], want)
+	if len(names) != 1 || names[0] != filepath.Base(out) {
+		t.Fatalf("the conversion left %v, want exactly [%q]: one grain that is not the posting is not a second file", names, filepath.Base(out))
 	}
 
-	postings := rowsOf[postingRow](t, posting)
-	if len(postings) != postingTypes {
-		t.Fatalf("the posting table holds %d rows, want %d: its grain is the posting", len(postings), postingTypes)
+	written, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("reading the posting table back: %v", err)
+	}
+
+	if rows := rowsOf[postingRow](t, written); len(rows) != postingTypes {
+		t.Errorf("the posting table holds %d rows, want %d: its grain is the posting", len(rows), postingTypes)
 	}
 }
 
 // TestHeaderContextIsDenormalizedOntoEveryPosting is the decision that makes the
 // posting table usable on its own.
 func TestHeaderContextIsDenormalizedOntoEveryPosting(t *testing.T) {
-	_, posting, err := converted(t, postingTypes, postingTypes)
-	if err != nil {
-		t.Fatalf("convert: %v", err)
-	}
-
-	for i, row := range rowsOf[postingRow](t, posting) {
+	for i, row := range rowsOf[postingRow](t, postingTable(t, postingTypes)) {
 		if row.HdrLedgerID != "GL-MAIN" || row.HdrPeriod != 202601 || row.HdrCurrency != "USD" {
 			t.Errorf("posting row %d carries (%q, %d, %q), want the header's (%q, %d, %q): a query filtering on the period has to be able to do it without a join",
 				i, row.HdrLedgerID, row.HdrPeriod, row.HdrCurrency, "GL-MAIN", 202601, "USD")
@@ -225,12 +279,16 @@ func TestHeaderContextIsDenormalizedOntoEveryPosting(t *testing.T) {
 // TestTrailerFieldsDoNotPromote is the other half of that decision, and the
 // reason it is a test rather than a sentence: TRL-COUNT and TRL-NET are
 // summaries *of* the posting rows, so denormalizing them would make
-// SUM(trl_net) return the total times the row count.
+// SUM(trl_net) return the total times the row count. With no second table to
+// keep them in, "they do not promote" now means there is no column for them
+// anywhere.
+//
+// HDR-COUNT is here for a different reason. It is a summary too, but it is one
+// the generated reader has already enforced — `ledger.sexpr` reads it into a
+// register and holds the body to it — so a column for it would be a number that
+// can only ever agree with a row count a query can take for itself.
 func TestTrailerFieldsDoNotPromote(t *testing.T) {
-	_, posting, err := converted(t, postingTypes, postingTypes)
-	if err != nil {
-		t.Fatalf("convert: %v", err)
-	}
+	posting := postingTable(t, postingTypes)
 
 	f, err := parquet.OpenFile(bytes.NewReader(posting), int64(len(posting)))
 	if err != nil {
@@ -241,6 +299,10 @@ func TestTrailerFieldsDoNotPromote(t *testing.T) {
 		if strings.HasPrefix(field.Name(), "trl_") {
 			t.Errorf("the posting table carries a %q column: a trailer field is a summary of these rows, and one on every row is a summary multiplied by the row count", field.Name())
 		}
+
+		if field.Name() == "hdr_count" {
+			t.Error("the posting table carries an hdr_count column: ledger.Reader already holds the body to HDR-COUNT, so the column is a count that cannot disagree with COUNT(*)")
+		}
 	}
 }
 
@@ -249,13 +311,8 @@ func TestTrailerFieldsDoNotPromote(t *testing.T) {
 // so PST-TYPE and the group that is present have to name which of the two a row
 // was.
 func TestTheMergedTableKeepsTheRecordTypeRecoverable(t *testing.T) {
-	_, posting, err := converted(t, postingTypes, postingTypes)
-	if err != nil {
-		t.Fatalf("convert: %v", err)
-	}
-
 	byType := make(map[string]postingRow)
-	for _, row := range rowsOf[postingRow](t, posting) {
+	for _, row := range rowsOf[postingRow](t, postingTable(t, postingTypes)) {
 		byType[row.PstType] = row
 	}
 
@@ -311,10 +368,7 @@ func present(row postingRow) string {
 // column that is null on every row of every extract is one a query has to know
 // to ignore.
 func TestTheOnlyDescriptionOfATailIsARequiredColumn(t *testing.T) {
-	_, posting, err := converted(t, postingTypes, postingTypes)
-	if err != nil {
-		t.Fatalf("convert: %v", err)
-	}
+	posting := postingTable(t, postingTypes)
 
 	f, err := parquet.OpenFile(bytes.NewReader(posting), int64(len(posting)))
 	if err != nil {
@@ -357,10 +411,7 @@ func TestEveryPostingReadIsAPostingWritten(t *testing.T) {
 		t.Fatalf("this fixture has %d postings and the batch is %d: a whole number of batches is the one file a missing terminal flush does not lose rows from", postings, batchSize)
 	}
 
-	_, posting, err := converted(t, postings, postings)
-	if err != nil {
-		t.Fatalf("convert: %v", err)
-	}
+	posting := postingTable(t, postings)
 
 	rows := rowsOf[postingRow](t, posting)
 	if len(rows) != postings {
@@ -383,22 +434,21 @@ func TestEveryPostingReadIsAPostingWritten(t *testing.T) {
 	}
 }
 
-// TestTheThreeAmountsRoundTripThroughDecimal is the claim that looks like it
+// TestTheTwoAmountColumnsRoundTripThroughDecimal is the claim that looks like it
 // needs a conversion and does not.
 //
 // cpybkc-gen-go writes a COMP-3 item as an unscaled int64 with the scale in its
 // doc comment, which is what DECIMAL(p,s) is, so the mapping is an annotation.
 // Reading the written file back and comparing against what the ledger reader
 // produced is what makes that a fact rather than a plausible sentence.
-func TestTheThreeAmountsRoundTripThroughDecimal(t *testing.T) {
-	extract, posting, err := converted(t, postingTypes, postingTypes)
-	if err != nil {
-		t.Fatalf("convert: %v", err)
-	}
-
-	if got := rowsOf[extractRow](t, extract)[0].TrlNet; got != trailerNet {
-		t.Errorf("TRL-NET came back as %d, want %d", got, trailerNet)
-	}
+//
+// TRL-NET is the third amount of the same shape and it is not here, because it
+// is no longer a column: it is read, reconciled and discarded, which is
+// [TestTheTrailerNetIsReconciled]. That all three carry scale 2 is what lets the
+// reconciliation be plain addition, and it is the reason the mapping is worth
+// stating for an item nothing writes.
+func TestTheTwoAmountColumnsRoundTripThroughDecimal(t *testing.T) {
+	posting := postingTable(t, postingTypes)
 
 	debits, credits := 0, 0
 
@@ -427,7 +477,6 @@ func TestTheThreeAmountsRoundTripThroughDecimal(t *testing.T) {
 		t.Fatalf("%d debit and %d credit rows carried an amount to compare, want some of each", debits, credits)
 	}
 
-	assertDecimal(t, extract, "trl_net", 15, 2)
 	assertDecimal(t, posting, "pst_debit.pdb_amount", 13, 2)
 	assertDecimal(t, posting, "pst_credit.pcr_amount", 11, 2)
 }
@@ -475,10 +524,10 @@ func assertDecimal(t *testing.T, file []byte, path string, precision, scale int3
 	}
 }
 
-// TestTheTrailerCountIsReconciled is the check a conversion that streams can
-// still make, and it runs before either footer is written.
+// TestTheTrailerCountIsReconciled is one of the two checks a conversion that
+// streams can still make, and it runs before the footer is written.
 func TestTheTrailerCountIsReconciled(t *testing.T) {
-	extract, posting, err := converted(t, postingTypes, postingTypes+1)
+	posting, err := converted(t, postingTypes, postingTypes+1, netOf(postingTypes))
 	if err == nil {
 		t.Fatalf("a file whose TRL-COUNT is %d and whose body holds %d postings converted without complaint", postingTypes+1, postingTypes)
 	}
@@ -487,8 +536,78 @@ func TestTheTrailerCountIsReconciled(t *testing.T) {
 		t.Errorf("the reconciliation failure is %q, and it does not name TRL-COUNT", err)
 	}
 
-	assertUnopenable(t, extract, "extract")
 	assertUnopenable(t, posting, "posting")
+}
+
+// TestTheTrailerNetIsReconciled is the other, and it is the one that costs an
+// accumulator: TRL-COUNT falls out of the row count, and TRL-NET does not.
+//
+// TRL-NET, PDB-AMOUNT and PCR-AMOUNT all carry scale 2, so what is summed here
+// is the unscaled integers as they stand and nothing multiplies or divides by a
+// hundred. A conversion that rescaled one side would fail this on every fixture,
+// which is the point of running it over a net that is not zero.
+func TestTheTrailerNetIsReconciled(t *testing.T) {
+	// One cent out. A reconciliation that compared anything coarser than the
+	// unscaled integer — the count, the magnitude, the sign — would pass this.
+	const off = 1
+
+	posting, err := converted(t, postingTypes, postingTypes, netOf(postingTypes)+off)
+	if err == nil {
+		t.Fatalf("a file whose TRL-NET is %d and whose postings sum to %d converted without complaint", netOf(postingTypes)+off, netOf(postingTypes))
+	}
+
+	if !strings.Contains(err.Error(), "TRL-NET") {
+		t.Errorf("the reconciliation failure is %q, and it does not name TRL-NET", err)
+	}
+
+	assertUnopenable(t, posting, "posting")
+}
+
+// TestTheNetTakesEachAmountWithTheSignTheRecordStoresIt is the assumption this
+// conversion makes that the copybook does not.
+//
+// `posting.cpy` gives both amounts a signed PICTURE and says nothing about what
+// a debit or a credit does to a total, so a converter that reconciles TRL-NET at
+// all has to pick. This one adds every amount with the sign the record stores
+// it under: the file is read as one that already carries the sign, which is what
+// the fixtures do — [posting] stores its credits negative.
+//
+// The fixture here is the other kind of layout, the one where both amounts are
+// stored as magnitudes and the credit is meant to subtract. Its trailer is
+// right for that layout and this conversion reports it as wrong, which is
+// exactly what an adopter whose file is shaped that way must see happen rather
+// than have quietly accepted. README.md, "The sign the net assumes", is where
+// the choice is argued.
+func TestTheNetTakesEachAmountWithTheSignTheRecordStoresIt(t *testing.T) {
+	const magnitude = int64(50000)
+
+	debit := &ledger.DebitPosting{PstAccount: "ACCT000001", PstSequence: 1, PstType: "DR"}
+	debit.PstDebit.PdbAmount = magnitude
+
+	// Stored positive, and meant to subtract. That is the layout this
+	// conversion is not.
+	credit := &ledger.CreditPosting{PstAccount: "ACCT000002", PstSequence: 2, PstType: "CR"}
+	credit.PstCredit.PcrAmount = magnitude
+
+	src := &oneOff{records: []ledger.Record{
+		&ledger.LedgerHeader{HdrType: "01", HdrLedgerId: "GL-MAIN", HdrPeriod: 202601, HdrCurrency: "USD", HdrCount: 2},
+		debit,
+		credit,
+		// Debits less credits, which is zero — and this conversion sums them
+		// to twice the magnitude instead.
+		&ledger.LedgerTrailer{TrlType: "99", TrlCount: 2, TrlNet: 0},
+	}}
+
+	var posting bytes.Buffer
+
+	err := convert(src, &posting)
+	if err == nil {
+		t.Fatal("an extract whose credits are stored positive and meant to subtract reconciled against a net this conversion did not compute")
+	}
+
+	if !strings.Contains(err.Error(), fmt.Sprint(2*magnitude)) {
+		t.Errorf("the reconciliation failure is %q, and it does not say what this conversion summed the amounts to: an adopter whose layout is the other one finds out from this line", err)
+	}
 }
 
 // unmappable is a record no transition of this layout admits, which is what a
@@ -528,9 +647,9 @@ func TestAMappingErrorFailsTheConversion(t *testing.T) {
 		unmappable{},
 	}}
 
-	var extract, posting bytes.Buffer
+	var posting bytes.Buffer
 
-	err := convert(src, &extract, &posting)
+	err := convert(src, &posting)
 	if err == nil {
 		t.Fatal("a record neither of the two posting types describes converted without complaint")
 	}
@@ -547,9 +666,9 @@ func TestAMappingErrorFailsTheConversion(t *testing.T) {
 func TestAPostingBeforeItsHeaderIsReported(t *testing.T) {
 	src := &oneOff{records: []ledger.Record{posting(1)}}
 
-	var extract, posting bytes.Buffer
+	var written bytes.Buffer
 
-	err := convert(src, &extract, &posting)
+	err := convert(src, &written)
 	if err == nil {
 		t.Fatal("a posting ahead of its header converted without complaint")
 	}

--- a/example/parquet/convert_test.go
+++ b/example/parquet/convert_test.go
@@ -87,13 +87,21 @@ func ledgerBytes(t *testing.T, n int32, trlCount int32, trlNet int64) []byte {
 // PDB-AMOUNT is thirteen digits and PCR-AMOUNT eleven, and a value that fits in
 // both would not tell a mistaken precision from a correct one.
 //
-// The debit is thirteen digits and not nine-nine-nine-nine, because now that
-// TRL-NET is reconciled the largest fixture here has to sum inside the
-// trailer's own fifteen: 999 postings of this one come to
-// 887,012,346,228,013, which fits, where 999 of a full 9,999,999,999,999 would
-// not. That is a property a real layout's trailer has to have and this one only
-// just does — a trailer two digits narrower than the sum of the rows it totals
-// is a layout that cannot describe its own worst case.
+// The debit shrank from a full 9,999,999,999,999 when TRL-NET started being
+// reconciled, because the largest fixture here now has to sum inside the
+// trailer's own fifteen digits. What fits is the **alternating** 999-posting
+// fixture — 499 debits and 500 credits, netting 887,012,346,228,013 — and not
+// 999 debits, which come to 1,874,666,667,776,013 and do not. The headroom is
+// in the alternation and not in the constant, so a change to which record type
+// [posting] hands out, or a fixture longer than 999, overflows TRL-NET and
+// arrives as a reconciliation failure that has nothing to do with the
+// conversion.
+//
+// That the margin is this thin is a property of the layout rather than of the
+// fixture: TRL-NET is two digits wider than PDB-AMOUNT, so a file of more than
+// about a hundred like-signed postings has a total its own trailer cannot
+// describe. A real layout's trailer has to be wide enough for the rows it
+// totals, and this one only just is.
 //
 // The credit is negative because this file stores the sign of a posting on the
 // posting; see [TestTheNetTakesEachAmountWithTheSignTheRecordStoresIt].
@@ -105,16 +113,33 @@ const (
 // netOf is the TRL-NET a well-formed fixture of n postings carries: the amounts
 // its records store, summed.
 //
-// It is arithmetic over this file's own two constants rather than a second copy
-// of the conversion's accumulator — [posting] hands out a debit on every even i,
-// so n/2 of them are debits and the rest credits. A constant written down here
-// instead would have to be recomputed by hand every time either amount moved,
-// and the reconciliation would start failing for a reason that is not the one
-// under test.
+// It walks [posting] rather than counting the record types itself. Closed-form
+// arithmetic over the two constants is shorter, and it was wrong to write:
+// n/2 debits is only right because [ledgerBytes] numbers its postings from one,
+// and a loop that started from zero would leave every fixture failing its own
+// TRL-NET reconciliation for a reason that has nothing to do with the
+// conversion. Reading the fixture is not a second copy of the conversion's
+// accumulator — it never touches convert.go — and it survives a change to
+// either the alternation or the loop base.
 func netOf(n int32) int64 {
-	debits := n / 2
+	net := int64(0)
 
-	return int64(debits)*debitAmount + int64(n-debits)*creditAmount
+	for i := int32(1); i <= n; i++ {
+		switch rec := posting(i).(type) {
+		case *ledger.DebitPosting:
+			net += rec.PstDebit.PdbAmount
+		case *ledger.CreditPosting:
+			net += rec.PstCredit.PcrAmount
+		default:
+			// posting hands out one of the two, so this is unreachable —
+			// and a third record type added to the fixture without an arm
+			// here would otherwise silently net to zero for it, which is a
+			// TRL-NET the conversion would then be blamed for.
+			panic(fmt.Sprintf("the fixture handed out a %T, and netOf knows the two record types this layout names", rec))
+		}
+	}
+
+	return net
 }
 
 // posting is the i'th posting of a fixture, of the i'th of the two record types.
@@ -227,29 +252,14 @@ func rowsOf[T any](t *testing.T, b []byte) []T {
 // directory that reads back with exactly one entry in it is both halves of the
 // claim at once.
 func TestTheConversionWritesOneFile(t *testing.T) {
-	in := filepath.Join(t.TempDir(), "ledger.dat")
-	if err := os.WriteFile(in, ledgerBytes(t, postingTypes, postingTypes, netOf(postingTypes)), 0o600); err != nil {
-		t.Fatalf("writing the fixture extract: %v", err)
-	}
-
-	// A directory that is not there yet, because the invocation README.md
-	// documents has to run on a machine that has never run it.
-	dir := filepath.Join(t.TempDir(), "out")
-	out := filepath.Join(dir, "posting.parquet")
+	in := extractOnDisk(t, postingTypes, netOf(postingTypes))
+	dir, out := outputPath(t)
 
 	if err := run([]string{"-in", in, "-out", out}, io.Discard); err != nil {
 		t.Fatalf("run: %v", err)
 	}
 
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatalf("reading the output directory back: %v", err)
-	}
-
-	names := make([]string, 0, len(entries))
-	for _, entry := range entries {
-		names = append(names, entry.Name())
-	}
+	names := entryNames(t, dir)
 
 	if len(names) != 1 || names[0] != filepath.Base(out) {
 		t.Fatalf("the conversion left %v, want exactly [%q]: one grain that is not the posting is not a second file", names, filepath.Base(out))
@@ -262,6 +272,103 @@ func TestTheConversionWritesOneFile(t *testing.T) {
 
 	if rows := rowsOf[postingRow](t, written); len(rows) != postingTypes {
 		t.Errorf("the posting table holds %d rows, want %d: its grain is the posting", len(rows), postingTypes)
+	}
+}
+
+// extractOnDisk writes a fixture of n postings whose trailer totals trlNet to a
+// file, and returns the path, for the tests that go through [run].
+func extractOnDisk(t *testing.T, n int32, trlNet int64) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "ledger.dat")
+	if err := os.WriteFile(path, ledgerBytes(t, n, n, trlNet), 0o600); err != nil {
+		t.Fatalf("writing the fixture extract: %v", err)
+	}
+
+	return path
+}
+
+// outputPath is a -out under a directory that is not there yet, because the
+// invocation README.md documents has to run on a machine that has never run it.
+func outputPath(t *testing.T) (dir, out string) {
+	t.Helper()
+
+	dir = filepath.Join(t.TempDir(), "out")
+
+	return dir, filepath.Join(dir, "posting.parquet")
+}
+
+// entryNames is what a directory holds, which is how a claim about how many
+// files a run wrote is asserted.
+func entryNames(t *testing.T, dir string) []string {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading %s back: %v", dir, err)
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+
+	return names
+}
+
+// TestAFailedRunLeavesNoFileBehind is the on-disk half of both reconciliations,
+// and it is the half [TestTheTrailerCountIsReconciled] and
+// [TestTheTrailerNetIsReconciled] cannot assert: they convert into a buffer, so
+// what they show is that the bytes are unopenable, not that write cleaned up
+// after itself.
+//
+// What is on the disk after a failed run is not an unopenable file. It is no
+// file: the footer was never written, and write removes the path it created
+// rather than leaving bytes somebody has to know to distrust.
+func TestAFailedRunLeavesNoFileBehind(t *testing.T) {
+	// One cent out, which is the reconciliation failing rather than the reader.
+	in := extractOnDisk(t, postingTypes, netOf(postingTypes)+1)
+	dir, out := outputPath(t)
+
+	err := run([]string{"-in", in, "-out", out}, io.Discard)
+	if err == nil {
+		t.Fatal("a file whose TRL-NET disagrees with its own postings converted without complaint")
+	}
+
+	if !strings.Contains(err.Error(), "TRL-NET") {
+		t.Errorf("the failure is %q, and it does not name TRL-NET", err)
+	}
+
+	if names := entryNames(t, dir); len(names) != 0 {
+		t.Errorf("the failed run left %v behind, want nothing: a half-converted file that survives is one somebody queries", names)
+	}
+}
+
+// TestOutNamingADirectoryIsReportedAgainstTheRightFlag is the upgrade path.
+//
+// -out named a directory while this conversion wrote two files, so the
+// invocation an adopter already has hands over one that exists. Left to
+// os.Create that is "is a directory" under a wrapper naming the input, which
+// sends somebody to look at their extract over a mistake in a flag.
+func TestOutNamingADirectoryIsReportedAgainstTheRightFlag(t *testing.T) {
+	in := extractOnDisk(t, postingTypes, netOf(postingTypes))
+	dir := t.TempDir()
+
+	err := run([]string{"-in", in, "-out", dir}, io.Discard)
+	if err == nil {
+		t.Fatal("-out naming a directory was accepted, and the conversion writes a file")
+	}
+
+	if !strings.Contains(err.Error(), "-out") {
+		t.Errorf("the failure is %q, and it does not name the flag that is wrong", err)
+	}
+
+	if strings.Contains(err.Error(), in) {
+		t.Errorf("the failure is %q, and it names the input file: the mistake is in -out, and an error that mentions the extract sends somebody to read the wrong thing", err)
+	}
+
+	if names := entryNames(t, dir); len(names) != 0 {
+		t.Errorf("the rejected run left %v in the directory it refused, want nothing", names)
 	}
 }
 


### PR DESCRIPTION
Closes #306

`example/parquet` wrote two files. It now writes one, at the posting grain, and
spends the file-level grain rather than storing it.

## Acceptance criteria

- [x] **The conversion writes exactly one Parquet file.** `extractRow` and
  `extractRowOf` are gone, `convert` takes one `io.Writer` and `write` one path.
  `TestTheConversionWritesOneFile` goes through `run` rather than `convert` —
  "one file" is a claim about the disk, not about how many writers were opened —
  and reads the output directory back expecting exactly one entry.
- [x] **Every posting row carries the header's identifying fields; no `trl_`
  column and no `hdr_count` column exists.** `TestTrailerFieldsDoNotPromote`
  now asserts both absences over the one remaining schema;
  `TestHeaderContextIsDenormalizedOntoEveryPosting` is unchanged in intent.
- [x] **`TRL-COUNT` and `TRL-NET` are both reconciled before the footer is
  written, and a mismatch in either fails the run leaving nothing a Parquet
  reader will open — asserted for both.** `TestTheTrailerCountIsReconciled` and
  the new `TestTheTrailerNetIsReconciled` each assert the failure names its item
  and each end in `assertUnopenable`. The net test is one cent out, because a
  reconciliation comparing anything coarser than the unscaled integer would pass
  a larger error.
- [x] **The sign convention the net assumes is stated in the code and in
  `README.md` as an assumption the copybook does not make.** See below.
- [x] **`README.md` no longer argues that two grains means two files.** "Two
  grains, so two files" is now "Two grains, one table", and it argues from the
  key: a file-level table has none, so it can only be joined on the denormalized
  fields that are already on every posting row. It ends with the rule to try
  first on your own layout, and with the case that does earn a second table — a
  parent field that is neither identifying nor a summary.
- [x] **Whether `-out` names a directory or the output file is decided, and the
  documented invocation matches.** It names the file, defaulting to
  `posting.parquet`; the directory it sits in is still created. The documented
  invocation is now `-out /tmp/ledger/posting.parquet`, and
  `TestTheConversionWritesOneFile` runs it against a directory that does not
  exist yet.
- [x] **`dagger call example-parquet-ci` green** — and `dagger call ci`, both
  from an ordinary clone as `CONTRIBUTING.md` requires.

## The judgment calls

**The sign.** `posting.cpy` gives both amounts a signed `PICTURE` and says
nothing about what a debit or a credit does to a total, so a converter that
reconciles `TRL-NET` at all has to pick one. This one **adds every amount with
the sign the record stores it under**. It is stated at `postingRowOf`, argued in
README.md's new "The sign the net assumes", and named in the error the check
produces. `TestTheNetTakesEachAmountWithTheSignTheRecordStoresIt` feeds it the
other kind of layout — magnitudes, credit meant to subtract — and requires the
mismatch to be reported rather than accepted.

**Where that leaves "The semantics stop at the copybook".** That section now has
a subsection drawing the line it was implicitly on: a semantic that changes what
is *stored* is out, a semantic that only *checks* what is stored can be in if it
is stated and falsifiable. The test of the distinction is what the assumption
does when it is wrong — a guessed date mis-stores every row silently, a guessed
sign fails a check on the first file.

**The accumulator.** Plain `int64` addition with no rescaling, because all three
amounts carry scale 2 — a property of this layout and not of decimals, so it is
commented at the accumulator and given its own README section. It cannot
overflow on a file this layout describes: `HDR-COUNT` is `PIC 9(3)`, so at most
999 amounts of at most thirteen digits are summed.

**`debitAmount` moved** from 9876543210987 to 1876543210987. With `TRL-NET` now
reconciled, the 999-posting fixture has to sum inside the trailer's own fifteen
digits, and 999 of the old value did not. The constant's comment says so — a
trailer narrower than the sum of the rows it totals is a layout that cannot
describe its own worst case.

## Verified

`dagger call ci` and `dagger call example-parquet-ci`, both green, run from an
ordinary clone of this branch because the pipeline does not run from a git
worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)