### PR TITLE
story(resolve): name the two byte runs in the sequence ambiguity diagnostic

### DIFF
--- a/internal/resolve/automaton_errors.go
+++ b/internal/resolve/automaton_errors.go
@@ -396,8 +396,18 @@ type ByteRun struct {
 // Both ends rather than an offset and a width, because what an adopter compares
 // is two runs, and two pairs of endpoints can be compared by eye while an offset
 // beside a width cannot.
+//
+// A run of no bytes says so rather than being drawn as one. It is a state a
+// fault really carries — [SequenceAmbiguityError.Runs] is the zero pair wherever
+// there was no target to place, which [SequenceAmbiguityError.placed] is what
+// keeps out of the message — and computing the last byte of a run that has none
+// gives an end before its start, so a `%v` of the fault anywhere else would read
+// `bytes 0--1`.
 func (r ByteRun) String() string {
-	if r.Width == 1 {
+	switch {
+	case r.Width <= 0:
+		return "no bytes"
+	case r.Width == 1:
 		return fmt.Sprintf("byte %d", r.At)
 	}
 

--- a/internal/resolve/automaton_errors.go
+++ b/internal/resolve/automaton_errors.go
@@ -267,6 +267,17 @@ func (e *UnboundRegisterError) Diagnostic() diag.Diagnostic {
 // says which of the two shapes it is, because the fixes differ: one is a
 // discriminator to narrow and the other is a record type that offers nothing to
 // tell it apart by.
+//
+// [SequenceAmbiguityError.Runs] is the pair of byte runs the two discriminators
+// actually compared, and naming them is what tells the two remaining shapes
+// apart. Once intersecting runs whose literals disagree are accepted (#325),
+// what is left is either a pair whose runs share no byte — which no literal
+// either record could carry would ever separate, so the layout needs a count, a
+// trailer or a different target — or a pair agreeing on a literal over the bytes
+// they do share, which is a clash in the literals and is the adopter's to fix
+// there. Discussion #323 is what the distinction costs when it is missing: four
+// rounds to establish where the two targets sat, and a report filed against
+// sequencing operators that turned out to be irrelevant.
 type SequenceAmbiguityError struct {
 	// Pos is where the second of the two record names was written, and First
 	// where the first was.
@@ -283,6 +294,14 @@ type SequenceAmbiguityError struct {
 	// Records are the records the two transitions admit.
 	Records [2]string
 
+	// Runs are the bytes each discriminator's target occupies in the record
+	// it belongs to, in the same order as Records.
+	//
+	// Both are the zero run where one of the two carries no predicate, since
+	// there is then no second target to place and Unguarded is what the
+	// message is about instead.
+	Runs [2]ByteRun
+
 	// Unguarded reports that one of the two carries no predicate at all.
 	Unguarded bool
 
@@ -298,8 +317,14 @@ func (e *SequenceAmbiguityError) Error() string { return e.Diagnostic().String()
 // Diagnostic is what the error says, and where.
 func (e *SequenceAmbiguityError) Diagnostic() diag.Diagnostic {
 	why := "their discriminators can both match one record"
-	if e.Unguarded {
+
+	switch {
+	case e.Unguarded:
+		// A record type offering nothing to tell it apart by is not about a
+		// run of bytes, so it keeps the wording it had.
 		why = "one of them carries no discriminator, so it matches every record"
+	case e.placed():
+		why = e.compared()
 	}
 
 	separated := ""
@@ -315,6 +340,84 @@ func (e *SequenceAmbiguityError) Diagnostic() diag.Diagnostic {
 		Spans: spans(e.Pos, e.First, "the other is admitted here"),
 	}
 }
+
+// placed reports whether both targets were located in their records.
+//
+// A run of no bytes is not one an item can occupy, so it is what "there was no
+// target to place" looks like: the unguarded pair, where one of the two carries
+// no predicate at all, and the pair [compiler.stretchOf] could not place — which
+// is a misspelled item [compiler.discriminator] has already reported, and not
+// something to name a byte offset over.
+func (e *SequenceAmbiguityError) placed() bool {
+	return e.Runs[0].Width > 0 && e.Runs[1].Width > 0
+}
+
+// compared is the two runs the discriminators read and what sharing or not
+// sharing bytes leaves an adopter to do about them.
+//
+// The two are opposite answers rather than degrees of the same one, which is why
+// the message says which it is. Runs that share no byte are told apart by
+// nothing a literal can express — a record carries an `S` at byte zero and an
+// `X` at byte ten at the same time — so the resolution is a count, a trailer or
+// a different target, and an adopter who reads "their discriminators overlap"
+// and goes looking for a better literal is looking for something that does not
+// exist. Runs that do share bytes and agree over them are the ordinary clash,
+// and the literals are exactly where it is fixed.
+func (e *SequenceAmbiguityError) compared() string {
+	read := fmt.Sprintf("their discriminators read %s %s and %s %s",
+		e.Records[0], e.Runs[0], e.Records[1], e.Runs[1])
+
+	window, sharing := e.Runs[0].shares(e.Runs[1])
+	if !sharing {
+		return read + ", which share no byte, so no literal either could carry would tell the two apart"
+	}
+
+	return read + fmt.Sprintf(", and they agree on a literal over %s", window)
+}
+
+// ByteRun is where a discriminator's target sits in the record it belongs to:
+// the offset of its first byte, counting from zero, and how many bytes it
+// covers.
+//
+// It is the offset within that record and not within the file, because that is
+// what a consumer reading the record in front of it has: the run
+// [compiler.stretchOf] takes off the record's own static layout, which is the
+// same run in every record of that type.
+type ByteRun struct {
+	// At is the offset of the first byte, counting from zero, and Width the
+	// number of bytes.
+	At    int
+	Width int
+}
+
+// String draws the run the way a diagnostic names it: `byte 4` for one byte and
+// `bytes 4-5` for a run of them, ends included.
+//
+// Both ends rather than an offset and a width, because what an adopter compares
+// is two runs, and two pairs of endpoints can be compared by eye while an offset
+// beside a width cannot.
+func (r ByteRun) String() string {
+	if r.Width == 1 {
+		return fmt.Sprintf("byte %d", r.At)
+	}
+
+	return fmt.Sprintf("bytes %d-%d", r.At, r.At+r.Width-1)
+}
+
+// shares is the run both cover, and whether they cover one at all.
+//
+// It is [stretch.shares] asked of the pair a fault carries, so that the message
+// intersects the two runs exactly as the check that raised it did. Two readings
+// of what "share no bytes" means would be a diagnostic that says a different
+// literal cannot help about a pair [overlap] decided on a literal.
+func (r ByteRun) shares(other ByteRun) (ByteRun, bool) {
+	window, sharing := r.stretch().shares(other.stretch())
+
+	return window.run(), sharing
+}
+
+// stretch is the run as the overlap check spells it.
+func (r ByteRun) stretch() stretch { return stretch{at: r.At, width: r.Width} }
 
 // SequenceAcceptanceError is a point in the expression that would accept end of
 // input under either of two different sets of guards.

--- a/internal/resolve/automaton_test.go
+++ b/internal/resolve/automaton_test.go
@@ -1177,6 +1177,19 @@ func TestATransitionCarryingNoPredicateBesideAnEligibleSiblingIsRejected(t *test
 	if ambiguous.State != 0 {
 		t.Errorf("the fault is at state %d, want the start state", ambiguous.State)
 	}
+
+	// This shape is not about a run of bytes and keeps the wording it had
+	// (#326). A record type offering nothing to tell it apart by has no
+	// second target to compare with, and naming a byte offset here would
+	// point an adopter at the discriminator that is fine.
+	message := ambiguous.Error()
+	if !strings.Contains(message, "one of them carries no discriminator, so it matches every record") {
+		t.Errorf("the unguarded shape has been reworded: %s", message)
+	}
+
+	if strings.Contains(message, "byte") {
+		t.Errorf("the unguarded shape names a run of bytes, and there is no pair of runs to name: %s", message)
+	}
 }
 
 // TestTwoRecordsAtOnePointTestingOneRunOfBytesForOneValueAreRejected is
@@ -1433,6 +1446,169 @@ func TestAOneOfOverlapsWhereAnyOfItsValuesAgreesOnTheSharedWindow(t *testing.T) 
 				t.Fatalf("compiling reported %v, want an ambiguity", err)
 			}
 		})
+	}
+}
+
+// TestTheAmbiguityDiagnosticNamesTheRunsTheDiscriminatorsRead is #326: the
+// offset and width of each discriminator's target is the one fact that decides
+// what an adopter does next, and it is the one fact the message used to
+// withhold.
+//
+// Discussion #323 is what withholding it costs. It took four rounds to establish
+// where the adopter's two targets sat, and the report was filed against the
+// sequencing operators — which turned out to be irrelevant, because the fault
+// was two type codes that did not line up.
+//
+// The two shapes are asserted together because the whole point is that they read
+// differently. Runs sharing no byte are told apart by nothing a literal can
+// express and the layout needs a count, a trailer or a different target; runs
+// agreeing over the bytes they share are a clash in the literals and are fixed
+// there. Once #325 narrowed the check to the shared window, those are the only
+// two shapes left, so the message can say which it is without hedging.
+func TestTheAmbiguityDiagnosticNamesTheRunsTheDiscriminatorsRead(t *testing.T) {
+	t.Parallel()
+
+	// A detail whose type code sits behind a lead byte, so that the two
+	// discriminators read runs that share nothing at all.
+	shifted := `01 DTL-REC.
+   05 DTL-LEAD PIC X(1).
+   05 DTL-TYPE PIC X(1).
+   05 DTL-BODY PIC X(20).
+`
+
+	disjoint := countedRunCopybooks()
+	disjoint["DETAIL"] = shifted
+
+	tests := map[string]struct {
+		source    string
+		copybooks map[string]string
+		runs      [2]ByteRun
+		wants     []string
+	}{
+		// HEADER's type code is byte zero of a header and DETAIL's is byte
+		// one of a detail, so no record can be told apart by either literal:
+		// a record carries an `H` at byte zero and a `D` at byte one at the
+		// same time.
+		"runs sharing no bytes": {
+			source: `(record HEADER (copybook "hdr.cpy" HDR-REC))
+(record DETAIL (copybook "dtl.cpy" DTL-REC))
+(discriminate HEADER (equals (item HEADER HDR-TYPE) "H"))
+(discriminate DETAIL (equals (item DETAIL DTL-TYPE) "D"))
+(sequence (alt HEADER DETAIL))`,
+			copybooks: disjoint,
+			runs:      [2]ByteRun{{At: 0, Width: 1}, {At: 1, Width: 1}},
+			wants: []string{
+				"HEADER byte 0",
+				"DETAIL byte 1",
+				"share no byte",
+				"no literal either could carry would tell the two apart",
+			},
+		},
+
+		// The genuine clash: one run, one literal, and two records asking
+		// for it.
+		"identical runs agreeing on a literal": {
+			source: `(record HEADER (copybook "hdr.cpy" HDR-REC))
+(record DETAIL (copybook "dtl.cpy" DTL-REC))
+(discriminate HEADER (equals (item HEADER HDR-TYPE) "H"))
+(discriminate DETAIL (equals (item DETAIL DTL-TYPE) "H"))
+(sequence (alt HEADER DETAIL))`,
+			copybooks: countedRunCopybooks(),
+			runs:      [2]ByteRun{{At: 0, Width: 1}, {At: 0, Width: 1}},
+			wants: []string{
+				"HEADER byte 0",
+				"DETAIL byte 0",
+				"agree on a literal over byte 0",
+			},
+		},
+
+		// Runs of different widths at one offset, which is where naming both
+		// ends earns its keep: `bytes 0-1` beside `byte 0` says which of the
+		// two reads further and over what the two were compared.
+		"intersecting runs of different widths": {
+			source: `(record NARROW (copybook "narrow.cpy" NAR-REC))
+(record WIDE (copybook "wide.cpy" WID-REC))
+(discriminate NARROW (equals (item NARROW NAR-TYPE) "D"))
+(discriminate WIDE (equals (item WIDE WID-TYPE) "DD"))
+(sequence (alt NARROW WIDE))`,
+			copybooks: sharedWindowCopybooks(),
+			runs:      [2]ByteRun{{At: 0, Width: 1}, {At: 0, Width: 2}},
+			wants: []string{
+				"NARROW byte 0",
+				"WIDE bytes 0-1",
+				"agree on a literal over byte 0",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var ambiguous *SequenceAmbiguityError
+			if err := refused(t, test.source, test.copybooks); !errors.As(err, &ambiguous) {
+				t.Fatalf("compiling reported %v, want an ambiguity", err)
+			}
+
+			if ambiguous.Runs != test.runs {
+				t.Errorf("the fault carries %v, want %v", ambiguous.Runs, test.runs)
+			}
+
+			for _, want := range test.wants {
+				if !strings.Contains(ambiguous.Error(), want) {
+					t.Errorf("the diagnostic does not say %q: %s", want, ambiguous.Error())
+				}
+			}
+
+			// The fault is about a pair the layout named, and the spans are
+			// still the two places it named them. Naming the bytes is an
+			// addition to what the message says and not a move of where it
+			// points.
+			if spans := ambiguous.Diagnostic().Spans; len(spans) != 2 {
+				t.Errorf("the fault carries %d spans, want the two appearances", len(spans))
+			}
+		})
+	}
+}
+
+// TestTheAmbiguityDiagnosticStillSaysGuardsCanHoldTogether pins the other shape
+// #326 leaves alone.
+//
+// Guards are not about a byte run either: two transitions whose guards can hold
+// at the same time are both eligible, and saying so is what stops an adopter
+// wondering whether the guards were read at all. The clause is kept beside the
+// runs rather than replaced by them.
+func TestTheAmbiguityDiagnosticStillSaysGuardsCanHoldTogether(t *testing.T) {
+	t.Parallel()
+
+	// After the header the state offers an unguarded detail beside a summary
+	// the flag governs, and the two type codes are the same byte asked for
+	// the same value.
+	source := `(record HEADER (copybook "hdr.cpy" HDR-REC))
+(record DETAIL (copybook "dtl.cpy" DTL-REC))
+(record SUMMARY (copybook "sum.cpy" SUM-REC))
+(discriminate HEADER (equals (item HEADER HDR-TYPE) "H"))
+(discriminate DETAIL (equals (item DETAIL DTL-TYPE) "D"))
+(discriminate SUMMARY (equals (item SUMMARY SUM-TYPE) "D"))
+(sequence (seq HEADER (alt DETAIL (when (item HEADER SUM-FLAG) "Y" SUMMARY))))`
+
+	var ambiguous *SequenceAmbiguityError
+	if err := refused(t, source, countedRunCopybooks()); !errors.As(err, &ambiguous) {
+		t.Fatalf("compiling reported %v, want an ambiguity", err)
+	}
+
+	if !ambiguous.Guards {
+		t.Fatalf("the fault does not say guards are carried, and the summary's is: %v", ambiguous)
+	}
+
+	for _, want := range []string{
+		"DETAIL byte 0",
+		"SUMMARY byte 0",
+		"and their guards can hold at the same time",
+	} {
+		if !strings.Contains(ambiguous.Error(), want) {
+			t.Errorf("the diagnostic does not say %q: %s", want, ambiguous.Error())
+		}
 	}
 }
 

--- a/internal/resolve/automaton_test.go
+++ b/internal/resolve/automaton_test.go
@@ -1190,6 +1190,16 @@ func TestATransitionCarryingNoPredicateBesideAnEligibleSiblingIsRejected(t *test
 	if strings.Contains(message, "byte") {
 		t.Errorf("the unguarded shape names a run of bytes, and there is no pair of runs to name: %s", message)
 	}
+
+	// The runs the fault carries are the zero pair here, and a run of no
+	// bytes says so rather than being drawn as one: the last byte of a run
+	// that has none is the byte before its first, so drawing it gives
+	// `bytes 0--1` to anyone who renders the fault's runs directly.
+	for _, run := range ambiguous.Runs {
+		if run.String() != "no bytes" {
+			t.Errorf("a target that is not there renders as %s, want no bytes", run)
+		}
+	}
 }
 
 // TestTwoRecordsAtOnePointTestingOneRunOfBytesForOneValueAreRejected is

--- a/internal/resolve/predicate.go
+++ b/internal/resolve/predicate.go
@@ -399,6 +399,10 @@ type stretch struct{ at, width int }
 // end is the offset one past the run's last byte.
 func (s stretch) end() int { return s.at + s.width }
 
+// run is the same run as a fault carries it, so that a diagnostic naming the
+// bytes two discriminators read names the ones the check actually intersected.
+func (s stretch) run() ByteRun { return ByteRun{At: s.at, Width: s.width} }
+
 // shares is the run both stretches cover, and whether they cover one at all.
 //
 // The empty intersection is reported as a second return rather than as a run of

--- a/internal/resolve/sequence.go
+++ b/internal/resolve/sequence.go
@@ -638,12 +638,39 @@ func (c *compiler) checkAmbiguity(a *Automaton) {
 					First:     layoutSpan(c.positions[first.To.ID-1].pos),
 					State:     state.ID,
 					Records:   [2]string{first.Record, second.Record},
+					Runs:      c.runsOf(first, second),
 					Unguarded: first.Predicate == nil || second.Predicate == nil,
 					Guards:    len(first.Guards) > 0 || len(second.Guards) > 0,
 				})
 			}
 		}
 	}
