### PR TITLE
story(ir): decide whether a batch boundary may be told by ordered evaluation

### DIFF
--- a/docs/ir/SPEC.md
+++ b/docs/ir/SPEC.md
@@ -2661,6 +2661,56 @@ The evaluation order is normative all the same, so that two consumers handed the
 same bytes do the same work in the same order and report the same thing when
 something is wrong with them.
 
+That permission is a consumer's, and it is not a producer's. **Ordered
+evaluation does not license an overlapping pair.** A producer **MUST NOT** emit
+two transitions leaving one state whose guards can hold at the same time and
+whose predicates can both match one record on the grounds that a consumer would
+try them in the order the state carries, and `resolve` **MUST** reject such a
+layout whether or not the layout says that is what it intends (#324). The
+asymmetry is only apparent: stopping at the first match is safe *because* at
+most one transition can match, which is what the paragraphs above establish, and
+reading the permission the other way round makes an optimisation into the thing
+that was meant to justify it.
+
+The shape that asks for it is real, and naming it here is cheaper than meeting
+it as a diagnostic. A file that is a sequence of batches — a header, then
+details until the next header — has two records eligible at the state after a
+header, and where the two discriminators name runs at different offsets or of
+different widths the runs do not line up and one record can satisfy both tests
+(#323). *Try the header's test first, and read anything that fails it as a
+detail* reads that file, and is presumably what the vendor reader that wrote it
+does. `layout/SPEC.md` states the shape, and what a layout may write instead, at
+[A batch boundary told only by evaluation
+order](../layout/SPEC.md#a-batch-boundary-told-only-by-evaluation-order).
+
+What such a descriptor gives up is the whole of what the overlap rule gives.
+Ordered matching encodes *try the header first*; it is not a proof that the two
+tests cannot both hold. A detail whose account number begins with the header's
+literal at that offset is then read as a header, the batch is split in the wrong
+place, and no rule in this document fires on it — those bytes matched a
+predicate the descriptor carries, so it is not an undescribed record, and where
+the two records share an extent the framing has nothing to disagree with either
+([The extent governs, and framing is checked against
+it](#the-extent-governs-and-framing-is-checked-against-it)). Admitting it is
+admitting a layout that opts out of the check, which is the `otherwise`
+`layout/SPEC.md` refuses under another spelling: an arm that catches what the
+others missed is what *last in the order* means, whether the lastness is written
+as a keyword or as a position.
+
+Both spellings of the permission were weighed against [Versioning and
+compatibility](#versioning-and-compatibility), and the safer one costs more. A
+pair a consumer can *tell* is ordered — a marker on the state, or a third member
+of the predicate set — is an addition a consumer must understand in order to
+stay correct, so the IR version advances and every existing consumer refuses
+every descriptor until it is taught the marker: a bill paid by everyone who has
+one, for a shape one reported file has. The spelling that costs nothing is the
+worse of the two, because leaving the ordering to be inferred from transition
+order alone is invisible to an old consumer, which reads the descriptor as
+conforming, keeps its own order, and misreads the file rather than refusing it.
+`v0.0.4` is released, so neither is free. And the two directions are not
+symmetric in time: this refusal can be lifted later at exactly that price, while
+a permission cannot be withdrawn from the descriptors already written under it.
+
 Where no transition matches, the input is a record the layout does not describe.
 A consumer **MUST** report that rather than skipping ahead to a transition that
 matches later or falling through to a default. There is no default, and a file
@@ -3909,7 +3959,7 @@ records offer them.
 | [The encoding profile, applied](#the-encoding-profile-applied) | #33 `resolve`; an item that carries bytes rather than characters by #275; the fifth axis, the binary width staircase resolved from the dialect, by #293; which consumers the axis rule binds, settled by #297 |
 | [Names](#names) | #30 `layout`, #38 `resolve`; what a record node resolved from a `REDEFINES` is called, settled by #164 |
 | [The sequencing automaton](#the-sequencing-automaton) | #36 `resolve`, #76, #77, #80, #84, #88 `ir` |
-| [Discriminator predicates](#discriminator-predicates) | #28 `layout`, #37 `resolve`, #80, #84, #88, #90, #94 `ir` |
+| [Discriminator predicates](#discriminator-predicates) | #28 `layout`, #37 `resolve`, #80, #84, #88, #90, #94 `ir`; whether a producer may emit an overlapping pair resolved by evaluation order, settled unchanged by #324 against discussion #323 |
 | [Writing a file](#writing-a-file) | #79, #80, #82, #88, #89, #90 `ir`, #51, #52 `gen-go` |
 | [Versioning and compatibility](#versioning-and-compatibility) | #17, #18 `ir` |
 | [Why protobuf, and why no gRPC](#why-protobuf-and-why-no-grpc) | #17, #19 `ir` |

--- a/docs/layout/SPEC.md
+++ b/docs/layout/SPEC.md
@@ -1166,6 +1166,21 @@ miss, and the IR refuses the reading in as many words, because a state offering
 two transitions that can both apply is a layout that was rejected before a
 consumer saw it.
 
+Nor does the *order* two strategies are written in become one. There is no form
+saying to try one discriminator first and read what it does not match as the
+other record, and no spelling is reserved for one — not a fourth strategy, not a
+modifier on `discriminate`, and not a rule reading the order of the
+`discriminate` forms or of an `alt`'s operands. That was reopened by
+[discussion #323](https://github.com/Zaba505/cpybkc/discussions/323), where a
+file that is a sequence of batches needs exactly it, and settled unchanged
+(#324): a first-match ordering over two discriminators that can both match one
+record *is* the default arm, spelled as a position rather than as a keyword, and
+[`ir/SPEC.md`](../ir/SPEC.md#when-two-match-and-when-none-does) refuses the
+descriptor it would lower into, weighing there what admitting it would cost a
+released IR version. The shape that asks for it, and the four things a layout
+may write instead, are [A batch boundary told only by evaluation
+order](#a-batch-boundary-told-only-by-evaluation-order).
+
 ### The strategies that are not in the set, and where each one went
 
 Five ways of telling record types apart were proposed for this format (#28).
@@ -1854,6 +1869,53 @@ What an adopter writes instead is stated where the loss is — the two record
 names where the flag is the discriminating item, and a check of their own beside
 the generated reader where it is not.
 
+### A batch boundary told only by evaluation order
+
+`(+ (seq HEADER (* DATA)))` — a header, then details until the next header — is
+an ordinary layout and compiles. What is **not** describable is that shape where
+the two records can be told apart only by *trying the header's discriminator
+first*. At the state after a `HEADER` the sequence admits `DATA`, by another
+pass of the inner `*`, and `HEADER`, by the outer `+`'s back edge; where the two
+discriminators name runs at different offsets or of different widths, one record
+can satisfy both tests, and `resolve` rejects the layout naming both records.
+There is no form saying to try one of them first, and none is planned ([Three
+strategies, and the set is closed for
+v1](#three-strategies-and-the-set-is-closed-for-v1)).
+
+Four things separate those two transitions, and a layout needs **one** of them:
+
+- **a type code at a common offset and width in both records**, which makes the
+  two literals name the same run, so `equals` on each provably excludes the
+  other;
+- **a count in the header**, written `(times …)` on the inner repetition, which
+  separates the two transitions by a guard instead of by bytes ([Two operators
+  read a value, and they are the automaton's
+  memory](#two-operators-read-a-value-and-they-are-the-automatons-memory));
+- **a trailer ending each batch**, `(+ (seq HEADER (* DATA) TRAILER))`, which
+  moves the back edge to a state where `HEADER` is the only record admitted;
+- **an item with a bounded value set** at the offset and width of the other
+  record's discriminator, which `one-of` can name to line the two runs up.
+
+Reason: ordered matching would encode *try `HEADER` first*, which is not a proof
+that the two tests cannot both hold, and that proof is the whole of what the
+overlap check gives. Where a detail's account number can begin with the header's
+literal at that offset, a first-match reader reads that detail as a header and
+splits the batch in the wrong place, with no diagnostic anywhere: those bytes
+matched a predicate the descriptor carries, so it is not an undescribed record,
+and where the two records share an extent the framing has nothing to disagree
+with either. So it is a convention a layout would assert about its data rather
+than something either layer can check, and the layer that would have to carry it
+refuses it — [`ir/SPEC.md`](../ir/SPEC.md#when-two-match-and-when-none-does)
+holds the refusal and weighs what admitting it would cost a released IR version,
+which is where the decision would be reopened.
+
+Raised by [discussion #323](https://github.com/Zaba505/cpybkc/discussions/323),
+whose adopter has none of the four and vendor copybooks that cannot be changed,
+and settled by #324. It is a limit of the same kind as [a record told apart only
+by its length](../ir/SPEC.md#a-record-told-apart-only-by-its-length), and it is
+stated here for the same reason: an adopter meets it in prose rather than in a
+diagnostic.
+
 ### The copybook language
 
 Level numbers, `PIC` clauses, `OCCURS`, `REDEFINES` — the contents of a copybook
@@ -2165,7 +2227,7 @@ and neither is a second profile.
 | [The encoding profile](#the-encoding-profile) | #25 `layout`; an item that carries bytes rather than text, and the conversion residue left out beside it, by #275; a worked example of the converted file the section calls the most common, by #273; why the binary width staircase `codec/SPEC.md` declares fifth is not one of these four, by #293 |
 | [Physical framing](#physical-framing) | #26 `layout` |
 | [Record definitions](#record-definitions) | #27, #30 `layout`; `copybook-reading` by #35 `resolve`; which alternative a `record` form is, a rename naming a record, and a rename being per record, settled by #164 |
-| [Discrimination](#discrimination) | #28 `layout`; the strategies lowered into IR predicates, the literals resolved to bytes, and the rules on a target that need a copybook, by #37 `resolve` |
+| [Discrimination](#discrimination) | #28 `layout`; the strategies lowered into IR predicates, the literals resolved to bytes, and the rules on a target that need a copybook, by #37 `resolve`; that neither a strategy nor the order two are written in becomes a default arm, and the batch shape that is undescribable without one, settled by #324 against discussion #323 |
 | [Sequencing](#sequencing) | #29 `layout`; the expression compiled to an automaton, and the rules on `times` and `when` that need a copybook, by #36 `resolve`; what a `when` does and does not require, and where a guard lands on a repetition, settled by #144 against the compiler #36 had already produced |
 | [The published schema](#the-published-schema) | #23 `layout` |
 | [Validation and diagnostics](#validation-and-diagnostics) | #24, #31 `layout` |


### PR DESCRIPTION
Closes #324

## The decision

**A producer may not emit two transitions leaving one state whose predicates
overlap, resolved by evaluation order.** The refusal stands, and both specs now
say so where the question is asked rather than leaving it to be met as a
diagnostic.

The asymmetry the issue names — that the IR already defines a normative
evaluation order and already lets a consumer stop at the first match — resolves
the other way round from how it reads. First-match is sound *because* at most
one transition can match, which is what the overlap rule establishes. Reading it
as a producer permission makes an optimisation into the thing that was meant to
justify it.

Three things decided it:

- **What would be given up is the whole of what the check gives.** Ordered
  matching encodes *try `HEADER` first*, not a proof the two tests cannot both
  hold. A detail whose account number begins with the header's literal at that
  offset is read as a header and the batch splits in the wrong place, with no
  diagnostic anywhere: those bytes matched a predicate the descriptor carries,
  so it is not an undescribed record, and where the two records share an extent
  the framing has nothing to disagree with either.
- **Versioning (AC 7).** The safe spelling — a marker a consumer can *tell* is
  ordered, whether a state flag or a third predicate member — is an addition a
  consumer must understand to stay correct, so the IR version advances and every
  existing consumer refuses every descriptor until taught it: a bill paid by
  everyone who has one, for a shape one reported file has. The spelling that
  costs nothing (infer it from transition order alone) is worse, because it is
  invisible to an old consumer, which reads the descriptor as conforming and
  misreads the file rather than refusing it. `v0.0.4` is released, so neither is
  free.
- **The two directions are not symmetric in time.** The refusal can be lifted
  later at exactly that price; a permission cannot be withdrawn from the
  descriptors already written under it.

It is also the `otherwise` `layout/SPEC.md` already refuses, under another
spelling: an arm that catches what the others missed is what *last in the order*
means, whether the lastness is written as a keyword or as a position.

## Acceptance criteria

- [x] `docs/ir/SPEC.md` states whether a producer may emit two transitions
  leaving one state whose predicates overlap, resolved by evaluation order — in
  [When two match, and when none
  does](https://github.com/Zaba505/cpybkc/blob/issue-324/docs/ir/SPEC.md#when-two-match-and-when-none-does),
  immediately after the consumer permission it is easy to read as licence.
  **MUST NOT**, and `resolve` **MUST** reject such a layout whether or not the
  layout says the order is what it intends.
- [ ] ~If it may, the descriptor says so explicitly~ — not applicable; it may
  not. The two spellings it would have taken are weighed in the same section
  rather than left unstated, because which one is cheaper is the argument.
- [ ] ~If it may, the guarantee that is given up is stated where the permission
  is granted~ — not applicable. The guarantee is stated where the refusal is, as
  what admitting it would cost.
- [x] If it may not, `docs/layout/SPEC.md` states the shape that is
  undescribable — [A batch boundary told only by evaluation
  order](https://github.com/Zaba505/cpybkc/blob/issue-324/docs/layout/SPEC.md#a-batch-boundary-told-only-by-evaluation-order),
  a new Out of Scope entry naming misaligned discriminators with no count, no
  trailer and no bounded-value item, and cross-linked to *a record told apart
  only by its length* as a limit of the same kind. It also names the **four**
  constructions that do separate the pair, so the entry sends an adopter
  somewhere rather than only refusing.
- [x] "An `otherwise` or a default arm is deliberately absent" is updated to
  match, and the **surface spelling is settled rather than deferred**: no form,
  no fourth strategy, no modifier on `discriminate`, and no rule reading the
  order of the `discriminate` forms or of an `alt`'s operands. No follow-on
  story is needed, because there is nothing left to spell.
- [x] The decision names discussion #323 as the motivating case — in both specs
  and in both story-mapping tables.
- [x] The breaking change is weighed against the versioning policy, with
  `v0.0.4` released; see the bullet above.

## Judgment calls

- **The refusal is normative in `ir/SPEC.md` and the shape is descriptive in
  `layout/SPEC.md`**, rather than stated twice. That mirrors how a record told
  apart only by its length is already handled: the layer that would have to
  carry the thing refuses it, and the adopter-facing layer names the file it
  costs. AC 4's "alongside" is honoured by cross-link and by matching that
  entry's shape, not by moving the ir entry.
- **No code changed.** `resolve` already rejects the pair, and its diagnostic
  already names both records; this story decided whether it should stop, and it
  should not.

## Verification

`dagger call ci` from an ordinary clone (it cannot run from a git worktree — see
`CONTRIBUTING.md`), green in 2m6s. Every anchor added or targeted by the new
prose was checked to resolve against a heading in the file it names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
