### PR TITLE
story(resolve): prove discriminator disjointness from the copybook byte domains

### DIFF
--- a/docs/ir/SPEC.md
+++ b/docs/ir/SPEC.md
@@ -2630,6 +2630,64 @@ question `layout/SPEC.md` defers to this document — what happens when two
 discriminators match — has an answer at the one place it is cheap: it does not
 arise, because such an IR is never produced.
 
+Whether two predicates *can* both match is decided on bytes, in two steps, and
+`resolve` **MUST** take both before it refuses a pair.
+
+**The runs are intersected.** Two predicates whose runs share bytes and whose
+literals disagree anywhere in that shared window cannot both match, because one
+byte would have to hold two values at once: a `HEADER` keyed on byte zero equal
+to `H` beside a `DATA` keyed on bytes zero and one equal to `DD` is such a pair,
+and requiring the two runs to be identical instead called every pair like it
+ambiguous (#325). A **bytes one of** predicate is inside that rule with nothing
+added, since the window belongs to the runs and not to the values: the pair
+overlaps where any value of the one agrees with any value of the other across it.
+
+**And the copybooks are consulted.** Agreeing over that window — which every pair
+whose runs share no byte does vacuously — is not the end of the question. The run
+one discriminator reads is covered, *inside the other record*, by an item with a
+PICTURE and a USAGE, and those bound what a record of that type may hold there.
+Where the literal one predicate asks for is a byte the other record's item can
+never carry, no record of that type satisfies that predicate however far apart
+the two runs are; where that holds in **both** directions the two tests are
+exclusive, and `resolve` **MUST** admit the pair rather than refusing it (#330).
+Both directions are required, and the requirement is not conservatism: the record
+that *can* carry the other's literal is exactly the record that satisfies both
+tests at once, so one direction alone proves nothing.
+
+A byte domain is what an item's PICTURE and USAGE say each of its bytes may hold.
+Only these are claimed:
+
+| Shape | Domain |
+|---|---|
+| unsigned zoned DISPLAY | the charset's ten digit bytes, at every position |
+| alphanumeric, `PIC X` | every byte value, so nothing is proved |
+| binary — `COMP`, `COMP-5` | every bit pattern, so nothing is proved |
+
+Everything else is **declined**, and a decline leaves the pair overlapping and
+refused exactly as it was before the copybooks were read. A producer **MUST**
+decline rather than narrow wherever the record's static layout does not settle
+which item covers the run: a run no single elementary item wholly contains, a run
+landing on the slack bytes a SYNCHRONIZED item pushed in front of itself, a run
+at or after a repetition whose count is a reference, a run inside a table, a run
+more than one description of the same storage covers, and a run whose charset the
+encoding profile does not state. A packed item and a signed zoned one do have a
+domain and are declined all the same, because stating one means restating where
+the encoding puts a sign — a second reading of an encoding, kept in a second
+place, which is the disagreement this refinement is not worth. Declining costs a
+refusal that could have been narrowed; guessing costs a file read as the wrong
+record type.
+
+**The proof holds over well-formed records, and that is a narrowing.** A record
+whose bytes are what its own copybook's items admit is inside the proof. A record
+carrying a byte outside the domain of the item describing it — a corrupt record,
+a file written by something that did not honour the copybook — is outside it, and
+a consumer handed one may take a transition this rule proved could not be taken.
+Everywhere else in this document the overlap rule is a claim about *any* input;
+here it is a claim about inputs the layout is right about, and the difference is
+stated rather than absorbed. It is not a new exposure so much as a new place to
+find an old one: such a file is a file the layout is already wrong about, and
+what it loses is the diagnostic it would otherwise have got.
+
 Guards narrow which pairs that rule is about. Two transitions leaving one state
 whose guards cannot hold at the same time are never both eligible, and their
 predicates **MAY** overlap freely — which is what makes a counted run of records
@@ -2682,6 +2740,15 @@ detail* reads that file, and is presumably what the vendor reader that wrote it
 does. `layout/SPEC.md` states the shape, and what a layout may write instead, at
 [A batch boundary told only by evaluation
 order](../layout/SPEC.md#a-batch-boundary-told-only-by-evaluation-order).
+
+The copybooks decide how often that shape actually arises, which is why they are
+consulted above. Where the item covering the header's run inside a detail is
+numeric — an account number, a sequence number, a date — and the item covering
+the detail's run inside a header is too, the two tests are provably exclusive and
+the layout compiles with nothing added to it and nothing asked of the adopter.
+What is left over is the shape where at least one of those items is `PIC X`, and
+there the paragraph above stands unchanged: nothing in the copybooks separates
+the two, and ordered evaluation is not a proof that they are separate.
 
 What such a descriptor gives up is the whole of what the overlap rule gives.
 Ordered matching encodes *try the header first*; it is not a proof that the two

--- a/internal/resolve/automaton_test.go
+++ b/internal/resolve/automaton_test.go
@@ -1772,3 +1772,226 @@ func TestCompileSequenceRefusesNoSequence(t *testing.T) {
 		t.Errorf("compiling nothing reported %v, want %v", err, ErrNilSequence)
 	}
 }
+
+// The copybooks the byte-domain tests below are written over. Every record is
+// twenty-one bytes wide and carries a one-byte type code — the header's at byte
+// zero and the detail's at byte ten — which is discussion #323's shape: two
+// discriminators whose runs never meet, at a state where both records are
+// eligible.
+//
+// What differs between the details is the one item covering byte zero, which is
+// what the header's literal is asked of. The header is fixed, and byte ten falls
+// inside its five-digit sequence number.
+const (
+	batchHeader = `01 BAT-HDR.
+   05 BAT-TYPE PIC X(1).
+   05 BAT-ID   PIC 9(9).
+   05 BAT-SEQ  PIC 9(5).
+   05 BAT-BODY PIC X(6).
+`
+
+	batchDetail = `01 BDT-REC.
+   05 BDT-KEY  %s.
+   05 BDT-TYPE PIC X(1).
+   05 BDT-BODY PIC X(10).
+`
+)
+
+// batchCopybooks binds HEADER to that header and DETAIL to that detail, with the
+// ten bytes ahead of its type code described by key.
+func batchCopybooks(key string) map[string]string {
+	return map[string]string{
+		"HEADER": batchHeader,
+		"DETAIL": fmt.Sprintf(batchDetail, key),
+	}
+}
+
+// batchSource is the layout those two are read under: a file of batches, each a
+// header followed by its details, which puts both records on the state after a
+// detail.
+const batchSource = `(record HEADER (copybook "header.cpy" BAT-HDR))
+(record DETAIL (copybook "detail.cpy" BDT-REC))
+(discriminate HEADER (equals (item HEADER BAT-TYPE) "H"))
+(discriminate DETAIL (equals (item DETAIL BDT-TYPE) "D"))
+(sequence (+ (seq HEADER (+ DETAIL))))`
+
+// TestDiscriminatorsOverDifferentRunsAreDisjointWhereTheCopybooksForbidTheOpposingLiteral
+// is #330: two runs that share no byte are decided on what the copybooks say
+// those bytes may hold, and not on the general truth that a record can carry one
+// value at byte zero and another at byte ten.
+//
+// The header is keyed on byte zero equal to `H` and the detail on byte ten equal
+// to `D`, both EBCDIC letters. Byte ten of a header is inside a five-digit
+// DISPLAY item, so a header can never carry `D` there; where byte zero of a
+// detail is a ten-digit DISPLAY item it can never carry `H` either, and the two
+// tests are then provably exclusive with nothing added to the layout. Where byte
+// zero of a detail is anything this cannot state a domain for, the pair is left
+// overlapping and refused exactly as before.
+func TestDiscriminatorsOverDifferentRunsAreDisjointWhereTheCopybooksForbidTheOpposingLiteral(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		key       string
+		ambiguous bool
+	}{
+		// The whole point: neither record can hold the other's letter.
+		"an unsigned zoned item holds digits and no letter": {
+			key: "PIC 9(10)", ambiguous: false,
+		},
+
+		// "Any byte value may appear in an alphanumeric field", so this
+		// proves nothing and the refusal stands. One direction is not
+		// enough: a detail carrying `H` at byte zero and `D` at byte ten
+		// satisfies both tests, whatever the header says about byte ten.
+		"an alphanumeric item holds any byte": {
+			key: "PIC X(10)", ambiguous: true,
+		},
+
+		// The sign is an overpunch on one of the ten digits, and where
+		// codec puts it is codec's to say rather than this package's.
+		"a signed zoned item is declined": {
+			key: "PIC S9(10)", ambiguous: true,
+		},
+
+		// A packed item's digits are nibbles and its last nibble is the
+		// sign; same reason.
+		"a packed item is declined": {
+			key: "PIC 9(18) COMP-3", ambiguous: true,
+		},
+
+		// A binary item is a bit pattern with no bytes ruled out.
+		"a binary item is declined": {
+			key: "PIC 9(9) COMP.\n   05 BDT-PAD  PIC X(6)", ambiguous: true,
+		},
+
+		// BLANK WHEN ZERO puts the charset's spaces in a numeric item, so
+		// the digits are not the whole of what it holds.
+		"a numeric item blank when zero is declined": {
+			key: "PIC 9(10) BLANK WHEN ZERO", ambiguous: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if !test.ambiguous {
+				compiled(t, batchSource, batchCopybooks(test.key))
+
+				return
+			}
+
+			var ambiguous *SequenceAmbiguityError
+			if err := refused(t, batchSource, batchCopybooks(test.key)); !errors.As(err, &ambiguous) {
+				t.Fatalf("compiling reported %v, want an ambiguity", err)
+			}
+
+			// The refusal is the one #326 wrote: the two runs are what an
+			// adopter reads the message for, and narrowing when the pair is
+			// refused does not change what is said when it is.
+			want := [2]ByteRun{{At: 0, Width: 1}, {At: 10, Width: 1}}
+			if ambiguous.Runs != want && ambiguous.Runs != [2]ByteRun{want[1], want[0]} {
+				t.Errorf("the fault names the runs %v, want %v", ambiguous.Runs, want)
+			}
+		})
+	}
+}
+
+// TestTheByteDomainIsDeclinedWhereTheLayoutDoesNotSettleTheItem is the soundness
+// half: the refinement reads a domain only where the record's own layout says
+// which item covers the opposing run, and every other shape is left overlapping.
+//
+// Each detail below keys on a run the header describes with something other than
+// one item at a fixed offset, and each is refused for that reason alone — byte
+// zero of every one of them is a zoned item that cannot hold `H`, so the pair
+// would be disjoint if the header's side of the question had an answer.
+func TestTheByteDomainIsDeclinedWhereTheLayoutDoesNotSettleTheItem(t *testing.T) {
+	t.Parallel()
+
+	// A two-byte type code at byte nine spans the header's nine-digit
+	// identifier and its sequence number, and one at byte ten sits wholly
+	// inside the sequence number.
+	spanning := `01 BSP-REC.
+   05 BSP-KEY  PIC 9(9).
+   05 BSP-TYPE PIC X(2).
+   05 BSP-BODY PIC X(10).
+`
+
+	inside := `01 BSP-REC.
+   05 BSP-KEY  PIC 9(10).
+   05 BSP-TYPE PIC X(2).
+   05 BSP-BODY PIC X(9).
+`
+
+	// Slack: a four-byte binary item SYNCHRONIZED onto a four-byte boundary
+	// leaves bytes nine, ten and eleven belonging to no item at all.
+	slack := `01 BSL-HDR.
+   05 BSL-TYPE PIC X(1).
+   05 BSL-FILL PIC X(8).
+   05 BSL-BIN  PIC 9(9) COMP SYNC.
+`
+
+	// An OCCURS DEPENDING ON ahead of byte ten moves every byte at or after
+	// it, so the static layout does not say which item is there.
+	variable := `01 BOD-HDR.
+   05 BOD-TYPE  PIC X(1).
+   05 BOD-COUNT PIC 9(2).
+   05 BOD-TAB   PIC X(4) OCCURS 1 TO 5 TIMES DEPENDING ON BOD-COUNT.
+   05 BOD-SEQ   PIC 9(5).
+`
+
+	tests := map[string]struct {
+		header    string
+		record    string
+		detail    string
+		item      string
+		literal   string
+		ambiguous bool
+	}{
+		"the opposing run spans two items": {
+			header: batchHeader, record: "BAT-HDR", detail: spanning,
+			item: "BSP-TYPE", literal: `"DD"`, ambiguous: true,
+		},
+
+		"the opposing run sits inside one": {
+			header: batchHeader, record: "BAT-HDR", detail: inside,
+			item: "BSP-TYPE", literal: `"DD"`, ambiguous: false,
+		},
+
+		"the opposing run lands on slack": {
+			header: slack, record: "BSL-HDR", detail: fmt.Sprintf(batchDetail, "PIC 9(10)"),
+			item: "BDT-TYPE", literal: `"D"`, ambiguous: true,
+		},
+
+		"the opposing run sits in an ODO-variable region": {
+			header: variable, record: "BOD-HDR", detail: fmt.Sprintf(batchDetail, "PIC 9(10)"),
+			item: "BDT-TYPE", literal: `"D"`, ambiguous: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			headerType := recordOf(t, test.header).Children[0].Name
+			source := `(record HEADER (copybook "header.cpy" ` + test.record + `))
+(record DETAIL (copybook "detail.cpy" BDT-REC))
+(discriminate HEADER (equals (item HEADER ` + headerType + `) "H"))
+(discriminate DETAIL (equals (item DETAIL ` + test.item + `) ` + test.literal + `))
+(sequence (+ (seq HEADER (+ DETAIL))))`
+
+			copybooks := map[string]string{"HEADER": test.header, "DETAIL": test.detail}
+
+			if !test.ambiguous {
+				compiled(t, source, copybooks)
+
+				return
+			}
+
+			var ambiguous *SequenceAmbiguityError
+			if err := refused(t, source, copybooks); !errors.As(err, &ambiguous) {
+				t.Fatalf("compiling reported %v, want an ambiguity", err)
+			}
+		})
+	}
+}