+}
+
+// runsOf is the pair of byte runs two transitions' discriminators read, in the
+// order the pair is reported in, and the zero pair where either target has no
+// run to name.
+//
+// The offsets are the ones [compiler.predicatesOverlap] has just decided the
+// pair on, taken again from [compiler.stretchOf] rather than threaded back out
+// of it: this is the failing path — one pair, in a layout that is about to be
+// refused — and a question named for the answer it gives keeps giving only that
+// answer.
+//
+// Either run being absent is not a fault of its own. A transition carrying no
+// predicate has no target at all (#80), and one whose target this cannot place
+// is a misspelled item [compiler.discriminator] has already reported; the
+// message says what it can say about the pair instead of naming an offset it
+// does not have.
+func (c *compiler) runsOf(first, second *Transition) [2]ByteRun {
+	over, ok := c.stretchOf(first.Record, first.Predicate)
+	against, againstOK := c.stretchOf(second.Record, second.Predicate)
+
+	if !ok || !againstOK {
+		return [2]ByteRun{}
+	}
+
+	return [2]ByteRun{over.run(), against.run()}
 }
 
 // reportUnnameable reports an overlapping pair one of whose records offers no


### PR DESCRIPTION
Closes #326.

`SequenceAmbiguityError` named the two records and the state but never the two runs of bytes it had just compared. Discussion #323 is what that costs: four rounds to establish where the adopter's two discriminators sat, and a report filed against sequencing operators that turned out to be irrelevant. The fault now carries both runs and says which of the two remaining shapes it is.

