### PR TITLE
story(resolve): order a state's transitions by the offset each discriminator reads

### DIFF
--- a/docs/ir/SPEC.md
+++ b/docs/ir/SPEC.md
@@ -2113,6 +2113,72 @@ is unambiguous and a consumer is entitled to assume it. Which pairs of
 transitions that test is over, once guards are present, is [When two
 match](#when-two-match-and-when-none-does)'s.
 
+### Transitions are ordered by what they read
+
+A state's transitions are an order of evaluation, and that order is a property a
+producer owes rather than a by-product of however the sequencing was written.
+The transitions leaving one state that carry a predicate **MUST** be ordered
+among themselves by the offset of the first byte their predicate reads,
+ascending; and two whose predicates begin at the same byte by the offset of the
+last, ascending. The offsets are the ones [Ordering and width, and no
+offset](#ordering-and-width-and-no-offset) makes a consumer sum, over the record
+the transition admits, and no node carries either of them: this is a statement
+about the order the transitions are in, not a second statement of where anything
+is.
+
+A transition carrying no predicate **MUST** keep the position it already had. It
+reads no byte of the record, so there is no offset to order it by, and [A
+transition may carry no
+predicate](#a-transition-may-carry-no-predicate) stands unchanged: it is
+evaluated in the order the state carries like every other transition, it is not
+tried last, and it does not catch what the others miss. Ordering it behind
+everything that reads a run would have made it the default arm that section
+refuses.
+
+Two predicates reading exactly the same run are ordered alike by this rule, and
+the producer **MUST** leave them in whatever order it already had them —
+`resolve` sorts stably. That is the tie-break, and it is deterministic in the
+sense [Identity, ordering and
+determinism](#identity-ordering-and-determinism) asks for: identical inputs
+produce byte-identical IR. It is not a claim that two producers reaching the same
+graph by different constructions would agree there, and it does not need to be:
+two transitions reading one run are told apart by their literals, which [When two
+match](#when-two-match-and-when-none-does) has already required to disagree.
+
+Reason: the order the algebra leaves behind is an artifact of expression nesting
+and nothing else, and on the file shape this is most visible on, it is exactly
+backwards. Compiling `(+ (seq HEADER (* DATA)))` — a header, then details until
+the next header — the inner repetition links its own back edge before the
+enclosing `seq` links the way from a header into a detail, and the outer `+`
+links the way from a detail back to a header last of all. So the state after a
+detail carries the detail's test ahead of the header's, and an adopter has no
+lever to correct it: the two competitors come from different nesting levels, so
+the order of an `(alt …)`'s branches cannot reach them. A hand-written streaming
+reader has no such problem, because it tests discriminators in the order it
+reaches their bytes — byte 0 before byte 8 — and that order is derivable from
+the copybooks alone, needs nothing from the adopter, and is what a vendor reader
+of such a file already does.
+
+**This is not a licence to overlap.** Ordering the transitions makes the order
+meaningful; it does not make it a proof, and the paragraph in [When two match,
+and when none does](#when-two-match-and-when-none-does) refusing an overlapping
+pair on the strength of evaluation order stands exactly as it was (#324). Nor
+does it change what any conforming consumer does: a consumer already evaluates
+the transitions in the order the state carries them, so this is a requirement on
+what a producer puts in the descriptor and adds nothing a consumer must
+understand. It is therefore not a change [Versioning and
+compatibility](#versioning-and-compatibility) prices — the version does not
+advance, because a descriptor carrying transitions in this order is read
+correctly by a consumer that has never heard of this section.
+
+Where the pair at a state is provably disjoint — which is every pair a producer
+may emit — the order cannot be observed at all, and the diff a descriptor shows
+on adopting this rule is a reordering rather than a change of behaviour. What it
+buys is that the order is stated: a state whose two transitions could both be
+reached is a state whose evaluation order somebody has to be able to reason
+about, and reasoning about the nesting depth of the expression that produced it
+is not reasoning anybody can do from a descriptor.
+
 ### The automaton remembers, in registers
 
 A file shape this project exists to read: a header carries a flag saying whether
@@ -2717,7 +2783,10 @@ stated as a restriction.
 A consumer **MAY** therefore stop at the first eligible transition that matches.
 The evaluation order is normative all the same, so that two consumers handed the
 same bytes do the same work in the same order and report the same thing when
-something is wrong with them.
+something is wrong with them. What that order *is* — the offset each
+discriminator reads, and not the shape of the expression the automaton was
+compiled from — is [Transitions are ordered by what they
+read](#transitions-are-ordered-by-what-they-read)'s (#331).
 
 That permission is a consumer's, and it is not a producer's. **Ordered
 evaluation does not license an overlapping pair.** A producer **MUST NOT** emit
@@ -4025,7 +4094,7 @@ records offer them.
 | [Physical framing](#physical-framing) | #78, #88, #92, #94 `ir`, #26 `layout`, #52 `gen-go` |
 | [The encoding profile, applied](#the-encoding-profile-applied) | #33 `resolve`; an item that carries bytes rather than characters by #275; the fifth axis, the binary width staircase resolved from the dialect, by #293; which consumers the axis rule binds, settled by #297 |
 | [Names](#names) | #30 `layout`, #38 `resolve`; what a record node resolved from a `REDEFINES` is called, settled by #164 |
-| [The sequencing automaton](#the-sequencing-automaton) | #36 `resolve`, #76, #77, #80, #84, #88 `ir` |
+| [The sequencing automaton](#the-sequencing-automaton) | #36 `resolve`, #76, #77, #80, #84, #88 `ir`; the order a state's transitions are carried in, made a property of what each discriminator reads by #331 |
 | [Discriminator predicates](#discriminator-predicates) | #28 `layout`, #37 `resolve`, #80, #84, #88, #90, #94 `ir`; whether a producer may emit an overlapping pair resolved by evaluation order, settled unchanged by #324 against discussion #323 |
 | [Writing a file](#writing-a-file) | #79, #80, #82, #88, #89, #90 `ir`, #51, #52 `gen-go` |
 | [Versioning and compatibility](#versioning-and-compatibility) | #17, #18 `ir` |

--- a/example/ledger/graph/graph.md
+++ b/example/ledger/graph/graph.md
@@ -8,16 +8,16 @@
 stateDiagram-v2
     [*] --> s40
     s40 --> s41: LEDGER-HEADER, when HDR-TYPE = 0xF0 0xF1, then r39 = HDR-COUNT
+    s41 --> s44: LEDGER-TRAILER, when TRL-TYPE = 0xF9 0xF9, if r39 = 0
     s41 --> s42: DEBIT-POSTING, when PST-TYPE = 0xC4 0xD9, if r39 greater than zero, then r39 = r39 - 1
     s41 --> s43: CREDIT-POSTING, when PST-TYPE = 0xC3 0xD9, if r39 greater than zero, then r39 = r39 - 1
-    s41 --> s44: LEDGER-TRAILER, when TRL-TYPE = 0xF9 0xF9, if r39 = 0
+    s44 --> [*]
+    s42 --> s44: LEDGER-TRAILER, when TRL-TYPE = 0xF9 0xF9, if r39 = 0
     s42 --> s42: DEBIT-POSTING, when PST-TYPE = 0xC4 0xD9, if r39 greater than zero, then r39 = r39 - 1
     s42 --> s43: CREDIT-POSTING, when PST-TYPE = 0xC3 0xD9, if r39 greater than zero, then r39 = r39 - 1
-    s42 --> s44: LEDGER-TRAILER, when TRL-TYPE = 0xF9 0xF9, if r39 = 0
+    s43 --> s44: LEDGER-TRAILER, when TRL-TYPE = 0xF9 0xF9, if r39 = 0
     s43 --> s42: DEBIT-POSTING, when PST-TYPE = 0xC4 0xD9, if r39 greater than zero, then r39 = r39 - 1
     s43 --> s43: CREDIT-POSTING, when PST-TYPE = 0xC3 0xD9, if r39 greater than zero, then r39 = r39 - 1
-    s43 --> s44: LEDGER-TRAILER, when TRL-TYPE = 0xF9 0xF9, if r39 = 0
-    s44 --> [*]
 ```
 
 ## Registers
@@ -45,6 +45,15 @@ Each record's items, in containment order, beginning at the first byte of the re
 | 12 | 6 | HDR-PERIOD | DISPLAY | 9(6) | always |
 | 18 | 3 | HDR-CURRENCY | DISPLAY | X(3) | always |
 | 21 | 3 | HDR-COUNT | DISPLAY | 9(3) | always |
+
+### LEDGER-TRAILER
+
+| Offset | Width | Item | Usage | Picture | Present |
+| --- | --- | --- | --- | --- | --- |
+| 0 | 2 | TRL-TYPE | DISPLAY | X(2) | always |
+| 2 | 6 | TRL-COUNT | DISPLAY | 9(6) | always |
+| 8 | 8 | TRL-NET | PACKED-DECIMAL | S9(13)V9(2) | always |
+| 16 | 8 | *filler* | DISPLAY | X(8) | always |
 
 ### DEBIT-POSTING
 
@@ -76,12 +85,3 @@ Each record's items, in containment order, beginning at the first byte of the re
 | 42 | 8 | PST-TAIL-REF | — | — | always |
 | 42 | 4 | PST-TAIL-REF.PTR-BATCH | DISPLAY | 9(4) | always |
 | 46 | 4 | PST-TAIL-REF.PTR-LINE | DISPLAY | 9(4) | always |
-
-### LEDGER-TRAILER
-
-| Offset | Width | Item | Usage | Picture | Present |
-| --- | --- | --- | --- | --- | --- |
-| 0 | 2 | TRL-TYPE | DISPLAY | X(2) | always |
-| 2 | 6 | TRL-COUNT | DISPLAY | 9(6) | always |
-| 8 | 8 | TRL-NET | PACKED-DECIMAL | S9(13)V9(2) | always |
-| 16 | 8 | *filler* | DISPLAY | X(8) | always |

--- a/example/ledger/ledger/file.go
+++ b/example/ledger/ledger/file.go
@@ -207,14 +207,36 @@ func (r *Reader) Next() (Record, error) {
 
 		var excluded string
 
-		// Transition 1, which admits POSTING-RECORD.
+		// Transition 1, which admits LEDGER-TRAILER.
+		if !r.register39Bound {
+			return nil, r.unbound(39)
+		}
+
+		if r.register39 == 0 {
+			expected = append(expected, "LEDGER-TRAILER")
+			if matches2At0(r.look) {
+				rec := new(LedgerTrailer)
+
+				if err := r.admit(rec); err != nil {
+					return nil, err
+				}
+
+				r.state = 4
+
+				return rec, nil
+			}
+		} else if excluded == "" && matches2At0(r.look) {
+			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted LEDGER-TRAILER, which is taken only where the register the descriptor carries as node 39 is 0; node 39 holds %d", r.register39)
+		}
+
+		// Transition 2, which admits POSTING-RECORD.
 		if !r.register39Bound {
 			return nil, r.unbound(39)
 		}
 
 		if r.register39 > 0 {
 			expected = append(expected, "POSTING-RECORD")
-			if matches2At12(r.look) {
+			if matches3At12(r.look) {
 				rec := new(DebitPosting)
 
 				if err := r.admit(rec); err != nil {
@@ -235,18 +257,18 @@ func (r *Reader) Next() (Record, error) {
 
 				return rec, nil
 			}
-		} else if excluded == "" && matches2At12(r.look) {
+		} else if excluded == "" && matches3At12(r.look) {
 			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 39 is greater than zero; node 39 holds %d", r.register39)
 		}
 
-		// Transition 2, which admits POSTING-RECORD.
+		// Transition 3, which admits POSTING-RECORD.
 		if !r.register39Bound {
 			return nil, r.unbound(39)
 		}
 
 		if r.register39 > 0 {
 			expected = append(expected, "POSTING-RECORD")
-			if matches3At12(r.look) {
+			if matches4At12(r.look) {
 				rec := new(CreditPosting)
 
 				if err := r.admit(rec); err != nil {
@@ -267,30 +289,8 @@ func (r *Reader) Next() (Record, error) {
 
 				return rec, nil
 			}
-		} else if excluded == "" && matches3At12(r.look) {
+		} else if excluded == "" && matches4At12(r.look) {
 			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 39 is greater than zero; node 39 holds %d", r.register39)
-		}
-
-		// Transition 3, which admits LEDGER-TRAILER.
-		if !r.register39Bound {
-			return nil, r.unbound(39)
-		}
-
-		if r.register39 == 0 {
-			expected = append(expected, "LEDGER-TRAILER")
-			if matches4At0(r.look) {
-				rec := new(LedgerTrailer)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				r.state = 4
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches4At0(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted LEDGER-TRAILER, which is taken only where the register the descriptor carries as node 39 is 0; node 39 holds %d", r.register39)
 		}
 
 		return nil, r.undescribed(expected, excluded)
@@ -299,14 +299,36 @@ func (r *Reader) Next() (Record, error) {
 
 		var excluded string
 
-		// Transition 1, which admits POSTING-RECORD.
+		// Transition 1, which admits LEDGER-TRAILER.
+		if !r.register39Bound {
+			return nil, r.unbound(39)
+		}
+
+		if r.register39 == 0 {
+			expected = append(expected, "LEDGER-TRAILER")
+			if matches2At0(r.look) {
+				rec := new(LedgerTrailer)
+
+				if err := r.admit(rec); err != nil {
+					return nil, err
+				}
+
+				r.state = 4
+
+				return rec, nil
+			}
+		} else if excluded == "" && matches2At0(r.look) {
+			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted LEDGER-TRAILER, which is taken only where the register the descriptor carries as node 39 is 0; node 39 holds %d", r.register39)
+		}
+
+		// Transition 2, which admits POSTING-RECORD.
 		if !r.register39Bound {
 			return nil, r.unbound(39)
 		}
 
 		if r.register39 > 0 {
 			expected = append(expected, "POSTING-RECORD")
-			if matches2At12(r.look) {
+			if matches3At12(r.look) {
 				rec := new(DebitPosting)
 
 				if err := r.admit(rec); err != nil {
@@ -327,18 +349,18 @@ func (r *Reader) Next() (Record, error) {
 
 				return rec, nil
 			}
-		} else if excluded == "" && matches2At12(r.look) {
+		} else if excluded == "" && matches3At12(r.look) {
 			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 39 is greater than zero; node 39 holds %d", r.register39)
 		}
 
-		// Transition 2, which admits POSTING-RECORD.
+		// Transition 3, which admits POSTING-RECORD.
 		if !r.register39Bound {
 			return nil, r.unbound(39)
 		}
 
 		if r.register39 > 0 {
 			expected = append(expected, "POSTING-RECORD")
-			if matches3At12(r.look) {
+			if matches4At12(r.look) {
 				rec := new(CreditPosting)
 
 				if err := r.admit(rec); err != nil {
@@ -359,30 +381,8 @@ func (r *Reader) Next() (Record, error) {
 
 				return rec, nil
 			}
-		} else if excluded == "" && matches3At12(r.look) {
+		} else if excluded == "" && matches4At12(r.look) {
 			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 39 is greater than zero; node 39 holds %d", r.register39)
-		}
-
-		// Transition 3, which admits LEDGER-TRAILER.
-		if !r.register39Bound {
-			return nil, r.unbound(39)
-		}
-
-		if r.register39 == 0 {
-			expected = append(expected, "LEDGER-TRAILER")
-			if matches4At0(r.look) {
-				rec := new(LedgerTrailer)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				r.state = 4
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches4At0(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted LEDGER-TRAILER, which is taken only where the register the descriptor carries as node 39 is 0; node 39 holds %d", r.register39)
 		}
 
 		return nil, r.undescribed(expected, excluded)
@@ -391,14 +391,36 @@ func (r *Reader) Next() (Record, error) {
 
 		var excluded string
 
-		// Transition 1, which admits POSTING-RECORD.
+		// Transition 1, which admits LEDGER-TRAILER.
+		if !r.register39Bound {
+			return nil, r.unbound(39)
+		}
+
+		if r.register39 == 0 {
+			expected = append(expected, "LEDGER-TRAILER")
+			if matches2At0(r.look) {
+				rec := new(LedgerTrailer)
+
+				if err := r.admit(rec); err != nil {
+					return nil, err
+				}
+
+				r.state = 4
+
+				return rec, nil
+			}
+		} else if excluded == "" && matches2At0(r.look) {
+			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted LEDGER-TRAILER, which is taken only where the register the descriptor carries as node 39 is 0; node 39 holds %d", r.register39)
+		}
+
+		// Transition 2, which admits POSTING-RECORD.
 		if !r.register39Bound {
 			return nil, r.unbound(39)
 		}
 
 		if r.register39 > 0 {
 			expected = append(expected, "POSTING-RECORD")
-			if matches2At12(r.look) {
+			if matches3At12(r.look) {
 				rec := new(DebitPosting)
 
 				if err := r.admit(rec); err != nil {
@@ -419,18 +441,18 @@ func (r *Reader) Next() (Record, error) {
 
 				return rec, nil
 			}
-		} else if excluded == "" && matches2At12(r.look) {
+		} else if excluded == "" && matches3At12(r.look) {
 			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 39 is greater than zero; node 39 holds %d", r.register39)
 		}
 
-		// Transition 2, which admits POSTING-RECORD.
+		// Transition 3, which admits POSTING-RECORD.
 		if !r.register39Bound {
 			return nil, r.unbound(39)
 		}
 
 		if r.register39 > 0 {
 			expected = append(expected, "POSTING-RECORD")
-			if matches3At12(r.look) {
+			if matches4At12(r.look) {
 				rec := new(CreditPosting)
 
 				if err := r.admit(rec); err != nil {
@@ -451,30 +473,8 @@ func (r *Reader) Next() (Record, error) {
 
 				return rec, nil
 			}
-		} else if excluded == "" && matches3At12(r.look) {
+		} else if excluded == "" && matches4At12(r.look) {
 			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted POSTING-RECORD, which is taken only where the register the descriptor carries as node 39 is greater than zero; node 39 holds %d", r.register39)
-		}
-
-		// Transition 3, which admits LEDGER-TRAILER.
-		if !r.register39Bound {
-			return nil, r.unbound(39)
-		}
-
-		if r.register39 == 0 {
-			expected = append(expected, "LEDGER-TRAILER")
-			if matches4At0(r.look) {
-				rec := new(LedgerTrailer)
-
-				if err := r.admit(rec); err != nil {
-					return nil, err
-				}
-
-				r.state = 4
-
-				return rec, nil
-			}
-		} else if excluded == "" && matches4At0(r.look) {
-			excluded = fmt.Sprintf("a guard excluded the transition that would have admitted LEDGER-TRAILER, which is taken only where the register the descriptor carries as node 39 is 0; node 39 holds %d", r.register39)
 		}
 
 		return nil, r.undescribed(expected, excluded)
@@ -634,8 +634,8 @@ func matches1At0(b []byte) bool {
 	return bytes.Equal(b[0:2], []byte("\xf0\xf1"))
 }
 
-// matches2At12 is the predicate over bytes 12:14 of a record: the transitions it
-// selects admit POSTING-RECORD.
+// matches2At0 is the predicate over bytes 0:2 of a record: the transitions it
+// selects admit LEDGER-TRAILER.
 //
 // One function per distinct predicate rather than one per transition that
 // tests it. A predicate is a function of where it reads, how wide that window
@@ -646,12 +646,12 @@ func matches1At0(b []byte) bool {
 // reader hands it the record the framing bounds, or as much of the input as it
 // can see where the framing bounds nothing; a writer hands it the whole of the
 // record it is about to emit.
-func matches2At12(b []byte) bool {
-	if len(b) < 14 {
+func matches2At0(b []byte) bool {
+	if len(b) < 2 {
 		return false
 	}
 
-	return bytes.Equal(b[12:14], []byte("\xc4\xd9"))
+	return bytes.Equal(b[0:2], []byte("\xf9\xf9"))
 }
 
 // matches3At12 is the predicate over bytes 12:14 of a record: the transitions it
@@ -671,11 +671,11 @@ func matches3At12(b []byte) bool {
 		return false
 	}
 
-	return bytes.Equal(b[12:14], []byte("\xc3\xd9"))
+	return bytes.Equal(b[12:14], []byte("\xc4\xd9"))
 }
 
-// matches4At0 is the predicate over bytes 0:2 of a record: the transitions it
-// selects admit LEDGER-TRAILER.
+// matches4At12 is the predicate over bytes 12:14 of a record: the transitions it
+// selects admit POSTING-RECORD.
 //
 // One function per distinct predicate rather than one per transition that
 // tests it. A predicate is a function of where it reads, how wide that window
@@ -686,12 +686,12 @@ func matches3At12(b []byte) bool {
 // reader hands it the record the framing bounds, or as much of the input as it
 // can see where the framing bounds nothing; a writer hands it the whole of the
 // record it is about to emit.
-func matches4At0(b []byte) bool {
-	if len(b) < 2 {
+func matches4At12(b []byte) bool {
+	if len(b) < 14 {
 		return false
 	}
 
-	return bytes.Equal(b[0:2], []byte("\xf9\xf9"))
+	return bytes.Equal(b[12:14], []byte("\xc3\xd9"))
 }
 
 // Writer writes the records of one file, walking the automaton this descriptor
@@ -833,13 +833,13 @@ func (w *Writer) writeCreditPosting(rec *CreditPosting) error {
 
 	switch w.state {
 	case 1: // the state the descriptor carries as node 41
-		// Transition 2 of that state.
+		// Transition 3 of that state.
 		if !w.register39Bound {
 			return w.unbound(39)
 		}
 
 		if w.register39 > 0 {
-			if matches3At12(raw) {
+			if matches4At12(raw) {
 				if err := w.emit(raw); err != nil {
 					return err
 				}
@@ -859,17 +859,17 @@ func (w *Writer) writeCreditPosting(rec *CreditPosting) error {
 
 				return nil
 			}
-		} else if excluded == "" && matches3At12(raw) {
+		} else if excluded == "" && matches4At12(raw) {
 			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 39 is greater than zero; node 39 holds %d", w.register39)
 		}
 	case 2: // the state the descriptor carries as node 42
-		// Transition 2 of that state.
+		// Transition 3 of that state.
 		if !w.register39Bound {
 			return w.unbound(39)
 		}
 
 		if w.register39 > 0 {
-			if matches3At12(raw) {
+			if matches4At12(raw) {
 				if err := w.emit(raw); err != nil {
 					return err
 				}
@@ -889,17 +889,17 @@ func (w *Writer) writeCreditPosting(rec *CreditPosting) error {
 
 				return nil
 			}
-		} else if excluded == "" && matches3At12(raw) {
+		} else if excluded == "" && matches4At12(raw) {
 			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 39 is greater than zero; node 39 holds %d", w.register39)
 		}
 	case 3: // the state the descriptor carries as node 43
-		// Transition 2 of that state.
+		// Transition 3 of that state.
 		if !w.register39Bound {
 			return w.unbound(39)
 		}
 
 		if w.register39 > 0 {
-			if matches3At12(raw) {
+			if matches4At12(raw) {
 				if err := w.emit(raw); err != nil {
 					return err
 				}
@@ -919,7 +919,7 @@ func (w *Writer) writeCreditPosting(rec *CreditPosting) error {
 
 				return nil
 			}
-		} else if excluded == "" && matches3At12(raw) {
+		} else if excluded == "" && matches4At12(raw) {
 			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 39 is greater than zero; node 39 holds %d", w.register39)
 		}
 	}
@@ -953,13 +953,13 @@ func (w *Writer) writeDebitPosting(rec *DebitPosting) error {
 
 	switch w.state {
 	case 1: // the state the descriptor carries as node 41
-		// Transition 1 of that state.
+		// Transition 2 of that state.
 		if !w.register39Bound {
 			return w.unbound(39)
 		}
 
 		if w.register39 > 0 {
-			if matches2At12(raw) {
+			if matches3At12(raw) {
 				if err := w.emit(raw); err != nil {
 					return err
 				}
@@ -979,17 +979,17 @@ func (w *Writer) writeDebitPosting(rec *DebitPosting) error {
 
 				return nil
 			}
-		} else if excluded == "" && matches2At12(raw) {
+		} else if excluded == "" && matches3At12(raw) {
 			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 39 is greater than zero; node 39 holds %d", w.register39)
 		}
 	case 2: // the state the descriptor carries as node 42
-		// Transition 1 of that state.
+		// Transition 2 of that state.
 		if !w.register39Bound {
 			return w.unbound(39)
 		}
 
 		if w.register39 > 0 {
-			if matches2At12(raw) {
+			if matches3At12(raw) {
 				if err := w.emit(raw); err != nil {
 					return err
 				}
@@ -1009,17 +1009,17 @@ func (w *Writer) writeDebitPosting(rec *DebitPosting) error {
 
 				return nil
 			}
-		} else if excluded == "" && matches2At12(raw) {
+		} else if excluded == "" && matches3At12(raw) {
 			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 39 is greater than zero; node 39 holds %d", w.register39)
 		}
 	case 3: // the state the descriptor carries as node 43
-		// Transition 1 of that state.
+		// Transition 2 of that state.
 		if !w.register39Bound {
 			return w.unbound(39)
 		}
 
 		if w.register39 > 0 {
-			if matches2At12(raw) {
+			if matches3At12(raw) {
 				if err := w.emit(raw); err != nil {
 					return err
 				}
@@ -1039,7 +1039,7 @@ func (w *Writer) writeDebitPosting(rec *DebitPosting) error {
 
 				return nil
 			}
-		} else if excluded == "" && matches2At12(raw) {
+		} else if excluded == "" && matches3At12(raw) {
 			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 39 is greater than zero; node 39 holds %d", w.register39)
 		}
 	}
@@ -1116,13 +1116,13 @@ func (w *Writer) writeLedgerTrailer(rec *LedgerTrailer) error {
 
 	switch w.state {
 	case 1: // the state the descriptor carries as node 41
-		// Transition 3 of that state.
+		// Transition 1 of that state.
 		if !w.register39Bound {
 			return w.unbound(39)
 		}
 
 		if w.register39 == 0 {
-			if matches4At0(raw) {
+			if matches2At0(raw) {
 				if err := w.emit(raw); err != nil {
 					return err
 				}
@@ -1132,17 +1132,17 @@ func (w *Writer) writeLedgerTrailer(rec *LedgerTrailer) error {
 
 				return nil
 			}
-		} else if excluded == "" && matches4At0(raw) {
+		} else if excluded == "" && matches2At0(raw) {
 			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 39 is 0; node 39 holds %d", w.register39)
 		}
 	case 2: // the state the descriptor carries as node 42
-		// Transition 3 of that state.
+		// Transition 1 of that state.
 		if !w.register39Bound {
 			return w.unbound(39)
 		}
 
 		if w.register39 == 0 {
-			if matches4At0(raw) {
+			if matches2At0(raw) {
 				if err := w.emit(raw); err != nil {
 					return err
 				}
@@ -1152,17 +1152,17 @@ func (w *Writer) writeLedgerTrailer(rec *LedgerTrailer) error {
 
 				return nil
 			}
-		} else if excluded == "" && matches4At0(raw) {
+		} else if excluded == "" && matches2At0(raw) {
 			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 39 is 0; node 39 holds %d", w.register39)
 		}
 	case 3: // the state the descriptor carries as node 43
-		// Transition 3 of that state.
+		// Transition 1 of that state.
 		if !w.register39Bound {
 			return w.unbound(39)
 		}
 
 		if w.register39 == 0 {
-			if matches4At0(raw) {
+			if matches2At0(raw) {
 				if err := w.emit(raw); err != nil {
 					return err
 				}
@@ -1172,7 +1172,7 @@ func (w *Writer) writeLedgerTrailer(rec *LedgerTrailer) error {
 
 				return nil
 			}
-		} else if excluded == "" && matches4At0(raw) {
+		} else if excluded == "" && matches2At0(raw) {
 			excluded = fmt.Sprintf("a guard excluded the transition that would have taken it, which is taken only where the register the descriptor carries as node 39 is 0; node 39 holds %d", w.register39)
 		}
 	}

--- a/internal/assemble/assemble_test.go
+++ b/internal/assemble/assemble_test.go
@@ -1279,3 +1279,91 @@ func TestCharsetNoneReachesTheFieldTheOverrideNames(t *testing.T) {
 11 transition record=1 to=8 predicate=10
 `)
 }
+
+// The batched file docs/ir/SPEC.md's "Transitions are ordered by what they read"
+// is written for: a header keyed on the record's first byte, a detail keyed ten
+// bytes in, and both admissible at the state after a detail. The ten digits
+// ahead of the detail's type code are what make the pair provably exclusive, so
+// what a descriptor carries here is an order rather than a refusal.
+const (
+	batchHeader = `01 BAT-HDR.
+   05 BAT-TYPE PIC X(1).
+   05 BAT-ID   PIC 9(9).
+   05 BAT-SEQ  PIC 9(5).
+   05 BAT-BODY PIC X(6).
+`
+
+	batchDetail = `01 BDT-REC.
+   05 BDT-KEY  PIC 9(10).
+   05 BDT-TYPE PIC X(1).
+   05 BDT-BODY PIC X(10).
+`
+)
+
+const batched = `(framing (recfm FB) (lrecl 21))
+(encoding (charset cp037) (sign-convention ebcdic) (byte-order big-endian) (float-format hfp))
+(record HEADER (copybook "header.cpy" BAT-HDR))
+(record DETAIL (copybook "detail.cpy" BDT-REC))
+(discriminate HEADER (equals (item HEADER BAT-TYPE) "H"))
+(discriminate DETAIL (equals (item DETAIL BDT-TYPE) "D"))
+(sequence (+ (seq HEADER (+ DETAIL))))`
+
+// TestTheOrderAStateCarriesItsTransitionsInSurvivesAssembly is docs/ir/SPEC.md's
+// "Transitions are ordered by what they read" asserted one layer on: the order
+// `resolve` decided is the order the state node's transition list is in, and
+// nothing between here and the wire re-derives it (#331).
+//
+// It is asserted over the record each transition admits rather than over the
+// identifiers, because identifiers are assigned by this traversal and would
+// come out ascending whatever order the transitions were in — which is the one
+// way this assertion could pass while saying nothing.
+func TestTheOrderAStateCarriesItsTransitionsInSurvivesAssembly(t *testing.T) {
+	t.Parallel()
+
+	descriptor := assembled(t, batched, map[string]string{"HEADER": batchHeader, "DETAIL": batchDetail})
+
+	var admitted [][]string
+	for _, node := range descriptor.GetNodes() {
+		state, isState := node.GetKind().(*irpb.Node_State)
+		if !isState || len(state.State.GetTransitionIds()) < 2 {
+			continue
+		}
+
+		var records []string
+		for _, at := range state.State.GetTransitionIds() {
+			records = append(records, recordAdmittedBy(t, descriptor, at))
+		}
+
+		admitted = append(admitted, records)
+	}
+
+	// The names are the copybooks' `01`-levels, which is what a record node
+	// carries (docs/ir/SPEC.md, "Names").
+	want := [][]string{{"BAT-HDR", "BDT-REC"}}
+	if !slices.EqualFunc(admitted, want, slices.Equal) {
+		t.Errorf("the states offering a choice admit %v, want %v — the header's code is byte zero and the detail's is byte ten",
+			admitted, want)
+	}
+}
+
+// recordAdmittedBy is the name of the record one transition node admits.
+func recordAdmittedBy(t *testing.T, d *irpb.Descriptor, transition uint64) string {
+	t.Helper()
+
+	byID := make(map[uint64]*irpb.Node, len(d.GetNodes()))
+	for _, node := range d.GetNodes() {
+		byID[node.GetId()] = node
+	}
+
+	edge, isTransition := byID[transition].GetKind().(*irpb.Node_Transition)
+	if !isTransition {
+		t.Fatalf("node %d is not a transition", transition)
+	}
+
+	record, isRecord := byID[edge.Transition.GetRecordId()].GetKind().(*irpb.Node_Record)
+	if !isRecord {
+		t.Fatalf("transition %d admits node %d, which is not a record", transition, edge.Transition.GetRecordId())
+	}
+
+	return record.Record.GetNames().GetOriginal()
+}

--- a/internal/resolve/automaton.go
+++ b/internal/resolve/automaton.go
@@ -421,6 +421,12 @@ type State struct {
 	Acceptance []Guard
 
 	// Transitions are the edges leaving the state, in evaluation order.
+	//
+	// The order is the one docs/ir/SPEC.md's "Transitions are ordered by
+	// what they read" requires and not the one the expression walk left
+	// behind: by the first byte each predicate reads, then by the last, with
+	// a transition carrying no predicate left where it was
+	// ([compiler.order], #331).
 	Transitions []*Transition
 }
 

--- a/internal/resolve/automaton_test.go
+++ b/internal/resolve/automaton_test.go
@@ -912,7 +912,12 @@ state 5 accepts
 			t.Fatalf("compiling reported %v, want an ambiguity", err)
 		}
 
-		if ambiguous.Records != [2]string{"DETAIL", "TRAILER"} {
+		// The pair is named in the state's evaluation order, and that order
+		// is now the copybooks' rather than the walk's: the trailer's type
+		// code is the record's first byte and the detail's flag is its
+		// second, so the trailer's test is tried first and is named first
+		// (#331).
+		if ambiguous.Records != [2]string{"TRAILER", "DETAIL"} {
 			t.Errorf("the fault names %v, want the pair a discriminator on the flag cannot separate",
 				ambiguous.Records)
 		}

--- a/internal/resolve/order_test.go
+++ b/internal/resolve/order_test.go
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 Richard Carson Derr
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package resolve
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Zaba505/cobol-go/copybook"
+)
+
+// This file is docs/ir/SPEC.md's "Transitions are ordered by what they read":
+// the order a state's transitions leave this package in, and the three things
+// the rule says about it.
+
+// TestTransitionsAreOrderedByTheOffsetEachDiscriminatorReads is the rule on the
+// shape that made it worth stating — a header, then details until the next
+// header — and on the state where the walk gets it backwards (#323, #331).
+//
+// The order the transitions arrive in is an artifact of nesting. `name`
+// allocates position 0 for the header and 1 for the detail; the inner `(+
+// DETAIL)` links the detail's back edge into `follow[1]` first, and only then
+// does the outer `(+ ...)` link the way from a detail back to a header — so the
+// state after a detail arrives carrying the detail's test ahead of the header's,
+// which is the inverse of what reads such a file, and neither `(alt ...)` nor
+// anything else in the layout can reach it, since the two competitors come from
+// different nesting levels.
+//
+// What is asserted is that it does not leave that way. The header's type code is
+// the record's first byte and the detail's is ten bytes in, so a consumer
+// reaches the header's first and the state carries it first.
+func TestTransitionsAreOrderedByTheOffsetEachDiscriminatorReads(t *testing.T) {
+	t.Parallel()
+
+	// The detail's leading ten bytes are the digits that make the pair
+	// provably exclusive, so what is asserted here is an order and not a
+	// refusal (docs/ir/SPEC.md, "When two match, and when none does", #330).
+	assertRendering(t, compiled(t, batchSource, batchCopybooks("PIC 9(10)")), `
+state 0
+  on bytes-equal BAT-TYPE "H", admit HEADER, go to 1
+state 1
+  on bytes-equal BDT-TYPE "D", admit DETAIL, go to 2
+state 2 accepts
+  on bytes-equal BAT-TYPE "H", admit HEADER, go to 1
+  on bytes-equal BDT-TYPE "D", admit DETAIL, go to 2
+`)
+}
+
+// TestTwoRunsBeginningAtOneOffsetAreOrderedByWhereTheyEnd is the tie-break, and
+// it is the first rule again rather than a second one: a consumer standing at
+// the byte both runs begin at has read enough to decide the shorter test before
+// it has read enough to decide the longer.
+//
+// The two runs share their first byte and the literals disagree there, which is
+// the whole of what admits the pair — the shared window is intersected rather
+// than required to be the whole of either run (docs/ir/SPEC.md, "When two match,
+// and when none does", #325). The walk offers the wider of the two first, so the
+// order asserted here is one only the tie-break produces.
+func TestTwoRunsBeginningAtOneOffsetAreOrderedByWhereTheyEnd(t *testing.T) {
+	t.Parallel()
+
+	copybooks := map[string]string{
+		"HEADER": `01 BAT-HDR.
+   05 BAT-TYPE PIC X(1).
+   05 BAT-BODY PIC X(20).
+`,
+		"DETAIL": `01 BDT-REC.
+   05 BDT-TYPE PIC X(2).
+   05 BDT-BODY PIC X(19).
+`,
+	}
+
+	source := `(record HEADER (copybook "header.cpy" BAT-HDR))
+(record DETAIL (copybook "detail.cpy" BDT-REC))
+(discriminate HEADER (equals (item HEADER BAT-TYPE) "H"))
+(discriminate DETAIL (equals (item DETAIL BDT-TYPE) "DD"))
+(sequence (+ (seq HEADER (+ DETAIL))))`
+
+	assertRendering(t, compiled(t, source, copybooks), `
+state 0
+  on bytes-equal BAT-TYPE "H", admit HEADER, go to 1
+state 1
+  on bytes-equal BDT-TYPE "DD", admit DETAIL, go to 2
+state 2 accepts
+  on bytes-equal BAT-TYPE "H", admit HEADER, go to 1
+  on bytes-equal BDT-TYPE "DD", admit DETAIL, go to 2
+`)
+}
+
+// TestATransitionCarryingNoPredicateKeepsItsPosition is the third thing the rule
+// says, and it is a restraint rather than an order: such a transition reads no
+// byte of the record, so there is no offset to order it by and it is left
+// exactly where the walk put it.
+//
+// That it is left there rather than swept to the end is the point. A transition
+// carrying no predicate is not a default arm, and docs/ir/SPEC.md's "A
+// transition may carry no predicate" says so in those words — it is evaluated in
+// the order the state carries like every other transition, it is not tried last,
+// and it does not catch what the others miss (#80). Ordering it behind
+// everything that reads a run would have written the opposite into every
+// descriptor.
+//
+// The assertion is over [compiler.order] rather than over a compiled layout,
+// because a legal state offering such a transition between two others cannot be
+// written: it matches every record, so the overlap rule refuses the state unless
+// guards separate the three — and guards are not what this rule is about.
+func TestATransitionCarryingNoPredicateKeepsItsPosition(t *testing.T) {
+	t.Parallel()
+
+	copybooks := batchCopybooks("PIC 9(10)")
+	header, detail := recordOf(t, copybooks["HEADER"]), recordOf(t, copybooks["DETAIL"])
+
+	c := &compiler{
+		opts: Sequencing{
+			Dialect: copybook.IBMEnterprise(),
+			Records: []SequencedRecord{
+				{Name: "HEADER", Item: header},
+				{Name: "DETAIL", Item: detail},
+			},
+		},
+		layouts: make(map[string]*copybook.Layout),
+	}
+
+	// Ten bytes in, one byte in, and nothing at all — in the order the walk
+	// is entitled to hand them over.
+	late := &Transition{Record: "DETAIL", Predicate: &Predicate{Target: fieldNamed(t, detail, "BDT-TYPE")}}
+	anything := &Transition{Record: "DETAIL"}
+	early := &Transition{Record: "HEADER", Predicate: &Predicate{Target: fieldNamed(t, header, "BAT-TYPE")}}
+
+	state := &State{Transitions: []*Transition{late, anything, early}}
+
+	c.order(state)
+
+	want := []*Transition{early, anything, late}
+	for at := range state.Transitions {
+		if state.Transitions[at] == want[at] {
+			continue
+		}
+
+		t.Fatalf("the state carries %s, want the two that read a run exchanged and the one that reads none left where it was",
+			renderTransitions(state))
+	}
+}
+
+// renderTransitions draws one state's transitions, for a failure whose subject
+// is the order they are in.
+func renderTransitions(state *State) string {
+	rendered := make([]string, 0, len(state.Transitions))
+	for _, transition := range state.Transitions {
+		rendered = append(rendered, renderTransition(transition))
+	}
+
+	return "[" + strings.Join(rendered, "; ") + "]"
+}

--- a/internal/resolve/sequence.go
+++ b/internal/resolve/sequence.go
@@ -6,6 +6,7 @@
 package resolve
 
 import (
+	"cmp"
 	"maps"
 	"slices"
 	"strconv"
@@ -254,7 +255,8 @@ func (c *compiler) assemble(top facts) *Automaton {
 }
 
 // edges builds one state's outgoing transitions out of the ways into the
-// positions that may follow it.
+// positions that may follow it, and leaves them in the order a consumer
+// evaluates them ([compiler.order]).
 func (c *compiler) edges(from *State, ways []entry, states []*State) {
 	for _, way := range ways {
 		if !satisfiable(way.guards) {
@@ -277,6 +279,90 @@ func (c *compiler) edges(from *State, ways []entry, states []*State) {
 			Bindings:  mergeBindings(way.binding, c.bindings(record.record)),
 			To:        to,
 		})
+	}
+
+	c.order(from)
+}
+
+// order puts one state's transitions into the evaluation order docs/ir/SPEC.md's
+// "Transitions are ordered by what they read" requires: the transitions whose
+// predicates read a run of the record are ordered among themselves by where that
+// run begins and then by where it ends, and everything else stays where the walk
+// left it.
+//
+// The order the transitions arrive in is the expression walk's, and the walk's
+// order is an artifact of how deeply the record names happened to be nested
+// rather than of anything an adopter wrote. Tracing `(+ (seq HEADER (* DATA)))`,
+// the inner `(* DATA)` links its own back edge before the enclosing `seq` links
+// the way from a header into a detail and before the outer `+` links the way from
+// a detail back to a header, so the state after a HEADER arrives carrying the
+// detail's test ahead of the header's — the inverse of what reads a batched file,
+// and a pair the adopter has no lever to reach, since the two competitors come
+// from different nesting levels and `(alt ...)` orders only siblings (#323).
+//
+// A hand-written streaming reader has no such problem, because it tests
+// discriminators in the order it reaches their bytes: byte 0 before byte 8. That
+// order is derivable from the copybooks alone, so it is derived here, once, and
+// the descriptor carries it — which is what makes the order a property a producer
+// owes rather than a by-product of the algebra.
+//
+// It is a sort and never a filter, and it is not a licence. Nothing is added,
+// nothing is dropped, and no transition's predicate, guards or bindings are
+// touched: a pair whose merged guards are unsatisfiable is as un-co-eligible
+// after it as before, and [compiler.checkAmbiguity] refuses an overlapping pair
+// whatever order it ends up in. Where the overlap rule has already proved a pair
+// disjoint, the order it lands in cannot be observed at all.
+func (c *compiler) order(state *State) {
+	runs := make(map[*Transition]stretch, len(state.Transitions))
+
+	var reading []*Transition
+	var slots []int
+
+	for at, transition := range state.Transitions {
+		run, ok := c.stretchOf(transition.Record, transition.Predicate)
+		if !ok {
+			// A transition carrying no predicate reads no byte of the
+			// record, so there is no offset to order it by and it keeps the
+			// position the walk gave it. That is docs/ir/SPEC.md's "A
+			// transition may carry no predicate" left standing rather than
+			// narrowed: such a transition is still not a default arm, it is
+			// still not moved to the end of the list, and wherever its
+			// guards can hold it is the only eligible transition its state
+			// offers anyway (#80).
+			//
+			// A predicate whose run this package could not locate — a target
+			// naming no item of the record, a copybook that would not lay
+			// out — is here too. The fault is already reported against the
+			// discriminator, and ordering it by an offset nobody knows would
+			// be inventing one.
+			continue
+		}
+
+		runs[transition] = run
+		reading = append(reading, transition)
+		slots = append(slots, at)
+	}
+
+	slices.SortStableFunc(reading, func(one, other *Transition) int {
+		first, second := runs[one], runs[other]
+
+		if by := cmp.Compare(first.at, second.at); by != 0 {
+			return by
+		}
+
+		// Two runs beginning at the same byte are ordered by where they end,
+		// which is the same rule again rather than a second one: a reader
+		// standing at that byte has read enough to decide the shorter test
+		// before it has read enough to decide the longer. Two runs that begin
+		// and end together are one run, no order tells them apart, and the
+		// sort is stable so they stay as they were.
+		return cmp.Compare(first.end(), second.end())
+	})
+
+	// Back into the slots they came out of, which is what leaves every other
+	// transition at the index it already had.
+	for i, transition := range reading {
+		state.Transitions[slots[i]] = transition
 	}
 }
 


### PR DESCRIPTION
Closes #331

A state's transitions arrived in the order the expression walk left them, and
that order is an artifact of nesting rather than of anything an adopter wrote.
Tracing `(+ (seq HEADER (* DATA)))`, the inner repetition links its own back edge
before the enclosing `seq` links the way from a header into a detail, and the
outer `+` links the way from a detail back to a header last of all — so the state
after a detail carried **the detail's test first**, the inverse of what reads a
batched file, and a pair `(alt …)` cannot reach because the two competitors come
from different nesting levels.

`resolve` now derives the order from the copybooks, the way a hand-written
streaming reader does: it reaches byte 0 before byte 8, so it evaluates the test
at byte 0 first.

## Acceptance criteria

- [x] **A state's transitions are ordered by the first byte each discriminator
  reads, ascending, with a stated and deterministic tie-break for two runs
  beginning at the same offset.** `compiler.order` (`internal/resolve/sequence.go`)
  sorts by the run's start, then by its end — the same rule again rather than a
  second one, since a reader standing at the shared first byte has read enough to
  decide the shorter test before the longer. Two runs that begin *and* end
  together read the same bytes and no order tells them apart, so the sort is
  stable and they stay as they were.
- [x] **Stated normatively in `docs/ir/SPEC.md`** as
  *Transitions are ordered by what they read*, a subsection of *The sequencing
  automaton* directly under the paragraph stating the read loop's evaluation
  order, and cross-referenced from *When two match, and when none does*.
- [x] **A transition carrying no predicate keeps its existing position rule.** It
  reads no byte, so there is no offset to order it by: only the transitions that
  read a run are permuted, and each is put back into a slot one of them already
  occupied. It is therefore never moved ahead of a transition carrying a
  predicate, and — just as important — never swept behind one, which would have
  made it the default arm *A transition may carry no predicate* refuses.
- [x] **Guards are unaffected.** Nothing is added, dropped or rewritten;
  `satisfiable`/`mergeGuards` and `checkAmbiguity` see the same pairs they saw
  before, in the same records.
- [x] **Stable end to end.** `internal/assemble` appends `TransitionIds` in the
  automaton's own order, `irpb` carries a repeated field, and a consumer walks it
  back in order. `TestTheOrderAStateCarriesItsTransitionsInSurvivesAssembly`
  asserts it at the descriptor, over the *record each transition admits* rather
  than over the identifiers — identifiers are assigned by that traversal and would
  read ascending whatever order the transitions were in.
- [x] **Goldens and corpus.** `example/ledger` regenerated: `graph/graph.md` and
  `ledger/file.go`. The `cmd/cpybkc-gen-graph` goldens and the conformance corpus
  needed no change — every record in them carries its type code at byte 0 with the
  same width, so every pair ties and the stable sort leaves them exactly as they
  were.
- [x] **No `IrVersion` bump.** Transition order is already carried by the
  descriptor and a conforming consumer already evaluates in the order the state
  gives, so nothing here is an addition a consumer must understand.

## The diff is a reordering, not a behaviour change

`example/ledger` is the only golden that moves, and it moves for the reason this
story exists: `LEDGER-TRAILER` is keyed on the record's first two bytes and a
posting on bytes twelve and thirteen, so the trailer's transition now comes first
at every state offering both. Those transitions are separated by a guard on the
posting counter (`if r39 = 0` against `if r39 greater than zero`), so at most one
is ever eligible and the reordering cannot be observed by a reader — the
regenerated `example/ledger/ledger` tests and the round-trip pass unchanged.
The predicate helper names renumber (`matches2At0` and friends) purely because
they are numbered in emission order.

One diagnostic moves with it: the sequence-ambiguity fault names its pair in the
state's evaluation order, so the flag-beside-the-type-code case in
`automaton_test.go` now reports `TRAILER, DETAIL` — the trailer's code is byte
zero and the detail's flag is byte one. The pair asserted is the same pair; only
which is named first changed, and it changed to the order a consumer tries them
in.

## Judgment calls

- **The tie-break is the run's end, and beyond that the producer's existing
  order.** A fully-specified cross-producer tie-break for two identical runs would
  have to compare literals or record names, and it would buy nothing: two
  transitions reading one identical run are already required to disagree in their
  literals, so no input can reach both and no order between them is observable.
  What is required instead is stability, which is what *Identity, ordering and
  determinism* already asks for.
- **A predicate whose run `resolve` cannot locate** — a target naming no item of
  the record, a copybook that will not lay out — is left where it was, beside the
  transitions carrying no predicate. The fault is already reported against the
  discriminator, and ordering by an offset nobody knows would be inventing one.
- **The rule is a producer's, not a consumer's**, and the SPEC says so in those
  words, so the version does not advance and no existing consumer changes.

## Verified

`dagger call ci`, from an ordinary clone (`dagger call` cannot run from a git
worktree — CONTRIBUTING.md, *The pipeline does not run from a git worktree*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