--- a/internal/resolve/discriminator.go
+++ b/internal/resolve/discriminator.go
@@ -869,10 +869,25 @@ func (r *resolver) checkArmOverlap(c cluster, table *copybook.Item, arms []Arm, 
 
 	for i := range arms {
 		for j := i + 1; j < len(arms); j++ {
-			over := stretch{at: targets[i].Offset, width: targets[i].Length}
-			against := stretch{at: targets[j].Offset, width: targets[j].Length}
+			// Neither side carries byte domains, and that is the answer
+			// rather than a corner left unswept. The domain refinement
+			// [overlap] applies to a pair of records asks what the *other*
+			// record's copybook covers the opposing run with (#330); here the
+			// two arms are alternatives of one REDEFINES cluster, so every run
+			// either arm reads is covered by both descriptions of the same
+			// storage — which is exactly the shape [covering] declines, and
+			// handing it the record's layout would decline every pair while
+			// reading as though the copybooks had been consulted.
+			over := discriminant{
+				predicate: arms[i].Predicate,
+				run:       stretch{at: targets[i].Offset, width: targets[i].Length},
+			}
+			against := discriminant{
+				predicate: arms[j].Predicate,
+				run:       stretch{at: targets[j].Offset, width: targets[j].Length},
+			}
 
-			if !overlap(arms[i].Predicate, over, arms[j].Predicate, against) {
+			if !overlap(over, against) {
 				continue
 			}
 

--- a/internal/resolve/doc.go
+++ b/internal/resolve/doc.go
@@ -261,9 +261,11 @@
 // it.
 //
 // On a pair the overlap rule admits it is a gate of its own. Two predicates are
-// told apart by the bytes their runs share (#325), so a pair reading runs of
-// different widths can be unambiguous and still have the wider read reach past
-// the shorter record. [compiler.reportReach] carries both readings.
+// told apart by the bytes their runs share (#325) and by what each record's
+// copybook admits at the other's run (#330), so a pair reading runs of different
+// widths — or runs sharing no byte at all — can be unambiguous and still have one
+// of them reach past the shorter record. [compiler.reportReach] carries both
+// readings.
 //
 // [Sequencing.Framing] is what that is keyed on, and a caller stating no framing
 // states neither mechanism, so the rule is not run. It cannot be inferred from

--- a/internal/resolve/predicate.go
+++ b/internal/resolve/predicate.go
@@ -444,19 +444,14 @@ type discriminant struct {
 	admits domains
 }
 
-// carries reports whether a well-formed record of this side's type could hold a
-// value's bytes over a run of its own.
-//
-// Everything it cannot settle is `true`, which is what keeps the refinement a
-// narrowing of a refusal rather than a widening of one: a record whose copybook
-// says nothing about those bytes is left able to carry them, and the pair stays
-// overlapping exactly as it was before this was consulted.
-func (d discriminant) carries(value Value, over stretch) bool {
-	if d.admits == nil || !comparableOver(value, over) {
-		return true
+// domainOver is what a well-formed record of this side's type may hold over one
+// run of its bytes, and nil where its copybook settles nothing there.
+func (d discriminant) domainOver(over stretch) byteDomain {
+	if d.admits == nil {
+		return nil
 	}
 
-	return d.admits(over).admits(value.Bytes)
+	return d.admits(over)
 }
 
 // overlap reports whether one input can satisfy both predicates, each read at
@@ -515,14 +510,22 @@ func overlap(first, second discriminant) bool {
 
 	window, sharing := first.run.shares(second.run)
 
+	// Both domains are properties of the two runs and of neither side's
+	// values, so they are taken once here rather than once inside the pair
+	// walk: two `one-of` predicates are a product of value lists, and reading
+	// the same item off the same layout for every pair in it is one answer
+	// computed a quadratic number of times.
+	firstOverSecond := first.domainOver(second.run)
+	secondOverFirst := second.domainOver(first.run)
+
 	return slices.ContainsFunc(first.predicate.Values, func(one Value) bool {
 		return slices.ContainsFunc(second.predicate.Values, func(other Value) bool {
 			if sharing && !agree(one, first.run, other, second.run, window) {
 				return false
 			}
 
-			return first.carries(other, second.run) ||
-				second.carries(one, first.run)
+			return firstOverSecond.carries(other, second.run) ||
+				secondOverFirst.carries(one, first.run)
 		})
 	})
 }
@@ -574,6 +577,21 @@ type domains func(run stretch) byteDomain
 // position and a packed item's sign nibble are the two this cannot state yet,
 // and both are one position of an item whose others are digits.
 type byteDomain [][]byte
+
+// carries reports whether a well-formed record could hold a value's bytes over
+// the run this domain was taken at.
+//
+// Everything it cannot settle is `true`, which is what keeps the refinement a
+// narrowing of a refusal rather than a widening of one: a record whose copybook
+// says nothing about those bytes is left able to carry them, and the pair stays
+// overlapping exactly as it was before this was consulted.
+func (d byteDomain) carries(value Value, over stretch) bool {
+	if d == nil || !comparableOver(value, over) {
+		return true
+	}
+
+	return d.admits(value.Bytes)
+}
 
 // admits reports whether a well-formed record could carry these bytes over the
 // run the domain was taken at.

--- a/internal/resolve/predicate.go
+++ b/internal/resolve/predicate.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	cobol "github.com/Zaba505/cobol-go"
 	"github.com/Zaba505/cobol-go/codec"
 	"github.com/Zaba505/cobol-go/copybook"
 	"github.com/Zaba505/cobol-go/picture"
@@ -406,10 +407,11 @@ func (s stretch) run() ByteRun { return ByteRun{At: s.at, Width: s.width} }
 // shares is the run both stretches cover, and whether they cover one at all.
 //
 // The empty intersection is reported as a second return rather than as a run of
-// no bytes, because the two are opposite answers here: runs sharing nothing
-// overlap unconditionally, and a shared run of nothing would read as two values
-// agreeing everywhere they are compared, which is the same `true` reached for
-// the opposite reason.
+// no bytes, because the two are opposite answers here: runs sharing nothing are
+// two values nothing compares, and a shared run of nothing would read as two
+// values agreeing everywhere they are compared, which is the same `true` reached
+// for the opposite reason. What separates them afterwards is what the copybooks
+// admit at each run rather than what the values say ([overlap]).
 func (s stretch) shares(other stretch) (stretch, bool) {
 	from := max(s.at, other.at)
 	to := min(s.end(), other.end())
@@ -421,6 +423,42 @@ func (s stretch) shares(other stretch) (stretch, bool) {
 	return stretch{at: from, width: to - from}, true
 }
 
+// discriminant is one side of an overlap question: a predicate, the run of one
+// record's bytes it reads, and what that record's copybook admits at any other
+// run of the same bytes.
+//
+// The third member is what turns "both may match" into a proof for a pair whose
+// runs never meet. A discriminator reads a run of the input, and the *other*
+// record covers that run with an item of its own carrying a PICTURE and a
+// USAGE; where the literal the other discriminator asks for is a byte that item
+// can never hold, no record of this type satisfies that predicate, whatever the
+// runs do (#330).
+type discriminant struct {
+	// predicate is the test, nil where the transition or arm carries none.
+	predicate *Predicate
+
+	// run is the bytes of its own record that test reads.
+	run stretch
+
+	// admits is that record's byte domains, nil where none can be taken.
+	admits domains
+}
+
+// carries reports whether a well-formed record of this side's type could hold a
+// value's bytes over a run of its own.
+//
+// Everything it cannot settle is `true`, which is what keeps the refinement a
+// narrowing of a refusal rather than a widening of one: a record whose copybook
+// says nothing about those bytes is left able to carry them, and the pair stays
+// overlapping exactly as it was before this was consulted.
+func (d discriminant) carries(value Value, over stretch) bool {
+	if d.admits == nil || !comparableOver(value, over) {
+		return true
+	}
+
+	return d.admits(over).admits(value.Bytes)
+}
+
 // overlap reports whether one input can satisfy both predicates, each read at
 // the run of bytes given for it.
 //
@@ -430,20 +468,37 @@ func (s stretch) shares(other stretch) (stretch, bool) {
 // positions overlap just as thoroughly as two reading one, because a record can
 // carry an `S` at byte zero and an `X` at byte ten at the same time.
 //
-// So the runs are intersected rather than compared. Two sharing no byte always
-// overlap, for that reason. Two sharing some bytes are decided on the bytes they
-// share and on nothing else: a `HEADER` keyed on byte zero equal to `H` beside a
-// `DATA` keyed on bytes zero and one equal to `DD` cannot both match, because
-// byte zero would have to be `H` and `D` at once, and a pair that disagrees
-// anywhere in the shared window is proof no input satisfies both. Requiring the
-// two runs to be identical instead called every such pair ambiguous, which was
-// the implementation being coarser than the rule it implements (#325).
+// So the runs are intersected rather than compared. Two sharing some bytes are
+// decided on the bytes they share: a `HEADER` keyed on byte zero equal to `H`
+// beside a `DATA` keyed on bytes zero and one equal to `DD` cannot both match,
+// because byte zero would have to be `H` and `D` at once, and a pair that
+// disagrees anywhere in the shared window is proof no input satisfies both.
+// Requiring the two runs to be identical instead called every such pair
+// ambiguous, which was the implementation being coarser than the rule it
+// implements (#325).
 //
 // The window is shared by the *runs* and not by the values, so a `one-of` is
 // inside the same rule with nothing added: the predicates overlap where any
 // value of the one agrees with any value of the other across that window, which
 // for identical runs is the intersection of the two value sets and is the answer
 // this has always given there.
+//
+// A pair agreeing over that window — and every pair whose runs share no byte at
+// all, which agrees vacuously — is then asked what the two *copybooks* say. Each
+// side has to be able to carry the other's literal at the other's run, because
+// an input satisfying both is a well-formed record of one of the two types and
+// therefore holds, everywhere that type describes, a byte that type admits. So
+// the pair survives only where the first record could carry the second's literal
+// at the second's run, or the second could carry the first's at the first's; a
+// pair failing both is two tests one input cannot pass, however far apart the
+// bytes they read are (#330). Neither direction is enough on its own: the record
+// that *can* hold the other's literal is exactly the record that satisfies both
+// tests at once.
+//
+// That proof is over well-formed records, which is a narrowing of the invariant
+// and is stated as one in docs/ir/SPEC.md's "When two match, and when none
+// does". A record carrying bytes its own copybook's items cannot hold is outside
+// it, and is a file the layout is already wrong about.
 //
 // A run of bytes rather than a field, because two records built to different
 // copybooks is the ordinary case and is the case docs/ir/SPEC.md's "A counted
@@ -453,19 +508,21 @@ func (s stretch) shares(other stretch) (stretch, bool) {
 //
 // A predicate that is absent matches every record, so it overlaps everything
 // (#80).
-func overlap(first *Predicate, at stretch, second *Predicate, against stretch) bool {
-	if first == nil || second == nil {
+func overlap(first, second discriminant) bool {
+	if first.predicate == nil || second.predicate == nil {
 		return true
 	}
 
-	window, sharing := at.shares(against)
-	if !sharing {
-		return true
-	}
+	window, sharing := first.run.shares(second.run)
 
-	return slices.ContainsFunc(first.Values, func(one Value) bool {
-		return slices.ContainsFunc(second.Values, func(other Value) bool {
-			return agree(one, at, other, against, window)
+	return slices.ContainsFunc(first.predicate.Values, func(one Value) bool {
+		return slices.ContainsFunc(second.predicate.Values, func(other Value) bool {
+			if sharing && !agree(one, first.run, other, second.run, window) {
+				return false
+			}
+
+			return first.carries(other, second.run) ||
+				second.carries(one, first.run)
 		})
 	})
 }
@@ -495,6 +552,192 @@ func agree(one Value, at stretch, other Value, against stretch, window stretch) 
 // resolved against.
 func comparableOver(value Value, run stretch) bool {
 	return value.Bytes != nil && len(value.Bytes) == run.width
+}
+
+// domains is what one record's copybook admits over a run of that record's
+// bytes: the question a discriminator reading *another* record's run asks of it.
+//
+// A nil result — from a nil `domains` or from a call that can settle nothing —
+// is "this copybook says nothing about those bytes", and every caller reads it
+// as the record being able to carry anything there. That is the direction the
+// whole refinement has to fail in: an unsound domain turns an ambiguity into a
+// layout that compiles and a file read as the wrong record type, while a domain
+// declined turns nothing into anything worse than the refusal already given.
+type domains func(run stretch) byteDomain
+
+// byteDomain is what a copybook says one run of a record's bytes may hold: one
+// set of admissible bytes per byte of the run, and a nil set at a position
+// nothing here can state.
+//
+// One set per position rather than one for the run, because the shapes with a
+// domain are not uniform along their bytes — a signed zoned item's sign
+// position and a packed item's sign nibble are the two this cannot state yet,
+// and both are one position of an item whose others are digits.
+type byteDomain [][]byte
+
+// admits reports whether a well-formed record could carry these bytes over the
+// run the domain was taken at.
+//
+// A domain that is not the width of the value is not a disagreement but a
+// question this cannot ask, so it admits: the two came from different readings
+// of the same run and comparing them position by position would compare bytes
+// nobody claimed line up.
+func (d byteDomain) admits(want []byte) bool {
+	if len(d) != len(want) {
+		return true
+	}
+
+	for at, b := range want {
+		if d[at] != nil && !slices.Contains(d[at], b) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// domainsOf reads one record's byte domains off its layout.
+//
+// The axes are a function rather than a value because the four encoding axes
+// are per item — an override reaching one item and not its sibling is what
+// [axesOf] folds — and the item is not known until the run is.
+func domainsOf(built *copybook.Layout, axes func(*copybook.Field) layoutmodel.Axes) domains {
+	if built == nil || axes == nil {
+		return nil
+	}
+
+	return func(run stretch) byteDomain {
+		item, ok := covering(built, run)
+		if !ok {
+			return nil
+		}
+
+		whole := itemDomain(item, axes(item.Field))
+		if whole == nil {
+			return nil
+		}
+
+		return whole[run.at-item.Offset : run.end()-item.Offset]
+	}
+}
+
+// covering is the one elementary item whose storage holds every byte of a run,
+// and whether the record's layout settles which item that is.
+//
+// Everything it declines is a soundness bound rather than a gap to fill later,
+// and there are four of them. A run no elementary item wholly contains is a run
+// spanning an item boundary or landing on the slack a SYNCHRONIZED item pushed
+// in front of itself, and slack belongs to no item and is described by nothing
+// (KindSlack in node.go). A run at or after a repetition whose count is a
+// reference sits at an offset that moves with the record's own data, so the
+// static layout does not say which bytes it is. A run inside a table is one
+// occurrence of many and this places only the first. And a run more than one
+// item covers is a REDEFINES cluster — two descriptions of one run of storage,
+// either of which a well-formed record may be — so the domain is the union of
+// the members' and reading one of them would be reading the wrong one half the
+// time.
+func covering(built *copybook.Layout, run stretch) (*copybook.Item, bool) {
+	for _, item := range built.Items() {
+		if item.MinOccurs != item.MaxOccurs && item.Offset < run.end() {
+			return nil, false
+		}
+	}
+
+	var found *copybook.Item
+
+	for _, item := range built.Items() {
+		if item.Field.Kind != copybook.KindElementary {
+			continue
+		}
+
+		if run.at < item.Offset || run.end() > item.Offset+item.Length {
+			continue
+		}
+
+		if item.Occurs > 1 || item.MaxOccurs > 1 || enclosingTable(item) != nil {
+			return nil, false
+		}
+
+		if found != nil {
+			return nil, false
+		}
+
+		found = item
+	}
+
+	return found, found != nil
+}
+
+// itemDomain is what one item's PICTURE and USAGE say each of its bytes may
+// hold, or nil where they settle nothing.
+//
+// This is the one reading of a byte domain in this repository, and it states one
+// shape: the unsigned zoned DISPLAY item, whose every byte is one of the
+// charset's ten digits. The other three shapes docs/ir/SPEC.md's "When two match,
+// and when none does" lists are declined here and each for its own reason.
+// `PIC X` and the binary usages have no domain to state — "Any byte value may
+// appear in an alphanumeric field" (cobol-go, codec/decoder.go) and a binary
+// item is a bit pattern — so consulting them proves nothing. A packed item and a
+// signed zoned one do have one, and it is not stated here because stating it
+// would mean writing down where `codec` puts a sign nibble and an overpunch: a
+// second reading of an encoding cobol-go already implements and does not export,
+// which is the disagreement between two repositories that
+// [github.com/Zaba505/cobol-go/copybook] exists here to prevent. Zaba505/cobol-go#134
+// asks for the domain API those two shapes need; until it lands they decline,
+// which costs a refusal that could have been narrowed and never an unsound
+// proof.
+//
+// The shape itself is [zonedUnsigned]'s, asked as a question rather than
+// re-derived, and the bytes are [charsetOf]'s table rather than ten constants —
+// so what an unsigned zoned item is, and what a digit's byte is, are each read
+// in one place and read the same way the literal on the other side of the
+// comparison was resolved. Where `charsetOf` has no table the domain declines
+// rather than guessing; where it has a borrowed one, the ten digits are inside
+// the subset codec/SPEC.md states is identical across every EBCDIC code page the
+// charset axis admits, which is the same subset [invariant] holds a literal to.
+//
+// BLANK WHEN ZERO is the one clause that takes the domain away from a shape that
+// otherwise has one: the item holds the charset's spaces when its value is zero,
+// which is a byte outside the digits and inside a perfectly well-formed record.
+func itemDomain(item *copybook.Item, axes layoutmodel.Axes) byteDomain {
+	if zonedUnsigned(item.Field) != "" || blankWhenZero(item.Field) {
+		return nil
+	}
+
+	charset, _ := charsetOf(axes.Charset)
+	if charset == nil {
+		return nil
+	}
+
+	digits := make([]byte, 0, 10)
+	for digit := '0'; digit <= '9'; digit++ {
+		encoded, ok := charset.FromUnicode(digit)
+		if !ok {
+			return nil
+		}
+
+		digits = append(digits, encoded)
+	}
+
+	domain := make(byteDomain, item.Length)
+	for at := range domain {
+		domain[at] = digits
+	}
+
+	return domain
+}
+
+// blankWhenZero reports whether the item's entry carries BLANK WHEN ZERO.
+func blankWhenZero(field *copybook.Field) bool {
+	if field == nil || field.Entry == nil {
+		return false
+	}
+
+	return slices.ContainsFunc(field.Entry.Clauses, func(clause cobol.DataClause) bool {
+		_, blank := clause.(*cobol.BlankWhenZeroClause)
+
+		return blank
+	})
 }
 
 // literals resolves a strategy's literals against the field they are compared

--- a/internal/resolve/predicate_test.go
+++ b/internal/resolve/predicate_test.go
@@ -805,3 +805,210 @@ func TestValueEqualityDoesNotDependOnWhichAnswerIsAsked(t *testing.T) {
 		})
 	}
 }
+
+// layoutOf lays a copybook source out under the dialect every test here states.
+func layoutOf(t *testing.T, source string) *copybook.Layout {
+	t.Helper()
+
+	built, err := copybook.NewLayout(recordOf(t, source), copybook.IBMEnterprise())
+	if err != nil {
+		t.Fatalf("laying the copybook out: %v", err)
+	}
+
+	return built
+}
+
+// TestTheItemCoveringARunIsTakenOnlyWhereTheLayoutSettlesIt is the soundness
+// bound of #330's refinement, asked of [covering] rather than of a pair of
+// records: everything the static layout does not settle has to decline, because
+// a domain read off the wrong item turns an ambiguity into a layout that
+// compiles and a file read as the wrong record type.
+//
+// Two of these are not reachable through a pair of records at all. Slack belongs
+// to no item and sits only in front of a binary item, so a record whose byte the
+// refinement declines for slack declines for the binary item either way; and a
+// run covered by a REDEFINES cluster is every run of the arm overlap check,
+// which passes no domains at all. They are held here so that the reason each
+// declines is the reason written down rather than the one that happens to
+// coincide with it.
+func TestTheItemCoveringARunIsTakenOnlyWhereTheLayoutSettlesIt(t *testing.T) {
+	t.Parallel()
+
+	const plain = `01 PLA-REC.
+   05 PLA-TYPE PIC X(1).
+   05 PLA-ID   PIC 9(9).
+   05 PLA-SEQ  PIC 9(5).
+`
+
+	// BIN-BIN is SYNCHRONIZED onto a four-byte boundary, so bytes nine, ten
+	// and eleven are slack: part of the record and described by no item.
+	const synchronized = `01 BIN-REC.
+   05 BIN-TYPE PIC X(1).
+   05 BIN-FILL PIC X(8).
+   05 BIN-BIN  PIC 9(9) COMP SYNC.
+`
+
+	const depending = `01 ODO-REC.
+   05 ODO-COUNT PIC 9(2).
+   05 ODO-TAB   PIC X(4) OCCURS 1 TO 5 TIMES DEPENDING ON ODO-COUNT.
+   05 ODO-SEQ   PIC 9(5).
+`
+
+	const table = `01 TAB-REC.
+   05 TAB-TYPE PIC X(1).
+   05 TAB-TAB  PIC 9(2) OCCURS 5 TIMES.
+`
+
+	const redefined = `01 RED-REC.
+   05 RED-TYPE PIC X(1).
+   05 RED-BODY PIC 9(8).
+   05 RED-ALT REDEFINES RED-BODY.
+      10 RED-ALT-A PIC X(4).
+      10 RED-ALT-B PIC X(4).
+`
+
+	tests := map[string]struct {
+		copybook string
+		run      stretch
+		want     string
+	}{
+		"a run inside one elementary item": {
+			copybook: plain, run: stretch{at: 10, width: 1}, want: "PLA-SEQ",
+		},
+
+		"a run that is the whole of one item": {
+			copybook: plain, run: stretch{at: 1, width: 9}, want: "PLA-ID",
+		},
+
+		"a run spanning two items": {
+			copybook: plain, run: stretch{at: 9, width: 2}, want: "",
+		},
+
+		"a run past the last byte of the record": {
+			copybook: plain, run: stretch{at: 14, width: 2}, want: "",
+		},
+
+		"a run landing on slack": {
+			copybook: synchronized, run: stretch{at: 10, width: 1}, want: "",
+		},
+
+		"a run ahead of a repetition whose count is a reference": {
+			copybook: depending, run: stretch{at: 0, width: 2}, want: "ODO-COUNT",
+		},
+
+		"a run after a repetition whose count is a reference": {
+			copybook: depending, run: stretch{at: 23, width: 5}, want: "",
+		},
+
+		"a run inside a table": {
+			copybook: table, run: stretch{at: 3, width: 2}, want: "",
+		},
+
+		"a run more than one description covers": {
+			copybook: redefined, run: stretch{at: 1, width: 2}, want: "",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			item, ok := covering(layoutOf(t, test.copybook), test.run)
+			if !ok {
+				if test.want != "" {
+					t.Fatalf("the run is covered by no item, want %s", test.want)
+				}
+
+				return
+			}
+
+			if test.want == "" {
+				t.Fatalf("the run is covered by %s, want no item at all", item.Field.Name)
+			}
+
+			if item.Field.Name != test.want {
+				t.Errorf("the run is covered by %s, want %s", item.Field.Name, test.want)
+			}
+		})
+	}
+}
+
+// TestOnlyTheUnsignedZonedItemStatesAByteDomain is the other half: what a
+// PICTURE and a USAGE are read as once the item is known.
+//
+// The one shape stated is the unsigned zoned DISPLAY item, whose bytes are the
+// charset's ten digits and nothing else. Every other shape declines, and the
+// declines are not all the same kind of thing — `PIC X` and the binary usages
+// have no domain to state, while a packed item and a signed zoned one have one
+// this package will not write a second reading of (Zaba505/cobol-go#134).
+func TestOnlyTheUnsignedZonedItemStatesAByteDomain(t *testing.T) {
+	t.Parallel()
+
+	// F0 through F9: the digits of cp037, which codec/SPEC.md states are the
+	// digits of every EBCDIC code page the charset axis admits.
+	ebcdicDigits := []byte{0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9}
+
+	tests := map[string]struct {
+		picture string
+		charset layoutmodel.Charset
+		want    []byte
+	}{
+		"an unsigned zoned item": {
+			picture: "PIC 9(3)", charset: layoutmodel.CP037, want: ebcdicDigits,
+		},
+
+		"an unsigned zoned item on a borrowed table": {
+			picture: "PIC 9(3)", charset: layoutmodel.CP1047, want: ebcdicDigits,
+		},
+
+		"an unsigned zoned item in ASCII": {
+			picture: "PIC 9(3)", charset: layoutmodel.ASCII,
+			want: []byte("0123456789"),
+		},
+
+		"an alphanumeric item": {picture: "PIC X(3)", charset: layoutmodel.CP037},
+		"a signed zoned item":  {picture: "PIC S9(3)", charset: layoutmodel.CP037},
+		"a scaled item":        {picture: "PIC 9V99", charset: layoutmodel.CP037},
+		"a packed item":        {picture: "PIC 9(5) COMP-3", charset: layoutmodel.CP037},
+		"a binary item":        {picture: "PIC 9(4) COMP", charset: layoutmodel.CP037},
+
+		"an item nothing states a charset for": {picture: "PIC 9(3)"},
+
+		"an item whose bytes are not characters": {
+			picture: "PIC 9(3)", charset: layoutmodel.None,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			built := layoutOf(t, "01 DOM-REC.\n   05 DOM-ITEM "+test.picture+".\n")
+
+			item, ok := covering(built, stretch{at: 0, width: 1})
+			if !ok {
+				t.Fatalf("the item covers no run of its own record")
+			}
+
+			domain := itemDomain(item, layoutmodel.Axes{Charset: test.charset})
+
+			if test.want == nil {
+				if domain != nil {
+					t.Errorf("the item states the domain %x, want none", domain)
+				}
+
+				return
+			}
+
+			if len(domain) != item.Length {
+				t.Fatalf("the domain covers %d bytes, want %d", len(domain), item.Length)
+			}
+
+			for at, set := range domain {
+				if string(set) != string(test.want) {
+					t.Errorf("byte %d admits %x, want %x", at, set, test.want)
+				}
+			}
+		})
+	}
+}

--- a/internal/resolve/sequence.go
+++ b/internal/resolve/sequence.go
@@ -739,8 +739,8 @@ func (c *compiler) predicatesOverlap(first, second *Transition) bool {
 		return true
 	}
 
-	over, ok := c.stretchOf(first.Record, first.Predicate)
-	against, againstOK := c.stretchOf(second.Record, second.Predicate)
+	over, ok := c.discriminant(first)
+	against, againstOK := c.discriminant(second)
 	if !ok || !againstOK {
 		// A discriminator whose target this cannot place is one
 		// [compiler.discriminator] has already reported, and an ambiguity
@@ -749,7 +749,34 @@ func (c *compiler) predicatesOverlap(first, second *Transition) bool {
 		return false
 	}
 
-	return overlap(first.Predicate, over, second.Predicate, against)
+	return overlap(over, against)
+}
+
+// discriminant is one transition's side of an overlap question: what it tests,
+// the run of its record's bytes it reads, and what that record's copybook admits
+// anywhere else in it.
+//
+// The third is why this is built here rather than inside [overlap]: the byte
+// domains are the record's copybook, and the copybook is the compiler's to hold
+// (#330).
+func (c *compiler) discriminant(transition *Transition) (discriminant, bool) {
+	run, ok := c.stretchOf(transition.Record, transition.Predicate)
+	if !ok {
+		return discriminant{}, false
+	}
+
+	known, knownOK := c.record(transition.Record)
+	if !knownOK {
+		return discriminant{}, false
+	}
+
+	return discriminant{
+		predicate: transition.Predicate,
+		run:       run,
+		admits: domainsOf(c.layoutOf(known), func(field *copybook.Field) layoutmodel.Axes {
+			return axesOf(c.opts.Encoding, c.opts.EncodingOverrides, field)
+		}),
+	}, true
 }
 
 // satisfiable reports whether some register file satisfies every guard in the


### PR DESCRIPTION
Closes #330.

`overlap` returned `true` unconditionally for two discriminators whose runs share no
byte, on the sound but coarse grounds that a record can carry one value at byte zero
and another at byte ten. It now asks what the *other* record's copybook says those
bytes may hold, and admits the pair where neither record could carry the other's
literal.

Discussion #323's shape is the case: a header keyed on byte zero equal to `H` beside a
detail keyed on byte ten equal to `D`. Byte ten of the header is inside a numeric
DISPLAY item, so a header can never carry `D` there; where byte zero of the detail is
numeric DISPLAY too, it can never carry `H`. The layout compiles, with nothing added to
it and nothing asked of the adopter. Where either of those items is `PIC X`, the refusal
stands unchanged and reads exactly as #326 and #329 left it.

## Acceptance criteria

- [x] `overlap` consults the byte domain of the item covering each run inside the
      opposing record, and reports the pair disjoint where a literal byte lies outside
      it — `overlap`/`discriminant.carries` in `internal/resolve/predicate.go`, with the
      run intersection of #325 kept ahead of it.
- [x] The refinement is sound: `covering` declines a run no single elementary item
      wholly contains (a span across an item boundary, and the slack a SYNCHRONIZED item
      pushes in front of itself, which belongs to no item), a run at or after a
      repetition whose count is a reference, a run inside a table, and a run more than
      one description of the same storage covers. `itemDomain` declines `PIC X`, every
      binary usage, the packed and signed shapes, and BLANK WHEN ZERO.
- [x] Restricted to what `charsetOf` gives a table for, declining otherwise. The only
      bytes ever claimed are the ten digits, which `codec/SPEC.md` states are identical
      across every EBCDIC code page the charset axis admits — the same invariant subset
      `invariant` holds a literal to.
- [x] The byte domains are read from one place. `itemDomain` is it, and it is built out
      of `zonedUnsigned` and `charsetOf` rather than a second reading of either.
- [x] `docs/ir/SPEC.md`, "When two match, and when none does", states the refined test
      normatively — the two steps, the table of shapes with a domain, the declines, and
      why both directions are required.
- [x] The same section states that the proof holds over well-formed records, and that a
      corrupt record carrying bytes outside its item's domain is outside it — a
      narrowing of the invariant rather than something absorbed silently.
- [x] No `IrVersion` bump. Nothing about an emitted descriptor changed; this decides
      only which layouts are refused.
- [x] Conformance: `TestDiscriminatorsOverDifferentRunsAreDisjointWhereTheCopybooksForbidTheOpposingLiteral`
      compiles the batch shape with a numeric item at the opposing offset and refuses
      every other shape, asserting the refusal still names both runs as #326 gave it.

## Judgment calls

**Both directions are required, not either.** An input satisfying both predicates is a
well-formed record of one of the two types, so the pair survives where *either* record
could carry the other's literal. Proving only one direction leaves the other record able
to satisfy both tests at once, which is the ambiguity the rule is about. The SPEC says
so explicitly, because "a literal byte lies outside it" reads like one direction would
do.

**The refinement applies to intersecting runs too, not only to disjoint ones.** A pair
agreeing over its shared window is asked the same question about the bytes outside it.
The disjoint-run case is the one #330 was filed for and is the vacuous case of the same
rule.

**Packed and signed zoned items are declined although they have a domain.** Stating them
means writing down where `codec` puts a sign nibble and an overpunch, neither of which
cobol-go exports — a second reading of an encoding, kept in a second place, which is the
disagreement `copybook` is depended on here to prevent. Zaba505/cobol-go#134 asks for the
domain API; until it lands those two shapes cost a refusal that could have been narrowed
and never an unsound proof.

**The arm overlap check passes no domains.** Two arms of a variant are alternatives of
one REDEFINES cluster, so every run either reads is covered by both descriptions of the
same storage — exactly the shape `covering` declines. Handing it the record's layout
would decline every pair while reading as though the copybooks had been consulted; the
comment at the call site says so.

**`overlap` now takes two `discriminant`s.** The third member is the record's byte
domains, which are the compiler's to hold, so the struct is what carries them in rather
than a fifth and sixth positional argument.

No public API changed: `overlap`, `discriminant`, `covering`, `itemDomain`, `byteDomain`
and `domains` are all unexported.

## Verified

- `dagger call ci` — green, from an ordinary clone of `issue-330` (`CONTRIBUTING.md`,
  "The pipeline does not run from a git worktree").
- `go test ./internal/resolve/` green, including the twenty new cases.
- The new tests were confirmed to fail with `discriminant.carries` short-circuited to
  `true`, so they pin the addition rather than passing vacuously.