Before:

```
at state 1 the sequence admits DETAIL and SUMMARY, and their discriminators can both match one
record: a consumer reaching that point has no way to tell which record is in front of it
```

After, runs that share no byte:

```
at state 0 the sequence admits HEADER and DETAIL, and their discriminators read HEADER byte 0 and
DETAIL byte 1, which share no byte, so no literal either could carry would tell the two apart: a
consumer reaching that point has no way to tell which record is in front of it
```

After, runs that overlap and agree on a literal:

```
at state 0 the sequence admits NARROW and WIDE, and their discriminators read NARROW byte 0 and
WIDE bytes 0-1, and they agree on a literal over byte 0: a consumer reaching that point has no
way to tell which record is in front of it
```

## Acceptance Criteria

- [x] `SequenceAmbiguityError` carries the two targets' offsets and widths and renders them in the message — a new `Runs [2]ByteRun` field, in the same order as `Records`, filled by `compiler.runsOf` from the same `compiler.stretchOf` the overlap check decided the pair on.
- [x] The message distinguishes runs that share no bytes from runs that overlap and agree on a literal — `SequenceAmbiguityError.compared` intersects the pair through `ByteRun.shares`, which delegates to `stretch.shares`, so the message and the check that raised it read "share no byte" the same way.
- [x] Where the runs share no bytes, the message says a different literal cannot resolve it — "which share no byte, so no literal either could carry would tell the two apart".
- [x] The `Unguarded` and `Guards` shapes keep their current wording — `Unguarded` short-circuits the run clause, `Guards` still appends ", and their guards can hold at the same time" beside it. Both are now pinned by tests.
- [x] The copybook span already carried on the fault is unchanged — `spans(e.Pos, e.First, ...)` is untouched, and a subtest asserts the fault still carries its two spans.
- [x] Diagnostic tests cover the disjoint and identical-run cases, matching on the rendered runs — `TestTheAmbiguityDiagnosticNamesTheRunsTheDiscriminatorsRead`, with a third case for intersecting runs of different widths.
- [x] `docs/layout/SPEC.md`'s "Every diagnostic carries a span, and some carry two" needs no change — the spans are unchanged; this adds to what the message *says*, not to where it points. No doc change in this PR.

