### PR TITLE
story(ir): a batch boundary may be told by ordered evaluation

### DIFF
--- a/docs/ir/SPEC.md
+++ b/docs/ir/SPEC.md
@@ -2159,21 +2159,26 @@ reaches their bytes — byte 0 before byte 8 — and that order is derivable fro
 the copybooks alone, needs nothing from the adopter, and is what a vendor reader
 of such a file already does.
 
-**This is not a licence to overlap.** Ordering the transitions makes the order
-meaningful; it does not make it a proof, and the paragraph in [When two match,
-and when none does](#when-two-match-and-when-none-does) refusing an overlapping
-pair on the strength of evaluation order stands exactly as it was (#324). Nor
-does it change what any conforming consumer does: a consumer already evaluates
-the transitions in the order the state carries them, so this is a requirement on
-what a producer puts in the descriptor and adds nothing a consumer must
-understand. It is therefore not a change [Versioning and
-compatibility](#versioning-and-compatibility) prices — the version does not
-advance, because a descriptor carrying transitions in this order is read
-correctly by a consumer that has never heard of this section.
+**Ordering the transitions makes the order meaningful; it does not make it a
+proof.** What it licenses is stated where the licence is, and it is narrower than
+"overlap": [A batch boundary is told by the
+order](#a-batch-boundary-is-told-by-the-order) admits a pair whose two
+discriminators read runs sharing no byte, on the grounds that the order is the
+one a reader of those bytes reaches them in, and a pair whose runs *do* share a
+byte is refused there as it always was (#332, reversing #324 on the first of the
+two and leaving the second alone). Nor does the rule here change what any
+conforming consumer does: a consumer already evaluates the transitions in the
+order the state carries them, so this is a requirement on what a producer puts in
+the descriptor and adds nothing a consumer must understand. It is therefore not a
+change [Versioning and compatibility](#versioning-and-compatibility) prices — the
+version does not advance, because a descriptor carrying transitions in this order
+is read correctly by a consumer that has never heard of this section.
 
-Where the pair at a state is provably disjoint — which is every pair a producer
-may emit — the order cannot be observed at all, and the diff a descriptor shows
-on adopting this rule is a reordering rather than a change of behaviour. What it
+Where the pair at a state is provably disjoint the order cannot be observed at
+all, and the diff a descriptor shows on adopting this rule is a reordering rather
+than a change of behaviour. Where it is not — the pair the section above admits —
+the order is the whole of what reads the file, which is why it is stated here
+rather than left to the walk. What it
 buys is that the order is stated: a state whose two transitions could both be
 reached is a state whose evaluation order somebody has to be able to reason
 about, and reasoning about the nesting depth of the expression that produced it
@@ -2686,15 +2691,23 @@ against a reference that **MAY** be absent (#80).
 ### When two match, and when none does
 
 Two transitions leaving the same state **MUST NOT** be selected by predicates
-that can both match the same record; `resolve` rejects a layout whose
-discriminators overlap (#37). The test is whether one input can satisfy both,
-not whether the two read the same bytes: a state offering a transition keyed on
-a record's first field beside one keyed on its tenth is where the narrower
-reading lets a real ambiguity through, and predicates reading different fields
-at different positions overlap just as thoroughly as two reading one. So the
-question `layout/SPEC.md` defers to this document — what happens when two
-discriminators match — has an answer at the one place it is cheap: it does not
-arise, because such an IR is never produced.
+that can both match the same record *and* that read runs of bytes sharing one;
+`resolve` rejects a layout whose discriminators ask for the same bytes and agree
+about them (#37). The test of whether one input can satisfy both is not whether
+the two read the same bytes — predicates reading different fields at different
+positions can both match one record just as thoroughly as two reading one — but
+what follows from the answer is not the same in the two cases. A pair whose runs
+share a byte is told apart by the literals over that byte, so a pair agreeing
+there is a clash in the literals and the layout is refused; a pair whose runs
+share none is told apart by nothing a literal could express, and the order the
+state carries resolves it instead ([A batch boundary is told by the
+order](#a-batch-boundary-is-told-by-the-order), #332).
+
+So the question `layout/SPEC.md` defers to this document — what happens when two
+discriminators match — has an answer here, and it is two answers. For a pair
+reading one run it does not arise, because such an IR is never produced. For a
+pair reading two that never meet it is the order, and what that costs is stated
+below rather than left to be discovered.
 
 Whether two predicates *can* both match is decided on bytes, in two steps, and
 `resolve` **MUST** take both before it refuses a pair.
@@ -2729,8 +2742,10 @@ Only these are claimed:
 | alphanumeric, `PIC X` | every byte value, so nothing is proved |
 | binary — `COMP`, `COMP-5` | every bit pattern, so nothing is proved |
 
-Everything else is **declined**, and a decline leaves the pair overlapping and
-refused exactly as it was before the copybooks were read. A producer **MUST**
+Everything else is **declined**, and a decline leaves the pair overlapping
+exactly as it was before the copybooks were read — refused where the two runs
+share a byte, and resting on the order where they do not ([A batch boundary is
+told by the order](#a-batch-boundary-is-told-by-the-order)). A producer **MUST**
 decline rather than narrow wherever the record's static layout does not settle
 which item covers the run: a run no single elementary item wholly contains, a run
 landing on the slack bytes a SYNCHRONIZED item pushed in front of itself, a run
@@ -2740,8 +2755,8 @@ encoding profile does not state. A packed item and a signed zoned one do have a
 domain and are declined all the same, because stating one means restating where
 the encoding puts a sign — a second reading of an encoding, kept in a second
 place, which is the disagreement this refinement is not worth. Declining costs a
-refusal that could have been narrowed; guessing costs a file read as the wrong
-record type.
+refusal, or a descriptor resting on its order, where either could have been
+narrowed to a proof; guessing costs a file read as the wrong record type.
 
 **The proof holds over well-formed records, and that is a narrowing.** A record
 whose bytes are what its own copybook's items admit is inside the proof. A record
@@ -2761,16 +2776,20 @@ expressible at all, since the transition reading another detail and the one
 moving past them can be selected by the very same test on the very same bytes,
 and only the counter separates them. For every other pair — both unguarded, or
 guarded compatibly — the rule above stands unchanged and a producer **MUST NOT**
-emit one.
+emit one whose two runs share a byte.
 
 A transition carrying no predicate ([A transition may carry no
 predicate](#a-transition-may-carry-no-predicate)) is inside that rule rather
-than beside it. It matches every record, so it overlaps every transition leaving
-its state whose guards can hold at the same time as its own, and a producer
-**MUST NOT** emit one where such a transition exists. That is the whole answer
-for a transition not selected by record content, and it is the same answer as
-for one that is: the question was never what a predicate reads, only whether one
-input can satisfy two of them (#80).
+than beside it, and the narrowing above does not reach it. It matches every
+record, so it overlaps every transition leaving its state whose guards can hold
+at the same time as its own, and a producer **MUST NOT** emit one where such a
+transition exists. The permission below is not available to it and **MUST NOT**
+be read as covering it: it reads no run, so there is no pair of runs to share
+nothing, and there is no input it would leave for a transition after it —
+ordering it ahead of one would make that one unreachable and ordering it behind
+would make it the default arm [A transition may carry no
+predicate](#a-transition-may-carry-no-predicate) refuses in as many words (#80,
+#332).
 
 That check stays decidable because of what a guard is not. A flat conjunction of
 three tests over a fixed set of declared registers, with no arithmetic in it
@@ -2788,64 +2807,12 @@ discriminator reads, and not the shape of the expression the automaton was
 compiled from — is [Transitions are ordered by what they
 read](#transitions-are-ordered-by-what-they-read)'s (#331).
 
-That permission is a consumer's, and it is not a producer's. **Ordered
-evaluation does not license an overlapping pair.** A producer **MUST NOT** emit
-two transitions leaving one state whose guards can hold at the same time and
-whose predicates can both match one record on the grounds that a consumer would
-try them in the order the state carries, and `resolve` **MUST** reject such a
-layout whether or not the layout says that is what it intends (#324). The
-asymmetry is only apparent: stopping at the first match is safe *because* at
-most one transition can match, which is what the paragraphs above establish, and
-reading the permission the other way round makes an optimisation into the thing
-that was meant to justify it.
-
-The shape that asks for it is real, and naming it here is cheaper than meeting
-it as a diagnostic. A file that is a sequence of batches — a header, then
-details until the next header — has two records eligible at the state after a
-header, and where the two discriminators name runs at different offsets or of
-different widths the runs do not line up and one record can satisfy both tests
-(#323). *Try the header's test first, and read anything that fails it as a
-detail* reads that file, and is presumably what the vendor reader that wrote it
-does. `layout/SPEC.md` states the shape, and what a layout may write instead, at
-[A batch boundary told only by evaluation
-order](../layout/SPEC.md#a-batch-boundary-told-only-by-evaluation-order).
-
-The copybooks decide how often that shape actually arises, which is why they are
-consulted above. Where the item covering the header's run inside a detail is
-numeric — an account number, a sequence number, a date — and the item covering
-the detail's run inside a header is too, the two tests are provably exclusive and
-the layout compiles with nothing added to it and nothing asked of the adopter.
-What is left over is the shape where at least one of those items is `PIC X`, and
-there the paragraph above stands unchanged: nothing in the copybooks separates
-the two, and ordered evaluation is not a proof that they are separate.
-
-What such a descriptor gives up is the whole of what the overlap rule gives.
-Ordered matching encodes *try the header first*; it is not a proof that the two
-tests cannot both hold. A detail whose account number begins with the header's
-literal at that offset is then read as a header, the batch is split in the wrong
-place, and no rule in this document fires on it — those bytes matched a
-predicate the descriptor carries, so it is not an undescribed record, and where
-the two records share an extent the framing has nothing to disagree with either
-([The extent governs, and framing is checked against
-it](#the-extent-governs-and-framing-is-checked-against-it)). Admitting it is
-admitting a layout that opts out of the check, which is the `otherwise`
-`layout/SPEC.md` refuses under another spelling: an arm that catches what the
-others missed is what *last in the order* means, whether the lastness is written
-as a keyword or as a position.
-
-Both spellings of the permission were weighed against [Versioning and
-compatibility](#versioning-and-compatibility), and the safer one costs more. A
-pair a consumer can *tell* is ordered — a marker on the state, or a third member
-of the predicate set — is an addition a consumer must understand in order to
-stay correct, so the IR version advances and every existing consumer refuses
-every descriptor until it is taught the marker: a bill paid by everyone who has
-one, for a shape one reported file has. The spelling that costs nothing is the
-worse of the two, because leaving the ordering to be inferred from transition
-order alone is invisible to an old consumer, which reads the descriptor as
-conforming, keeps its own order, and misreads the file rather than refusing it.
-`v0.0.4` is released, so neither is free. And the two directions are not
-symmetric in time: this refusal can be lifted later at exactly that price, while
-a permission cannot be withdrawn from the descriptors already written under it.
+That order is also the whole of what resolves a pair the rule above no longer
+refuses, and it asks a consumer for nothing it was not already doing: it
+evaluates the transitions in the order the state carries and stops at the first
+that matches, which is what this document has required of it since before the
+pair was admitted. The permission below is therefore a producer's, and the
+consumer requirement it leans on is the one already stated.
 
 Where no transition matches, the input is a record the layout does not describe.
 A consumer **MUST** report that rather than skipping ahead to a transition that
@@ -2872,6 +2839,105 @@ means the layout is missing a record type, while a detail arriving after its
 counter reached zero means the file and its own header disagree about how many
 there are. Both are reported and neither is skipped; only the wording differs,
 and it is the wording that saves a day.
+
+### A batch boundary is told by the order
+
+A producer **MAY** emit two transitions leaving one state whose guards can hold
+at the same time and whose predicates can both match one record, provided the
+runs of bytes the two predicates read share none. A consumer resolves such a
+pair by the order the state carries — the first eligible transition whose
+predicate matches admits the record — which is the [evaluation
+order](#transitions-are-ordered-by-what-they-read) it already follows, so there
+is nothing further it is asked to do. `resolve` **MUST** admit that layout
+rather than refusing it (#332).
+
+The shape that asks for it is a file that is a sequence of batches: a header,
+then details until the next header. Two records are eligible at the state after
+a header, and where the two discriminators name runs at different offsets or of
+different widths the runs do not line up and one record can satisfy both tests
+(#323). *Try the header's test first, and read anything that fails it as a
+detail* reads that file, and is what the vendor reader that wrote it does.
+`layout/SPEC.md` writes the shape out at [A batch boundary, told by the
+order](../layout/SPEC.md#a-batch-boundary-told-by-the-order).
+
+**This reverses #324**, which refused exactly this pair, and it reverses it
+because the thing that weighing was missing has since landed. At the time the
+order a state carried was an artifact of expression nesting — on this very shape,
+exactly backwards — so relying on it needed a marker saying the order was meant,
+and a marker is an addition every consumer must understand. [Transitions are
+ordered by what they read](#transitions-are-ordered-by-what-they-read) removed
+that: the order is the offset each discriminator reads, derived from the
+copybooks, stated normatively, and already followed by every conforming consumer
+(#331).
+
+The asymmetry #324 relied on is **withdrawn**, and withdrawing it rather than
+restating it is the honest reading. That asymmetry said stopping at the first
+match is safe *because* at most one transition can match, so ordered evaluation
+could not be turned round into a licence to overlap. Both halves survive for a
+pair whose runs share a byte, where the literals could have told the two apart
+and a pair agreeing over them is still refused. Neither is what decides this
+pair, because at that state more than one transition can match, and what makes
+the first match the right answer is instead that the order is the order a reader
+of those bytes reaches them in. A consumer's obligation is unchanged either way; what narrowed
+is the producer's.
+
+**What the permission gives up is the whole of what the overlap rule gives, and
+it is not free.** Ordered matching encodes *try the header's test first*; it is
+not a proof that the two tests cannot both hold. A detail whose account number
+begins with the header's literal at the header's own offset is read as a header,
+the batch splits in the wrong place, and no rule in this document fires on it:
+those bytes matched a predicate the descriptor carries, so it is not an
+undescribed record, and where the two records share an extent the framing has
+nothing to disagree with either ([The extent governs, and framing is checked
+against it](#the-extent-governs-and-framing-is-checked-against-it)). **The
+mis-split is not diagnosed**, at compile time or at read time, and there is
+nothing here to diagnose it from. Ordered matching is a convention the layout
+asserts about its data rather than something either layer can check, and
+admitting the pair is admitting a layout that says so. A producer **SHOULD**
+prefer any construction making the two tests provably exclusive where the file
+allows one — a type code at a common offset and width, a count in the header, a
+trailer ending each batch — and rely on the order where it does not.
+
+The copybooks decide how often a descriptor actually rests on that convention,
+which is why they are consulted above. Where the item covering the header's run
+inside a detail is numeric — an account number, a sequence number, a date — and
+the item covering the detail's run inside a header is too, the two tests are
+provably exclusive, the order at that state cannot be observed at all, and
+nothing is given up. What rests on the order is the shape where at least one of
+those items is `PIC X`, or is one the refinement declines.
+
+Two rules still refuse a pair this one admits, and both are about something other
+than telling the two records apart. [A predicate never reads past the record in
+front of it](#a-predicate-never-reads-past-the-record-in-front-of-it) refuses a
+target read out of a record shorter than the target ends, which no order makes
+safe: the bytes are not the record's, whichever transition is tried first. [A
+record with nothing outside a table to
+name](#a-record-with-nothing-outside-a-table-to-name) refuses a record offering
+no target at all, which is a transition carrying no predicate and is not a pair
+of runs. Each keeps its own diagnostic, in its own words, because each sends an
+adopter somewhere different.
+
+Weighed against [Versioning and compatibility](#versioning-and-compatibility)
+with `v0.0.4` released: **`IrVersion` does not advance.** No field is added, none
+changes meaning, and no closed set grows a member — the descriptor a producer
+writes under this permission is one it could already have written, and what
+changed is that `resolve` now emits it instead of refusing to. Nor is it an
+addition a consumer must understand in order to stay correct: the order it must
+follow is the one this document already requires of it, and a consumer that has
+never heard of this section reads a batched file correctly by doing exactly what
+it already does. That is the cheaper of the two spellings #324 weighed, and it is
+no longer the worse one, because what made it worse — an order left to be
+inferred from however the sequencing was nested — is what #331 removed.
+
+The bill this does not settle is the writer's. [A writer walks the same
+automaton](#a-writer-walks-the-same-automaton) derives reader and writer landing
+in the same place from there being at most one transition a record can match,
+which is not true at such a state, and a writer narrowing only by the predicate
+of the record it was asked to write can emit a record its own reader routes
+somewhere else. That check belongs to the writer and is stated there; the two
+**MUST** be adopted together, since a producer admitting the pair without it
+turns a convention the layout asserts into a file this format's own tools break
+(#333).
 
 ### A predicate never reads past the record in front of it
 
@@ -3156,7 +3222,15 @@ the same occurrence, and `resolve` **MUST** reject a layout whose alternatives
 overlap, naming the record, the repeating group and both arms (#37, #90). That
 is [When two match, and when none does](#when-two-match-and-when-none-does) at
 this scope and for its reasons, so the arms' order decides nothing and a
-consumer **MAY** stop at the first arm that matches. The order is normative all
+consumer **MAY** stop at the first arm that matches. It is that rule without the
+permission beside it: [A batch boundary is told by the
+order](#a-batch-boundary-is-told-by-the-order) admits a pair of *transitions*
+whose runs share no byte, and no arm of a variant is admitted that way. The two
+scopes are not alike — the arms of a variant are alternative descriptions of one
+run of storage rather than two record types a state offers, so an arm reading a
+run another arm does not is reading bytes that arm describes differently, and
+there is no adopter with vendor copybooks and no fourth construction behind it
+(#332). The order is normative all
 the same, so that two consumers do the same work in the same order and report
 the same thing when something is wrong with the bytes.
 
@@ -3245,21 +3319,40 @@ byte window and can try any predicate against it; a writer has a record, and a
 predicate belonging to a transition admitting some *other* record names a field
 at an offset the record in hand may not even reach. What makes the narrowed walk
 land in the same place anyway is [When two match, and when none
-does](#when-two-match-and-when-none-does): no two transitions leaving a state
-can both match one input, so bytes satisfying the predicate of a transition
+does](#when-two-match-and-when-none-does): where no two transitions leaving a
+state can both match one input, bytes satisfying the predicate of a transition
 admitting this record satisfy no earlier transition's predicate, and the reader
 arrives at the transition the writer took. That rule is load-bearing on this
 side too, and without it a writer could emit a record its reader routes
 somewhere else.
+
+It is load-bearing enough that where it no longer holds the derivation has to be
+replaced rather than dropped. At a state carrying the pair [A batch boundary is
+told by the order](#a-batch-boundary-is-told-by-the-order) admits, two
+transitions can both match one input, so the narrowed walk is no longer *proved*
+to land where the reader lands: a writer that has narrowed to this record's own
+transition and evaluated only its predicate can emit a record an earlier
+transition's predicate also matches, and the reader — following the same
+normative order — takes that earlier one. What restores agreement is the order,
+spent on the writing side as it is spent on the reading side: at such a state a
+writer **MUST** evaluate the predicates of the transitions ordered before the one
+it took, against the bytes it is about to emit, and **MUST** report a record any
+of them matches rather than emitting it. That is the same refusal as the
+paragraph below, reached for a different reason, and it is what keeps a
+convention the layout asserts from being broken by this format's own writer
+(#333).
 
 Two transitions may admit the same record and differ only in the state they move
 to — a header deciding whether a later record type appears at all is written
 that way. A writer needs no rule for that beyond the one above, and for the
 reason reading needs none: a transition is never labelled with a record name, so
 the predicates decide there as they decide everywhere else, and where neither of
-the two carries one the guards do — nothing else could, since no two eligible
-transitions leaving a state may both match ([When two match, and when none
-does](#when-two-match-and-when-none-does)).
+the two carries one the guards do — nothing else could, since a transition
+carrying no predicate may not sit beside an eligible sibling at all ([When two
+match, and when none does](#when-two-match-and-when-none-does)). Where both
+carry one and the order is what separates them, the order decides, on the
+writing side as on the reading side ([A batch boundary is told by the
+order](#a-batch-boundary-is-told-by-the-order)).
 
 Where no transition matches, a writer **MUST** report it, and **MUST NOT** emit
 the record anyway or take a transition whose predicate is false. The record does
@@ -4095,7 +4188,7 @@ records offer them.
 | [The encoding profile, applied](#the-encoding-profile-applied) | #33 `resolve`; an item that carries bytes rather than characters by #275; the fifth axis, the binary width staircase resolved from the dialect, by #293; which consumers the axis rule binds, settled by #297 |
 | [Names](#names) | #30 `layout`, #38 `resolve`; what a record node resolved from a `REDEFINES` is called, settled by #164 |
 | [The sequencing automaton](#the-sequencing-automaton) | #36 `resolve`, #76, #77, #80, #84, #88 `ir`; the order a state's transitions are carried in, made a property of what each discriminator reads by #331 |
-| [Discriminator predicates](#discriminator-predicates) | #28 `layout`, #37 `resolve`, #80, #84, #88, #90, #94 `ir`; whether a producer may emit an overlapping pair resolved by evaluation order, settled unchanged by #324 against discussion #323 |
+| [Discriminator predicates](#discriminator-predicates) | #28 `layout`, #37 `resolve`, #80, #84, #88, #90, #94 `ir`; whether a producer may emit an overlapping pair resolved by evaluation order, refused by #324 and admitted by #332 for the pair whose runs share no byte, against discussion #323 |
 | [Writing a file](#writing-a-file) | #79, #80, #82, #88, #89, #90 `ir`, #51, #52 `gen-go` |
 | [Versioning and compatibility](#versioning-and-compatibility) | #17, #18 `ir` |
 | [Why protobuf, and why no gRPC](#why-protobuf-and-why-no-grpc) | #17, #19 `ir` |

--- a/docs/layout/SPEC.md
+++ b/docs/layout/SPEC.md
@@ -1162,24 +1162,129 @@ each record type rather than something standing outside them.
 
 An `otherwise` or a default arm is deliberately absent. `single-record-type`
 does not become one: it is not tried last, it does not catch what the others
-miss, and the IR refuses the reading in as many words, because a state offering
-two transitions that can both apply is a layout that was rejected before a
-consumer saw it.
+miss, and the IR refuses the reading in as many words, because a record admitted
+by a strategy that tests nothing may not sit at a state beside a record that is
+eligible with it.
 
-Nor does the *order* two strategies are written in become one. There is no form
-saying to try one discriminator first and read what it does not match as the
-other record, and no spelling is reserved for one — not a fourth strategy, not a
-modifier on `discriminate`, and not a rule reading the order of the
-`discriminate` forms or of an `alt`'s operands. That was reopened by
-[discussion #323](https://github.com/Zaba505/cpybkc/discussions/323), where a
-file that is a sequence of batches needs exactly it, and settled unchanged
-(#324): a first-match ordering over two discriminators that can both match one
-record *is* the default arm, spelled as a position rather than as a keyword, and
-[`ir/SPEC.md`](../ir/SPEC.md#when-two-match-and-when-none-does) refuses the
-descriptor it would lower into, weighing there what admitting it would cost a
-released IR version. The shape that asks for it, and the four things a layout
-may write instead, are [A batch boundary told only by evaluation
-order](#a-batch-boundary-told-only-by-evaluation-order).
+Nor is there a form saying to try one discriminator first and read what it does
+not match as the other record. No spelling is reserved for one — not a fourth
+strategy, not a modifier on `discriminate`, and not a rule reading the order of
+the `discriminate` forms or of an `alt`'s operands — and there is nothing to
+write, because the order is not the layout's to choose. Where two records
+eligible at one point key on runs of bytes that share none, the resolved
+automaton evaluates them in the order a reader reaches those bytes in, which the
+copybooks decide and which neither the layout nor the shape of its sequencing
+can reach
+([`ir/SPEC.md`](../ir/SPEC.md#transitions-are-ordered-by-what-they-read)).
+
+That is not the `otherwise` this section refuses, and the difference is worth
+being exact about, because it was read as one and refused as one until #332. An
+`otherwise` catches what the others missed, so what it admits depends on every
+arm beside it and on nothing about its own record; the ordered pair is two tests
+that each say what they are looking for, tried in an order derived from the
+records themselves. What it *does* share with an `otherwise` is the cost: the
+order is a convention a layout asserts about its data rather than a proof that
+the two tests cannot both hold, and a record satisfying the earlier test is read
+as that record with no diagnostic anywhere. So the layout still says nothing
+about ordering, and what an adopter is choosing when they write two such
+discriminators is set out at [A batch boundary, told by the
+order](#a-batch-boundary-told-by-the-order). Two records keying on runs that *do*
+share a byte are refused where their literals agree over it, which is a clash
+the literals are the place to fix
+([`ir/SPEC.md`](../ir/SPEC.md#when-two-match-and-when-none-does)).
+
+### A batch boundary, told by the order
+
+`(+ (seq HEADER (* DATA)))` — a header, then details until the next header — is
+the commonest shape a batched extract takes, and it is an ordinary layout. At
+the state after a `HEADER` the sequence admits `DATA`, by another pass of the
+inner `*`, and `HEADER` again, by the outer `+`'s back edge, so both records are
+eligible and something has to tell them apart.
+
+Where the two type codes sit at one offset and one width, `equals` on each
+provably excludes the other and there is nothing more to say. This section is
+about the file where they do not, because that file is common and its copybooks
+usually cannot be changed:
+
+```
+01  BATCH-HEADER.
+    05  BH-TYPE          PIC X(3).
+    05  BH-BATCH-NO      PIC 9(6).
+    05  BH-DATE          PIC X(8).
+    05  BH-FILLER        PIC X(23).
+
+01  BATCH-DETAIL.
+    05  BD-ACCOUNT       PIC X(10).
+    05  BD-TYPE          PIC X(1).
+    05  BD-AMOUNT        PIC 9(11).
+    05  BD-FILLER        PIC X(18).
+```
+
+```
+(record HEADER (copybook "batch.cpy" BATCH-HEADER))
+(record DETAIL (copybook "batch.cpy" BATCH-DETAIL))
+
+(discriminate HEADER (equals (item HEADER BH-TYPE) "HDR"))
+(discriminate DETAIL (equals (item DETAIL BD-TYPE) "D"))
+
+(sequence (+ (seq HEADER (* DETAIL))))
+```
+
+The header is told by three bytes at the front and the detail by one byte behind
+its account number, so the two runs never meet: bytes 0–2 in a header and byte
+10 in a detail. No literal either record could carry separates them, because a
+record carries `HDR` at bytes 0–2 and a `D` at byte 10 at the same time. What
+reads the file is trying the header's test first, and that is what the resolved
+automaton does — not because this layout said so, but because the header's run
+begins at the earlier byte and transitions are evaluated in the order a reader
+reaches their bytes
+([`ir/SPEC.md`](../ir/SPEC.md#transitions-are-ordered-by-what-they-read)).
+
+**What the layout is asserting, by writing it.** That no detail carries `HDR` in
+the first three bytes of its account number. Nothing checks that: `resolve`
+cannot, because the account number is `PIC X` and every byte is a byte it may
+hold, and a consumer cannot, because such a detail matches a predicate the
+descriptor carries — so it is not an undescribed record, and where the two
+records are the same width the framing has nothing to disagree with either. The
+batch simply splits in the wrong place, and the file is reported complete
+([`ir/SPEC.md`](../ir/SPEC.md#a-batch-boundary-is-told-by-the-order)).
+
+That is the whole of what is given up, and it is given up because the
+alternative was refusing a file the adopter has (discussion #323, reversing
+#324). Four constructions make the pair provably exclusive instead, and a layout
+that can write **one** of them **SHOULD**:
+
+- **a type code at a common offset and width in both records**, which makes the
+  two literals name the same run, so `equals` on each provably excludes the
+  other;
+- **an item with a bounded value set** at the offset and width of the other
+  record's discriminator, which `one-of` can name to line the two runs up;
+- **a count in the header**, written `(times …)` on the inner repetition, which
+  separates the two transitions by a guard instead of by bytes ([Two operators
+  read a value, and they are the automaton's
+  memory](#two-operators-read-a-value-and-they-are-the-automatons-memory));
+- **a trailer ending each batch**, `(+ (seq HEADER (* DATA) TRAILER))`, which
+  moves the back edge to a state where `HEADER` is the only record admitted.
+
+The copybooks often supply the first without anybody writing anything. Where the
+ten bytes a header carries at the detail's type-code offset are a numeric
+`DISPLAY` item — a batch number, a date, a sequence — a header can never hold
+the detail's literal there, and where the same holds in the other direction the
+two tests are proved exclusive from the copybooks alone and the order at that
+state cannot be observed
+([`ir/SPEC.md`](../ir/SPEC.md#when-two-match-and-when-none-does)). What is left
+resting on the order is the pair where at least one of those items is `PIC X`,
+which is the pair written out above.
+
+Two things are still refused here, and neither is about the order. A pair whose
+runs *do* share a byte and whose literals agree over it is a clash in the
+literals, and `resolve` names both records and both runs. And a discriminator
+reading past the end of the shortest record its state can put in front of a
+consumer is refused whatever the other record does, under the framings that
+leave the bound to the layout — a detail keyed behind a twenty-byte account
+number, beside a twelve-byte header, is that fault and not this permission
+([`ir/SPEC.md`](../ir/SPEC.md#a-predicate-never-reads-past-the-record-in-front-of-it)).
+
 
 ### The strategies that are not in the set, and where each one went
 
@@ -1869,53 +1974,6 @@ What an adopter writes instead is stated where the loss is — the two record
 names where the flag is the discriminating item, and a check of their own beside
 the generated reader where it is not.
 
-### A batch boundary told only by evaluation order
-
-`(+ (seq HEADER (* DATA)))` — a header, then details until the next header — is
-an ordinary layout and compiles. What is **not** describable is that shape where
-the two records can be told apart only by *trying the header's discriminator
-first*. At the state after a `HEADER` the sequence admits `DATA`, by another
-pass of the inner `*`, and `HEADER`, by the outer `+`'s back edge; where the two
-discriminators name runs at different offsets or of different widths, one record
-can satisfy both tests, and `resolve` rejects the layout naming both records.
-There is no form saying to try one of them first, and none is planned ([Three
-strategies, and the set is closed for
-v1](#three-strategies-and-the-set-is-closed-for-v1)).
-
-Four things separate those two transitions, and a layout needs **one** of them:
-
-- **a type code at a common offset and width in both records**, which makes the
-  two literals name the same run, so `equals` on each provably excludes the
-  other;
-- **a count in the header**, written `(times …)` on the inner repetition, which
-  separates the two transitions by a guard instead of by bytes ([Two operators
-  read a value, and they are the automaton's
-  memory](#two-operators-read-a-value-and-they-are-the-automatons-memory));
-- **a trailer ending each batch**, `(+ (seq HEADER (* DATA) TRAILER))`, which
-  moves the back edge to a state where `HEADER` is the only record admitted;
-- **an item with a bounded value set** at the offset and width of the other
-  record's discriminator, which `one-of` can name to line the two runs up.
-
-Reason: ordered matching would encode *try `HEADER` first*, which is not a proof
-that the two tests cannot both hold, and that proof is the whole of what the
-overlap check gives. Where a detail's account number can begin with the header's
-literal at that offset, a first-match reader reads that detail as a header and
-splits the batch in the wrong place, with no diagnostic anywhere: those bytes
-matched a predicate the descriptor carries, so it is not an undescribed record,
-and where the two records share an extent the framing has nothing to disagree
-with either. So it is a convention a layout would assert about its data rather
-than something either layer can check, and the layer that would have to carry it
-refuses it — [`ir/SPEC.md`](../ir/SPEC.md#when-two-match-and-when-none-does)
-holds the refusal and weighs what admitting it would cost a released IR version,
-which is where the decision would be reopened.
-
-Raised by [discussion #323](https://github.com/Zaba505/cpybkc/discussions/323),
-whose adopter has none of the four and vendor copybooks that cannot be changed,
-and settled by #324. It is a limit of the same kind as [a record told apart only
-by its length](../ir/SPEC.md#a-record-told-apart-only-by-its-length), and it is
-stated here for the same reason: an adopter meets it in prose rather than in a
-diagnostic.
-
 ### The copybook language
 
 Level numbers, `PIC` clauses, `OCCURS`, `REDEFINES` — the contents of a copybook
@@ -2227,7 +2285,7 @@ and neither is a second profile.
 | [The encoding profile](#the-encoding-profile) | #25 `layout`; an item that carries bytes rather than text, and the conversion residue left out beside it, by #275; a worked example of the converted file the section calls the most common, by #273; why the binary width staircase `codec/SPEC.md` declares fifth is not one of these four, by #293 |
 | [Physical framing](#physical-framing) | #26 `layout` |
 | [Record definitions](#record-definitions) | #27, #30 `layout`; `copybook-reading` by #35 `resolve`; which alternative a `record` form is, a rename naming a record, and a rename being per record, settled by #164 |
-| [Discrimination](#discrimination) | #28 `layout`; the strategies lowered into IR predicates, the literals resolved to bytes, and the rules on a target that need a copybook, by #37 `resolve`; that neither a strategy nor the order two are written in becomes a default arm, and the batch shape that is undescribable without one, settled by #324 against discussion #323 |
+| [Discrimination](#discrimination) | #28 `layout`; the strategies lowered into IR predicates, the literals resolved to bytes, and the rules on a target that need a copybook, by #37 `resolve`; that neither a strategy nor the order two are written in becomes a default arm, refused by #324 and reopened by #332 for the batch shape whose two discriminators read runs sharing no byte, against discussion #323 |
 | [Sequencing](#sequencing) | #29 `layout`; the expression compiled to an automaton, and the rules on `times` and `when` that need a copybook, by #36 `resolve`; what a `when` does and does not require, and where a guard lands on a repetition, settled by #144 against the compiler #36 had already produced |
 | [The published schema](#the-published-schema) | #23 `layout` |
 | [Validation and diagnostics](#validation-and-diagnostics) | #24, #31 `layout` |

--- a/internal/resolve/automaton.go
+++ b/internal/resolve/automaton.go
@@ -149,13 +149,17 @@ import (
 // step.
 //
 // And no two transitions leaving one state are eligible together and selected by
-// predicates that can both match one record ("When two match, and when none
-// does"). Guards narrow which pairs that is about: two transitions whose guards
-// cannot hold at the same time may be selected by the very same test on the very
-// same bytes, which is what makes a counted run expressible at all. A transition
-// carrying no predicate is inside that rule rather than beside it — it matches
-// every record, so it overlaps every sibling whose guards can hold at the same
-// time as its own (#80).
+// predicates that can both match one record over bytes both of them read ("When
+// two match, and when none does"). Guards narrow which pairs that is about: two
+// transitions whose guards cannot hold at the same time may be selected by the
+// very same test on the very same bytes, which is what makes a counted run
+// expressible at all. So does what the two read: a pair whose runs share no byte
+// is told apart by nothing a literal could express, and the order the state
+// carries resolves it instead ("A batch boundary is told by the order", #332). A
+// transition carrying no predicate is inside the rule rather than beside it and
+// outside that permission — it matches every record, so it overlaps every
+// sibling whose guards can hold at the same time as its own and reads no run to
+// be ordered by (#80).
 
 // RegisterKind is what a register holds, one member of the closed set
 // docs/ir/SPEC.md's "The automaton remembers, in registers" admits.
@@ -569,8 +573,9 @@ type Sequencing struct {
 //     binding, including the run counted by a field of the record being counted
 //     ([UnboundRegisterError], #88);
 //   - two transitions leaving one state whose guards can hold at the same time
-//     and whose predicates can both match one record, a transition carrying no
-//     predicate included ([SequenceAmbiguityError], #37, #80);
+//     and whose predicates can both match one record over bytes both of them
+//     read, a transition carrying no predicate included
+//     ([SequenceAmbiguityError], #37, #80, #332);
 //   - a state whose acceptance would have to be a disjunction of guard lists,
 //     which is not a shape a state can carry ([SequenceAcceptanceError]).
 //

--- a/internal/resolve/automaton_errors.go
+++ b/internal/resolve/automaton_errors.go
@@ -253,12 +253,17 @@ func (e *UnboundRegisterError) Diagnostic() diag.Diagnostic {
 
 // SequenceAmbiguityError is two transitions leaving one state that can be
 // eligible together and are selected by predicates that can both match one
-// record.
+// record over the bytes both of them read.
 //
-// docs/ir/SPEC.md's "When two match, and when none does" refuses the pair rather
-// than settling it, so that the question docs/layout/SPEC.md defers — what
-// happens when two discriminators match — does not arise: such an IR is never
-// produced.
+// docs/ir/SPEC.md's "When two match, and when none does" refuses that pair
+// rather than settling it, so that the question docs/layout/SPEC.md defers —
+// what happens when two discriminators match — does not arise there: such an IR
+// is never produced.
+//
+// It is not every pair a record can satisfy both of. Two discriminators reading
+// runs that share no byte are settled by the order the state carries and are not
+// this fault (#332); what is left here is the pair asking for the same bytes and
+// agreeing about them, which is a clash in the literals.
 //
 // [SequenceAmbiguityError.Unguarded] is the case #80 folds into the same rule. A
 // transition carrying no predicate matches every record, so it overlaps every
@@ -269,15 +274,13 @@ func (e *UnboundRegisterError) Diagnostic() diag.Diagnostic {
 // tell it apart by.
 //
 // [SequenceAmbiguityError.Runs] is the pair of byte runs the two discriminators
-// actually compared, and naming them is what tells the two remaining shapes
-// apart. Once intersecting runs whose literals disagree are accepted (#325),
-// what is left is either a pair whose runs share no byte — which no literal
-// either record could carry would ever separate, so the layout needs a count, a
-// trailer or a different target — or a pair agreeing on a literal over the bytes
-// they do share, which is a clash in the literals and is the adopter's to fix
-// there. Discussion #323 is what the distinction costs when it is missing: four
-// rounds to establish where the two targets sat, and a report filed against
-// sequencing operators that turned out to be irrelevant.
+// actually compared, and naming them is what points an adopter at the literals
+// to change. Discussion #323 is what withholding them costs: four rounds to
+// establish where the two targets sat, and a report filed against sequencing
+// operators that turned out to be irrelevant. The shape that report was actually
+// about — two runs that share no byte — is no longer refused at all, so what
+// reaches this message is a pair agreeing on a literal over the bytes they do
+// share, and the window is the whole of what has to change (#326, #332).
 type SequenceAmbiguityError struct {
 	// Pos is where the second of the two record names was written, and First
 	// where the first was.
@@ -352,24 +355,21 @@ func (e *SequenceAmbiguityError) placed() bool {
 	return e.Runs[0].Width > 0 && e.Runs[1].Width > 0
 }
 
-// compared is the two runs the discriminators read and what sharing or not
-// sharing bytes leaves an adopter to do about them.
+// compared is the two runs the discriminators read and the window over which
+// they agree, which is where an adopter changes a literal.
 //
-// The two are opposite answers rather than degrees of the same one, which is why
-// the message says which it is. Runs that share no byte are told apart by
-// nothing a literal can express — a record carries an `S` at byte zero and an
-// `X` at byte ten at the same time — so the resolution is a count, a trailer or
-// a different target, and an adopter who reads "their discriminators overlap"
-// and goes looking for a better literal is looking for something that does not
-// exist. Runs that do share bytes and agree over them are the ordinary clash,
-// and the literals are exactly where it is fixed.
+// A pair reaching this shares bytes, because [compiler.resolvedByOrder] settles
+// the pair that does not on the order the state carries (#332). The window is
+// named all the same rather than assumed: the fault is an exported value anyone
+// may construct, and two runs that share nothing have no window to point at, so
+// the message says what it can about them and invents no agreement.
 func (e *SequenceAmbiguityError) compared() string {
 	read := fmt.Sprintf("their discriminators read %s %s and %s %s",
 		e.Records[0], e.Runs[0], e.Records[1], e.Runs[1])
 
 	window, sharing := e.Runs[0].shares(e.Runs[1])
 	if !sharing {
-		return read + ", which share no byte, so no literal either could carry would tell the two apart"
+		return read
 	}
 
 	return read + fmt.Sprintf(", and they agree on a literal over %s", window)

--- a/internal/resolve/automaton_test.go
+++ b/internal/resolve/automaton_test.go
@@ -245,6 +245,26 @@ func assertRendering(t *testing.T, a *Automaton, want string) {
 	}
 }
 
+// stateAdmitting is the first state offering the named record beside at least
+// one other, which is the state any rule about a pair is about.
+func stateAdmitting(t *testing.T, a *Automaton, record string) *State {
+	t.Helper()
+
+	for _, state := range a.States {
+		if len(state.Transitions) < 2 {
+			continue
+		}
+
+		if slices.Contains(admits(state), record) {
+			return state
+		}
+	}
+
+	t.Fatalf("no state offers %s beside another record:\n%s", record, renderAutomaton(a))
+
+	return nil
+}
+
 // TestTheCountedRunOfTheAppendix compiles docs/ir/SPEC.md's "A counted run, as
 // nodes" and asserts the graph against it.
 //
@@ -881,15 +901,21 @@ state 5 accepts
 `)
 	})
 
-	t.Run("a flag beside the type code is an overlap, not a missing feature", func(t *testing.T) {
+	t.Run("a flag beside the type code is settled by the order, and says what that costs", func(t *testing.T) {
 		t.Parallel()
 
-		// The precondition on the branch above, stated as the fault an
-		// adopter meets where it does not hold. Telling the two details apart
-		// needs the flag and telling either of them from the trailer needs
-		// the type code, and a discriminator is one test on one item — so
-		// `resolve` reports the pair that can both match one record rather
-		// than a shape the format is missing.
+		// The precondition on the branch above, stated as what an adopter
+		// gets where it does not hold. Telling the two details apart needs
+		// the flag and telling either of them from the trailer needs the type
+		// code, and a discriminator is one test on one item — so the trailer's
+		// test and the detail's read runs that share no byte, and the order
+		// the state carries resolves them (#332).
+		//
+		// What that costs is stated rather than diagnosed: the trailer's test
+		// reads byte zero and the detail's byte one, so the trailer is tried
+		// first and a detail whose first byte is `T` is read as a trailer.
+		// Until this story the layout was refused instead, which asked the
+		// adopter for a record shape the file does not have.
 		overlapping := `(record HEADER (copybook "hdr.cpy" HDR-REC))
 (record DETAIL (copybook "dtl.cpy" DTL-REC))
 (record DETAIL-FLAGGED (copybook "dtl.cpy" DTL-REC))
@@ -905,21 +931,16 @@ state 5 accepts
 		copybooks := flaggedRunCopybooks()
 		copybooks["DETAIL-FLAGGED"] = flagged
 
-		err := refused(t, overlapping, copybooks)
+		automaton := compiled(t, overlapping, copybooks)
 
-		var ambiguous *SequenceAmbiguityError
-		if !errors.As(err, &ambiguous) {
-			t.Fatalf("compiling reported %v, want an ambiguity", err)
-		}
-
-		// The pair is named in the state's evaluation order, and that order
-		// is now the copybooks' rather than the walk's: the trailer's type
-		// code is the record's first byte and the detail's flag is its
-		// second, so the trailer's test is tried first and is named first
+		// The state a detail leads to, where the trailer and both details
+		// compete. The order is the copybooks' rather than the walk's: the
+		// trailer's type code is the record's first byte and the flag both
+		// details key on is its second, so the trailer's test is tried first
 		// (#331).
-		if ambiguous.Records != [2]string{"TRAILER", "DETAIL"} {
-			t.Errorf("the fault names %v, want the pair a discriminator on the flag cannot separate",
-				ambiguous.Records)
+		state := stateAdmitting(t, automaton, "TRAILER")
+		if got := admits(state); got[0] != "TRAILER" {
+			t.Errorf("the state tries %s first, want the discriminator reading the earlier byte: %v", got[0], got)
 		}
 	})
 }
@@ -1236,14 +1257,20 @@ func TestTwoRecordsAtOnePointTestingOneRunOfBytesForOneValueAreRejected(t *testi
 	}
 }
 
-// TestTwoDiscriminatorsOverDifferentRunsOfBytesOverlap is the reading
-// docs/ir/SPEC.md insists on: the test is whether one input can satisfy both,
-// not whether the two read the same bytes.
+// TestTwoDiscriminatorsOverRunsSharingNoByteAreResolvedByTheOrder is #332: a
+// record keyed on its first byte beside one keyed on its second is a pair one
+// input can satisfy both of, and the order the state carries is what settles it.
 //
-// A record keyed on its first byte beside one keyed on its second is where the
-// narrower reading lets a real ambiguity through, because a record can carry
-// both values at once.
-func TestTwoDiscriminatorsOverDifferentRunsOfBytesOverlap(t *testing.T) {
+// It was refused until this story, on the grounds that ordered matching is not a
+// proof of disjointness — which is true, and is now what the layout asserts
+// rather than what it is refused for. No literal either record could carry would
+// separate the two, because a record carries an `H` at byte zero and a `D` at
+// byte one at the same time, so refusing it asked the adopter for a construction
+// that does not exist for the file in front of them (discussion #323).
+//
+// The order is the copybooks' rather than the walk's, so the header's test is
+// tried first: it reads byte zero and the detail's reads byte one (#331).
+func TestTwoDiscriminatorsOverRunsSharingNoByteAreResolvedByTheOrder(t *testing.T) {
 	t.Parallel()
 
 	elsewhere := `01 DTL-REC.
@@ -1261,9 +1288,14 @@ func TestTwoDiscriminatorsOverDifferentRunsOfBytesOverlap(t *testing.T) {
 (discriminate DETAIL (equals (item DETAIL DTL-TYPE) "D"))
 (sequence (alt HEADER DETAIL))`
 
-	var ambiguous *SequenceAmbiguityError
-	if err := refused(t, source, copybooks); !errors.As(err, &ambiguous) {
-		t.Fatalf("compiling reported %v, want an ambiguity", err)
+	automaton := compiled(t, source, copybooks)
+
+	if admitted := admits(automaton.States[0]); len(admitted) != 2 {
+		t.Fatalf("the start state admits %v, want both records", admitted)
+	}
+
+	if got := admits(automaton.States[0]); got[0] != "HEADER" {
+		t.Errorf("the state tries %s first, want the discriminator reading the earlier byte", got[0])
 	}
 }
 
@@ -1474,25 +1506,13 @@ func TestAOneOfOverlapsWhereAnyOfItsValuesAgreesOnTheSharedWindow(t *testing.T) 
 // sequencing operators — which turned out to be irrelevant, because the fault
 // was two type codes that did not line up.
 //
-// The two shapes are asserted together because the whole point is that they read
-// differently. Runs sharing no byte are told apart by nothing a literal can
-// express and the layout needs a count, a trailer or a different target; runs
-// agreeing over the bytes they share are a clash in the literals and are fixed
-// there. Once #325 narrowed the check to the shared window, those are the only
-// two shapes left, so the message can say which it is without hedging.
+// One shape reaches the message now. Runs that share no byte are settled by the
+// order the state carries and are not refused at all (#332), so what is left is
+// the pair asking for the same bytes and agreeing about them — a clash in the
+// literals, fixed where the literals are written, and the window is what says
+// which bytes to change.
 func TestTheAmbiguityDiagnosticNamesTheRunsTheDiscriminatorsRead(t *testing.T) {
 	t.Parallel()
-
-	// A detail whose type code sits behind a lead byte, so that the two
-	// discriminators read runs that share nothing at all.
-	shifted := `01 DTL-REC.
-   05 DTL-LEAD PIC X(1).
-   05 DTL-TYPE PIC X(1).
-   05 DTL-BODY PIC X(20).
-`
-
-	disjoint := countedRunCopybooks()
-	disjoint["DETAIL"] = shifted
 
 	tests := map[string]struct {
 		source    string
@@ -1500,26 +1520,6 @@ func TestTheAmbiguityDiagnosticNamesTheRunsTheDiscriminatorsRead(t *testing.T) {
 		runs      [2]ByteRun
 		wants     []string
 	}{
-		// HEADER's type code is byte zero of a header and DETAIL's is byte
-		// one of a detail, so no record can be told apart by either literal:
-		// a record carries an `H` at byte zero and a `D` at byte one at the
-		// same time.
-		"runs sharing no bytes": {
-			source: `(record HEADER (copybook "hdr.cpy" HDR-REC))
-(record DETAIL (copybook "dtl.cpy" DTL-REC))
-(discriminate HEADER (equals (item HEADER HDR-TYPE) "H"))
-(discriminate DETAIL (equals (item DETAIL DTL-TYPE) "D"))
-(sequence (alt HEADER DETAIL))`,
-			copybooks: disjoint,
-			runs:      [2]ByteRun{{At: 0, Width: 1}, {At: 1, Width: 1}},
-			wants: []string{
-				"HEADER byte 0",
-				"DETAIL byte 1",
-				"share no byte",
-				"no literal either could carry would tell the two apart",
-			},
-		},
-
 		// The genuine clash: one run, one literal, and two records asking
 		// for it.
 		"identical runs agreeing on a literal": {
@@ -1820,182 +1820,65 @@ const batchSource = `(record HEADER (copybook "header.cpy" BAT-HDR))
 (discriminate DETAIL (equals (item DETAIL BDT-TYPE) "D"))
 (sequence (+ (seq HEADER (+ DETAIL))))`
 
-// TestDiscriminatorsOverDifferentRunsAreDisjointWhereTheCopybooksForbidTheOpposingLiteral
-// is #330: two runs that share no byte are decided on what the copybooks say
-// those bytes may hold, and not on the general truth that a record can carry one
-// value at byte zero and another at byte ten.
+// TestTheBatchShapeCompilesWhetherOrNotTheCopybooksProveThePairDisjoint is the
+// two halves of discussion #323's shape, and after #332 they compile alike.
 //
 // The header is keyed on byte zero equal to `H` and the detail on byte ten equal
-// to `D`, both EBCDIC letters. Byte ten of a header is inside a five-digit
-// DISPLAY item, so a header can never carry `D` there; where byte zero of a
-// detail is a ten-digit DISPLAY item it can never carry `H` either, and the two
-// tests are then provably exclusive with nothing added to the layout. Where byte
-// zero of a detail is anything this cannot state a domain for, the pair is left
-// overlapping and refused exactly as before.
-func TestDiscriminatorsOverDifferentRunsAreDisjointWhereTheCopybooksForbidTheOpposingLiteral(t *testing.T) {
+// to `D`, so the two runs share no byte and one record can satisfy both tests
+// unless something forbids it. Where byte zero of a detail is a zoned item it
+// can never hold `H`, the pair is provably exclusive and the order at the state
+// is unobservable (#330). Where it is `PIC X` — or anything the refinement
+// declines — nothing separates the two and the order the state carries is what
+// reads the file: the header's test reads the earlier byte, so it is tried
+// first, and a detail carrying `H` at byte zero is read as a header with no
+// diagnostic anywhere (#332).
+//
+// What the copybooks say therefore no longer decides whether the layout
+// compiles. It decides what a consumer is relying on, which is why the proof is
+// still taken; the proof itself is asserted over [covering] and [byteDomain] in
+// predicate_test.go, where a declined shape has an answer to assert.
+func TestTheBatchShapeCompilesWhetherOrNotTheCopybooksProveThePairDisjoint(t *testing.T) {
 	t.Parallel()
 
-	tests := map[string]struct {
-		key       string
-		ambiguous bool
-	}{
-		// The whole point: neither record can hold the other's letter.
-		"an unsigned zoned item holds digits and no letter": {
-			key: "PIC 9(10)", ambiguous: false,
-		},
+	keys := []string{
+		// Neither record can hold the other's letter, so the pair is proved
+		// disjoint and needs no order.
+		"PIC 9(10)",
 
-		// "Any byte value may appear in an alphanumeric field", so this
-		// proves nothing and the refusal stands. One direction is not
-		// enough: a detail carrying `H` at byte zero and `D` at byte ten
-		// satisfies both tests, whatever the header says about byte ten.
-		"an alphanumeric item holds any byte": {
-			key: "PIC X(10)", ambiguous: true,
-		},
+		// "Any byte value may appear in an alphanumeric field", so nothing is
+		// proved and the order is what separates the two.
+		"PIC X(10)",
 
-		// The sign is an overpunch on one of the ten digits, and where
-		// codec puts it is codec's to say rather than this package's.
-		"a signed zoned item is declined": {
-			key: "PIC S9(10)", ambiguous: true,
-		},
+		// The sign is an overpunch on one of the ten digits, and where codec
+		// puts it is codec's to say rather than this package's.
+		"PIC S9(10)",
 
-		// A packed item's digits are nibbles and its last nibble is the
-		// sign; same reason.
-		"a packed item is declined": {
-			key: "PIC 9(18) COMP-3", ambiguous: true,
-		},
+		// A packed item's digits are nibbles and its last nibble is the sign;
+		// same reason.
+		"PIC 9(18) COMP-3",
 
 		// A binary item is a bit pattern with no bytes ruled out.
-		"a binary item is declined": {
-			key: "PIC 9(9) COMP.\n   05 BDT-PAD  PIC X(6)", ambiguous: true,
-		},
+		"PIC 9(9) COMP.\n   05 BDT-PAD  PIC X(6)",
 
-		// BLANK WHEN ZERO puts the charset's spaces in a numeric item, so
-		// the digits are not the whole of what it holds.
-		"a numeric item blank when zero is declined": {
-			key: "PIC 9(10) BLANK WHEN ZERO", ambiguous: true,
-		},
+		// BLANK WHEN ZERO puts the charset's spaces in a numeric item, so the
+		// digits are not the whole of what it holds.
+		"PIC 9(10) BLANK WHEN ZERO",
 	}
 
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
+	for _, key := range keys {
+		t.Run(key, func(t *testing.T) {
 			t.Parallel()
 
-			if !test.ambiguous {
-				compiled(t, batchSource, batchCopybooks(test.key))
+			automaton := compiled(t, batchSource, batchCopybooks(key))
 
-				return
-			}
-
-			var ambiguous *SequenceAmbiguityError
-			if err := refused(t, batchSource, batchCopybooks(test.key)); !errors.As(err, &ambiguous) {
-				t.Fatalf("compiling reported %v, want an ambiguity", err)
-			}
-
-			// The refusal is the one #326 wrote: the two runs are what an
-			// adopter reads the message for, and narrowing when the pair is
-			// refused does not change what is said when it is.
-			want := [2]ByteRun{{At: 0, Width: 1}, {At: 10, Width: 1}}
-			if ambiguous.Runs != want && ambiguous.Runs != [2]ByteRun{want[1], want[0]} {
-				t.Errorf("the fault names the runs %v, want %v", ambiguous.Runs, want)
-			}
-		})
-	}
-}
-
-// TestTheByteDomainIsDeclinedWhereTheLayoutDoesNotSettleTheItem is the soundness
-// half: the refinement reads a domain only where the record's own layout says
-// which item covers the opposing run, and every other shape is left overlapping.
-//
-// Each detail below keys on a run the header describes with something other than
-// one item at a fixed offset, and each is refused for that reason alone — byte
-// zero of every one of them is a zoned item that cannot hold `H`, so the pair
-// would be disjoint if the header's side of the question had an answer.
-func TestTheByteDomainIsDeclinedWhereTheLayoutDoesNotSettleTheItem(t *testing.T) {
-	t.Parallel()
-
-	// A two-byte type code at byte nine spans the header's nine-digit
-	// identifier and its sequence number, and one at byte ten sits wholly
-	// inside the sequence number.
-	spanning := `01 BSP-REC.
-   05 BSP-KEY  PIC 9(9).
-   05 BSP-TYPE PIC X(2).
-   05 BSP-BODY PIC X(10).
-`
-
-	inside := `01 BSP-REC.
-   05 BSP-KEY  PIC 9(10).
-   05 BSP-TYPE PIC X(2).
-   05 BSP-BODY PIC X(9).
-`
-
-	// Slack: a four-byte binary item SYNCHRONIZED onto a four-byte boundary
-	// leaves bytes nine, ten and eleven belonging to no item at all.
-	slack := `01 BSL-HDR.
-   05 BSL-TYPE PIC X(1).
-   05 BSL-FILL PIC X(8).
-   05 BSL-BIN  PIC 9(9) COMP SYNC.
-`
-
-	// An OCCURS DEPENDING ON ahead of byte ten moves every byte at or after
-	// it, so the static layout does not say which item is there.
-	variable := `01 BOD-HDR.
-   05 BOD-TYPE  PIC X(1).
-   05 BOD-COUNT PIC 9(2).
-   05 BOD-TAB   PIC X(4) OCCURS 1 TO 5 TIMES DEPENDING ON BOD-COUNT.
-   05 BOD-SEQ   PIC 9(5).
-`
-
-	tests := map[string]struct {
-		header    string
-		record    string
-		detail    string
-		item      string
-		literal   string
-		ambiguous bool
-	}{
-		"the opposing run spans two items": {
-			header: batchHeader, record: "BAT-HDR", detail: spanning,
-			item: "BSP-TYPE", literal: `"DD"`, ambiguous: true,
-		},
-
-		"the opposing run sits inside one": {
-			header: batchHeader, record: "BAT-HDR", detail: inside,
-			item: "BSP-TYPE", literal: `"DD"`, ambiguous: false,
-		},
-
-		"the opposing run lands on slack": {
-			header: slack, record: "BSL-HDR", detail: fmt.Sprintf(batchDetail, "PIC 9(10)"),
-			item: "BDT-TYPE", literal: `"D"`, ambiguous: true,
-		},
-
-		"the opposing run sits in an ODO-variable region": {
-			header: variable, record: "BOD-HDR", detail: fmt.Sprintf(batchDetail, "PIC 9(10)"),
-			item: "BDT-TYPE", literal: `"D"`, ambiguous: true,
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			headerType := recordOf(t, test.header).Children[0].Name
-			source := `(record HEADER (copybook "header.cpy" ` + test.record + `))
-(record DETAIL (copybook "detail.cpy" BDT-REC))
-(discriminate HEADER (equals (item HEADER ` + headerType + `) "H"))
-(discriminate DETAIL (equals (item DETAIL ` + test.item + `) ` + test.literal + `))
-(sequence (+ (seq HEADER (+ DETAIL))))`
-
-			copybooks := map[string]string{"HEADER": test.header, "DETAIL": test.detail}
-
-			if !test.ambiguous {
-				compiled(t, source, copybooks)
-
-				return
-			}
-
-			var ambiguous *SequenceAmbiguityError
-			if err := refused(t, source, copybooks); !errors.As(err, &ambiguous) {
-				t.Fatalf("compiling reported %v, want an ambiguity", err)
+			// The state after a detail, where the next header and the next
+			// detail compete. The header's type code is byte zero and the
+			// detail's is byte ten, so the header is tried first (#331) —
+			// which is the order that reads a batched file and the whole of
+			// what the permission rests on.
+			state := stateAdmitting(t, automaton, "HEADER")
+			if got := admits(state); got[0] != "HEADER" {
+				t.Errorf("the state tries %s first, want the discriminator reading the earlier byte: %v", got[0], got)
 			}
 		})
 	}

--- a/internal/resolve/doc.go
+++ b/internal/resolve/doc.go
@@ -252,20 +252,20 @@
 // [PredicateReachError] naming the record the target is in, the target and the
 // shorter record it would be read past the end of.
 //
-// On an overlapping pair it is a diagnostic rather than a second gate, and
-// knowing which it is matters to anyone changing either rule: such a layout is
-// one the overlap rule refuses anyway, so what the reach rule adds there is the
-// message — which bytes a consumer would have read and out of which record, in
-// place of a report that two discriminators could both match. That is why the
-// specific message replaces the generic one rather than being reported beside
-// it.
+// On a pair the overlap rule refuses it is a diagnostic rather than a second
+// gate, and knowing which it is matters to anyone changing either rule: such a
+// layout is refused anyway, so what the reach rule adds there is the message —
+// which bytes a consumer would have read and out of which record, in place of a
+// report that two discriminators could both match. That is why the specific
+// message replaces the generic one rather than being reported beside it.
 //
-// On a pair the overlap rule admits it is a gate of its own. Two predicates are
-// told apart by the bytes their runs share (#325) and by what each record's
-// copybook admits at the other's run (#330), so a pair reading runs of different
-// widths — or runs sharing no byte at all — can be unambiguous and still have one
-// of them reach past the shorter record. [compiler.reportReach] carries both
-// readings.
+// Everywhere else it is a gate of its own, and that is most pairs now. Two
+// predicates are told apart by the bytes their runs share (#325) and by what
+// each record's copybook admits at the other's run (#330), and a pair whose runs
+// share no byte is admitted whatever those say, on the order the state carries
+// (#332) — so a pair can be perfectly readable and still have one of the two
+// reach past the shorter record the state can put in front of a consumer.
+// [compiler.reportReach] carries both readings, and is asked of every pair.
 //
 // [Sequencing.Framing] is what that is keyed on, and a caller stating no framing
 // states neither mechanism, so the rule is not run. It cannot be inferred from

--- a/internal/resolve/reach_test.go
+++ b/internal/resolve/reach_test.go
@@ -459,7 +459,8 @@ func TestTheBatchShapeIsAdmittedAndStillHeldToTheReachRule(t *testing.T) {
 	t.Run("the detail's target is read past the end of a header", func(t *testing.T) {
 		t.Parallel()
 
-		reach := reachFaultIn(t, refused(t, source, map[string]string{"HEADER": header, "DETAIL": past}))
+		err := refused(t, source, map[string]string{"HEADER": header, "DETAIL": past})
+		reach := reachFaultIn(t, err)
 
 		if reach.Record != "DETAIL" || reach.Beside != "HEADER" || reach.Ends != 21 || reach.Extent != 12 {
 			t.Errorf("the fault is %s's target ending at byte %d beside %s at %d bytes, want DETAIL's at 21 beside HEADER at 12",
@@ -469,8 +470,13 @@ func TestTheBatchShapeIsAdmittedAndStillHeldToTheReachRule(t *testing.T) {
 		// And it is this rule's fault and not the overlap rule's: the pair
 		// the order would otherwise have settled is still refused here, in
 		// words that name the read rather than the pair (#332).
+		//
+		// The whole error is asked rather than the reach fault taken out of
+		// it, because faults are joined: asking the extracted one whether it
+		// is also an ambiguity is a question with one answer whatever the
+		// compilation reported.
 		var ambiguity *SequenceAmbiguityError
-		if errors.As(reach, &ambiguity) {
+		if errors.As(err, &ambiguity) {
 			t.Errorf("the overlap rule reported the same pair as well: %v", ambiguity)
 		}
 	})

--- a/internal/resolve/reach_test.go
+++ b/internal/resolve/reach_test.go
@@ -26,13 +26,13 @@ import (
 // behind an account key every record of that type carries. That is the shape a
 // worked example is built on, and the whole difficulty is that it looks right.
 //
-// Every one of these layouts but the last is refused by the overlap rule as
-// well, because the two runs share no byte and a pair like that is told apart by
-// nothing. So what those rejecting tests assert is *which* diagnostic an adopter
-// gets, and they assert the generic one is not reported beside it. The last is
-// the pair the overlap rule admits and this one does not, which is why the check
-// is asked of every pair a state can offer rather than only of the overlapping
-// ones (#325).
+// None of these layouts is refused by the overlap rule any more. The two runs
+// share no byte, and the order the state carries settles a pair like that
+// (#332) — so this rule is the only thing left that refuses them, and the
+// relaxations below are layouts that compile rather than layouts refused in
+// other words. That is also what makes the check worth asking of every pair a
+// state can offer rather than only of the overlapping ones (#325): it is no
+// longer standing behind a check that would have refused the same layout anyway.
 
 // The copybooks these tests discriminate. `reachHeader` is ten bytes with its
 // type code at the front; `reachDetail` carries a twenty-byte key in front of
@@ -136,14 +136,14 @@ func reachFaultIn(t *testing.T, err error) *PredicateReachError {
 	return reach
 }
 
-// leftToTheOverlapRule asserts that a pair was reported as the ambiguity it also
-// is, and not as a reach fault.
+// notHeldToTheReachRule asserts that a layout this rule does not run on
+// compiles, and names the reach fault where one was reported anyway.
 //
-// It is what the relaxations assert. The pair is refused either way — two
-// predicates whose runs share no byte are told apart by nothing — so what a
-// relaxation changes is the diagnostic, and a test asserting the compilation
-// failed would pass without the rule being relaxed at all.
-func leftToTheOverlapRule(t *testing.T, err error) {
+// It is what the relaxations assert. Nothing else refuses these layouts: the two
+// discriminators read runs that share no byte, and the order the state carries
+// resolves that pair (#332), so a relaxation is the difference between a
+// compilation and a refusal rather than between two diagnostics.
+func notHeldToTheReachRule(t *testing.T, err error) {
 	t.Helper()
 
 	var reach *PredicateReachError
@@ -151,9 +151,8 @@ func leftToTheOverlapRule(t *testing.T, err error) {
 		t.Fatalf("the reach rule was run: %v", reach)
 	}
 
-	var ambiguity *SequenceAmbiguityError
-	if !errors.As(err, &ambiguity) {
-		t.Fatalf("compiling reported %v, want the overlap rule's own fault", err)
+	if err != nil {
+		t.Fatalf("compiling reported %v, want a layout this rule does not run on", err)
 	}
 }
 
@@ -247,10 +246,9 @@ func TestATargetStraddlingTheBoundIsRejectedOnTheSameFooting(t *testing.T) {
 //
 // Under **descriptor-word** and **segmented** the length of the record in front
 // of the consumer is in hand before any predicate runs, so a target outside it
-// does not match and no file is misread. The layout is still refused, because
-// two predicates over different runs of bytes are told apart by nothing — but it
-// is refused as the ambiguity it is, and not for a read that cannot happen
-// there.
+// does not match and no file is misread. The layout compiles there, and the
+// difference is the whole of what the framing buys: the same two copybooks under
+// a delimited framing are refused for a read this one bounds.
 func TestTheRuleIsRelaxedWhereTheFramingStatesEachRecordsLength(t *testing.T) {
 	t.Parallel()
 
@@ -261,7 +259,8 @@ func TestTheRuleIsRelaxedWhereTheFramingStatesEachRecordsLength(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			leftToTheOverlapRule(t, refused(t, reachLayout(framing), reachCopybooks(reachDetail)))
+			_, err := compileLayout(t, reachLayout(framing), reachCopybooks(reachDetail))
+			notHeldToTheReachRule(t, err)
 		})
 	}
 }
@@ -277,7 +276,8 @@ func TestTheRuleIsRelaxedWhereTheFramingStatesEachRecordsLength(t *testing.T) {
 func TestALayoutStatingNoFramingIsNotHeldToEitherMechanism(t *testing.T) {
 	t.Parallel()
 
-	leftToTheOverlapRule(t, refused(t, reachLayout(""), reachCopybooks(reachDetail)))
+	_, err := compileLayout(t, reachLayout(""), reachCopybooks(reachDetail))
+	notHeldToTheReachRule(t, err)
 }
 
 // TestAFixedLengthDatasetBoundsThePredicateByItsLRECL is why docs/ir/SPEC.md
@@ -292,7 +292,8 @@ func TestALayoutStatingNoFramingIsNotHeldToEitherMechanism(t *testing.T) {
 func TestAFixedLengthDatasetBoundsThePredicateByItsLRECL(t *testing.T) {
 	t.Parallel()
 
-	leftToTheOverlapRule(t, refused(t, reachLayout(fixedFraming), reachCopybooks(reachDetail)))
+	_, err := compileLayout(t, reachLayout(fixedFraming), reachCopybooks(reachDetail))
+	notHeldToTheReachRule(t, err)
 }
 
 // TestTheShortestRecordIsMeasuredAtTheMinimumOccurrences is the *shortest* in
@@ -331,7 +332,7 @@ func TestTheShortestRecordIsMeasuredAtTheMinimumOccurrences(t *testing.T) {
 		opts.Reading = layoutmodel.NoODOSlide
 
 		_, err := CompileSequence(opts)
-		leftToTheOverlapRule(t, err)
+		notHeldToTheReachRule(t, err)
 	})
 }
 
@@ -398,4 +399,79 @@ func TestAPredicateReachingPastAShorterRecordIsRejectedWhereThePairIsUnambiguous
 		t.Errorf("the target ends at byte %d against a record of %d bytes, want byte 2 against 1",
 			reach.Ends, reach.Extent)
 	}
+}
+
+// TestTheBatchShapeIsAdmittedAndStillHeldToTheReachRule is the pairing #332
+// leaves behind, asserted on the shape that story is about: a sequence of
+// batches whose two discriminators sit at different offsets and different
+// widths.
+//
+// The overlap rule no longer refuses it and this one still can, and the two are
+// independent. What decides is not whether the runs meet — they never do here —
+// but whether either target is read out of a record shorter than the target
+// ends. So the first of these compiles with the pair left to the order, and the
+// second is refused in this rule's own words, naming the record whose bytes
+// would have been read past.
+func TestTheBatchShapeIsAdmittedAndStillHeldToTheReachRule(t *testing.T) {
+	t.Parallel()
+
+	// A header keyed on three bytes at the front, and a batch detail keyed on
+	// one byte behind a key of its own — different offsets and different
+	// widths, which is the pair that has no run to share.
+	const header = `01 B-HDR.
+   05 B-TYPE PIC X(3).
+   05 B-ID   PIC X(9).
+`
+
+	const inside = `01 B-DTL.
+   05 D-KEY  PIC X(8).
+   05 D-TYPE PIC X(1).
+   05 D-AMT  PIC X(3).
+`
+
+	const past = `01 B-DTL.
+   05 D-KEY  PIC X(20).
+   05 D-TYPE PIC X(1).
+   05 D-AMT  PIC X(3).
+`
+
+	source := delimitedFraming + `
+(record HEADER (copybook "header.cpy" B-HDR))
+(record DETAIL (copybook "detail.cpy" B-DTL))
+(discriminate HEADER (equals (item HEADER B-TYPE) "HDR"))
+(discriminate DETAIL (equals (item DETAIL D-TYPE) "D"))
+(sequence (+ (seq HEADER (* DETAIL))))`
+
+	t.Run("both targets are inside both records", func(t *testing.T) {
+		t.Parallel()
+
+		automaton := compiled(t, source, map[string]string{"HEADER": header, "DETAIL": inside})
+
+		// The header's run begins at byte zero and the detail's at byte
+		// eight, so the header's test is tried first — which is the order
+		// that reads a batched file (#331).
+		state := stateAdmitting(t, automaton, "HEADER")
+		if got := admits(state); got[0] != "HEADER" {
+			t.Errorf("the state tries %s first, want the discriminator reading the earlier byte: %v", got[0], got)
+		}
+	})
+
+	t.Run("the detail's target is read past the end of a header", func(t *testing.T) {
+		t.Parallel()
+
+		reach := reachFaultIn(t, refused(t, source, map[string]string{"HEADER": header, "DETAIL": past}))
+
+		if reach.Record != "DETAIL" || reach.Beside != "HEADER" || reach.Ends != 21 || reach.Extent != 12 {
+			t.Errorf("the fault is %s's target ending at byte %d beside %s at %d bytes, want DETAIL's at 21 beside HEADER at 12",
+				reach.Record, reach.Ends, reach.Beside, reach.Extent)
+		}
+
+		// And it is this rule's fault and not the overlap rule's: the pair
+		// the order would otherwise have settled is still refused here, in
+		// words that name the read rather than the pair (#332).
+		var ambiguity *SequenceAmbiguityError
+		if errors.As(reach, &ambiguity) {
+			t.Errorf("the overlap rule reported the same pair as well: %v", ambiguity)
+		}
+	})
 }

--- a/internal/resolve/sequence.go
+++ b/internal/resolve/sequence.go
@@ -662,7 +662,8 @@ func unboundRead(bound map[int]bool, register *Register, state *State, on *Trans
 
 // checkAmbiguity holds every state to docs/ir/SPEC.md's "When two match, and
 // when none does": two transitions leaving one state must not be eligible
-// together and selected by predicates that can both match one record.
+// together and selected by predicates that can both match one record over the
+// bytes both of them read.
 //
 // Guards narrow which pairs the rule is about. Two transitions whose guards
 // cannot hold at the same time are never both eligible, and their predicates may
@@ -670,6 +671,12 @@ func unboundRead(bound map[int]bool, register *Register, state *State, on *Trans
 // the transition reading another detail and the one moving past them are
 // selected by the very same test on the very same bytes and only the counter
 // separates them.
+//
+// So does what the two discriminators read. A pair whose runs share a byte and
+// agree over it is a clash in the literals, and refusing it names something the
+// adopter fixes where it is written; a pair whose runs share no byte is one no
+// literal either record could carry would ever separate, and the order the state
+// carries resolves it instead ([compiler.resolvedByOrder], #332).
 func (c *compiler) checkAmbiguity(a *Automaton) {
 	for _, state := range a.States {
 		for i, first := range state.Transitions {
@@ -716,6 +723,19 @@ func (c *compiler) checkAmbiguity(a *Automaton) {
 				// (docs/ir/SPEC.md, "A predicate never reads past the
 				// record in front of it", #94).
 				if c.reportReach(state, first, second) {
+					continue
+				}
+
+				// The order the state carries resolves a pair whose
+				// discriminators read runs sharing no byte, and this
+				// is where that permission is spent (#332). It sits
+				// behind the two refusals above because neither of
+				// them is about telling the pair apart: one is a
+				// record offering no target to name and the other a
+				// read leaving the record in front of the consumer,
+				// and both are still faults over a pair the order
+				// would otherwise have settled.
+				if c.resolvedByOrder(first, second) {
 					continue
 				}
 
@@ -836,6 +856,53 @@ func (c *compiler) predicatesOverlap(first, second *Transition) bool {
 	}
 
 	return overlap(over, against)
+}
+
+// resolvedByOrder reports whether the order the state carries settles this pair
+// on its own, which docs/ir/SPEC.md's "When two match, and when none does"
+// permits a producer to rely on.
+//
+// The question is whether the two discriminators read runs that share a byte.
+// Sharing one, the pair is separable by the literals themselves — the layout
+// asked for the same bytes twice and one of the two asks for something else
+// instead — and a refusal names a fix the adopter can make where the literals
+// are written. Sharing none, no literal either record could carry would ever
+// separate them: a record carries an `H` at byte zero and a `D` at byte ten at
+// the same time, so the pair is told apart by trying one of the two first and by
+// nothing else. That is the shape a sequence of batches takes when the header's
+// type code and the detail's do not line up (discussion #323), and the four
+// constructions docs/layout/SPEC.md used to offer instead are all things an
+// adopter with vendor copybooks cannot write.
+//
+// What it gives up is stated in both documents and is not diagnosed anywhere: a
+// detail carrying the header's literal at the header's own run is read as a
+// header and the batch splits in the wrong place. Ordered matching is a
+// convention the layout asserts about its data, not a proof that the two tests
+// cannot both hold.
+//
+// A transition carrying no predicate is not resolved by order and never reaches
+// this. It matches every record, so there is no run to compare and no input it
+// would leave for the transition after it; docs/ir/SPEC.md's "A transition may
+// carry no predicate" refuses the reading that would make it a default arm, and
+// the fault below says so in its own words (#80).
+func (c *compiler) resolvedByOrder(first, second *Transition) bool {
+	if first.Predicate == nil || second.Predicate == nil {
+		return false
+	}
+
+	over, ok := c.stretchOf(first.Record, first.Predicate)
+	against, againstOK := c.stretchOf(second.Record, second.Predicate)
+	if !ok || !againstOK {
+		// A target this cannot place is a misspelled item
+		// [compiler.discriminator] has already reported, and a pair admitted
+		// on the strength of two runs neither of which was found is a layout
+		// admitted for a reason nobody stated.
+		return false
+	}
+
+	_, sharing := over.shares(against)
+
+	return !sharing
 }
 
 // discriminant is one transition's side of an overlap question: what it tests,


### PR DESCRIPTION
Closes #332

Reverses #324 for the pair [discussion #323](https://github.com/Zaba505/cpybkc/discussions/323) is about: a sequence of batches, `(+ (seq HEADER (* DATA)))`, whose two discriminators do not line up.

## The judgment call that shaped the rule

The permission is granted for a pair whose two predicates read **runs of bytes that share none**, and withheld from a pair whose runs share a byte.

That line is where every statement of the shape already sat — `ir/SPEC.md`, the removed Out of Scope entry, #332 and #334 all describe the admitted shape as "runs at different offsets or of different widths [that] do not line up" — and it is the line the two remaining refusals already read differently. A pair whose runs share a byte and agree over it is a clash in the *literals*: the layout asked for the same bytes twice, and the adopter fixes it where the literals are written. A pair whose runs share none is separable by nothing a literal could express, which is exactly discussion #323's complaint — the adopter has none of the four constructions and vendor copybooks that cannot be changed. Admitting only the second keeps every refusal that names a fixable mistake, including `HEADER "H"@0` beside `DETAIL "H"@0`, where first-match would silently make the second transition unreachable.

A transition carrying **no** predicate is outside the permission: it reads no run, so there is no pair of runs to share nothing, and ordering it either way makes it a default arm or makes its sibling unreachable — which `A transition may carry no predicate` refuses in as many words.

## Acceptance criteria

- [x] `ir/SPEC.md`, "When two match, and when none does", permits the pair, resolved by the order the state carries. The `MUST NOT` is narrowed to a pair whose runs share a byte, and the permission is spelt out in a new adjacent section, **A batch boundary is told by the order**.
- [x] The consumer requirement is reconciled with the normative evaluation order, and the asymmetry #324 relied on is **withdrawn explicitly** — a consumer's obligation is unchanged (it already evaluates in the order the state carries and stops at the first match); only the producer's narrowed. `Transitions are ordered by what they read` loses its "not a licence to overlap" paragraph in favour of naming what it does licence.
- [x] What is given up is stated where the permission is granted: ordered matching is a convention the layout asserts, not a proof, and **the mis-split is not diagnosed** — at compile time or at read time.
- [x] `checkAmbiguity` no longer refuses such a pair (`compiler.resolvedByOrder`); `reportUnnameable` and `reportReach` keep their refusals, and both are asked *before* the permission is spent so each keeps its own words.
- [x] **`reportReach` verified against the batch shape.** `TestTheBatchShapeIsAdmittedAndStillHeldToTheReachRule` pins both sides under a delimited framing: the shape compiles where both targets are inside both records, and is still refused by `PredicateReachError` where the detail's target ends 9 bytes past a header. That refusal is admitted as correct rather than deferred — no order makes a read outside the record safe — so no follow-up is filed.
- [x] `layout/SPEC.md`'s Out of Scope entry is removed, replaced by a worked example (`### A batch boundary, told by the order`) with copybooks, layout, the order that results, what the layout is asserting, and the four constructions that avoid it.
- [x] The `otherwise` paragraph is reconciled: an `otherwise` catches what the others missed; the ordered pair is two tests that each say what they look for, in an order the copybooks decide and the layout cannot reach. What they share is the cost.
- [x] **`IrVersion` does not advance**, and the section says why: no field added, none changed, no closed set grown, and nothing a consumer must understand — the order it must follow is already required of it. That is the cheaper of the two spellings #324 weighed, and it stopped being the worse one when #331 made the order derived and normative rather than an artifact of expression nesting.
- [x] #323 is named as the motivating case and #324 as the decision reversed, in both specs and in the appendix rows.

## Beyond the criteria

`A writer walks the same automaton` derived reader/writer agreement from there being at most one matching transition, which is false at an ordered state. Leaving that assertion standing in the same commit that falsifies it would have been a spec contradiction, so the paragraph now re-derives agreement from the order and states the writer's obligation (evaluate the predicates ordered *before* the one taken, and refuse a record any of them matches). The generator-side check, `synth.go` and the round-trip coverage remain #333's, which must land in the same release.

## What the tests now say

- The far-apart pair compiles and the earlier-reading discriminator is tried first (`TestTwoDiscriminatorsOverRunsSharingNoByteAreResolvedByTheOrder`, `TestTheBatchShapeCompilesWhetherOrNotTheCopybooksProveThePairDisjoint`).
- The sharing-run refusals are untouched — identical runs agreeing on a literal, intersecting runs of different widths agreeing on their shared byte, `one-of` over a shared window.
- The reach rule's relaxations now assert a **compilation** rather than a different diagnostic, because nothing else refuses those layouts any more.
- `SequenceAmbiguityError`'s "share no byte" wording is gone with the refusal it explained; the diagnostic keeps the window it names for the clash that is left (#326, #329).
- The byte-domain proof (#330, #335) no longer changes whether a far-apart pair compiles — it decides whether the descriptor rests on the order — so its end-to-end matrix is replaced by one asserting the shape compiles either way. The proof itself keeps its unit coverage over `covering` and `byteDomain` in `predicate_test.go`.

## Verification

`dagger call ci` green from a clean clone of this branch (a worktree's `.git` is a file, so `dagger call` cannot run from one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