## Judgment calls

**A run renders as `byte 4` or `bytes 4-5`, ends included** — not as an offset beside a width. What an adopter compares is two runs, and two pairs of endpoints can be compared by eye while an offset beside a width cannot. The single-byte form follows the `plural` helper already in the package: `byte 0`, not `bytes 0-0`. The hyphen is ASCII, so the message stays in the character set every other diagnostic here uses.

**`ByteRun` is exported; `stretch` stays internal.** The fault is part of the package's API and cannot carry an unexported field type, but the overlap check keeps the vocabulary it had. The two convert through `stretch.run` and `ByteRun.stretch`, and `ByteRun.shares` delegates rather than reimplementing the intersection — two readings of "share no bytes" would be a message saying a different literal cannot help about a pair `overlap` decided on a literal.

**`runsOf` takes the offsets from `stretchOf` again rather than threading them back out of `predicatesOverlap`.** This is the failing path — one pair, in a layout that is about to be refused — and `predicatesOverlap` keeps answering only the question its name asks.

**Neither run present is not a fault of its own.** A transition carrying no predicate has no target (#80), and one whose target could not be placed is a misspelled item `compiler.discriminator` has already reported. In both cases the runs are the zero pair, `placed` is false, and the message says what it can about the pair instead of naming an offset it does not have.

## Verification

`dagger call ci` — green. Run from an ordinary clone of this branch rather than from the per-issue worktree: a worktree's `.git` is a file, and the module's `gitDir` argument defaults to a directory at that path, so the filesync fails there before any stage runs.
